### PR TITLE
Abandon rating, reason, and notes not showing on an abandoned crop plan detail page

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -887,6 +887,7 @@
       "ABANDON_PLAN": "Abandon plan",
       "ABANDON_NOTES": "Abandonment notes",
       "ABANDON_REASON": "Reason for abandoning",
+      "COMPLETE_DATE": "Completed date",
       "COMPLETE_PLAN": "Complete plan",
       "DATE_OF_CHANGE": "Date of status change",
       "NOTES_CHAR_LIMIT": "Notes must be less than 10,000 characters",
@@ -961,7 +962,7 @@
     "PLANTING_NOTE": "Planting notes",
     "PLANTING_SOIL": "Planting soil to be used",
     "PLANTS_PER_CONTAINER": "# of plants/container",
-    "RATE_THIS_MANAGEMENT_PLAN": "Rate this management plan",
+    "RATE_THIS_MANAGEMENT_PLAN": "Plan rating",
     "REMOVE_PIN": "Remove pin",
     "ROW_METHOD": {
       "HISTORICAL_SAME_LENGTH": "Were the rows all the same length?",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -885,6 +885,7 @@
     "BROADCAST": "Broadcast or drill",
     "COMPLETE_PLAN": {
       "ABANDON_PLAN": "Abandon plan",
+      "ABANDON_NOTES": "Abandonment notes",
       "ABANDON_REASON": "Reason for abandoning",
       "COMPLETE_PLAN": "Complete plan",
       "DATE_OF_CHANGE": "Date of status change",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -888,6 +888,7 @@
     "BROADCAST": "Siembra a voleo o sembradora mecánica",
     "COMPLETE_PLAN": {
       "ABANDON_PLAN": "Abandonar plan",
+      "ABANDON_NOTES": "MISSING",
       "ABANDON_REASON": "Razón para abandonar",
       "COMPLETE_PLAN": "Completar plan",
       "DATE_OF_CHANGE": "Fecha de cambio de estado",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -890,6 +890,7 @@
       "ABANDON_PLAN": "Abandonar plan",
       "ABANDON_NOTES": "MISSING",
       "ABANDON_REASON": "Razón para abandonar",
+      "COMPLETE_DATE": "MISSING",
       "COMPLETE_PLAN": "Completar plan",
       "DATE_OF_CHANGE": "Fecha de cambio de estado",
       "NOTES_CHAR_LIMIT": "Las notas deben tener menos de 10,000 caracteres",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -891,6 +891,7 @@
       "ABANDON_PLAN": "Abandonner le plan",
       "ABANDON_NOTES": "MISSING",
       "ABANDON_REASON": "Raison de l'abandon",
+      "COMPLETE_DATE": "MISSING",
       "COMPLETE_PLAN": "Plan complet",
       "DATE_OF_CHANGE": "Date de changement de statut",
       "NOTES_CHAR_LIMIT": "Les notes doivent comporter moins de 10 000 caractères",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -889,6 +889,7 @@
     "BROADCAST": "Diffusion ou exercice",
     "COMPLETE_PLAN": {
       "ABANDON_PLAN": "Abandonner le plan",
+      "ABANDON_NOTES": "MISSING",
       "ABANDON_REASON": "Raison de l'abandon",
       "COMPLETE_PLAN": "Plan complet",
       "DATE_OF_CHANGE": "Date de changement de statut",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -890,6 +890,7 @@
       "ABANDON_PLAN": "Abandonar plano",
       "ABANDON_NOTES": "MISSING",
       "ABANDON_REASON": "Razão do abandono",
+      "COMPLETE_DATE": "MISSING",
       "COMPLETE_PLAN": "Plano completo",
       "DATE_OF_CHANGE": "Data de mudança do status",
       "NOTES_CHAR_LIMIT": "As observações não podem exceder 10.000 caractéres",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -888,6 +888,7 @@
     "BROADCAST": "Semeadura a lanço ou com máquina semeadora",
     "COMPLETE_PLAN": {
       "ABANDON_PLAN": "Abandonar plano",
+      "ABANDON_NOTES": "MISSING",
       "ABANDON_REASON": "Razão do abandono",
       "COMPLETE_PLAN": "Plano completo",
       "DATE_OF_CHANGE": "Data de mudança do status",

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -13,19 +13,19 @@ import { getDateInputFormat } from '../../../util/moment';
 import AbandonManagementPlanModal from '../../Modals/AbandonManagementPlanModal';
 import i18n from '../../../locales/i18n';
 
-export const SOMETHING_ELSE = 'SOMETHING_ELSE';
+export const SOMETHING_ELSE = 'Something Else';
 export const defaultAbandonManagementPlanReasonOptions = [
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.CROP_FAILURE'), value: 'CROP_FAILURE' },
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.LABOUR_ISSUE'), value: 'LABOUR_ISSUE' },
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.MARKET_PROBLEM'), value: 'MARKET_PROBLEM' },
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.WEATHER'), value: 'WEATHER' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.CROP_FAILURE'), value: 'Crop Failure' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.LABOUR_ISSUE'), value: 'Labour Issue' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.MARKET_PROBLEM'), value: 'Market Problem' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.WEATHER'), value: 'Weather' },
   {
     label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.MACHINERY_ISSUE'),
-    value: 'MACHINERY_ISSUE',
+    value: 'Machinery Issue',
   },
   {
     label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.SCHEDULING_ISSUE'),
-    value: 'SCHEDULING_ISSUE',
+    value: 'Scheduling Issue',
   },
   { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.SOMETHING_ELSE'), value: SOMETHING_ELSE },
 ];

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -15,17 +15,17 @@ import i18n from '../../../locales/i18n';
 
 export const SOMETHING_ELSE = 'Something Else';
 export const defaultAbandonManagementPlanReasonOptions = [
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.CROP_FAILURE'), value: 'Crop Failure' },
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.LABOUR_ISSUE'), value: 'Labour Issue' },
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.MARKET_PROBLEM'), value: 'Market Problem' },
-  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.WEATHER'), value: 'Weather' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.CROP_FAILURE'), value: 'CROP_FAILURE' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.LABOUR_ISSUE'), value: 'LABOUR_ISSUE' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.MARKET_PROBLEM'), value: 'MARKET_PROBLEM' },
+  { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.WEATHER'), value: 'WEATHER' },
   {
     label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.MACHINERY_ISSUE'),
-    value: 'Machinery Issue',
+    value: 'MACHINERY_ISSUE',
   },
   {
     label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.SCHEDULING_ISSUE'),
-    value: 'Scheduling Issue',
+    value: 'SCHEDULING_ISSUE',
   },
   { label: i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.SOMETHING_ELSE'), value: SOMETHING_ELSE },
 ];

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -91,7 +91,6 @@ export default function PureManagementDetail({
         )
       }
     >
-      {console.log(plan)}
       <CropHeader
         onBackClick={onBack}
         crop_translation_key={variety.crop_translation_key}

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -37,6 +37,8 @@ export default function PureManagementDetail({
     formState: { errors, isValid },
   } = useForm({
     defaultValues: {
+      abandon_date: getDateInputFormat(plan.abandon_date),
+      abandon_reason: plan.abandon_reason,
       complete_date: getDateInputFormat(plan.complete_date),
       complete_notes: plan.complete_notes,
       notes: plan.notes,
@@ -49,6 +51,9 @@ export default function PureManagementDetail({
     mode: 'onChange',
   });
 
+  const isAbandoned = plan.abandon_date ? true : false;
+  const DATE_OF_STATUS_CHANGE = isAbandoned ? 'abandon_date' : 'complete_date';
+  const ABANDON_REASON = 'abandon_reason';
   const COMPLETE_DATE = 'complete_date';
   const COMPLETE_NOTES = 'complete_notes';
   const PLAN_NOTES = 'notes';
@@ -106,10 +111,23 @@ export default function PureManagementDetail({
       <InputAutoSize
         style={{ marginBottom: '40px' }}
         label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
-        hookFormRegister={register(COMPLETE_DATE)}
-        errors={errors[COMPLETE_DATE]?.message}
+        hookFormRegister={register(DATE_OF_STATUS_CHANGE)}
+        errors={errors[DATE_OF_STATUS_CHANGE]?.message}
         disabled
       />
+
+      {isAbandoned && (
+        <InputAutoSize
+          style={{ marginBottom: '40px' }}
+          label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_REASON')}
+          hookFormRegister={register(ABANDON_REASON, {
+            maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.NOTES_CHAR_LIMIT') },
+          })}
+          errors={errors[ABANDON_REASON]?.message}
+          disabled
+        />
+      )}
+
       <Rating
         className={styles.rating}
         style={{ marginBottom: '34px' }}
@@ -120,7 +138,11 @@ export default function PureManagementDetail({
 
       <InputAutoSize
         style={{ marginBottom: '40px' }}
-        label={t('MANAGEMENT_PLAN.COMPLETION_NOTES')}
+        label={
+          isAbandoned
+            ? t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_NOTES')
+            : t('MANAGEMENT_PLAN.COMPLETION_NOTES')
+        }
         hookFormRegister={register(COMPLETE_NOTES, {
           maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.NOTES_CHAR_LIMIT') },
         })}
@@ -140,6 +162,7 @@ export default function PureManagementDetail({
       />
 
       <Unit
+        style={{ marginBottom: '46px' }}
         register={register}
         label={t('MANAGEMENT_PLAN.ESTIMATED_YIELD')}
         name={ESTIMATED_YIELD}

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -26,6 +26,16 @@ export default function PureManagementDetail({
   const { t } = useTranslation();
 
   const title = plan.name;
+  const isValidDate =
+    getDateInputFormat(plan.abandon_date) !== 'Invalid date' ||
+    getDateInputFormat(plan.complete_date) !== 'Invalid date';
+  const isSomethingElse =
+    plan.abandon_reason !== 'CROP_FAILURE' &&
+    plan.abandon_reason !== 'LABOUR_ISSUE' &&
+    plan.abandon_reason !== 'MARKET_PROBLEM' &&
+    plan.abandon_reason !== 'WEATHER' &&
+    plan.abandon_reason !== 'MACHINERY_ISSUE' &&
+    plan.abandon_reason !== 'SCHEDULING_ISSUE';
 
   const {
     register,
@@ -37,9 +47,11 @@ export default function PureManagementDetail({
     formState: { errors, isValid },
   } = useForm({
     defaultValues: {
-      abandon_date: getDateInputFormat(plan.abandon_date),
-      abandon_reason: plan.abandon_reason,
-      complete_date: getDateInputFormat(plan.complete_date),
+      abandon_date: isValidDate ? getDateInputFormat(plan.abandon_date) : '',
+      abandon_reason: isSomethingElse
+        ? plan.abandon_reason
+        : t(`MANAGEMENT_PLAN.COMPLETE_PLAN.REASON.${plan.abandon_reason}`),
+      complete_date: isValidDate ? getDateInputFormat(plan.complete_date) : '',
       complete_notes: plan.complete_notes,
       notes: plan.notes,
       crop_management_plan: {
@@ -54,7 +66,7 @@ export default function PureManagementDetail({
   const isAbandoned = plan.abandon_date ? true : false;
   const DATE_OF_STATUS_CHANGE = isAbandoned ? 'abandon_date' : 'complete_date';
   const ABANDON_REASON = 'abandon_reason';
-  const COMPLETE_DATE = 'complete_date';
+  const DATE = isAbandoned ? 'DATE_OF_CHANGE' : 'COMPLETE_DATE';
   const COMPLETE_NOTES = 'complete_notes';
   const PLAN_NOTES = 'notes';
   const ESTIMATED_YIELD = `crop_management_plan.estimated_yield`;
@@ -79,6 +91,7 @@ export default function PureManagementDetail({
         )
       }
     >
+      {console.log(plan)}
       <CropHeader
         onBackClick={onBack}
         crop_translation_key={variety.crop_translation_key}
@@ -110,7 +123,7 @@ export default function PureManagementDetail({
 
       <InputAutoSize
         style={{ marginBottom: '40px' }}
-        label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
+        label={t(`MANAGEMENT_PLAN.COMPLETE_PLAN.${DATE}`)}
         hookFormRegister={register(DATE_OF_STATUS_CHANGE)}
         errors={errors[DATE_OF_STATUS_CHANGE]?.message}
         disabled


### PR DESCRIPTION
Create 2 crop plans from any of the plants on the crop catalogue and complete one of the crop plans and abandon the other. Make sure to fill in the details of both the completed and abandoned crop plan such as abandon notes, reason for abandoning, completion notes, rating, etc. Once each of the crop plans have been completed you can then go on the details section of each and see that the completed crop plan does not show any abandonment details and the abandoned crop plan shows abandon details and reasoning.