### PR TITLE
LF 2364 augment type filter on task filter page

### DIFF
--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -4,6 +4,8 @@ import React, { useMemo, useRef } from 'react';
 
 import PureFilterPage from '../../../components/FilterPage';
 import { setTasksFilter, tasksFilterSelector } from '../../filterSlice';
+import { getTaskTypes } from '../../Task/saga';
+import { defaultTaskTypesSelector, userCreatedTaskTypesSelector } from '../../taskTypeSlice';
 
 import {
   ABANDONED,
@@ -29,14 +31,16 @@ const TasksFilterPage = ({ onGoBack }) => {
   const tasks = useSelector(tasksSelector);
   const dispatch = useDispatch();
   const locations = useSelector(locationsSelector);
+  const taskTypes = useSelector(defaultTaskTypesSelector);
+  const customTaskTypes = useSelector(userCreatedTaskTypesSelector);
+
+  useEffect(() => {});
 
   const statuses = [ABANDONED, COMPLETED, LATE, PLANNED];
 
-  const { taskTypes, assignees } = useMemo(() => {
-    let taskTypes = {};
+  const { assignees } = useMemo(() => {
     let assignees = {};
     for (const task of tasks) {
-      taskTypes[task.taskType.task_type_id] = task.taskType;
       if (task.assignee !== undefined) {
         const { user_id, first_name, last_name } = task.assignee;
         assignees[user_id] = `${first_name} ${last_name}`;

--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -1,6 +1,21 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <<https://www.gnu.org/licenses/>.>
+ */
+
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useEffect, useState } from 'react';
 
 import PureFilterPage from '../../../components/FilterPage';
 import { setTasksFilter, tasksFilterSelector } from '../../filterSlice';
@@ -24,6 +39,8 @@ import {
 import { DATE_RANGE, SEARCHABLE_MULTI_SELECT } from '../../../components/Filter/filterTypes';
 import { tasksSelector } from '../../taskSlice';
 import { locationsSelector } from '../../locationSlice';
+import { isAdminSelector } from '../../userFarmSlice';
+import { getSupportedTaskTypesSet } from '../../../components/Task/getSupportedTaskTypesSet';
 
 const TasksFilterPage = ({ onGoBack }) => {
   const { t } = useTranslation(['translation', 'filter', 'task']);
@@ -31,10 +48,23 @@ const TasksFilterPage = ({ onGoBack }) => {
   const tasks = useSelector(tasksSelector);
   const dispatch = useDispatch();
   const locations = useSelector(locationsSelector);
-  const taskTypes = useSelector(defaultTaskTypesSelector);
+  const defaultTaskTypes = useSelector(defaultTaskTypesSelector);
   const customTaskTypes = useSelector(userCreatedTaskTypesSelector);
 
-  useEffect(() => {});
+  const [taskTypes, setTaskTypes] = useState([]);
+
+  useEffect(() => {
+    dispatch(getTaskTypes());
+  }, []);
+
+  useEffect(() => {
+    const supportedTaskTypes = getSupportedTaskTypesSet(true);
+    const filteredDefaultTaskTypes = defaultTaskTypes?.filter(
+      (type) => type.deleted === false && supportedTaskTypes.has(type.task_translation_key),
+    );
+    const filteredCustomTaskTypes = customTaskTypes?.filter((type) => type.deleted === false);
+    setTaskTypes([...filteredDefaultTaskTypes, ...filteredCustomTaskTypes]);
+  }, [defaultTaskTypes, customTaskTypes]);
 
   const statuses = [ABANDONED, COMPLETED, LATE, PLANNED];
 

--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -39,7 +39,6 @@ import {
 import { DATE_RANGE, SEARCHABLE_MULTI_SELECT } from '../../../components/Filter/filterTypes';
 import { tasksSelector } from '../../taskSlice';
 import { locationsSelector } from '../../locationSlice';
-import { isAdminSelector } from '../../userFarmSlice';
 import { getSupportedTaskTypesSet } from '../../../components/Task/getSupportedTaskTypesSet';
 
 const TasksFilterPage = ({ onGoBack }) => {

--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -15,7 +15,7 @@
 
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import React, { useMemo, useRef, useEffect, useState } from 'react';
+import React, { useMemo, useRef, useEffect } from 'react';
 
 import PureFilterPage from '../../../components/FilterPage';
 import { setTasksFilter, tasksFilterSelector } from '../../filterSlice';
@@ -51,19 +51,24 @@ const TasksFilterPage = ({ onGoBack }) => {
   const defaultTaskTypes = useSelector(defaultTaskTypesSelector);
   const customTaskTypes = useSelector(userCreatedTaskTypesSelector);
 
-  const [taskTypes, setTaskTypes] = useState([]);
-
   useEffect(() => {
     dispatch(getTaskTypes());
   }, []);
 
-  useEffect(() => {
+  const taskTypes = useMemo(() => {
     const supportedTaskTypes = getSupportedTaskTypesSet(true);
-    const filteredDefaultTaskTypes = defaultTaskTypes?.filter(
-      (type) => type.deleted === false && supportedTaskTypes.has(type.task_translation_key),
-    );
-    const filteredCustomTaskTypes = customTaskTypes?.filter((type) => type.deleted === false);
-    setTaskTypes([...filteredDefaultTaskTypes, ...filteredCustomTaskTypes]);
+    let taskTypes = {};
+    for (const type of defaultTaskTypes) {
+      if (type.deleted === false && supportedTaskTypes.has(type.task_translation_key)) {
+        taskTypes[type.task_type_id] = type;
+      }
+    }
+    for (const type of customTaskTypes) {
+      if (type.deleted === false) {
+        taskTypes[type.task_type_id] = type;
+      }
+    }
+    return taskTypes;
   }, [defaultTaskTypes, customTaskTypes]);
 
   const statuses = [ABANDONED, COMPLETED, LATE, PLANNED];


### PR DESCRIPTION
Updated the filter on the task page to display all active task types, regardless of whether there is a task with that type currently.

To test:
1. Make sure you have at least one default task type and one custom task type on your farm which have no tasks associated with them
2. On the tasks page, go to filter tasks
3. Try to filter the tasks by type -> you should see all task types here, not just those which currently have a task

