### PR TITLE
Stop converting displayed dates to UTC

### DIFF
--- a/packages/webapp/src/util/moment.js
+++ b/packages/webapp/src/util/moment.js
@@ -51,12 +51,12 @@ export const getLocalizedDateString = (date, format = 'MMMM DD, YYYY') =>
  * @returns {string}
  */
 export const getManagementPlanCardDate = (date) =>
-  moment(date).locale(getLanguageFromLocalStorage()).utc().format(`MMM DD,'YY`);
+  moment(date).locale(getLanguageFromLocalStorage()).format(`MMM DD,'YY`);
 
 export const getManagementPlanTileDate = (date) =>
-  moment(date).locale(getLanguageFromLocalStorage()).utc().format(`MMM DD,'YY`);
+  moment(date).locale(getLanguageFromLocalStorage()).format(`MMM DD,'YY`);
 
 export const getTaskCardDate = (date) =>
-  moment(date).locale(getLanguageFromLocalStorage()).utc().format('MMM D, YYYY');
+  moment(date).locale(getLanguageFromLocalStorage()).format('MMM D, YYYY');
 
-export const getCurrentDateLong = (date) => moment().utc().format('L');
+export const getCurrentDateLong = () => moment().format('L');


### PR DESCRIPTION
I pushed this in case someone thinks it's important in the short term. Please note that I was not able to test/observe impact to EstimatedCropRevenue, ActualCropRevenue, or the survey (all call one of the modified functions) simply because I don't know how to access those areas of the app.