### PR TITLE
Updated language detection to handle french as well

### DIFF
--- a/packages/webapp/src/locales/i18n.js
+++ b/packages/webapp/src/locales/i18n.js
@@ -12,7 +12,7 @@ i18n
     defaultNS: 'translation',
     nsSeparator: ':',
     fallbackLng: 'en',
-    locales: ['en', 'pt', 'es'],
+    locales: ['en', 'pt', 'es', 'fr'],
     debug: false,
     detection: {
       lookupLocalStorage: 'litefarm_lang',


### PR DESCRIPTION
Fixed the case where the code would not automatically detect a french browser upon loading.

To test this: 
1. Clear all browser data for litefarm (localhost:3000)
2. Set your browser language to french (https://support.google.com/chrome/answer/173424?hl=en&co=GENIE.Platform%3DDesktop)
3. Remember to restart your browser
4. Go to the litefarm onboarding page - it should now be in french!