### PR TITLE
LF-2332/fix-estimated-yield-calculation-for-crops

### DIFF
--- a/packages/webapp/src/components/Crop/RowMethod/PureRowForm.jsx
+++ b/packages/webapp/src/components/Crop/RowMethod/PureRowForm.jsx
@@ -46,7 +46,16 @@ export default function PureRowForm({
 
   const IsValidNumberInput = (number) => number === 0 || number > 0;
 
-  const calculateEstimates = (length, spacing) => {
+  /**
+   * Calculates the plant count in one row given length of the row and plant spacing. 
+   * If length is perfectly divisible by spacing (i.e. 5m spacing in a 10m row),
+   * you can plant 3 crops (at 0m, 5m, and 10m).
+   * Otherwise (i.e. 6m spacing in a 10m row), you can plant only 2 crops (at 0m and 6m).
+   * @param {number} length 
+   * @param {number} spacing 
+   * @returns {number} plant count
+   */
+  const calculatePlantCountPerRow = (length, spacing) => {
     if (!(length % spacing)) {
       return (length + spacing) / spacing;
     } else {
@@ -72,14 +81,16 @@ export default function PureRowForm({
         shouldCalculatedSameLengthEstimatedValues || shouldCalculateDifferentLengthEstimatedValues,
       );
     } else if (shouldCalculatedSameLengthEstimatedValues) {
-      const estimated_seed_required = calculateEstimates(length_of_row, plant_spacing) * num_of_rows * average_seed_weight;
-      const estimated_yield = calculateEstimates(length_of_row, plant_spacing) * num_of_rows * yield_per_plant;
+      const plantCountPerRow = calculatePlantCountPerRow(length_of_row, plant_spacing);
+      const estimated_seed_required = plantCountPerRow * num_of_rows * average_seed_weight;
+      const estimated_yield = plantCountPerRow * num_of_rows * yield_per_plant;
       average_seed_weight && setValue(ESTIMATED_SEED, estimated_seed_required);
       yield_per_plant && setValue(ESTIMATED_YIELD, estimated_yield);
       setShowEstimatedValue(true);
     } else if (shouldCalculateDifferentLengthEstimatedValues) {
-      const estimated_seed_required = calculateEstimates(total_length, plant_spacing) * average_seed_weight;
-      const estimated_yield = calculateEstimates(total_length, plant_spacing) * yield_per_plant;
+      const totalPlantCount = calculatePlantCountPerRow(total_length, plant_spacing);
+      const estimated_seed_required = totalPlantCount * average_seed_weight;
+      const estimated_yield = totalPlantCount * yield_per_plant;
       average_seed_weight && setValue(ESTIMATED_SEED, estimated_seed_required);
       yield_per_plant && setValue(ESTIMATED_YIELD, estimated_yield);
       setShowEstimatedValue(true);

--- a/packages/webapp/src/components/Crop/RowMethod/PureRowForm.jsx
+++ b/packages/webapp/src/components/Crop/RowMethod/PureRowForm.jsx
@@ -46,6 +46,14 @@ export default function PureRowForm({
 
   const IsValidNumberInput = (number) => number === 0 || number > 0;
 
+  const calculateEstimates = (length, spacing) => {
+    if (!(length % spacing)) {
+      return (length + spacing) / spacing;
+    } else {
+      return Math.ceil(length / spacing);
+    }
+  }
+
   const [showEstimatedValue, setShowEstimatedValue] = useState(false);
   const shouldSkipEstimatedValueCalculationRef = useRef(true);
 
@@ -64,15 +72,14 @@ export default function PureRowForm({
         shouldCalculatedSameLengthEstimatedValues || shouldCalculateDifferentLengthEstimatedValues,
       );
     } else if (shouldCalculatedSameLengthEstimatedValues) {
-      const estimated_seed_required =
-        ((num_of_rows * length_of_row) / plant_spacing) * average_seed_weight;
-      const estimated_yield = ((num_of_rows * length_of_row) / plant_spacing) * yield_per_plant;
+      const estimated_seed_required = calculateEstimates(length_of_row, plant_spacing) * num_of_rows * average_seed_weight;
+      const estimated_yield = calculateEstimates(length_of_row, plant_spacing) * num_of_rows * yield_per_plant;
       average_seed_weight && setValue(ESTIMATED_SEED, estimated_seed_required);
       yield_per_plant && setValue(ESTIMATED_YIELD, estimated_yield);
       setShowEstimatedValue(true);
     } else if (shouldCalculateDifferentLengthEstimatedValues) {
-      const estimated_seed_required = (total_length / plant_spacing) * average_seed_weight;
-      const estimated_yield = (total_length / plant_spacing) * yield_per_plant;
+      const estimated_seed_required = calculateEstimates(total_length, plant_spacing) * average_seed_weight;
+      const estimated_yield = calculateEstimates(total_length, plant_spacing) * yield_per_plant;
       average_seed_weight && setValue(ESTIMATED_SEED, estimated_seed_required);
       yield_per_plant && setValue(ESTIMATED_YIELD, estimated_yield);
       setShowEstimatedValue(true);


### PR DESCRIPTION
Ticket [LF-2332](https://lite-farm.atlassian.net/browse/LF-2332)

Estimated annual harvest calculation for row planting method

For example for Apricots, 
- 30 meter rows and plant spacing at 15 meters, should equal 3 plants (0, 15, 30) per row at 10 rows = 30 plants
- 30 plants at 47.5 kg/plant = 1425

To Test:
1. Select any crops and create a plan
2. Select Rows for planting method
3. Check the estimated annual yield is correct

You can find each crop's yield per plant in Crop table.

If the length isn't perfectly divisible by spacing (i.e. 16 meter spacing in a 30 meter row), you cannot plant 2.875 plants each row. You will plant 2 plants per row (at 0 meter and 16 meter) and the estimated yield is calculated accordingly. 