### PR TITLE
LF-2163 and LF-2172  Addition of "Needs plan" counter in Crop catalogue and crop variety

### DIFF
--- a/packages/webapp/public/locales/en/common.json
+++ b/packages/webapp/public/locales/en/common.json
@@ -29,6 +29,7 @@
   "MAX_ERROR": "Please enter a value less than {{value}}",
   "MIN_ERROR": "Please enter a value greater than {{value}}",
   "NAME": "Name",
+  "NEEDS_PLAN": "Needs plan",
   "NEXT": "Next",
   "NO": "No",
   "NOT_SURE": "Not sure",

--- a/packages/webapp/public/locales/es/common.json
+++ b/packages/webapp/public/locales/es/common.json
@@ -29,6 +29,7 @@
   "MAX_ERROR": "Por favor, ingrese un valor menor que {{value}}",
   "MIN_ERROR": "Por favor, ingrese un valor mayor que {{value}}",
   "NAME": "Nombre",
+  "NEEDS_PLAN": "MISSING",
   "NEXT": "Próximo",
   "NO": "No",
   "NOT_SURE": "No estoy seguro/a",

--- a/packages/webapp/public/locales/fr/common.json
+++ b/packages/webapp/public/locales/fr/common.json
@@ -29,6 +29,7 @@
   "MAX_ERROR": "Veuillez saisir une valeur inférieure à {{value}}",
   "MIN_ERROR": "Veuillez saisir une valeur supérieur à {{value}}",
   "NAME": "Nom",
+  "NEEDS_PLAN": "MISSING",
   "NEXT": "Suivant",
   "NO": "Non",
   "NOT_SURE": "Pas certain",

--- a/packages/webapp/public/locales/pt/common.json
+++ b/packages/webapp/public/locales/pt/common.json
@@ -29,6 +29,7 @@
   "MAX_ERROR": "Insira um valor menor que {{value}}",
   "MIN_ERROR": "Insira um valor maior que {{value}}",
   "NAME": "Nome",
+  "NEEDS_PLAN": "MISSING",
   "NEXT": "Próximo",
   "NO": "Não",
   "NOT_SURE": "Não tem certeza",

--- a/packages/webapp/src/components/CropCatalogue/CropStatusInfoBox/index.jsx
+++ b/packages/webapp/src/components/CropCatalogue/CropStatusInfoBox/index.jsx
@@ -72,6 +72,10 @@ export default function CropStatusInfoBox({
             <Square color={'past'}>{status.past}</Square>
             {t('common:PAST')}
           </div>
+          <div className={classes.cropCountContainer}>
+            <Square color={'needsPlan'}>{status.noPlans}</Square>
+            {t('common:NEEDS_PLAN')}
+          </div>
         </div>
       )}
     </Card>
@@ -86,5 +90,6 @@ CropStatusInfoBox.propTypes = {
     active: PropTypes.number,
     planned: PropTypes.number,
     past: PropTypes.number,
+    noPlans: PropTypes.number,
   }),
 };

