### PR TITLE
[LF-2060] Name export zip with uuid, rm after upload

### DIFF
--- a/packages/api/src/controllers/organicCertifierSurveyController.js
+++ b/packages/api/src/controllers/organicCertifierSurveyController.js
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- *  This file (fertilizerController.js) is part of LiteFarm.
+ *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ const farmModel = require('../models/farmModel');
 const documentModel = require('../models/documentModel');
 const knex = require('./../util/knex');
 const Queue = require('bull');
+const { v4: uuidv4 } = require('uuid');
 const redisConf = {
   redis: {
     host: process.env.REDIS_HOST,
@@ -156,7 +157,7 @@ const organicCertifierSurveyController = {
       const data = await this.recordIAndDInfo(to_date, from_date, farm_id)
       const extraInfo = { ...data };
       const body = {
-        ...extraInfo, organicCertifierSurvey, certifier, certification,
+        exportId: uuidv4(), ...extraInfo, organicCertifierSurvey, certifier, certification,
         files, farm_id, email, first_name, farm_name, language_preference,
         from_date, to_date, submission: submission_id,
       };

--- a/packages/api/src/jobs/certification/do_retrieve.js
+++ b/packages/api/src/jobs/certification/do_retrieve.js
@@ -10,12 +10,12 @@ const bucketNames = {
 module.exports = (nextQueue, emailQueue) => (job, done) => {
   console.log('JOB DATA', JSON.stringify(job.data));
   console.log('STEP 1 > RETRIEVE DO', job.id);
-  const { farm_id, files, email, farm_name } = job.data;
+  const { exportId, farm_id, files, email } = job.data;
   const args = [
     's3', // command
     'cp', //sub command
     `s3://${getS3BucketName()}/${farm_id}/document`, // location
-    `temp/${farm_name}`, // destination
+    `temp/${exportId}`, // destination
     '--recursive',
     '--endpoint=https://nyc3.digitaloceanspaces.com',
     '--exclude=*',
@@ -27,7 +27,7 @@ module.exports = (nextQueue, emailQueue) => (job, done) => {
       newName: file_name,
     }));
     Promise.all(fileNames.map(({ oldName, newName }) => {
-      const directory = path.join(process.env.EXPORT_WD, 'temp', farm_name);
+      const directory = path.join(process.env.EXPORT_WD, 'temp', exportId);
       return fs.stat(path.join(directory, oldName)).then(() =>
         fs.rename(path.join(directory, oldName), path.join(directory, newName)),
       ).catch(e => console.log('Could not find file', newName));

--- a/packages/api/src/jobs/certification/pdf.js
+++ b/packages/api/src/jobs/certification/pdf.js
@@ -1,12 +1,10 @@
 const puppeteer = require('puppeteer');
 const fs = require('fs');
 const rp = require('request-promise');
-const { Model } = require('objection');
-const knex = Model.knex();
 const surveyStackURL = 'https://app.surveystack.io/api/';
 module.exports = (nextQueue, emailQueue) => async (job) => {
   console.log('STEP 3 > PDF');
-  const { farm_name, organicCertifierSurvey, certification, certifier } = job.data;
+  const { exportId, organicCertifierSurvey, certification, certifier } = job.data;
   const browser = await puppeteer.launch({ headless: true, ignoreDefaultArgs: ['--disable-extensions'] });
   const submission = await rp({ uri: `${surveyStackURL}/submissions/${job.data.submission}`, json: true });
   const survey = await rp({ uri: `${surveyStackURL}/surveys/${submission.meta.survey.id}`, json: true });
@@ -27,7 +25,7 @@ module.exports = (nextQueue, emailQueue) => async (job) => {
     }, data);
     await page.goto(process.env.REPORT_URL, { waitUntil: 'networkidle2' });
     const readablePDF = await page.createPDFStream({ format: 'a4' });
-    const writePDFStream = fs.createWriteStream(`${process.env.EXPORT_WD}/temp/${farm_name}/Additional survey questions.pdf`);
+    const writePDFStream = fs.createWriteStream(`${process.env.EXPORT_WD}/temp/${exportId}/Additional survey questions.pdf`);
     readablePDF.pipe(writePDFStream);
     nextQueue.add(job.data);
     setTimeout(() => {

--- a/packages/api/src/jobs/certification/recordD.js
+++ b/packages/api/src/jobs/certification/recordD.js
@@ -7,16 +7,16 @@ module.exports = (nextQueue, zipQueue, emailQueue) => (job) => {
     recordD,
     recordICrops,
     recordICleaners,
-    farm_id,
+    exportId,
     from_date,
     to_date,
     farm_name,
     language_preference,
   } = job.data;
   return i18n.changeLanguage(language_preference).then(() => Promise.all([
-    recordDGenerator(recordD, farm_id, from_date, to_date, farm_name),
-    recordIGeneration(recordICrops, farm_id, from_date, to_date, farm_name, true),
-    recordIGeneration(recordICleaners, farm_id, from_date, to_date, farm_name),
+    recordDGenerator(recordD, exportId, from_date, to_date, farm_name),
+    recordIGeneration(recordICrops, exportId, from_date, to_date, farm_name, true),
+    recordIGeneration(recordICleaners, exportId, from_date, to_date, farm_name),
   ])).then(() => {
     if (job.data.submission) {
       return Promise.resolve(nextQueue.add(job.data, { removeOnComplete: true }));

--- a/packages/api/src/jobs/certification/record_d_generation.js
+++ b/packages/api/src/jobs/certification/record_d_generation.js
@@ -21,7 +21,7 @@ const dataTransformsMapping = {
   genetically_engineered: boolToStringTransformation,
 }
 
-module.exports = (data, farm_id, from_date, to_date, farm_name) => {
+module.exports = (data, exportId, from_date, to_date, farm_name) => {
   return XlsxPopulate.fromBlankAsync()
     .then((workbook) => {
       const defaultStyles = {
@@ -123,7 +123,7 @@ module.exports = (data, farm_id, from_date, to_date, farm_name) => {
           workbook.sheet(0).cell(cell).value(value);
         });
       });
-      return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${farm_name}/iCertify-RecordD.xlsx`);
+      return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/iCertify-RecordD.xlsx`);
     })
 }
 

--- a/packages/api/src/jobs/certification/record_i_generation.js
+++ b/packages/api/src/jobs/certification/record_i_generation.js
@@ -1,6 +1,5 @@
 const XlsxPopulate = require('xlsx-populate');
 const i18n = require('../locales/i18n');
-const boolToStringTransformation = (bool) => bool ? 'Y' : bool !== null ? 'N' : 'N/A';
 const dataToCellMapping = {
   name: 'A',
   supplier: 'B',
@@ -14,7 +13,7 @@ const dataTransformsMapping = {
   product_quantity: (quantity) => quantity ? quantity.toFixed(2) : 0,
 }
 
-module.exports = (data, farm_id, from_date, to_date, farm_name, isInputs) => {
+module.exports = (data, exportId, from_date, to_date, farm_name, isInputs) => {
   return XlsxPopulate.fromBlankAsync()
     .then((workbook) => {
       const defaultStyles = {
@@ -126,7 +125,7 @@ module.exports = (data, farm_id, from_date, to_date, farm_name, isInputs) => {
           workbook.sheet(0).cell(cell).value(value);
         })
       })
-      return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${farm_name}/iCertify-RecordI-${title}.xlsx`);
+      return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/iCertify-RecordI-${title}.xlsx`);
     })
 }
 

--- a/packages/api/src/jobs/certification/upload.js
+++ b/packages/api/src/jobs/certification/upload.js
@@ -9,13 +9,13 @@ const bucketNames = {
 
 module.exports = (emailQueue) => (job, done) => {
   console.log('STEP 5 > Upload', job.id);
-  const { farm_id, farm_name, email } = job.data;
+  const { exportId, farm_id, email } = job.data;
   const dateIdentifier = Date.now();
   const fileIdentifier = `${getS3BucketName()}/${farm_id}/document/exports/${dateIdentifier}`
   const args = [
     's3', // command
     'cp', //sub command
-    `temp/${farm_name}.zip`, // location
+    `temp/${exportId}.zip`, // location
     `s3://${fileIdentifier}.zip`, // destination
     '--endpoint=https://nyc3.digitaloceanspaces.com',
   ]
@@ -23,8 +23,11 @@ module.exports = (emailQueue) => (job, done) => {
   awsCopyProcess.on('exit', childProcessExitCheck(() => {
     done();
     emailQueue.add({ ...job.data, file: fileIdentifier }, { removeOnComplete: true });
-    fs.rmdir(path.join(process.env.EXPORT_WD, 'temp', farm_name), { recursive: true }, (err) => {
-      if(!err) console.log('deleted temp folder', farm_name);
+    fs.rmdir(path.join(process.env.EXPORT_WD, 'temp', exportId), { recursive: true }, (err) => {
+      if (!err) console.log('deleted temp folder for export id', exportId);
+    })
+    fs.rm(path.join(process.env.EXPORT_WD, 'temp', `${exportId}.zip`), { recursive: true }, (err) => {
+      if (!err) console.log('deleted zip file for export id', exportId);
     })
   }, ()=> {
     done();

--- a/packages/api/src/jobs/certification/zip.js
+++ b/packages/api/src/jobs/certification/zip.js
@@ -2,9 +2,9 @@ const { spawn }= require('child_process')
 const path = require('path');
 module.exports = (nextQueue, emailQueue) => (job, done) => {
   console.log('STEP 4 > ZIP', job.id);
-  const { farm_name, email } = job.data;
+  const { exportId, email } = job.data;
   const zipProcess = spawn('zip',
-    ['-r', '-j', `${farm_name}.zip`, `${farm_name}`], { cwd: path.join(process.env.EXPORT_WD, 'temp') });
+    ['-r', '-j', `${exportId}.zip`, `${exportId}`], { cwd: path.join(process.env.EXPORT_WD, 'temp') });
   zipProcess.on('exit', childProcessExitCheck(() => {
     done();
     nextQueue.add(job.data, { removeOnComplete: true });


### PR DESCRIPTION
Previous server-side "scheduler" job created export as `farm_name.zip`. After copying that zip to aws (under a different filename), the inputs to the zip were deleted, but not the zip itself.
Later exports for the same farm would *refresh* the files in that existing zip, so that any old additional survey questions would remain in the zip though they were no longer appopriate.
This PR:
1. generates a uuid `exportId` for each export. The uuid is used for the zip file name instead of `farm_name`, to avoid possible collisions; and
2. deletes the zip file from the scheduler's file system after it has been copied to aws.