### PR TITLE
LF-2231/apricot plant spacing fix migration file

### DIFF
--- a/packages/api/db/migration/20220504213459_update-apricot-plant-spacing-from-crop-table.js
+++ b/packages/api/db/migration/20220504213459_update-apricot-plant-spacing-from-crop-table.js
@@ -1,3 +1,17 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <<https://www.gnu.org/licenses/>.>
+ */
 
 const tableName = "crop";
 const apricot_id = 31; // Apricot

--- a/packages/api/db/migration/20220504213459_update-apricot-plant-spacing-from-crop-table.js
+++ b/packages/api/db/migration/20220504213459_update-apricot-plant-spacing-from-crop-table.js
@@ -15,7 +15,7 @@
 
 const tableName = "crop";
 const apricot_id = 31; // Apricot
-const apricot_plant_spacing = 457.2; // in cm
+const apricot_plant_spacing = 4.572; // in m
 
 exports.up = async function(knex) {
   await knex(tableName)

--- a/packages/api/db/migration/20220504213459_update-apricot-plant-spacing-from-crop-table.js
+++ b/packages/api/db/migration/20220504213459_update-apricot-plant-spacing-from-crop-table.js
@@ -1,0 +1,16 @@
+
+const tableName = "crop";
+const apricot_id = 31; // Apricot
+const apricot_plant_spacing = 457.2; // in cm
+
+exports.up = async function(knex) {
+  await knex(tableName)
+    .where({ crop_id: apricot_id })
+    .update({ plant_spacing: apricot_plant_spacing });
+};
+
+exports.down = async function(knex) {
+  await knex(tableName)
+    .where({ crop_id: apricot_id })
+    .update({ plant_spacing: 15 });
+};


### PR DESCRIPTION
Ticket [LF-2331](https://lite-farm.atlassian.net/browse/LF-2331)

To Test:

1. Check `crop` table using your choice of PostgreSQL GUI. `crop_id` for Apricot is 31. Check that the `plant_spacing` column has a value of 15 for Apricot.
2. Run `npx knex migrate:up` and check the table again. The value should be now updated to 457.2.
3. `npx knex migrate:down` will revert the changes.