### PR TITLE
pass in missing props to noFarmNavbar

### DIFF
--- a/packages/webapp/src/containers/Navigation/index.js
+++ b/packages/webapp/src/containers/Navigation/index.js
@@ -38,7 +38,7 @@ const NavBar = (props) => {
     auth.logout();
   };
 
-  if (!isFarmSelected) return <NoFarmNavBar history/>
+  if (!isFarmSelected) return <NoFarmNavBar history={history}/>
 
   return (
     <PureNavBar logo={Logo}>


### PR DESCRIPTION
problem fixed: when logo is clicked in the noFarmNavbar, we encounter an error that says history is not found.