### PR TITLE
LF-2213/contextual return from tasks

### DIFF
--- a/packages/webapp/src/components/Crop/BedPlan/PureBedPlan.jsx
+++ b/packages/webapp/src/components/Crop/BedPlan/PureBedPlan.jsx
@@ -39,8 +39,6 @@ function PureBedPlan({
 
   const onSubmit = () => history.push(submitPath, location.state);
 
-  console.log(location);
-
   return (
     <Form
       buttonGroup={

--- a/packages/webapp/src/components/Crop/BedPlan/PureBedPlan.jsx
+++ b/packages/webapp/src/components/Crop/BedPlan/PureBedPlan.jsx
@@ -19,6 +19,7 @@ function PureBedPlan({
   prefix = `crop_management_plan.planting_management_plans.${isFinalPage ? 'final' : 'initial'}`,
   submitPath,
   onGoBack = () => history.back(),
+  location,
 }) {
   const { t } = useTranslation();
   const {
@@ -36,7 +37,9 @@ function PureBedPlan({
   });
   const { historyCancel } = useHookFormPersist(getValues);
 
-  const onSubmit = () => history.push(submitPath);
+  const onSubmit = () => history.push(submitPath, location.state);
+
+  console.log(location);
 
   return (
     <Form

--- a/packages/webapp/src/components/Crop/BedPlan/PurePlanGuidance.jsx
+++ b/packages/webapp/src/components/Crop/BedPlan/PurePlanGuidance.jsx
@@ -18,8 +18,9 @@ function PurePlanGuidance({
   prefix = `crop_management_plan.planting_management_plans.${isFinalPage ? 'final' : 'initial'}`,
   history,
   submitPath,
+  location,
   onGoBack = () => history.back(),
-  onSubmit = () => history.push(submitPath),
+  onSubmit = () => history.push(submitPath, location.state),
 }) {
   const { t } = useTranslation(['translation']);
   const {

--- a/packages/webapp/src/components/Crop/PlantInContainer/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantInContainer/index.jsx
@@ -19,7 +19,8 @@ export default function PurePlantInContainer({
   isHistorical,
   prefix = `crop_management_plan.planting_management_plans.${isFinalPage ? 'final' : 'initial'}`,
   submitPath,
-  onSubmit = () => history.push(submitPath),
+  location,
+  onSubmit = () => history.push(submitPath, location.state),
   onGoBack = () => history.back(),
 }) {
   const progress = useMemo(() => {

--- a/packages/webapp/src/components/Crop/RowMethod/index.jsx
+++ b/packages/webapp/src/components/Crop/RowMethod/index.jsx
@@ -19,6 +19,7 @@ export default function PureRowMethod({
   submitPath,
   onGoBack = () => history.back(),
   isHistoricalPage,
+  location,
 }) {
   const { t } = useTranslation();
   const {
@@ -37,7 +38,7 @@ export default function PureRowMethod({
 
   const { historyCancel } = useHookFormPersist(getValues);
 
-  const onSubmit = () => history.push(submitPath);
+  const onSubmit = () => history.push(submitPath, location.state);
 
   return (
     <Form

--- a/packages/webapp/src/components/Task/PureTaskPlantingMethod/PureManagementPlanPlantingMethod.jsx
+++ b/packages/webapp/src/components/Task/PureTaskPlantingMethod/PureManagementPlanPlantingMethod.jsx
@@ -8,7 +8,13 @@ import MultiStepPageTitle from '../../PageTitle/MultiStepPageTitle';
 import { cloneObject } from '../../../util';
 import { PurePlantingMethod } from '../../Crop/PlantingMethod/PurePlantingMethod';
 
-export function PureTaskPlantingMethod({ useHookFormPersist, persistedFormData, history, entryPath}) {
+export function PureTaskPlantingMethod({
+  useHookFormPersist,
+  persistedFormData,
+  history,
+  entryPath,
+  location,
+}) {
   const { t } = useTranslation();
 
   const {
@@ -26,13 +32,15 @@ export function PureTaskPlantingMethod({ useHookFormPersist, persistedFormData, 
   const PLANTING_METHOD = `transplant_task.planting_management_plan.planting_method`;
   const planting_method = watch(PLANTING_METHOD);
 
+  console.log(location);
+
   useHookFormPersist(getValues);
 
   const onError = () => {};
 
-  const onSubmit = () => history.push(`/add_task/${planting_method.toLowerCase()}`);
+  const onSubmit = () => history.push(`/add_task/${planting_method.toLowerCase()}`, location.state);
   const onGoBack = () => history.back();
-  const onCancel = () => history.push(entryPath);
+  const { historyCancel } = useHookFormPersist(getValues);
 
   const disabled = !isValid;
 
@@ -47,7 +55,7 @@ export function PureTaskPlantingMethod({ useHookFormPersist, persistedFormData, 
     >
       <MultiStepPageTitle
         onGoBack={onGoBack}
-        onCancel={onCancel}
+        onCancel={historyCancel}
         cancelModalTitle={t('ADD_TASK.CANCEL')}
         title={t('ADD_TASK.ADD_A_TASK')}
         value={62.5}

--- a/packages/webapp/src/components/Task/PureTaskPlantingMethod/PureManagementPlanPlantingMethod.jsx
+++ b/packages/webapp/src/components/Task/PureTaskPlantingMethod/PureManagementPlanPlantingMethod.jsx
@@ -32,8 +32,6 @@ export function PureTaskPlantingMethod({
   const PLANTING_METHOD = `transplant_task.planting_management_plan.planting_method`;
   const planting_method = watch(PLANTING_METHOD);
 
-  console.log(location);
-
   useHookFormPersist(getValues);
 
   const onError = () => {};

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -18,8 +18,6 @@ export default function PureTaskComplete({
   onSave,
   onGoBack,
   persistedFormData,
-
-
   useHookFormPersist,
 }) {
   const DURATION = 'duration';
@@ -44,7 +42,6 @@ export default function PureTaskComplete({
   });
 
   const { historyCancel } = useHookFormPersist(getValues);
-
 
   const progress = 66;
 

--- a/packages/webapp/src/containers/Crop/AddManagementPlan/BedPlan/BedPlan.jsx
+++ b/packages/webapp/src/containers/Crop/AddManagementPlan/BedPlan/BedPlan.jsx
@@ -6,7 +6,7 @@ import { cropVarietySelector } from '../../../cropVarietySlice';
 import { useMemo } from 'react';
 import { getBedMethodPaths } from '../../../../components/Crop/getAddManagementPlanPath';
 
-export default function BedPlan({ history, match }) {
+export default function BedPlan({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const crop_variety = useSelector(cropVarietySelector(match.params.variety_id));
   const isFinalPage = match.path === '/crop/:variety_id/add_management_plan/bed_method';
@@ -23,6 +23,7 @@ export default function BedPlan({ history, match }) {
         crop_variety={crop_variety}
         isFinalPage={isFinalPage}
         submitPath={submitPath}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Crop/AddManagementPlan/BedPlan/BedPlanGuidance.jsx
+++ b/packages/webapp/src/containers/Crop/AddManagementPlan/BedPlan/BedPlanGuidance.jsx
@@ -5,14 +5,11 @@ import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookF
 import { useMemo } from 'react';
 import { getBedGuidancePaths } from '../../../../components/Crop/getAddManagementPlanPath';
 
-export default function BedPlan({ history, match }) {
+export default function BedPlan({ history, match, location }) {
   const variety_id = match.params.variety_id;
   const system = useSelector(measurementSelector);
   const isFinalPage = match?.path === '/crop/:variety_id/add_management_plan/bed_guidance';
-  const { submitPath } = useMemo(
-    () => getBedGuidancePaths(variety_id, isFinalPage),
-    [],
-  );
+  const { submitPath } = useMemo(() => getBedGuidancePaths(variety_id, isFinalPage), []);
   return (
     <HookFormPersistProvider>
       <PurePlanGuidance
@@ -22,6 +19,7 @@ export default function BedPlan({ history, match }) {
         variety_id={variety_id}
         isFinalPage={isFinalPage}
         submitPath={submitPath}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Crop/AddManagementPlan/RowMethod/RowGuidance.jsx
+++ b/packages/webapp/src/containers/Crop/AddManagementPlan/RowMethod/RowGuidance.jsx
@@ -5,14 +5,11 @@ import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookF
 import { useMemo } from 'react';
 import { getRowGuidancePaths } from '../../../../components/Crop/getAddManagementPlanPath';
 
-export default function RowGuidance({ history, match }) {
+export default function RowGuidance({ history, match, location }) {
   const variety_id = match.params.variety_id;
   const system = useSelector(measurementSelector);
   const isFinalPage = match?.path === '/crop/:variety_id/add_management_plan/row_guidance';
-  const { submitPath } = useMemo(
-    () => getRowGuidancePaths(variety_id, isFinalPage),
-    [],
-  );
+  const { submitPath } = useMemo(() => getRowGuidancePaths(variety_id, isFinalPage), []);
   return (
     <HookFormPersistProvider>
       <PurePlanGuidance
@@ -22,6 +19,7 @@ export default function RowGuidance({ history, match }) {
         isFinalPage={isFinalPage}
         variety_id={variety_id}
         submitPath={submitPath}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
+++ b/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { taskCardContentByManagementPlanSelector } from '../../Task/taskCardContentSelector';
 import { onAddTask } from '../../Task/onAddTask';
 
-export default function ManagementTasks({ history, match }) {
+export default function ManagementTasks({ history, match, location }) {
   const dispatch = useDispatch();
   const variety_id = match.params.variety_id;
   const variety = useSelector(cropVarietySelector(variety_id));
@@ -54,7 +54,9 @@ export default function ManagementTasks({ history, match }) {
         {taskCardContents.map((task) => (
           <TaskCard
             key={task.task_id}
-            onClick={() => history.push(`/tasks/${task.task_id}/read_only`)}
+            onClick={() =>
+              history.push(`/tasks/${task.task_id}/read_only`, { pathname: location.pathname })
+            }
             style={{ marginBottom: '14px' }}
             taskCardContents={taskCardContents}
             {...task}

--- a/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
+++ b/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
@@ -39,11 +39,9 @@ export default function ManagementTasks({ history, match, location }) {
         onBack={onBack}
         onCompleted={onCompleted}
         onAbandon={onAbandon}
-        onAddTask={onAddTask(
-          dispatch,
-          history,
-          `/crop/${variety_id}/management_plan/${management_plan_id}/tasks`,
-        )}
+        onAddTask={onAddTask(dispatch, history, {
+          pathname: `/crop/${variety_id}/management_plan/${management_plan_id}/tasks`,
+        })}
         isAdmin={isAdmin}
         variety={variety}
         plan={plan}

--- a/packages/webapp/src/containers/Task/TaskAbandon/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAbandon/index.jsx
@@ -5,7 +5,7 @@ import { taskSelector } from '../../taskSlice';
 import { isAdminSelector, loginSelector } from '../../userFarmSlice';
 import { abandonTask } from '../saga';
 
-function TaskAbandon({ history, match }) {
+function TaskAbandon({ history, match, location }) {
   const { task_id } = match.params;
   const task = useSelector(taskSelector(task_id));
   const { user_id } = useSelector(loginSelector);
@@ -17,7 +17,10 @@ function TaskAbandon({ history, match }) {
   useEffect(() => {
     // Redirect user to the task's read only view if task is abandoned
     // or if user is worker and not assigned to the task
-    if (task.abandon_date || (!isAdmin && task.assignee_user_id !== user_id && task.owner_user_id !== user_id)) {
+    if (
+      task.abandon_date ||
+      (!isAdmin && task.assignee_user_id !== user_id && task.owner_user_id !== user_id)
+    ) {
       history.back();
     }
   }, []);
@@ -34,7 +37,13 @@ function TaskAbandon({ history, match }) {
     if (patchData.abandonment_reason === 'OTHER') {
       patchData.other_abandonment_reason = data.other_abandonment_reason;
     }
-    dispatch(abandonTask({ task_id, patchData }));
+    dispatch(
+      abandonTask({
+        task_id,
+        patchData,
+        returnPath: location.state ? location.state.pathname : null,
+      }),
+    );
   };
 
   const onGoBack = () => {

--- a/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
@@ -9,7 +9,7 @@ import { taskTypeSelector } from '../../taskTypeSlice';
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { createTask } from '../saga';
 
-export default function TaskManagement({ history, match }) {
+export default function TaskManagement({ history, match, location }) {
   const userFarms = useSelector(userFarmEntitiesSelector);
   const { farm_id } = useSelector(loginSelector);
   const userFarm = useSelector(userFarmSelector);
@@ -63,7 +63,11 @@ export default function TaskManagement({ history, match }) {
   }, []);
 
   const onSubmit = (data) => {
-    const postData = { ...persistedFormData, ...data };
+    const postData = {
+      ...persistedFormData,
+      ...data,
+      returnPath: location.state ? location.state.pathname : null,
+    };
     dispatch(createTask(postData));
   };
 

--- a/packages/webapp/src/containers/Task/TaskComplete/HarvestComplete/HarvestUses.jsx
+++ b/packages/webapp/src/containers/Task/TaskComplete/HarvestComplete/HarvestUses.jsx
@@ -8,7 +8,7 @@ import { harvestUseTypesSelector } from '../../../harvestUseTypeSlice';
 import { taskWithProductSelector } from '../../../taskSlice';
 import AddHarvestUseTypeModal from './AddHarvestUseType';
 
-function HarvestUses({ history, match }) {
+function HarvestUses({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const task_id = match.params.task_id;
   const persistedPaths = [
@@ -21,7 +21,7 @@ function HarvestUses({ history, match }) {
   const [showAddHarvestTypeModal, setShowAddHarvestTypeModal] = useState(false);
 
   const onContinue = (data) => {
-    history.push(`/tasks/${task_id}/complete`);
+    history.push(`/tasks/${task_id}/complete`, location.state);
   };
 
   const onGoBack = () => {

--- a/packages/webapp/src/containers/Task/TaskComplete/HarvestComplete/Quantity.jsx
+++ b/packages/webapp/src/containers/Task/TaskComplete/HarvestComplete/Quantity.jsx
@@ -5,16 +5,15 @@ import { measurementSelector } from '../../../userFarmSlice';
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
 import { taskWithProductSelector } from '../../../taskSlice';
 
-function HarvestCompleteQuantity({ history, match }) {
+function HarvestCompleteQuantity({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const task_id = match.params.task_id;
   const persistedPaths = [`/tasks/${task_id}/harvest_uses`];
   const task = useSelector(taskWithProductSelector(task_id));
 
   const onContinue = (data) => {
-    history.push(`/tasks/${task_id}/harvest_uses`);
+    history.push(`/tasks/${task_id}/harvest_uses`, location.state);
   };
-
 
   const onGoBack = () => {
     history.back();

--- a/packages/webapp/src/containers/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/containers/Task/TaskComplete/StepOne.jsx
@@ -6,7 +6,7 @@ import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookForm
 import { taskWithProductSelector } from '../../taskSlice';
 import { productsSelector } from '../../productSlice';
 
-function TaskCompleteStepOne({ history, match }) {
+function TaskCompleteStepOne({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const { farm_id } = useSelector(loginSelector);
   const task_id = match.params.task_id;
@@ -16,7 +16,7 @@ function TaskCompleteStepOne({ history, match }) {
   const persistedPaths = [`/tasks/${task_id}/complete`];
 
   const onContinue = (data) => {
-    history.push(persistedPaths[0]);
+    history.push(persistedPaths[0], location.state);
   };
 
   const onGoBack = () => {

--- a/packages/webapp/src/containers/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskComplete/index.jsx
@@ -4,13 +4,15 @@ import { useDispatch } from 'react-redux';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 import { completeTask } from '../saga';
 
-function TaskComplete({ history, match }) {
+function TaskComplete({ history, match, location }) {
   const dispatch = useDispatch();
   const task_id = match.params.task_id;
   const persistedPaths = [`/tasks/${task_id}/before_complete`, `/tasks/${task_id}/harvest_uses`];
 
+  const returnPath = location.state.pathname;
+
   const onSave = (data) => {
-    dispatch(completeTask({ task_id, data }));
+    dispatch(completeTask({ task_id, data, returnPath }));
   };
 
   const onGoBack = () => {
@@ -19,11 +21,7 @@ function TaskComplete({ history, match }) {
 
   return (
     <HookFormPersistProvider>
-      <PureTaskComplete
-        onSave={onSave}
-        onGoBack={onGoBack}
-        persistedPaths={persistedPaths}
-      />
+      <PureTaskComplete onSave={onSave} onGoBack={onGoBack} persistedPaths={persistedPaths} />
     </HookFormPersistProvider>
   );
 }

--- a/packages/webapp/src/containers/Task/TaskCrops/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCrops/index.jsx
@@ -10,7 +10,6 @@ import { cropLocationsSelector } from '../../locationSlice';
 import { useIsTaskType } from '../useIsTaskType';
 
 export default function ManagementPlanSelector({ history, match, location }) {
-  console.log(location);
   const isTransplantTask = useIsTaskType('TRANSPLANT_TASK');
   return isTransplantTask ? (
     <TransplantManagementPlansSelector history={history} match={match} location={location} />

--- a/packages/webapp/src/containers/Task/TaskCrops/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCrops/index.jsx
@@ -9,16 +9,17 @@ import {
 import { cropLocationsSelector } from '../../locationSlice';
 import { useIsTaskType } from '../useIsTaskType';
 
-export default function ManagementPlanSelector({ history, match }) {
+export default function ManagementPlanSelector({ history, match, location }) {
+  console.log(location);
   const isTransplantTask = useIsTaskType('TRANSPLANT_TASK');
   return isTransplantTask ? (
-    <TransplantManagementPlansSelector history={history} match={match} />
+    <TransplantManagementPlansSelector history={history} match={match} location={location} />
   ) : (
-    <TaskCrops history={history} match={match} />
+    <TaskCrops history={history} match={match} location={location} />
   );
 }
 
-function TransplantManagementPlansSelector({ history, match }) {
+function TransplantManagementPlansSelector({ history, match, location }) {
   const locations = useSelector(cropLocationsSelector);
   const onContinuePath = '/add_task/task_locations';
   const goBackPath = '/add_task/task_date';
@@ -30,6 +31,7 @@ function TransplantManagementPlansSelector({ history, match }) {
       history={history}
       match={match}
       isMulti={false}
+      location={location}
     />
   );
 }
@@ -40,16 +42,16 @@ function TaskCrops({
   goBackPath = '/add_task/task_locations',
   onContinuePath = '/add_task/task_details',
   locations,
+  location,
 }) {
   const persistedPaths = [goBackPath, onContinuePath];
-
 
   const handleGoBack = () => {
     history.back();
   };
 
   const onContinue = () => {
-    history.push(onContinuePath);
+    history.push(onContinuePath, location.state);
   };
   const onError = () => {};
   const persistedFormData = useSelector(hookFormPersistSelector);
@@ -57,11 +59,13 @@ function TaskCrops({
   const isHarvestTask = useIsTaskType('HARVEST_TASK');
   const showWildCrops = isTransplantTask || persistedFormData.show_wild_crop;
   const wildManagementPlanTiles = useCurrentWildManagementPlanTiles();
-  const activeAndCurrentManagementPlansByLocationIds = useActiveAndCurrentManagementPlanTilesByLocationIds(
-    locations || persistedFormData.locations,
-    showWildCrops,
-  );
-  const isRequired = isHarvestTask || isTransplantTask || (showWildCrops && !persistedFormData.locations?.length);
+  const activeAndCurrentManagementPlansByLocationIds =
+    useActiveAndCurrentManagementPlanTilesByLocationIds(
+      locations || persistedFormData.locations,
+      showWildCrops,
+    );
+  const isRequired =
+    isHarvestTask || isTransplantTask || (showWildCrops && !persistedFormData.locations?.length);
   return (
     <HookFormPersistProvider>
       <PureTaskCrops

--- a/packages/webapp/src/containers/Task/TaskDate/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskDate/index.jsx
@@ -3,15 +3,19 @@ import PureTaskDate from '../../../components/Task/TaskDate';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 import { useIsTaskType } from '../useIsTaskType';
 
-function TaskDate({ history, match }) {
+function TaskDate({ history, match, location }) {
   const onGoBack = () => {
     history.back();
   };
   const isTransplantTask = useIsTaskType('TRANSPLANT_TASK');
   const onContinue = () => {
-    history.push(isTransplantTask ? '/add_task/task_crops' : '/add_task/task_locations');
+    history.push(
+      isTransplantTask ? '/add_task/task_crops' : '/add_task/task_locations',
+      location.state,
+    );
   };
 
+  console.log(location);
 
   return (
     <HookFormPersistProvider>

--- a/packages/webapp/src/containers/Task/TaskDate/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskDate/index.jsx
@@ -15,8 +15,6 @@ function TaskDate({ history, match, location }) {
     );
   };
 
-  console.log(location);
-
   return (
     <HookFormPersistProvider>
       <PureTaskDate onGoBack={onGoBack} onContinue={onContinue} />

--- a/packages/webapp/src/containers/Task/TaskDetails/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskDetails/index.jsx
@@ -14,7 +14,7 @@ import {
 } from '../TaskCrops/useManagementPlanTilesByLocationIds';
 import { useIsTaskType } from '../useIsTaskType';
 
-function TaskDetails({ history, match }) {
+function TaskDetails({ history, match, location }) {
   const continuePath = '/add_task/task_assignment';
   const goBackPath = '/add_task/task_locations';
 
@@ -46,7 +46,7 @@ function TaskDetails({ history, match }) {
   };
 
   const onSubmit = () => {
-    history.push('/add_task/task_assignment');
+    history.push('/add_task/task_assignment', location.state);
   };
 
   const onError = () => {};

--- a/packages/webapp/src/containers/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskLocations/index.jsx
@@ -1,30 +1,37 @@
 import React from 'react';
-import { hookFormPersistSelector, setManagementPlansData } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
+import {
+  hookFormPersistSelector,
+  setManagementPlansData,
+} from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import PureTaskLocations from '../../../components/Task/TaskLocations';
 import { taskTypeIdNoCropsSelector } from '../../taskTypeSlice';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 import { userFarmSelector } from '../../userFarmSlice';
-import { cropLocationEntitiesSelector, cropLocationsSelector, locationsSelector } from '../../locationSlice';
+import {
+  cropLocationEntitiesSelector,
+  cropLocationsSelector,
+  locationsSelector,
+} from '../../locationSlice';
 import { useActiveAndCurrentManagementPlanTilesByLocationIds } from '../TaskCrops/useManagementPlanTilesByLocationIds';
 import { useIsTaskType } from '../useIsTaskType';
 import { useTranslation } from 'react-i18next';
 import { useReadOnlyPinCoordinates } from '../useReadOnlyPinCoordinates';
 import { useMaxZoom } from '../../Map/useMaxZoom';
 
-export default function TaskLocationsSwitch({ history, match }) {
+export default function TaskLocationsSwitch({ history, match, location }) {
   const isCropLocation = useIsTaskType('HARVEST_TASK');
   const isTransplantLocation = useIsTaskType('TRANSPLANT_TASK');
   if (isCropLocation) {
-    return <TaskActiveAndPlannedCropLocations history={history} />;
+    return <TaskActiveAndPlannedCropLocations history={history} location={location} />;
   } else if (isTransplantLocation) {
-    return <TaskTransplantLocations history={history} />;
+    return <TaskTransplantLocations history={history} location={location} />;
   } else {
-    return <TaskAllLocations history={history} />;
+    return <TaskAllLocations history={history} location={location} />;
   }
 }
 
-function TaskActiveAndPlannedCropLocations({ history }) {
+function TaskActiveAndPlannedCropLocations({ history, location }) {
   const cropLocations = useSelector(cropLocationsSelector);
   const cropLocationEntities = useSelector(cropLocationEntitiesSelector);
   const cropLocationsIds = cropLocations.map(({ location_id }) => ({ location_id }));
@@ -37,7 +44,7 @@ function TaskActiveAndPlannedCropLocations({ history }) {
   const readOnlyPinCoordinates = useReadOnlyPinCoordinates();
 
   const onContinue = () => {
-    history.push('/add_task/task_crops');
+    history.push('/add_task/task_crops', location.state);
   };
 
   const onGoBack = () => {
@@ -54,11 +61,11 @@ function TaskActiveAndPlannedCropLocations({ history }) {
   );
 }
 
-function TaskTransplantLocations({ history }) {
+function TaskTransplantLocations({ history, location }) {
   const { t } = useTranslation();
   const cropLocations = useSelector(cropLocationsSelector);
   const onContinue = () => {
-    history.push('/add_task/planting_method');
+    history.push('/add_task/planting_method', location.state);
   };
 
   const onGoBack = () => {
@@ -76,7 +83,7 @@ function TaskTransplantLocations({ history }) {
   );
 }
 
-function TaskAllLocations({ history }) {
+function TaskAllLocations({ history, location }) {
   const dispatch = useDispatch();
   const locations = useSelector(locationsSelector);
   const persistedFormData = useSelector(hookFormPersistSelector);
@@ -86,9 +93,9 @@ function TaskAllLocations({ history }) {
   const onContinue = () => {
     if (taskTypesBypassCrops.includes(persistedFormData.task_type_id)) {
       dispatch(setManagementPlansData([]));
-      return history.push('/add_task/task_details');
+      return history.push('/add_task/task_details', location.state);
     }
-    history.push('/add_task/task_crops');
+    history.push('/add_task/task_crops', location.state);
   };
 
   const onGoBack = () => {
@@ -114,7 +121,6 @@ function TaskLocations({
   onGoBack,
   readOnlyPinCoordinates,
 }) {
-
   const { grid_points } = useSelector(userFarmSelector);
   const { maxZoomRef, getMaxZoom } = useMaxZoom();
   return (

--- a/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
@@ -76,7 +76,7 @@ function TaskReadOnly({ history, match, location }) {
   };
 
   const onAbandon = () => {
-    history.push(`/tasks/${task_id}/abandon`);
+    history.push(`/tasks/${task_id}/abandon`, location.state);
   };
   const { maxZoomRef, getMaxZoom } = useMaxZoom();
 

--- a/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
@@ -33,7 +33,7 @@ import { isTaskType } from '../useIsTaskType';
 import { useMaxZoom } from '../../Map/useMaxZoom';
 import { assignTask, assignTasksOnDate, changeTaskDate } from '../saga';
 
-function TaskReadOnly({ history, match }) {
+function TaskReadOnly({ history, match, location }) {
   const task_id = match.params.task_id;
   const dispatch = useDispatch();
   const system = useSelector(measurementSelector);
@@ -62,12 +62,12 @@ function TaskReadOnly({ history, match }) {
       ]),
     );
     if (isHarvest) {
-      history.push(`/tasks/${task_id}/complete_harvest_quantity`);
+      history.push(`/tasks/${task_id}/complete_harvest_quantity`, location.state);
     } else if (isTaskTypeCustom) {
       dispatch(setFormData({ task_id, taskType: task.taskType }));
-      history.push(`/tasks/${task_id}/complete`);
+      history.push(`/tasks/${task_id}/complete`, location.state);
     } else {
-      history.push(`/tasks/${task_id}/before_complete`);
+      history.push(`/tasks/${task_id}/before_complete`, location.state);
     }
   };
 

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskBedGuidance.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskBedGuidance.jsx
@@ -5,13 +5,12 @@ import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookForm
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { managementPlanSelector } from '../../managementPlanSlice';
 
-export default function TaskBedGuidance({ history, match }) {
+export default function TaskBedGuidance({ history, match, location }) {
   const persistedFormData = useSelector(hookFormPersistSelector);
   const { crop_variety_id } = useSelector(
     managementPlanSelector(persistedFormData.managementPlans[0].management_plan_id),
   );
   const system = useSelector(measurementSelector);
-
 
   return (
     <HookFormPersistProvider>
@@ -23,6 +22,7 @@ export default function TaskBedGuidance({ history, match }) {
         isFinalPage={true}
         submitPath={'/add_task/task_assignment'}
         prefix={'transplant_task.planting_management_plan'}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskBedMethod.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskBedMethod.jsx
@@ -6,14 +6,13 @@ import { cropVarietySelector } from '../../cropVarietySlice';
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { managementPlanSelector } from '../../managementPlanSlice';
 
-export default function TaskBedPlan({ history, match }) {
+export default function TaskBedPlan({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const persistedFormData = useSelector(hookFormPersistSelector);
   const { crop_variety_id } = useSelector(
     managementPlanSelector(persistedFormData.managementPlans[0].management_plan_id),
   );
   const crop_variety = useSelector(cropVarietySelector(crop_variety_id));
-
 
   return (
     <HookFormPersistProvider>
@@ -25,6 +24,7 @@ export default function TaskBedPlan({ history, match }) {
         isFinalPage={true}
         submitPath={'/add_task/bed_guidance'}
         prefix={'transplant_task.planting_management_plan'}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskContainerMethod.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskContainerMethod.jsx
@@ -6,14 +6,13 @@ import { cropVarietySelector } from '../../cropVarietySlice';
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { managementPlanSelector } from '../../managementPlanSlice';
 
-export default function TaskPlantInContainer({ history, match }) {
+export default function TaskPlantInContainer({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const persistedFormData = useSelector(hookFormPersistSelector);
   const { crop_variety_id } = useSelector(
     managementPlanSelector(persistedFormData.managementPlans[0].management_plan_id),
   );
   const crop_variety = useSelector(cropVarietySelector(crop_variety_id));
-
 
   return (
     <HookFormPersistProvider>
@@ -25,6 +24,7 @@ export default function TaskPlantInContainer({ history, match }) {
         isFinalPage={true}
         submitPath={'/add_task/task_assignment'}
         prefix={'transplant_task.planting_management_plan'}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskRowGuidance.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskRowGuidance.jsx
@@ -5,13 +5,12 @@ import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookForm
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { managementPlanSelector } from '../../managementPlanSlice';
 
-export default function TaskRowGuidance({ history, match }) {
+export default function TaskRowGuidance({ history, match, location }) {
   const persistedFormData = useSelector(hookFormPersistSelector);
   const { crop_variety_id } = useSelector(
     managementPlanSelector(persistedFormData.managementPlans[0].management_plan_id),
   );
   const system = useSelector(measurementSelector);
-
 
   return (
     <HookFormPersistProvider>
@@ -22,6 +21,7 @@ export default function TaskRowGuidance({ history, match }) {
         isFinalPage={true}
         submitPath={'/add_task/task_assignment'}
         prefix={'transplant_task.planting_management_plan'}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskRowMethod.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskRowMethod.jsx
@@ -14,8 +14,6 @@ export default function TaskRowMethod({ history, match, location }) {
   );
   const crop_variety = useSelector(cropVarietySelector(crop_variety_id));
 
-  console.log(location);
-
   return (
     <HookFormPersistProvider>
       <PureRowMethod

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskRowMethod.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskRowMethod.jsx
@@ -6,7 +6,7 @@ import { cropVarietySelector } from '../../cropVarietySlice';
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { managementPlanSelector } from '../../managementPlanSlice';
 
-export default function TaskRowMethod({ history, match }) {
+export default function TaskRowMethod({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const persistedFormData = useSelector(hookFormPersistSelector);
   const { crop_variety_id } = useSelector(
@@ -14,6 +14,7 @@ export default function TaskRowMethod({ history, match }) {
   );
   const crop_variety = useSelector(cropVarietySelector(crop_variety_id));
 
+  console.log(location);
 
   return (
     <HookFormPersistProvider>
@@ -24,6 +25,7 @@ export default function TaskRowMethod({ history, match }) {
         history={history}
         submitPath={'/add_task/row_guidance'}
         prefix={'transplant_task.planting_management_plan'}
+        location={location}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskTransplantMethod.jsx
+++ b/packages/webapp/src/containers/Task/TaskTransplantMethod/TaskTransplantMethod.jsx
@@ -1,14 +1,10 @@
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
-import {
-  PureTaskPlantingMethod,
-} from '../../../components/Task/PureTaskPlantingMethod/PureManagementPlanPlantingMethod';
+import { PureTaskPlantingMethod } from '../../../components/Task/PureTaskPlantingMethod/PureManagementPlanPlantingMethod';
 
-export default function PlantingMethod({ history, match }) {
-
-
+export default function PlantingMethod({ history, match, location }) {
   return (
     <HookFormPersistProvider>
-      <PureTaskPlantingMethod history={history} />
+      <PureTaskPlantingMethod history={history} location={location} />
     </HookFormPersistProvider>
   );
 }

--- a/packages/webapp/src/containers/Task/TaskTypeSelection/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskTypeSelection/index.jsx
@@ -9,7 +9,7 @@ import { showedSpotlightSelector } from '../../showedSpotlightSlice';
 import { setSpotlightToShown } from '../../Map/saga';
 import { currentAndPlannedManagementPlansSelector } from '../../managementPlanSlice';
 
-function TaskTypeSelection({ history, match }) {
+function TaskTypeSelection({ history, match, location }) {
   const userFarm = useSelector(userFarmSelector);
   const dispatch = useDispatch();
   const taskTypes = useSelector(defaultTaskTypesSelector);
@@ -20,27 +20,26 @@ function TaskTypeSelection({ history, match }) {
   const { planting_task } = useSelector(showedSpotlightSelector);
   const isAdmin = useSelector(isAdminSelector);
 
-
   useEffect(() => {
     dispatch(getTaskTypes());
   }, []);
 
   const onCustomTask = () => {
-    history.push(customTaskPath);
+    history.push(customTaskPath, location.state);
   };
 
-  const onContinue = () => history.push(continuePath);
+  const onContinue = () => history.push(continuePath, location.state);
 
   const handleGoBack = () => {
     history.back();
   };
 
-  const onError = () => {
-  };
+  const onError = () => {};
 
   const updatePlantTaskSpotlight = () => dispatch(setSpotlightToShown('planting_task'));
 
-  const hasCurrentManagementPlans = useSelector(currentAndPlannedManagementPlansSelector)?.length > 0;
+  const hasCurrentManagementPlans =
+    useSelector(currentAndPlannedManagementPlansSelector)?.length > 0;
 
   return (
     <>

--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -108,7 +108,7 @@ export default function TaskPage({ history }) {
         <div className={styles.taskCount}>
           {t('TASK.TASKS_COUNT', { count: taskCardContents.length })}
         </div>
-        <AddLink onClick={onAddTask(dispatch, history, `/tasks`)}>{t('TASK.ADD_TASK')}</AddLink>
+        <AddLink onClick={onAddTask(dispatch, history, {})}>{t('TASK.ADD_TASK')}</AddLink>
       </div>
 
       <MuiFullPagePopup open={isFilterOpen} onClose={onFilterClose}>

--- a/packages/webapp/src/containers/Task/onAddTask.js
+++ b/packages/webapp/src/containers/Task/onAddTask.js
@@ -6,7 +6,7 @@ import { setPersistedPaths } from '../hooks/useHookFormPersist/hookFormPersistSl
  * @param history
  * @return {(function(): void)|*}
  */
-export const onAddTask = (dispatch, history) => () => {
+export const onAddTask = (dispatch, history, state) => () => {
   //TODO: remove all persistedPath in add task flow
   dispatch(
     setPersistedPaths([
@@ -28,5 +28,5 @@ export const onAddTask = (dispatch, history) => () => {
       '/add_task/row_guidance',
     ]),
   );
-  history.push('/add_task/task_type_selection');
+  history.push('/add_task/task_type_selection', state);
 };

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -472,7 +472,7 @@ const taskTypeGetCompleteTaskBodyFunctionMap = {
 
 export const completeTask = createAction('completeTaskSaga');
 
-export function* completeTaskSaga({ payload: { task_id, data } }) {
+export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
   const { taskUrl } = apiConfig;
   let { user_id, farm_id } = yield select(loginSelector);
   const { task_translation_key, isCustomTaskType } = data;
@@ -492,7 +492,7 @@ export function* completeTaskSaga({ payload: { task_id, data } }) {
       yield put(putTaskSuccess(result.data));
       yield call(onReqSuccessSaga, {
         message: i18n.t('message:TASK.COMPLETE.SUCCESS'),
-        pathname: '/tasks',
+        pathname: returnPath ?? '/tasks',
       });
     }
   } catch (e) {

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -504,16 +504,17 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
 export const abandonTask = createAction('abandonTaskSaga');
 
 export function* abandonTaskSaga({ payload: data }) {
+  console.log(data);
   const { taskUrl } = apiConfig;
   let { user_id, farm_id } = yield select(loginSelector);
-  const { task_id, patchData } = data;
+  const { task_id, patchData, returnPath } = data;
   const header = getHeader(user_id, farm_id);
   try {
     const result = yield call(axios.patch, `${taskUrl}/abandon/${task_id}`, patchData, header);
     if (result) {
       yield put(putTaskSuccess(result.data));
       yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.ABANDON.SUCCESS')));
-      history.push('/tasks');
+      history.push(returnPath ?? '/tasks');
     }
   } catch (e) {
     console.log(e);

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -391,7 +391,9 @@ const getPostTaskReqBody = (
 
 export const createTask = createAction('createTaskSaga');
 
-export function* createTaskSaga({ payload: data }) {
+export function* createTaskSaga({ payload }) {
+  const { returnPath, ...data } = payload;
+
   const { taskUrl } = apiConfig;
   let { user_id, farm_id } = yield select(loginSelector);
   const { task_translation_key, farm_id: task_farm_id } = yield select(
@@ -426,7 +428,7 @@ export function* createTaskSaga({ payload: data }) {
       yield call(getTasksSuccessSaga, { payload: isHarvest ? result.data : [result.data] });
       yield call(onReqSuccessSaga, {
         message: i18n.t('message:TASK.CREATE.SUCCESS'),
-        pathname: '/tasks',
+        pathname: returnPath ?? '/tasks',
       });
     }
   } catch (e) {


### PR DESCRIPTION
This PR adds contextual returns from tasks when starting on the crop plan page. To test it:
1. Make sure you have at least one crop plan
2. Add a task from the tasks view on the crop plan. When you finish adding the task, you should be returned to the crop plan, as opposed to the tasks page
3. From the crop plan, open a task and complete it. Upon completing, you should be returned to the crop plan
4. From the crop plan, open a task and abandon it. Upon abandoning, you should be returned to the crop plan