### PR TITLE
conversion util wanted to see 'in' instead of 'inches' this was causi…

### DIFF
--- a/packages/webapp/src/containers/Log/SeedingLog/index.js
+++ b/packages/webapp/src/containers/Log/SeedingLog/index.js
@@ -23,7 +23,7 @@ class SeedingLog extends Component {
 
     this.state = {
       date: moment(),
-      space_unit: getUnit(farm, 'cm', 'inches'),
+      space_unit: getUnit(farm, 'cm', 'in'),
       rate_unit: getUnit(farm, 'm2', 'ft2')
     };
     this.setDate = this.setDate.bind(this);


### PR DESCRIPTION
Error was occuring only with imperial units use case. Seemed to be that conversion util wanted to see abbreviation for units 'in' instead of 'inches' this was causing the error. I think this is more consistent in ui also to have in instead of inches so this was the only change needed to remove the bug. 
