### PR TITLE
Lf 2273 UI error on broadcast planting method

### DIFF
--- a/packages/webapp/src/components/Crop/BroadcastPlan/PureBroadcastForm.jsx
+++ b/packages/webapp/src/components/Crop/BroadcastPlan/PureBroadcastForm.jsx
@@ -129,7 +129,6 @@ export function PureBroadcastForm({
               input: {
                 borderTopRightRadius: '0px',
                 borderBottomRightRadius: '0px',
-                borderRightStyle: 'none',
                 ...greenInput,
               },
             }}

--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -9,7 +9,11 @@ import i18n from '../../../locales/i18n';
 import { integerOnKeyDown, numberOnKeyDown, preventNumberScrolling } from '../Input';
 import Select from 'react-select';
 import { styles as reactSelectDefaultStyles } from '../ReactSelect';
-import { area_total_area, getDefaultUnit, roundToTwoDecimal } from '../../../util/convert-units/unit';
+import {
+  area_total_area,
+  getDefaultUnit,
+  roundToTwoDecimal,
+} from '../../../util/convert-units/unit';
 import Infoi from '../../Tooltip/Infoi';
 import { Controller, get, useFormState } from 'react-hook-form';
 import { ReactComponent as Leaf } from '../../../assets/images/signUp/leaf.svg';
@@ -287,7 +291,7 @@ const Unit = ({
     <div className={clsx(styles.container)} style={{ ...style, ...classes.container }}>
       {label && (
         <div className={styles.labelContainer}>
-          <Label style={{ position: 'absolute', bottom: 0 }}>
+          <Label>
             {label}{' '}
             {optional && (
               <Label sm className={styles.sm}>

--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -54,6 +54,7 @@
   flex-direction: column;
   overflow: visible;
   position: relative;
+  justify-content: space-between;
 }
 
 .sm {


### PR DESCRIPTION
There was an alignment issue when the left form field on the second row had text overflowed to two lines. Fixed by using existing flex box and removing position absolute. 

Story: [LF-2273](https://lite-farm.atlassian.net/browse/LF-2273?atlOrigin=eyJpIjoiOTJiODViNDUwODMyNGJlOWJiMzNkNmQyY2ZlNmQ0MDIiLCJwIjoiaiJ9)

<img width="261" alt="Screen Shot 2022-05-05 at 9 46 54 AM" src="https://user-images.githubusercontent.com/104768598/166940508-ade3f0ba-df29-4838-afd1-024268a91aa1.png">
