### PR TITLE
[ST-388]  Adding crop's name on "Actual Revenue" 

### DIFF
--- a/packages/webapp/src/containers/Finances/ActualCropRevenue/index.js
+++ b/packages/webapp/src/containers/Finances/ActualCropRevenue/index.js
@@ -3,21 +3,27 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import FinanceGroup from '../../../components/Finances/FinanceGroup';
 import { getManagementPlanCardDate } from '../../../util/moment';
-import { cropVarietyEntitiesSelector } from '../../cropVarietySlice';
+import { cropVarietiesSelector } from '../../cropVarietySlice';
 import { setSelectedSale } from '../actions';
 import { convertFromMetric, roundToTwoDecimal } from '../../../util';
+import { useTranslation } from 'react-i18next';
 
 const ActualCropRevenue = ({ sale, history, ...props }) => {
   const { sale_id, sale_date, customer_name, crop_variety_sale } = sale;
 
   const dispatch = useDispatch();
+  const { t } = useTranslation();
 
   // TODO: optimize this - put in parent component or seek by id
-  const cropVarietyEntities = useSelector(cropVarietyEntitiesSelector);
+  const cropVarietyEntities = {};
+  const cropVarieties= useSelector(cropVarietiesSelector);
 
   let total = 0;
   for (const cvs of crop_variety_sale) {
     total += cvs.sale_value;
+    cropVarietyEntities[cvs.crop_variety_id] = cropVarieties.filter(
+      (c) => c.crop_variety_id === cvs.crop_variety_id
+    )[0]
   }
 
   const onClickForward = () => {
@@ -35,6 +41,11 @@ const ActualCropRevenue = ({ sale, history, ...props }) => {
         const convertedQuantity = roundToTwoDecimal(
           convertFromMetric(cvs.quantity.toString(), cvs.quantity_unit, 'kg').toString(),
         );
+        const cropVariety =  cropVarietyEntities[cvs.crop_variety_id];
+        const title = cropVariety.crop_variety_name
+          ? `${cropVariety.crop_variety_name}, ${t(`crop:${cropVariety.crop.crop_translation_key}`)}`
+          : t(`crop:${cropVariety.crop.crop_translation_key}`);
+
         return {
           title: cropVarietyEntities[cvs.crop_variety_id].crop_variety_name,
           subtitle: `${convertedQuantity} ${cvs.quantity_unit}`,

--- a/packages/webapp/src/containers/Finances/ActualCropRevenue/index.js
+++ b/packages/webapp/src/containers/Finances/ActualCropRevenue/index.js
@@ -47,7 +47,8 @@ const ActualCropRevenue = ({ sale, history, ...props }) => {
           : t(`crop:${cropVariety.crop.crop_translation_key}`);
 
         return {
-          title: cropVarietyEntities[cvs.crop_variety_id].crop_variety_name,
+          key: cvs.crop_variety_id,
+          title: title,
           subtitle: `${convertedQuantity} ${cvs.quantity_unit}`,
           amount: cvs.sale_value,
         };


### PR DESCRIPTION
Added the name of the crop as complement to the Crop variety name in the Actual revenue page.
I used the same pattern used in the estimated crop revenue.