### PR TITLE
Make Can this be grown as a cover crop required on add a crop type flow

### DIFF
--- a/packages/webapp/src/components/AddNewCrop/index.jsx
+++ b/packages/webapp/src/components/AddNewCrop/index.jsx
@@ -128,7 +128,7 @@ export default function PureAddNewCrop({
 
       <div style={{ marginBottom: '20px', fontSize: '16px' }}>{t('CROP_CATALOGUE.COVER_CROP')}</div>
       <div style={{ marginBottom: '20px' }}>
-        <RadioGroup hookFormControl={control} name="can_be_cover_crop" />
+        <RadioGroup required hookFormControl={control} name="can_be_cover_crop" />
       </div>
 
       <PhysiologyAnatomyDropDown


### PR DESCRIPTION
Go to crops and scroll all the way down on the varieties page. Fill out the name and crop group and the continue button should remain disabled. Once an option for "Can this be grown as a cover crop" is selected, the continue button should become active.