### PR TITLE
LF-2028 Soft delete farms where country and grid pts are NULL

### DIFF
--- a/packages/api/db/migration/20220301154943_soft-delete-countryless-farms.js
+++ b/packages/api/db/migration/20220301154943_soft-delete-countryless-farms.js
@@ -1,0 +1,17 @@
+exports.up = function (knex) {
+  return knex.schema.raw(`
+    UPDATE farm
+    SET deleted = true
+    WHERE country_id IS NULL
+      AND grid_points IS NULL;
+ `);
+};
+
+exports.down = function (knex) {
+  return knex.schema.raw(`
+    UPDATE farm
+    SET deleted = false 
+    WHERE country_id IS NULL
+      AND grid_points IS NULL;
+ `);
+};


### PR DESCRIPTION
In standup, we agreed to run this on beta as well as production. As a result, nothing here checks the environment-- the updates will just run. @JimmyRowland let me know if you think that should be handled differently.