### PR TITLE
Small map fixes

### DIFF
--- a/packages/webapp/src/components/Map/DrawingManager/styles.module.scss
+++ b/packages/webapp/src/components/Map/DrawingManager/styles.module.scss
@@ -36,4 +36,5 @@
   padding: 12px 15%;
   width: 50%;
   min-width: 204px;
+  pointer-events: auto;
 }

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -41,7 +41,9 @@ const useMapAssetRenderer = () => {
       );
       setAssetGeometries(newState);
     }
-    map.fitBounds(mapBounds);
+    // TODO: only fitBounds if there is at least one location in the farm
+    if (fields.length > 0)
+      map.fitBounds(mapBounds);
   };
   return { drawAssets };
 };


### PR DESCRIPTION
- if a farm has no locations (ie: newly created farm), the map will centre over the centre of the farm
- warning box can no longer be clicked through