### PR TITLE
Assign all tasks on date, on the task quick assign modal does not work

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,8 +11,6 @@
     "start": "set NODE_ENV=development&& node src/server.js",
     "start:prod": "node src/server.js",
     "nodemon": "set NODE_ENV=development&& nodemon src/server.js",
-    "nodemon-debug": "set NODE_ENV=development&& nodemon --inspect src/server.js",
-    "nodemon-bdebug": "set NODE_ENV=development&& nodemon --inspect-brk src/server.js",
     "debug-email-template": "set NODE_ENV=development&& DEBUG=email-templates nodemon src/server.js",
     "debug-i18n": "set NODE_ENV=development&& DEBUG=i18n:* nodemon src/server.js",
     "production": "NODE_ENV=production node src/server.js",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,6 +11,8 @@
     "start": "set NODE_ENV=development&& node src/server.js",
     "start:prod": "node src/server.js",
     "nodemon": "set NODE_ENV=development&& nodemon src/server.js",
+    "nodemon-debug": "set NODE_ENV=development&& nodemon --inspect src/server.js",
+    "nodemon-bdebug": "set NODE_ENV=development&& nodemon --inspect-brk src/server.js",
     "debug-email-template": "set NODE_ENV=development&& DEBUG=email-templates nodemon src/server.js",
     "debug-i18n": "set NODE_ENV=development&& DEBUG=i18n:* nodemon src/server.js",
     "production": "NODE_ENV=production node src/server.js",

--- a/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
+++ b/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
@@ -16,6 +16,7 @@ export default function TaskQuickAssignModal({
   onAssignTask,
   users,
   user,
+  taskCardContents,
 }) {
   const { t } = useTranslation();
   const selfOption = { label: `${user.first_name} ${user.last_name}`, value: user.user_id };
@@ -34,8 +35,24 @@ export default function TaskQuickAssignModal({
   const [selectedWorker, setWorker] = useState(isAssigned ? unAssignedOption : selfOption);
   const [assignAll, setAssignAll] = useState(false);
 
+  const checkUnassignedTaskForSameDate = () => {
+    const selectedTask = taskCardContents.find((t) => t.task_id == task_id);
+    let isUnassignedTaskPresent = false;
+    for (let task of taskCardContents) {
+      if (
+        task.completeOrDueDate === selectedTask.completeOrDueDate &&
+        !task.assignee &&
+        task.task_id !== task_id
+      ) {
+        isUnassignedTaskPresent = true;
+        break;
+      }
+    }
+    return isUnassignedTaskPresent;
+  };
+
   const onAssign = () => {
-    assignAll
+    assignAll && checkUnassignedTaskForSameDate()
       ? onAssignTasksOnDate({
           task_id: task_id,
           date: due_date,
@@ -46,6 +63,11 @@ export default function TaskQuickAssignModal({
           assignee_user_id: selectedWorker.value,
         });
     dismissModal();
+  };
+
+  const onCheckedAll = () => {
+    checkUnassignedTaskForSameDate();
+    setAssignAll(!assignAll);
   };
 
   const disabled = selectedWorker === null;
@@ -85,7 +107,7 @@ export default function TaskQuickAssignModal({
       <Checkbox
         style={{ paddingRight: '24px' }}
         label={t('ADD_TASK.ASSIGN_ALL_TO_PERSON')}
-        onChange={() => setAssignAll(!assignAll)}
+        onChange={onCheckedAll}
       />
     </ModalComponent>
   );

--- a/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
+++ b/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
@@ -66,7 +66,6 @@ export default function TaskQuickAssignModal({
   };
 
   const onCheckedAll = () => {
-    checkUnassignedTaskForSameDate();
     setAssignAll(!assignAll);
   };
 

--- a/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
+++ b/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
@@ -56,6 +56,7 @@ export default function ManagementTasks({ history, match }) {
             key={task.task_id}
             onClick={() => history.push(`/tasks/${task.task_id}/read_only`)}
             style={{ marginBottom: '14px' }}
+            taskCardContents={taskCardContents}
             {...task}
           />
         ))}

--- a/packages/webapp/src/containers/Task/TaskCard/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCard/index.jsx
@@ -20,6 +20,7 @@ const TaskCard = ({
   onClick = null,
   selected,
   happiness,
+  taskCardContents,
   classes = { card: {} },
   ...props
 }) => {
@@ -69,6 +70,7 @@ const TaskCard = ({
           onAssignTask={onAssignTask}
           users={users}
           user={user}
+          taskCardContents={taskCardContents}
           dismissModal={() => setShowTaskAssignModal(false)}
         />
       )}
@@ -98,6 +100,7 @@ TaskCard.propTypes = {
   onClickCompleteOrDueDate: PropTypes.func,
   selected: PropTypes.bool,
   task_id: PropTypes.number,
+  taskCardContents: PropTypes.array,
 };
 
 export default TaskCard;

--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -129,6 +129,7 @@ export default function TaskPage({ history }) {
             key={task.task_id}
             onClick={() => history.push(`/tasks/${task.task_id}/read_only`)}
             style={{ marginBottom: '14px' }}
+            taskCardContents={taskCardContents}
             {...task}
           />
         ))

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -123,7 +123,7 @@ export function* assignTaskOnDateSaga({ payload: { task_id, date, assignee_user_
     let modified_tasks = [];
     for (let i = 0; i < result.data.length; i++) {
       modified_tasks.push({
-        id: result.data[i],
+        id: result.data[i].task_id,
         changes: { assignee_user_id },
       });
     }


### PR DESCRIPTION
Assign all tasks on a date, on the task quick assign modal does not work

To test:
1. Go to http://localhost:3000/tasks
2. In the list of tasks, add two or more unassigned tasks for the same date.
3. click on unassigned, change it to some assignee and then click on the checkbox "Assign all unassigned tasks on this date to this person". then click on update.
4. You'll be able to see that the unassigned task will get updated with the assignee name for the same date.

For more details please check. 
https://lite-farm.atlassian.net/browse/LF-2314  

