### PR TITLE
Lf 2255 UI error on time unit selector for age of crop on cp flow

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <<https://www.gnu.org/licenses/>.>
+ */
+
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './unit.module.scss';
 import clsx from 'clsx';


### PR DESCRIPTION
Fixed UI issue where text was overlapping on the time unit selector when switching between time units. This issue was only showing up in safari, and on browsers in iOS.

Ticket: [LF-2255](https://lite-farm.atlassian.net/browse/LF-2255)

<img width="953" alt="Screen Shot 2022-05-10 at 10 59 02 AM" src="https://user-images.githubusercontent.com/104768598/167659437-8f7d5958-f2dd-439f-9df2-a97bd12639a5.png">

To test (On Safari or iOS): 
- Create a Crop Management Plan
- Select "In Ground"
- Change the time unit to something different like "months"
- See that there is no weird overlapping text