### PR TITLE
Fix file matching in lint-staged config

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -109,7 +109,7 @@
     "start-server-and-test": "^1.11.7"
   },
   "lint-staged": {
-    "*.{js}": [
+    "*.js": [
       "eslint --quiet --fix"
     ],
     "*.{js,css,md}": "prettier --write"


### PR DESCRIPTION
api .js files were not being checked by lint-staged. Apparently the curly braces can't be used around only one file extension.
`litefarm-api: [SKIPPED] No staged files match *.{js}`