### PR TITLE
LF-2178/Completed-notes-and-rating-not-showing-on-a-completed-crop-plan-detail-page

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -897,6 +897,7 @@
       },
       "WHAT_HAPPENED": "What happened?"
     },
+    "COMPLETION_NOTES": "Completion notes",
     "CONTAINER": "Container",
     "CONTAINER_OR_IN_GROUND": "Are you planting in a container or in ground?",
     "CONTAINER_TYPE": "Type of container",
@@ -955,6 +956,7 @@
     "PLANTING_NOTE": "Planting notes",
     "PLANTING_SOIL": "Planting soil to be used",
     "PLANTS_PER_CONTAINER": "# of plants/container",
+    "RATE_THIS_MANAGEMENT_PLAN": "Rate this management plan",
     "REMOVE_PIN": "Remove pin",
     "ROW_METHOD": {
       "HISTORICAL_SAME_LENGTH": "Were the rows all the same length?",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -900,6 +900,7 @@
       },
       "WHAT_HAPPENED": "¿Qué sucedió?"
     },
+    "COMPLETION_NOTES": "MISSING",
     "CONTAINER": "Maceta",
     "CONTAINER_OR_IN_GROUND": "¿Está plantando en una maceta o en el suelo?",
     "CONTAINER_TYPE": "Tipo de maceta",
@@ -958,6 +959,7 @@
     "PLANTING_NOTE": "Notas de la siembra",
     "PLANTING_SOIL": "Suelo de siembra que se utilizará",
     "PLANTS_PER_CONTAINER": "# de plantas/maceta",
+    "RATE_THIS_MANAGEMENT_PLAN": "MISSING",
     "REMOVE_PIN": "Quitar el pin",
     "ROW_METHOD": {
       "HISTORICAL_SAME_LENGTH": "¿Tenían todas las filas la misma longitud?",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -901,6 +901,7 @@
       },
       "WHAT_HAPPENED": "Quest-ce qui est arrivé ?"
     },
+    "COMPLETION_NOTES": "MISSING",
     "CONTAINER": "Conteneur",
     "CONTAINER_OR_IN_GROUND": "Plantez-vous dans un conteneur ou en pleine terre\u00a0?",
     "CONTAINER_TYPE": "Type de conteneur",
@@ -959,6 +960,7 @@
     "PLANTING_NOTE": "Notes de plantation",
     "PLANTING_SOIL": "Terre de plantation à utiliser",
     "PLANTS_PER_CONTAINER": "# de plantes/conteneur",
+    "RATE_THIS_MANAGEMENT_PLAN": "MISSING",
     "REMOVE_PIN": "Supprimer l'épingle",
     "ROW_METHOD": {
       "HISTORICAL_SAME_LENGTH": "Les lignes étaient-elles toutes de la même longueur\u00a0?",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -900,6 +900,7 @@
       },
       "WHAT_HAPPENED": "O que aconteceu?"
     },
+    "COMPLETION_NOTES": "MISSING",
     "CONTAINER": "Recipiente",
     "CONTAINER_OR_IN_GROUND": "Você está plantando em um recipiente ou no solo?",
     "CONTAINER_TYPE": "Tipo de recipiente",
@@ -959,6 +960,7 @@
     "PLANTING_NOTE": "Notas de plantio",
     "PLANTING_SOIL": "Solo de plantio a ser usado",
     "PLANTS_PER_CONTAINER": "Nº de plantas /recipiente",
+    "RATE_THIS_MANAGEMENT_PLAN": "MISSING",
     "REMOVE_PIN": "Remover alfinete",
     "ROW_METHOD": {
       "HISTORICAL_SAME_LENGTH": "As linhas eram todas do mesmo comprimento?",

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -9,8 +9,10 @@ import styles from './styles.module.scss';
 import RouterTab from '../../RouterTab';
 import { useForm } from 'react-hook-form';
 import { seedYield } from '../../../util/convert-units/unit';
+import { getDateInputFormat } from '../../../util/moment';
 import Unit from '../../Form/Unit';
 import InputAutoSize from '../../Form/InputAutoSize';
+import Rating from '../../Rating';
 
 export default function PureManagementDetail({
   onBack,
@@ -35,6 +37,8 @@ export default function PureManagementDetail({
     formState: { errors, isValid },
   } = useForm({
     defaultValues: {
+      complete_date: getDateInputFormat(plan.complete_date),
+      complete_notes: plan.complete_notes,
       notes: plan.notes,
       crop_management_plan: {
         estimated_yield: plan.estimated_yield,
@@ -44,9 +48,13 @@ export default function PureManagementDetail({
     shouldUnregister: false,
     mode: 'onChange',
   });
+
+  const COMPLETE_DATE = 'complete_date';
+  const COMPLETE_NOTES = 'complete_notes';
+  const PLAN_NOTES = 'notes';
   const ESTIMATED_YIELD = `crop_management_plan.estimated_yield`;
   const ESTIMATED_YIELD_UNIT = `crop_management_plan.estimated_yield_unit`;
-  const NOTES = 'notes';
+
   return (
     <Layout
       buttonGroup={
@@ -97,12 +105,37 @@ export default function PureManagementDetail({
 
       <InputAutoSize
         style={{ marginBottom: '40px' }}
+        label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
+        hookFormRegister={register(COMPLETE_DATE)}
+        errors={errors[COMPLETE_DATE]?.message}
+        disabled
+      />
+      <Rating
+        className={styles.rating}
+        style={{ marginBottom: '34px' }}
+        label={t('MANAGEMENT_PLAN.RATE_THIS_MANAGEMENT_PLAN')}
+        stars={plan.rating}
+        onRate={() => {}}
+      />
+
+      <InputAutoSize
+        style={{ marginBottom: '40px' }}
+        label={t('MANAGEMENT_PLAN.COMPLETION_NOTES')}
+        hookFormRegister={register(COMPLETE_NOTES, {
+          maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.NOTES_CHAR_LIMIT') },
+        })}
+        errors={errors[COMPLETE_NOTES]?.message}
+        disabled
+      />
+
+      <InputAutoSize
+        style={{ marginBottom: '40px' }}
         label={t('MANAGEMENT_PLAN.PLAN_NOTES')}
-        hookFormRegister={register(NOTES, {
+        hookFormRegister={register(PLAN_NOTES, {
           maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.NOTES_CHAR_LIMIT') },
         })}
         optional
-        errors={errors[NOTES]?.message}
+        errors={errors[PLAN_NOTES]?.message}
         disabled
       />
 

--- a/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
+++ b/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
@@ -56,3 +56,8 @@
 .bottomText {
   color: var(--teal700);
 }
+
+.rating {
+  display: flex;
+  
+}


### PR DESCRIPTION
Select any crop and create a plan for the crop

When creating the crop plan, make sure to fill out
'plan notes'
'rating'
'completion notes'
in order to see in the details section of a completed crop plan

Go through the tasks created in the crop plan and complete the tasks and eventually complete the crop plan.

You can then see the details of the completed crop plan show as required in:

https://lite-farm.atlassian.net/jira/software/c/projects/LF/boards/1?modal=detail&selectedIssue=LF-2178
