### PR TITLE
LF-2156 and LF-2395 Micro copy (Select...) on ghost text for MP and task abandonment reason needs to be dynamic

### DIFF
--- a/packages/webapp/public/locales/fr/common.json
+++ b/packages/webapp/public/locales/fr/common.json
@@ -45,7 +45,7 @@
   "SAVE": "Enregistrer",
   "SAVE_CHANGES": "Enregistrer les changements",
   "SEARCH": "Rechercher",
-  "SELECT": "Selectionner",
+  "SELECT": "Choisir",
   "SKIP": "MISSING",
   "SORRY": "Désoler",
   "SUBMIT": "Soumettre",

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -106,6 +106,7 @@ export function PureCompleteManagementPlan({
                 }}
                 value={value}
                 style={{ marginBottom: '40px' }}
+                placeholder={t(`common:SELECT`)}
               />
             )}
           />

--- a/packages/webapp/src/components/Task/AbandonTask/index.jsx
+++ b/packages/webapp/src/components/Task/AbandonTask/index.jsx
@@ -64,11 +64,9 @@ const PureAbandonTask = ({ onSubmit, onError, onGoBack, hasAssignee }) => {
     >
       <PageTitle title={t('TASK.ABANDON.TITLE')} onGoBack={onGoBack} />
 
-
       <Info style={{ marginTop: '20px', marginBottom: '24px' }}>{t('TASK.ABANDON.INFO')}</Info>
 
       <Main style={{ marginBottom: '24px' }}>{t('TASK.ABANDON.WHEN')}</Main>
-
 
       <Input
         label={t('TASK.ABANDON.DATE')}
@@ -89,6 +87,7 @@ const PureAbandonTask = ({ onSubmit, onError, onGoBack, hasAssignee }) => {
             required={true}
             style={{ marginBottom: '24px' }}
             {...field}
+            placeholder={t(`common:SELECT`)}
           />
         )}
         rules={{ required: true }}


### PR DESCRIPTION
Create and abandon a crop plan and create and abandon a task. When selecting the options for reasons of abandonment the placeholder select text should be correct for each language