### PR TITLE
Lf 2250 able to input non numerical values in numerical inputs wage year phone

### DIFF
--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -121,7 +121,7 @@ const Input = ({
         ref={mergeRefs(hookFormRegister?.ref, input)}
         type={inputType}
         min={inputType === 'date' ? min : undefined}
-        max={inputType === 'date' ? (max || '9999-12-31') : undefined}
+        max={inputType === 'date' ? max || '9999-12-31' : undefined}
         onKeyDown={onKeyDown}
         name={name}
         placeholder={(!disabled && placeholder) || (isSearchBar && t('common:SEARCH'))}
@@ -193,7 +193,7 @@ export default Input;
 
 export const numberOnKeyDown = (e) => ['e', 'E', '+', '-'].includes(e.key) && e.preventDefault();
 export const integerOnKeyDown = (e) =>
-  ['e', 'E', '+', '-', '.'].includes(e.key) && e.preventDefault();
+  e.charCode > 47 && e.charCode < 58 ? true : e.preventDefault();
 export const preventNumberScrolling = (e) => e.target.blur();
 
 export const getInputErrors = (errors, name) => {

--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -121,7 +121,7 @@ const Input = ({
         ref={mergeRefs(hookFormRegister?.ref, input)}
         type={inputType}
         min={inputType === 'date' ? min : undefined}
-        max={inputType === 'date' ? max || '9999-12-31' : undefined}
+        max={inputType === 'date' ? (max || '9999-12-31') : undefined}
         onKeyDown={onKeyDown}
         name={name}
         placeholder={(!disabled && placeholder) || (isSearchBar && t('common:SEARCH'))}

--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -119,6 +119,7 @@ export default function PureInviteUser({ onInvite, onGoBack, roleOptions = [] })
       <Input
         label={t('INVITE_USER.BIRTH_YEAR')}
         type="number"
+        onKeyPress={integerOnKeyDown}
         hookFormRegister={register(BIRTHYEAR, {
           min: 1900,
           max: new Date().getFullYear(),
@@ -138,6 +139,7 @@ export default function PureInviteUser({ onInvite, onGoBack, roleOptions = [] })
         label={t('INVITE_USER.WAGE')}
         step="0.01"
         type="number"
+        onKeyPress={integerOnKeyDown}
         hookFormRegister={register(WAGE, { min: 0, valueAsNumber: true })}
         style={{ marginBottom: '24px' }}
         errors={errors[WAGE] && (errors[WAGE].message || t('INVITE_USER.WAGE_ERROR'))}
@@ -147,7 +149,7 @@ export default function PureInviteUser({ onInvite, onGoBack, roleOptions = [] })
         style={{ marginBottom: '24px' }}
         label={t('INVITE_USER.PHONE')}
         type={'number'}
-        onKeyDown={integerOnKeyDown}
+        onKeyPress={integerOnKeyDown}
         hookFormRegister={register(PHONE)}
         errors={errors[PHONE] && (errors[PHONE].message || t('INVITE_USER.PHONE_ERROR'))}
         optional


### PR DESCRIPTION
This PR ensures that numerical input fields on the "Invite user" page cannot accept non-numeric values.

To test:
1. Go to the "Invite User" page
2. Attempt to provide the “Birth Year”, “Hourly Wage”, and “Phone Number” inputs with non-numeric values. All non-numeric inputs should not be accepted

**Note:** This bug was found on iPhone. To properly test this PR one must do it using Safari because iPhone browsers behave similarly to Safari. Testing on an actual iPhone would be even better if possible.