### PR TITLE
Create backdated migration to do seeding

### DIFF
--- a/packages/api/db/migration/20210101000000_seed_data.js
+++ b/packages/api/db/migration/20210101000000_seed_data.js
@@ -1,0 +1,13 @@
+const { seed } = require('../seeds/put_all_datasets');
+
+// LF databases that are sufficiently old were manually seeded before running 2021 and later migrations.
+// This back-dated migration was created to achieve the same effect for databases created later.
+// `up()` checks existence of table `fertilizerLog`; its presence suggests the database needs seeding.
+
+exports.up = async function (knex) {
+  if (await knex.schema.hasTable('fertilizerLog')) await seed(knex);
+};
+
+exports.down = function () {
+  throw new Error('Function down() is not defined for the seed_data migration');
+};

--- a/packages/api/db/migration/20210814105812_fertilizer_to_soil_sample.js
+++ b/packages/api/db/migration/20210814105812_fertilizer_to_soil_sample.js
@@ -2,7 +2,8 @@ exports.up = function (knex) {
   return knex('task_type').update({
     task_name: 'Soil Amendment',
     task_translation_key: 'SOIL_AMENDMENT',
-  }).where({ task_translation_key: 'FERTILIZING' });
+  }).where({ task_translation_key: 'FERTILIZING' })
+    .orWhere({ task_translation_key: 'Fertilizing' });
 };
 
 exports.down = function (knex) {

--- a/packages/api/db/migration/20210831165750_fix_task_type_translation_key.js
+++ b/packages/api/db/migration/20210831165750_fix_task_type_translation_key.js
@@ -4,7 +4,7 @@ exports.up = function(knex) {
       {
         'task_name': 'Bed Preparation',
         'farm_id': null,
-        'task_translation_key': 'BED_PREPARATION',
+        // 'task_translation_key': 'BED_PREPARATION',
       },
     ).update({ task_translation_key: 'BED_PREPARATION_TASK' }),
     knex('task_type').where(
@@ -18,29 +18,28 @@ exports.up = function(knex) {
       {
         'task_name': 'Scouting',
         'farm_id': null,
-        'task_translation_key': 'SCOUTING',
+        // 'task_translation_key': 'SCOUTING',
       },
     ).update({ task_translation_key: 'SCOUTING_TASK' }),
     knex('task_type').where(
       {
         'task_name': 'Harvesting',
         'farm_id': null,
-        'task_translation_key': 'HARVESTING',
+        // 'task_translation_key': 'HARVESTING',
       },
     ).update({ task_translation_key: 'HARVEST_TASK' }),
     knex('task_type').where(
       {
         'task_name': 'Wash and Pack',
         'farm_id': null,
-        'task_translation_key': 'WASH_AND_PACK',
-      }
-      ,
+        // 'task_translation_key': 'WASH_AND_PACK',
+      },
     ).update({ task_translation_key: 'WASH_AND_PACK_TASK' }),
     knex('task_type').where(
       {
         'task_name': 'Pest Control',
         'farm_id': null,
-        'task_translation_key': 'PEST_CONTROL',
+        // 'task_translation_key': 'PEST_CONTROL',
       }
       ,
     ).update({ task_translation_key: 'PEST_CONTROL_TASK' }),
@@ -48,7 +47,7 @@ exports.up = function(knex) {
       {
         'task_name': 'Other',
         'farm_id': null,
-        'task_translation_key': 'OTHER',
+        // 'task_translation_key': 'OTHER',
       }
       ,
     ).update({ task_translation_key: 'OTHER_TASK' }),


### PR DESCRIPTION
Currently there is apparently no defined way to create a "correct" database from scratch. It appears that existing dev and production dbs were seeded at some point in the past, and then had migrations applied to them. Running the migrations alone is not sufficient to match the results. Applying the seeds after the migration will no longer work because migrations have changed the database.

This back-dated migration was created to achieve the same effect for databases created later. When migrations through 2020 have been applied, this new migration simply runs the seeding process, and then the 2021 migrations are applied with the seeded data in place. (The year boundary was identified as an appropriate point by trial and error.)

Because pre-existing databases have not applied this migration, it will activate on next migration. However, this is safe because the migration checks the existence of table `fertilizerLog`. Its presence suggests the database needs seeding; its absence skips the seeding to complete and log a "do nothing" migration.

BTW, the bad effect of this was failed attempts to create management plans. This was due to missing or mis-capitalized values for `task_type.task_translation_key`. This PR changes some existing migration `UPDATE`s to deal with capitalization. In most cases, portions of `WHERE` clauses were commented out because the filter string was not matching due to capitalization, and was also unneeded to match the record for update. I confirmed that this process populates `task_type` so that it matches production for the records in question.