--- a/packages/webapp/src/components/CropTile/index.jsx
+++ b/packages/webapp/src/components/CropTile/index.jsx
@@ -12,7 +12,7 @@ export default function PureCropTile({
   title,
   onClick,
   style,
-  cropCount,
+  cropCount = {},
   needsPlan,
   src,
   alt,
@@ -22,6 +22,7 @@ export default function PureCropTile({
   isSelected,
   status,
 }) {
+  const { active = 0, planned = 0, past = 0, noPlans = 0 } = cropCount;
   const { t } = useTranslation();
   return (
     <div
@@ -46,14 +47,14 @@ export default function PureCropTile({
         }}
       />
 
-      {cropCount && (
+      {planned + past + active !== 0 && (
         <div className={styles.cropCountContainer}>
-          <Square isCropTile>{cropCount.active}</Square>
+          <Square isCropTile>{active}</Square>
           <Square color={'planned'} isCropTile>
-            {cropCount.planned}
+            {planned}
           </Square>
           <Square color={'past'} isCropTile>
-            {cropCount.past}
+            {past}
           </Square>
         </div>
       )}
@@ -70,9 +71,11 @@ export default function PureCropTile({
         </div>
       )}
 
-      {needsPlan && (
+      {noPlans !== 0 && (
         <div className={styles.needsPlanContainer}>
-          <Square color={'needsPlan'} isCropTile style={{ borderBottomRightRadius: '4px' }} />
+          <Square color={'needsPlan'} isCropTile style={{ borderBottomRightRadius: '4px' }}>
+            {noPlans}
+          </Square>
         </div>
       )}
 

--- a/packages/webapp/src/components/Square/index.jsx
+++ b/packages/webapp/src/components/Square/index.jsx
@@ -52,7 +52,9 @@ export default function Square({ color = 'active', children, isCropTile, ...prop
       className={clsx(classes.container, classes[color], isCropTile && classes.cropTile)}
       {...props}
     >
-      {color === 'needsPlan' ? <FaExclamation style={{ fontSize: '12px' }} /> : children}
+      {/* commenting for the future use */}
+      {/* {color === 'needsPlan' ? <FaExclamation style={{ fontSize: '12px' }} /> : children} */}
+      {children}
     </div>
   );
 }

--- a/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
+++ b/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
@@ -30,6 +30,8 @@ function AddCropVarietyForm({ history, match }) {
     const cropData = {
       ...persistedFormData,
       ...data,
+      crop_variety_name: data.crop_variety_name.trim(),
+      supplier: data.supplier.trim(),
       compliance_file_url: '',
       organic: null,
       treated: null,

--- a/packages/webapp/src/containers/CropCatalogue/index.jsx
+++ b/packages/webapp/src/containers/CropCatalogue/index.jsx
@@ -24,7 +24,10 @@ import { isAdminSelector } from '../userFarmSlice';
 import useCropCatalogue from './useCropCatalogue';
 import useStringFilteredCrops from './useStringFilteredCrops';
 import useSortByCropTranslation from './useSortByCropTranslation';
-import { resetAndUnLockFormData, setPersistedPaths } from '../hooks/useHookFormPersist/hookFormPersistSlice';
+import {
+  resetAndUnLockFormData,
+  setPersistedPaths,
+} from '../hooks/useHookFormPersist/hookFormPersistSlice';
 import CatalogSpotlight from './CatalogSpotlight';
 import ActiveFilterBox from '../../components/ActiveFilterBox';
 import { useStartAddCropVarietyFlow } from '../CropVarieties/useStartAddCropVarietyFlow';
@@ -36,14 +39,8 @@ export default function CropCatalogue({ history }) {
 
   const [filterString, setFilterString] = useState('');
   const filterStringOnChange = (e) => setFilterString(e.target.value);
-  const {
-    active,
-    planned,
-    past,
-    sum,
-    cropCatalogue,
-    filteredCropsWithoutManagementPlan,
-  } = useCropCatalogue(filterString);
+  const { active, planned, past, noPlans, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
+    useCropCatalogue(filterString);
   const crops = useStringFilteredCrops(
     useSortByCropTranslation(useSelector(cropsSelector)),
     filterString,
@@ -73,11 +70,13 @@ export default function CropCatalogue({ history }) {
 
   const { onAddCropVariety } = useStartAddCropVarietyFlow();
   const onAddCrop = () => {
-    dispatch(setPersistedPaths([
-      '/crop/new',
-      '/crop/new/add_crop_variety',
-      '/crop/new/add_crop_variety/compliance',
-    ]));
+    dispatch(
+      setPersistedPaths([
+        '/crop/new',
+        '/crop/new/add_crop_variety',
+        '/crop/new/add_crop_variety/compliance',
+      ]),
+    );
     history.push('/crop/new');
   };
   return (
@@ -110,14 +109,14 @@ export default function CropCatalogue({ history }) {
           <>
             <PageBreak style={{ paddingBottom: '16px' }} label={t('CROP_CATALOGUE.ON_YOUR_FARM')} />
             <CropStatusInfoBox
-              status={{ active, past, planned }}
+              status={{ active, past, planned, noPlans }}
               style={{ marginBottom: '16px' }}
               date={date}
               setDate={setDate}
             />
             <PureCropTileContainer gap={gap} padding={padding}>
               {filteredCropsWithoutManagementPlan.map((cropVariety) => {
-                const { crop_translation_key, crop_photo_url, crop_id } = cropVariety;
+                const { crop_translation_key, crop_photo_url, crop_id, noPlansCount } = cropVariety;
                 const imageKey = cropVariety.crop_translation_key?.toLowerCase();
 
                 return (
@@ -128,7 +127,9 @@ export default function CropCatalogue({ history }) {
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => history.push(`/crop_varieties/crop/${cropVariety.crop_id}`)}
-                    needsPlan
+                    cropCount={{
+                      noPlans: noPlansCount,
+                    }}
                   />
                 );
               })}
@@ -151,6 +152,7 @@ export default function CropCatalogue({ history }) {
                       active: active.length,
                       planned: planned.length,
                       past: past.length,
+                      noPlans: cropCatalog?.noPlans?.length,
                     }}
                     needsPlan={needsPlan}
                     title={t(`crop:${crop_translation_key}`)}
@@ -200,10 +202,7 @@ export default function CropCatalogue({ history }) {
               </>
             )}
             <Text style={{ paddingBottom: '8px' }}>{t('CROP_CATALOGUE.CAN_NOT_FIND')}</Text>
-            <AddLink
-            data-cy='crop-addLink'
-              onClick={onAddCrop}
-            >
+            <AddLink data-cy="crop-addLink" onClick={onAddCrop}>
               {t('CROP_CATALOGUE.ADD_CROP')}
             </AddLink>
           </>

--- a/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
+++ b/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
@@ -7,7 +7,15 @@ import { useSelector } from 'react-redux';
 import { cropCatalogueFilterDateSelector, cropCatalogueFilterSelector } from '../filterSlice';
 import { useMemo } from 'react';
 import useStringFilteredCrops from './useStringFilteredCrops';
-import { ACTIVE, COMPLETE, LOCATION, PLANNED, STATUS, SUPPLIERS } from '../Filter/constants';
+import {
+  ACTIVE,
+  COMPLETE,
+  LOCATION,
+  PLANNED,
+  STATUS,
+  SUPPLIERS,
+  NEEDS_PLAN,
+} from '../Filter/constants';
 import { useTranslation } from 'react-i18next';
 import useFilterNoPlan from './useFilterNoPlan';
 import useSortByCropTranslation from './useSortByCropTranslation';
@@ -125,14 +133,19 @@ export default function useCropCatalogue(filterString) {
       active: statusFilter[ACTIVE].active ? catalogue.active : [],
       planned: statusFilter[PLANNED].active ? catalogue.planned : [],
       past: statusFilter[COMPLETE].active ? catalogue.past : [],
+      noPlans: statusFilter[NEEDS_PLAN].active ? catalogue.noPlans : [],
     }));
     return newCropCatalogue.filter(
-      (catalog) => catalog.active.length || catalog.past.length || catalog.planned.length,
+      (catalog) =>
+        catalog.active.length ||
+        catalog.past.length ||
+        catalog.planned.length ||
+        catalog.noPlans.length,
     );
   }, [cropCatalogueFilter[STATUS], cropCatalogue]);
 
   const cropCataloguesStatus = useMemo(() => {
-    const cropCataloguesStatus = { active: 0, planned: 0, past: 0 };
+    const cropCataloguesStatus = { active: 0, planned: 0, past: 0, noPlans: 0 };
     for (const managementPlansByStatus of cropCatalogueFilteredByStatus) {
       for (const status in cropCataloguesStatus) {
         cropCataloguesStatus[status] += managementPlansByStatus[status].length;
@@ -140,7 +153,11 @@ export default function useCropCatalogue(filterString) {
     }
     return {
       ...cropCataloguesStatus,
-      sum: cropCataloguesStatus.active + cropCataloguesStatus.planned + cropCataloguesStatus.past,
+      sum:
+        cropCataloguesStatus.active +
+        cropCataloguesStatus.planned +
+        cropCataloguesStatus.past +
+        cropCataloguesStatus.noPlans,
     };
   }, [cropCatalogueFilteredByStatus]);
 

--- a/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
+++ b/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
@@ -144,23 +144,6 @@ export default function useCropCatalogue(filterString) {
     );
   }, [cropCatalogueFilter[STATUS], cropCatalogue]);
 
-  const cropCataloguesStatus = useMemo(() => {
-    const cropCataloguesStatus = { active: 0, planned: 0, past: 0, noPlans: 0 };
-    for (const managementPlansByStatus of cropCatalogueFilteredByStatus) {
-      for (const status in cropCataloguesStatus) {
-        cropCataloguesStatus[status] += managementPlansByStatus[status].length;
-      }
-    }
-    return {
-      ...cropCataloguesStatus,
-      sum:
-        cropCataloguesStatus.active +
-        cropCataloguesStatus.planned +
-        cropCataloguesStatus.past +
-        cropCataloguesStatus.noPlans,
-    };
-  }, [cropCatalogueFilteredByStatus]);
-
   const { t } = useTranslation();
   const onlyOneOfTwoNumberIsZero = (i, j) => i + j > 0 && i * j === 0;
   const sortedCropCatalogue = useMemo(() => {
@@ -198,6 +181,27 @@ export default function useCropCatalogue(filterString) {
       needsPlan: cropIdsWithoutPlan.has(crop.crop_id),
     }));
   }, [filteredCropVarietiesWithoutManagementPlan, sortedCropCatalogue]);
+
+  const cropCataloguesStatus = useMemo(() => {
+    const cropCataloguesStatus = { active: 0, planned: 0, past: 0, noPlans: 0 };
+    for (const managementPlansByStatus of cropCatalogueFilteredByStatus) {
+      for (const status in cropCataloguesStatus) {
+        cropCataloguesStatus[status] += managementPlansByStatus[status].length;
+      }
+    }
+    cropCataloguesStatus.noPlans = filteredCropVarietiesWithoutManagementPlan.reduce((acc, c) => {
+      acc += c.noPlansCount;
+      return acc;
+    }, 0);
+    return {
+      ...cropCataloguesStatus,
+      sum:
+        cropCataloguesStatus.active +
+        cropCataloguesStatus.planned +
+        cropCataloguesStatus.past +
+        cropCataloguesStatus.noPlans,
+    };
+  }, [cropCatalogueFilteredByStatus, filteredCropVarietiesWithoutManagementPlan]);
 
   return {
     cropCatalogue: sortedCropCatalogueWithNeedsPlanProp,

--- a/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
+++ b/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
@@ -36,6 +36,7 @@ export default function useCropCatalogue(filterString) {
     useFilterNoPlan(filterString, false),
   );
 
+  // aggregates all crop varieties by crop id and counts the 'Need plans' count value.
   const filteredCropVarietiesWithoutManagementPlan =
     filteredCropVarietiesWithoutManagementPlanByCropVariety.reduce((acc, cropVariety) => {
       if (acc.length === 0) {
@@ -101,6 +102,8 @@ export default function useCropCatalogue(filterString) {
         managementPlansByCropId[managementPlan.crop_id][status].push(managementPlan);
       }
     }
+    // calcluates the needs plans values from crop varieties without management plan
+    // and merges it with the crop with the management plan
     const managementPlansByCropIdWithNoPlans = Object.values(managementPlansByCropId).reduce(
       (acc, currentValue) => {
         const noPlanFoundCrop = filteredCropVarietiesWithoutManagementPlanByCropVariety.filter(
@@ -182,6 +185,9 @@ export default function useCropCatalogue(filterString) {
     }));
   }, [filteredCropVarietiesWithoutManagementPlan, sortedCropCatalogue]);
 
+  // this method is used to calculate the sum of active, planned, past, noPlans of all
+  // crop varieties for a particular crop.
+  // calculates the active, planned, past, noPlans for CropStatusInfoBox component.
   const cropCataloguesStatus = useMemo(() => {
     const cropCataloguesStatus = { active: 0, planned: 0, past: 0, noPlans: 0 };
     for (const managementPlansByStatus of cropCatalogueFilteredByStatus) {

--- a/packages/webapp/src/containers/CropCatalogue/useFilterNoPlan.js
+++ b/packages/webapp/src/containers/CropCatalogue/useFilterNoPlan.js
@@ -11,7 +11,7 @@ import {
 } from '../managementPlanSlice';
 import { cropVarietiesSelector } from '../cropVarietySlice';
 
-export default function useFilterNoPlan(filterString) {
+export default function useFilterNoPlan(filterString, isCropSpecific = true) {
   const managementPlans = useSelector(managementPlansSelector);
   const cropVarieties = useSelector(cropVarietiesSelector);
   const cropCatalogueFilter = useSelector(cropCatalogueFilterSelector);
@@ -37,7 +37,7 @@ export default function useFilterNoPlan(filterString) {
       varietiesFilteredByString.filter(
         (cropVariety) => !cropVarietyIds.has(cropVariety.crop_variety_id),
       ),
-      'crop_id',
+      isCropSpecific ? 'crop_id' : 'crop_variety_id',
     );
   }, [managementPlans, varietiesFilteredByString]);
 

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -194,6 +194,8 @@ export default function CropVarieties({ history, match }) {
                   crop_photo_url,
                   crop_id,
                   needsPlan,
+                  noPlans,
+                  noPlansCount,
                   crop_variety_name,
                   crop_variety_id,
                 } = cropCatalog;
@@ -206,7 +208,7 @@ export default function CropVarieties({ history, match }) {
                       planned: planned.length,
                       past: past.length,
                     }}
-                    needsPlan={needsPlan}
+                    needsPlan={!!noPlansCount}
                     title={crop_variety_name}
                     src={crop_photo_url}
                     alt={imageKey}

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -6,12 +6,6 @@ import PureSearchbarAndFilter from '../../components/PopupFilter/PureSearchbarAn
 import { AddLink, Semibold } from '../../components/Typography';
 import { useDispatch, useSelector } from 'react-redux';
 import { cropSelector } from '../cropSlice';
-import {
-  cropVarietiesWithoutManagementPlanByCropIdSelector,
-  currentCropVarietiesByCropIdSelector,
-  expiredCropVarietiesByCropIdSelector,
-  plannedCropVarietiesByCropIdSelector,
-} from '../managementPlanSlice';
 import useCropTileListGap from '../../components/CropTile/useCropTileListGap';
 import PureCropTile from '../../components/CropTile';
 import PureCropTileContainer from '../../components/CropTile/CropTileContainer';
@@ -23,17 +17,11 @@ import {
   cropVarietyFilterSelector,
   isFilterCurrentlyActiveSelector,
   setCropCatalogueFilterDate,
-  setCropVarietyFilterDefault,
-  // cropCatalogueFilterSelector
 } from '../filterSlice';
 import { isAdminSelector } from '../userFarmSlice';
-import useStringFilteredCrops from '../CropCatalogue/useStringFilteredCrops';
-import useSortByVarietyName from './useSortByVarietyName';
 import { resetAndUnLockFormData } from '../hooks/useHookFormPersist/hookFormPersistSlice';
 import CropVarietyFilterPage from '../Filter/CropVariety';
 import ActiveFilterBox from '../../components/ActiveFilterBox';
-import useFilterVarieties from '../CropCatalogue/useFilterVarieties';
-import { ACTIVE, COMPLETE, NEEDS_PLAN, PLANNED } from '../Filter/constants';
 import { useStartAddCropVarietyFlow } from './useStartAddCropVarietyFlow';
 import useCropVarietyCatalogue from './useCropVarietyCatalogue';
 import CropStatusInfoBox from '../../components/CropCatalogue/CropStatusInfoBox';
@@ -57,41 +45,6 @@ export default function CropVarieties({ history, match }) {
 
   const { active, planned, past, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
     useCropVarietyCatalogue(filterString, crop_id);
-
-  const cropVarietiesWithoutManagementPlan = useFilterVarieties(
-    useStringFilteredCrops(
-      useSortByVarietyName(
-        useSelector(cropVarietiesWithoutManagementPlanByCropIdSelector(crop_id)),
-      ),
-      filterString,
-    ),
-    crop_id,
-    NEEDS_PLAN,
-  );
-  const currentCropVarieties = useFilterVarieties(
-    useStringFilteredCrops(
-      useSortByVarietyName(useSelector(currentCropVarietiesByCropIdSelector(crop_id))),
-      filterString,
-    ),
-    crop_id,
-    ACTIVE,
-  );
-  const plannedCropVarieties = useFilterVarieties(
-    useStringFilteredCrops(
-      useSortByVarietyName(useSelector(plannedCropVarietiesByCropIdSelector(crop_id))),
-      filterString,
-    ),
-    crop_id,
-    PLANNED,
-  );
-  const expiredCropVarieties = useFilterVarieties(
-    useStringFilteredCrops(
-      useSortByVarietyName(useSelector(expiredCropVarietiesByCropIdSelector(crop_id))),
-      filterString,
-    ),
-    crop_id,
-    COMPLETE,
-  );
 
   const {
     ref: containerRef,
@@ -227,128 +180,6 @@ export default function CropVarieties({ history, match }) {
           )
         )}
       </div>
-
-      {/* <div ref={containerRef}>
-        {!!cropVarietiesWithoutManagementPlan.length && (
-          <>
-            <PageBreak style={{ paddingBottom: '22px' }} label={t('CROP_VARIETIES.NEEDS_PLAN')} />
-            <PureCropTileContainer gap={gap} padding={padding}>
-              {cropVarietiesWithoutManagementPlan.map((cropVariety) => {
-                const {
-                  crop_translation_key,
-                  crop_variety_name,
-                  crop_variety_id,
-                  crop_variety_photo_url,
-                } = cropVariety;
-                const imageKey = crop_translation_key.toLowerCase();
-                return (
-                  <PureCropTile
-                    key={cropVariety.crop_variety_id}
-                    title={crop_variety_name || t(`crop:${crop_translation_key}`)}
-                    src={crop_variety_photo_url}
-                    alt={imageKey}
-                    style={{ width: cardWidth }}
-                    onClick={() => goToVarietyManagement(crop_variety_id)}
-                  />
-                );
-              })}
-            </PureCropTileContainer>
-          </>
-        )}
-
-        {!!currentCropVarieties.length && (
-          <>
-            <PageBreak style={{ paddingBottom: '22px' }} label={t('common:ACTIVE')} />
-            <PureCropTileContainer gap={gap} padding={padding}>
-              {currentCropVarieties.map((cropVariety) => {
-                const {
-                  crop_translation_key,
-                  crop_variety_name,
-                  crop_variety_id,
-                  crop_variety_photo_url,
-                } = cropVariety;
-                const imageKey = crop_translation_key.toLowerCase();
-                return (
-                  <PureCropTile
-                    key={cropVariety.crop_variety_id}
-                    title={crop_variety_name || t(`crop:${crop_translation_key}`)}
-                    src={crop_variety_photo_url}
-                    alt={imageKey}
-                    style={{ width: cardWidth }}
-                    onClick={() => goToVarietyManagement(crop_variety_id)}
-                  />
-                );
-              })}
-            </PureCropTileContainer>
-          </>
-        )}
-
-        {!!plannedCropVarieties.length && (
-          <>
-            <PageBreak style={{ paddingBottom: '22px' }} label={t('common:PLANNED')} />
-            <PureCropTileContainer gap={gap} padding={padding}>
-              {plannedCropVarieties.map((cropVariety) => {
-                const {
-                  crop_translation_key,
-                  crop_variety_name,
-                  crop_variety_id,
-                  crop_variety_photo_url,
-                } = cropVariety;
-                const imageKey = crop_translation_key.toLowerCase();
-                return (
-                  <PureCropTile
-                    key={cropVariety.crop_variety_id}
-                    title={crop_variety_name || t(`crop:${crop_translation_key}`)}
-                    src={crop_variety_photo_url}
-                    alt={imageKey}
-                    style={{ width: cardWidth }}
-                    onClick={() => goToVarietyManagement(crop_variety_id)}
-                  />
-                );
-              })}
-            </PureCropTileContainer>
-          </>
-        )}
-
-        {!!expiredCropVarieties.length && (
-          <>
-            <PageBreak style={{ paddingBottom: '22px' }} label={t('common:PAST')} />
-            <PureCropTileContainer gap={gap} padding={padding}>
-              {expiredCropVarieties.map((cropVariety) => {
-                const {
-                  crop_translation_key,
-                  crop_variety_name,
-                  crop_variety_id,
-                  crop_variety_photo_url,
-                } = cropVariety;
-                const imageKey = crop_translation_key.toLowerCase();
-                return (
-                  <PureCropTile
-                    key={cropVariety.crop_variety_id}
-                    title={crop_variety_name || t(`crop:${crop_translation_key}`)}
-                    src={crop_variety_photo_url}
-                    alt={imageKey}
-                    style={{ width: cardWidth }}
-                    onClick={() => goToVarietyManagement(crop_variety_id)}
-                    isPastVariety
-                  />
-                );
-              })}
-            </PureCropTileContainer>
-          </>
-        )}
-
-        {!cropVarietiesWithoutManagementPlan.length &&
-          !currentCropVarieties.length &&
-          !plannedCropVarieties.length &&
-          !expiredCropVarieties.length &&
-          isFilterCurrentlyActive && (
-            <Semibold style={{ color: 'var(--teal700)' }}>
-              {t('CROP_CATALOGUE.NO_RESULTS_FOUND')}
-            </Semibold>
-          )}
-      </div> */}
-
       {isAdmin && !isFilterCurrentlyActive && (
         <AddLink onClick={goToVarietyCreation}>{t('CROP_VARIETIES.ADD_VARIETY')}</AddLink>
       )}

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -51,7 +51,8 @@ export default function CropVarieties({ history, match }) {
     gap,
     padding,
     cardWidth,
-  } = useCropTileListGap([cropCatalogue.length, filteredCropsWithoutManagementPlan.length]);
+  } = useCropTileListGap([sum, cropCatalogue.length]);
+
   useEffect(() => {
     dispatch(getCropVarieties());
   }, []);

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -43,7 +43,7 @@ export default function CropVarieties({ history, match }) {
     dispatch(resetAndUnLockFormData());
   }, []);
 
-  const { active, planned, past, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
+  const { active, planned, past, noPlans, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
     useCropVarietyCatalogue(filterString, crop_id);
 
   const {
@@ -109,7 +109,7 @@ export default function CropVarieties({ history, match }) {
           <>
             <PageBreak style={{ paddingBottom: '16px' }} label={t('CROP_CATALOGUE.ON_YOUR_FARM')} />
             <CropStatusInfoBox
-              status={{ active, past, planned }}
+              status={{ active, past, planned, noPlans }}
               style={{ marginBottom: '16px' }}
               date={date}
               setDate={setDate}
@@ -122,6 +122,7 @@ export default function CropVarieties({ history, match }) {
                   crop_id,
                   crop_variety_name,
                   crop_variety_id,
+                  noPlansCount,
                 } = cropVariety;
                 const imageKey = cropVariety.crop_translation_key?.toLowerCase();
 
@@ -133,7 +134,9 @@ export default function CropVarieties({ history, match }) {
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => goToVarietyManagement(crop_variety_id)}
-                    needsPlan
+                    cropCount={{
+                      noPlans: noPlansCount,
+                    }}
                   />
                 );
               })}
@@ -160,6 +163,7 @@ export default function CropVarieties({ history, match }) {
                       active: active.length,
                       planned: planned.length,
                       past: past.length,
+                      noPlans: noPlans.length,
                     }}
                     needsPlan={!!noPlansCount}
                     title={crop_variety_name}

--- a/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
+++ b/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
@@ -1,0 +1,211 @@
+import {
+  getCurrentManagementPlans,
+  getExpiredManagementPlans,
+  getPlannedManagementPlans,
+} from '../managementPlanSlice';
+import { useSelector } from 'react-redux';
+import {
+  cropCatalogueFilterDateSelector,
+  cropCatalogueFilterSelector,
+  cropVarietyFilterSelector,
+} from '../filterSlice';
+import { useMemo } from 'react';
+import useStringFilteredCrops from '../CropCatalogue/useStringFilteredCrops';
+import { ACTIVE, COMPLETE, LOCATION, PLANNED, STATUS, SUPPLIERS } from '../Filter/constants';
+import { useTranslation } from 'react-i18next';
+import useFilterNoPlan from './useFilterNoPlan';
+import useSortByCropTranslation from '../CropCatalogue/useSortByCropTranslation';
+import { managementPlansWithCurrentLocationSelector } from '../Task/TaskCrops/managementPlansWithLocationSelector';
+
+export default function useCropCatalogue(filterString, crop_id) {
+  const managementPlansWithCurrentLocation = useSelector(
+    managementPlansWithCurrentLocationSelector,
+  );
+
+  const managementPlansWithCurrentLocationByCropId = managementPlansWithCurrentLocation.filter(
+    (c) => c.crop_id === crop_id,
+  );
+  const cropCatalogFilterDate = useSelector(cropCatalogueFilterDateSelector);
+  let cropCatalogueFilter = useSelector(cropVarietyFilterSelector(crop_id));
+  const managementPlansFilteredByFilterString = useStringFilteredCrops(
+    managementPlansWithCurrentLocationByCropId,
+    filterString,
+  );
+
+  if (!cropCatalogueFilter) {
+    cropCatalogueFilter = {
+      [LOCATION]: {},
+      [SUPPLIERS]: {},
+      [STATUS]: {},
+    };
+  }
+
+  const managementPlansFilteredByLocations = useMemo(() => {
+    const locationFilter = cropCatalogueFilter[LOCATION];
+    const included = new Set();
+    for (const location_id in locationFilter) {
+      if (locationFilter[location_id].active) included.add(location_id);
+    }
+    if (included.size === 0) return managementPlansFilteredByFilterString;
+    return managementPlansFilteredByFilterString.filter((managementPlan) =>
+      included.has(managementPlan.location?.location_id),
+    );
+  }, [cropCatalogueFilter[LOCATION], managementPlansFilteredByFilterString]);
+
+  const managementPlansFilteredBySuppliers = useMemo(() => {
+    const supplierFilter = cropCatalogueFilter[SUPPLIERS];
+    const included = new Set();
+    for (const supplier in supplierFilter) {
+      if (supplierFilter[supplier].active) included.add(supplier);
+    }
+    if (included.size === 0) return managementPlansFilteredByLocations;
+    return managementPlansFilteredByLocations.filter((managementPlan) =>
+      included.has(managementPlan.supplier),
+    );
+  }, [cropCatalogueFilter[SUPPLIERS], managementPlansFilteredByLocations]);
+
+  const cropCatalogue = useMemo(() => {
+    const time = new Date(cropCatalogFilterDate).getTime();
+    const managementPlansByStatus = {
+      active: getCurrentManagementPlans(managementPlansFilteredBySuppliers, time),
+      planned: getPlannedManagementPlans(managementPlansFilteredBySuppliers, time),
+      past: getExpiredManagementPlans(managementPlansFilteredBySuppliers, time),
+    };
+    const managementPlansByCropId = {};
+    for (const status in managementPlansByStatus) {
+      for (const managementPlan of managementPlansByStatus[status]) {
+        if (!managementPlansByCropId.hasOwnProperty(managementPlan.crop_variety_id)) {
+          managementPlansByCropId[managementPlan.crop_variety_id] = {
+            active: [],
+            planned: [],
+            past: [],
+            crop_common_name: managementPlan.crop_common_name,
+            crop_translation_key: managementPlan.crop_translation_key,
+            imageKey: managementPlan.crop_translation_key?.toLowerCase(),
+            crop_id: managementPlan.crop_id,
+            crop_photo_url: managementPlan.crop_photo_url,
+            crop_variety_id: managementPlan.crop_variety_id,
+            crop_variety_name: managementPlan.crop_variety_name,
+          };
+        }
+
+        managementPlansByCropId[managementPlan.crop_variety_id][status].push(managementPlan);
+      }
+    }
+    return Object.values(managementPlansByCropId);
+  }, [managementPlansFilteredBySuppliers, cropCatalogFilterDate]);
+
+  const cropCatalogueFilteredByStatus = useMemo(() => {
+    const statusFilter = cropCatalogueFilter[STATUS];
+    const included = new Set();
+    for (const status in statusFilter) {
+      if (statusFilter[status].active) included.add(status);
+    }
+    if (included.size === 0) return cropCatalogue;
+    const newCropCatalogue = cropCatalogue.map((catalogue) => {
+      return {
+        ...catalogue,
+        active: statusFilter[ACTIVE].active ? catalogue.active : [],
+        planned: statusFilter[PLANNED].active ? catalogue.planned : [],
+        past: statusFilter[COMPLETE].active ? catalogue.past : [],
+      };
+    });
+    return newCropCatalogue.filter(
+      (catalog) => catalog.active.length || catalog.past.length || catalog.planned.length,
+    );
+  }, [cropCatalogueFilter[STATUS], cropCatalogue]);
+
+  const cropCataloguesStatus = useMemo(() => {
+    const cropCataloguesStatus = { active: 0, planned: 0, past: 0 };
+    for (const managementPlansByStatus of cropCatalogueFilteredByStatus) {
+      for (const status in cropCataloguesStatus) {
+        cropCataloguesStatus[status] += managementPlansByStatus[status].length;
+      }
+    }
+    return {
+      ...cropCataloguesStatus,
+      sum: cropCataloguesStatus.active + cropCataloguesStatus.planned + cropCataloguesStatus.past,
+    };
+  }, [cropCatalogueFilteredByStatus]);
+
+  const { t } = useTranslation();
+  const onlyOneOfTwoNumberIsZero = (i, j) => i + j > 0 && i * j === 0;
+  const sortedCropCatalogue = useMemo(() => {
+    return cropCatalogueFilteredByStatus.sort((catalog_i, catalog_j) => {
+      if (onlyOneOfTwoNumberIsZero(catalog_i.active.length, catalog_j.active.length)) {
+        return catalog_j.active.length - catalog_i.active.length;
+      } else if (
+        onlyOneOfTwoNumberIsZero(catalog_i.planned.length, catalog_j.planned.length) &&
+        catalog_j.active.length === 0 &&
+        catalog_i.active.length === 0
+      ) {
+        return catalog_j.planned.length - catalog_i.planned.length;
+      } else {
+        return t(`crop:${catalog_i.crop_translation_key}`) >
+          t(`crop:${catalog_j.crop_translation_key}`)
+          ? 1
+          : -1;
+      }
+    });
+  }, [cropCatalogueFilteredByStatus]);
+
+  const filteredCropVarietiesWithoutManagementPlan = useSortByCropTranslation(
+    useFilterNoPlan(filterString),
+  );
+
+  const filteredCropVarietiesWithoutManagementPlanByCropId =
+    filteredCropVarietiesWithoutManagementPlan.filter((c) => c.crop_id === crop_id);
+
+  const filteredCropsWithoutManagementPlan = useMemo(() => {
+    const cropIdsWithPlan = new Set(
+      sortedCropCatalogue.map(({ crop_variety_id }) => crop_variety_id),
+    );
+    return filteredCropVarietiesWithoutManagementPlanByCropId.filter(
+      (cropVariety) => !cropIdsWithPlan.has(cropVariety.crop_variety_id),
+    );
+  }, [filteredCropVarietiesWithoutManagementPlanByCropId, sortedCropCatalogue]);
+
+  const sortedCropCatalogueWithNeedsPlanProp = useMemo(() => {
+    const cropIdsWithoutPlan = new Set(
+      filteredCropVarietiesWithoutManagementPlanByCropId.map(
+        ({ crop_variety_id }) => crop_variety_id,
+      ),
+    );
+    return sortedCropCatalogue.map((crop) => ({
+      ...crop,
+      needsPlan: cropIdsWithoutPlan.has(crop.crop_variety_id),
+    }));
+  }, [filteredCropVarietiesWithoutManagementPlanByCropId, sortedCropCatalogue]);
+
+  // console.log('filteredCropsWithoutManagementPlan', filteredCropsWithoutManagementPlan.map(c=>({
+  //   crop_variety_id: c.crop_variety_id,
+  //   crop_variety_name: c.crop_variety_name,
+  // })))
+  // console.log('sortedCropCatalogueWithNeedsPlanProp', sortedCropCatalogueWithNeedsPlanProp.map(c=>({
+  //   crop_variety_id: c.crop_variety_id,
+  //   crop_variety_name: c.crop_variety_name,
+  // })))
+
+  const _list_data = filteredCropsWithoutManagementPlan.reduce((previousValue, currentValue) => {
+    if (previousValue.length === 0) {
+      previousValue.push({ ...currentValue, noPlansCount: 1 });
+    } else {
+      let _f = previousValue.find((pre) => {
+        return pre.crop_variety_name === currentValue.crop_variety_name;
+      });
+      if (!_f) {
+        previousValue.push({ ...currentValue, noPlansCount: 1 });
+      } else {
+        const idx = previousValue.indexOf(_f);
+        previousValue[idx].noPlansCount += 1;
+      }
+    }
+    return previousValue;
+  }, []);
+
+  return {
+    cropCatalogue: sortedCropCatalogueWithNeedsPlanProp,
+    filteredCropsWithoutManagementPlan: _list_data,
+    ...cropCataloguesStatus,
+  };
+}

--- a/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
+++ b/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
@@ -99,6 +99,8 @@ export default function useCropVarietyCatalogue(filterString, crop_id) {
         managementPlansByCropId[managementPlan.crop_variety_id][status].push(managementPlan);
       }
     }
+    // calcluates the needs plans values from crop varieties without management plan
+    // and merges it with the crop with the management plan
     const managementPlansByCropIdWithNoPlans = Object.values(managementPlansByCropId).reduce(
       (acc, currentValue) => {
         const noPlanFoundCropVariety = withoutManagementPlanListByCropId.filter(
@@ -228,6 +230,7 @@ export default function useCropVarietyCatalogue(filterString, crop_id) {
 
   // this method is used to calculate the sum of active, planned, past, noPlans of all
   // crop varieties for a particular crop.
+  // Also, calculates the active, planned, past, noPlans for CropStatusInfoBox component
   const cropCataloguesStatus = useMemo(() => {
     const cropsWithoutManagementPlanCount = filteredCropsWithoutManagementPlanList.reduce(
       (acc, c) => {

--- a/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
+++ b/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
@@ -99,8 +99,7 @@ export default function useCropVarietyCatalogue(filterString, crop_id) {
         managementPlansByCropId[managementPlan.crop_variety_id][status].push(managementPlan);
       }
     }
-    const managementPlansByCropId_list = Object.values(managementPlansByCropId);
-    const managementPlansByCropIdWithNoPlans = managementPlansByCropId_list.reduce(
+    const managementPlansByCropIdWithNoPlans = Object.values(managementPlansByCropId).reduce(
       (acc, currentValue) => {
         const noPlanFoundCropVariety = withoutManagementPlanListByCropId.filter(
           (np) => np.crop_variety_name.trim() === currentValue.crop_variety_name.trim(),

--- a/packages/webapp/src/containers/CropVarieties/useFilterNoPlan.js
+++ b/packages/webapp/src/containers/CropVarieties/useFilterNoPlan.js
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { LOCATION, NEEDS_PLAN, STATUS, SUPPLIERS } from '../Filter/constants';
-import { cropCatalogueFilterSelector } from '../filterSlice';
+import { cropVarietyFilterSelector } from '../filterSlice';
 import useStringFilteredCrops from '../CropCatalogue/useStringFilteredCrops';
 import useSortByCropTranslation from '../CropCatalogue/useSortByCropTranslation';
 import {
@@ -11,10 +11,18 @@ import {
 } from '../managementPlanSlice';
 import { cropVarietiesSelector } from '../cropVarietySlice';
 
-export default function useFilterNoPlan(filterString) {
+export default function useFilterNoPlan(filterString, crop_id) {
   const managementPlans = useSelector(managementPlansSelector);
   const cropVarieties = useSelector(cropVarietiesSelector);
-  const cropCatalogueFilter = useSelector(cropCatalogueFilterSelector);
+  let cropCatalogueFilter = useSelector(cropVarietyFilterSelector(crop_id));
+
+  if (!cropCatalogueFilter) {
+    cropCatalogueFilter = {
+      [LOCATION]: {},
+      [SUPPLIERS]: {},
+      [STATUS]: {},
+    };
+  }
 
   const varietiesFilteredBySupplier = useMemo(() => {
     const supplierFilter = cropCatalogueFilter[SUPPLIERS];

--- a/packages/webapp/src/containers/CropVarieties/useFilterNoPlan.js
+++ b/packages/webapp/src/containers/CropVarieties/useFilterNoPlan.js
@@ -68,3 +68,6 @@ export default function useFilterNoPlan(filterString, crop_id) {
 
   return cropsFilteredByStatusAndLocation;
 }
+
+export const useFilterNoPlanByCropId = (filterString, crop_id) =>
+  useFilterNoPlan(filterString, crop_id).filter((c) => c.crop_id === crop_id);

--- a/packages/webapp/src/containers/CropVarieties/useFilterNoPlan.js
+++ b/packages/webapp/src/containers/CropVarieties/useFilterNoPlan.js
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { LOCATION, NEEDS_PLAN, STATUS, SUPPLIERS } from '../Filter/constants';
+import { cropCatalogueFilterSelector } from '../filterSlice';
+import useStringFilteredCrops from '../CropCatalogue/useStringFilteredCrops';
+import useSortByCropTranslation from '../CropCatalogue/useSortByCropTranslation';
+import {
+  cropsWithVarietyWithoutManagementPlanSelector,
+  getUniqueEntities,
+  managementPlansSelector,
+} from '../managementPlanSlice';
+import { cropVarietiesSelector } from '../cropVarietySlice';
+
+export default function useFilterNoPlan(filterString) {
+  const managementPlans = useSelector(managementPlansSelector);
+  const cropVarieties = useSelector(cropVarietiesSelector);
+  const cropCatalogueFilter = useSelector(cropCatalogueFilterSelector);
+
+  const varietiesFilteredBySupplier = useMemo(() => {
+    const supplierFilter = cropCatalogueFilter[SUPPLIERS];
+    const activeFilterSuppliers = new Set(
+      Object.keys(supplierFilter).filter((supplier) => supplierFilter[supplier].active),
+    );
+    return activeFilterSuppliers.size
+      ? cropVarieties.filter((crop) => activeFilterSuppliers.has(crop.supplier))
+      : cropVarieties;
+  }, [cropCatalogueFilter[SUPPLIERS], cropVarieties]);
+
+  const varietiesFilteredByString = useStringFilteredCrops(
+    useSortByCropTranslation(varietiesFilteredBySupplier),
+    filterString,
+  );
+
+  const cropsWithNoPlans = useMemo(() => {
+    const cropVarietyIds = new Set(managementPlans.map(({ crop_variety_id }) => crop_variety_id));
+    return getUniqueEntities(
+      varietiesFilteredByString.filter(
+        (cropVariety) => !cropVarietyIds.has(cropVariety.crop_variety_id),
+      ),
+      'crop_variety_id',
+    );
+  }, [managementPlans, varietiesFilteredByString]);
+
+  const cropsFilteredByStatusAndLocation = useMemo(() => {
+    const locationFilter = cropCatalogueFilter[LOCATION];
+    for (const location in locationFilter) {
+      if (locationFilter[location].active) {
+        return [];
+      }
+    }
+
+    const statusFilter = cropCatalogueFilter[STATUS];
+    const activeFilterStatus = new Set(
+      Object.keys(statusFilter).filter((status) => statusFilter[status].active),
+    );
+    if (!statusFilter[NEEDS_PLAN]?.active && activeFilterStatus.size) return [];
+
+    return cropsWithNoPlans;
+  }, [cropsWithNoPlans, cropCatalogueFilter[STATUS], cropCatalogueFilter[LOCATION]]);
+
+  return cropsFilteredByStatusAndLocation;
+}

--- a/packages/webapp/src/containers/Filter/CropVariety/index.jsx
+++ b/packages/webapp/src/containers/Filter/CropVariety/index.jsx
@@ -19,7 +19,7 @@ import {
   setCropVarietyFilter,
   setCropVarietyFilterDefault,
 } from '../../filterSlice';
-import { suppliersSelector } from '../../cropVarietySlice';
+import { suppliersByCropIdSelector } from '../../cropVarietySlice';
 import { SEARCHABLE_MULTI_SELECT } from '../../../components/Filter/filterTypes';
 
 const statuses = [ACTIVE, ABANDONED, PLANNED, COMPLETE, NEEDS_PLAN];
@@ -28,7 +28,7 @@ const CropVarietyFilterPage = ({ cropId, onGoBack }) => {
   const { t } = useTranslation(['translation', 'filter']);
   const cropEnabledLocations = useSelector(cropLocationsSelector);
   const cropVarietyFilter = useSelector(cropVarietyFilterSelector(cropId));
-  const suppliers = useSelector(suppliersSelector); //TODO: SELECT SUPPLIERS EXCLUSIVE TO THIS CROP
+  const suppliers = useSelector(suppliersByCropIdSelector(cropId));
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/packages/webapp/src/containers/Task/TaskCrops/managementPlansWithLocationSelector.js
+++ b/packages/webapp/src/containers/Task/TaskCrops/managementPlansWithLocationSelector.js
@@ -58,7 +58,7 @@ export const managementPlansWithCurrentLocationSelector = createSelector(
               //In ground wild crop location and planting method
               const planting_management_plan = plantingManagementPlanByManagementPlanEntities[
                 management_plan_id
-                ]?.find(
+              ]?.find(
                 (planting_management_plan) =>
                   !transplantTasksByManagementPlanId[management_plan_id]?.find?.(
                     (transplantTask) =>
@@ -76,7 +76,6 @@ export const managementPlansWithCurrentLocationSelector = createSelector(
     } catch (e) {
       return [];
     }
-
   },
 );
 
@@ -171,4 +170,9 @@ export const currentAndPlannedManagementPlansByLocationIdSelector = (location_id
       ...plannedManagementPlans,
       ...currentManagementPlans,
     ],
+  );
+
+export const managementPlansWithCurrentLocationByCropIdSelector = (cropId) =>
+  createSelector([managementPlansWithCurrentLocationSelector], (managementPlans) =>
+    managementPlans.filter((m) => m.crop_id === cropId),
   );

--- a/packages/webapp/src/containers/cropVarietySlice.js
+++ b/packages/webapp/src/containers/cropVarietySlice.js
@@ -188,3 +188,9 @@ export const suppliersByCropIdSelector = (cropId) => {
     return Array.from(suppliers);
   });
 };
+
+export const cropVarietiesByCropIdSelector = (cropId) => {
+  return createSelector([cropVarietiesSelector], (cropVarieties) =>
+    cropVarieties.filter((c) => c.crop_id === cropId),
+  );
+};

--- a/packages/webapp/src/containers/cropVarietySlice.js
+++ b/packages/webapp/src/containers/cropVarietySlice.js
@@ -173,3 +173,18 @@ export const suppliersSelector = createSelector([cropVarietiesSelector], (cropVa
   suppliers.delete(null);
   return Array.from(suppliers);
 });
+
+export const suppliersByCropIdSelector = (cropId) => {
+  return createSelector([cropVarietiesSelector], (cropVarieties) => {
+    const suppliers = new Set(
+      cropVarieties.reduce((acc, { crop_id, supplier }) => {
+        if (crop_id === cropId) {
+          acc.push(supplier);
+        }
+        return acc;
+      }, []),
+    );
+    suppliers.delete(null);
+    return Array.from(suppliers);
+  });
+};


### PR DESCRIPTION
Important! - this PR contains UI changes related to Lf-2163 and LF-2172. Please review the LF-2172 PR (https://github.com/LiteFarmOrg/LiteFarm/pull/1900)
and then this one.

To test:

- create a crop variety by selecting any crop from the crop catalog page. (http://localhost:3000/crop_catalogue)
- add more varieties for the same crop. (around 5)
- add a plan to any of the crop varieties.
- check for the count of active, planned, past, and needs plans.

For more details:
https://lite-farm.atlassian.net/browse/LF-2163
https://lite-farm.atlassian.net/browse/LF-2172