### PR TITLE
LF-2323: error when unassigning task from task card and read only task view

### DIFF
--- a/packages/api/src/middleware/validation/assignTask.js
+++ b/packages/api/src/middleware/validation/assignTask.js
@@ -25,6 +25,11 @@ async function validateAssigneeId(req, res, next) {
     return res.status(403).send('Not authorized to assign other people for this task');
   }
 
+  // if the assignee_user_id is null, this means that the task is 'Unassigned' which is a valid
+  if (assignee_user_id === null) {
+    return next();
+  }
+
   const userFarm = await userFarmModel
     .query()
     .where({

--- a/packages/webapp/src/components/Form/ReactSelect/index.jsx
+++ b/packages/webapp/src/components/Form/ReactSelect/index.jsx
@@ -17,7 +17,7 @@ export const styles = {
     },
     fontSize: '16px',
     lineHeight: '24px',
-    color: 'var(--fontColor)',
+    color: state.isDisabled ? 'var(--grey400)' : 'var(--fontColor)',
     fontStyle: 'normal',
     fontWeight: 'normal',
     fontFamily: '"Open Sans", "SansSerif", serif',

--- a/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
+++ b/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
@@ -19,13 +19,14 @@ export default function TaskQuickAssignModal({
 }) {
   const { t } = useTranslation();
   const selfOption = { label: `${user.first_name} ${user.last_name}`, value: user.user_id };
-  const unAssignedOption = { label: t('TASK.UNASSIGNED'), value: null };
+  const unAssignedOption = { label: t('TASK.UNASSIGNED'), value: null, isDisabled: false };
   const options = useMemo(() => {
     if (user.is_admin) {
       const options = users.map(({ first_name, last_name, user_id }) => ({
         label: `${first_name} ${last_name}`,
         value: user_id,
       }));
+      unAssignedOption.isDisabled = !isAssigned;
       options.unshift(unAssignedOption);
       return options;
     } else return [selfOption, unAssignedOption];


### PR DESCRIPTION
There was issue in validating the assignee_user_id where we were not accepting null as valid, when null is representing when a task is unassigned. So the validation was always throwing 400 when trying to make a task unassigned. 

Also added a check in the frontend such that if the task is currently unassigned, we can not assign it again to unassigned. 