### PR TITLE
Clicking < from variety detail page should be contextual

### DIFF
--- a/packages/webapp/src/components/Crop/Management.jsx
+++ b/packages/webapp/src/components/Crop/Management.jsx
@@ -34,7 +34,7 @@ export default function PureCropManagement({
 
   return (
     <Layout>
-      <CropHeader {...variety} onBackClick={onBack} />
+      <CropHeader {...variety} onBackClick={() => history.back()} />
       <RouterTab
         classes={{ container: { margin: '24px 0 26px 0' } }}
         history={history}

--- a/packages/webapp/src/components/CropListPage/index.jsx
+++ b/packages/webapp/src/components/CropListPage/index.jsx
@@ -25,15 +25,16 @@ export default function PureCropList({
   const isSearchable = true;
   const { t } = useTranslation();
 
-  const { ref: containerRef, gap, padding, cardWidth } = useCropTileListGap([
-    activeCrops?.length,
-    plannedCrops?.length,
-    pastCrops?.length,
-  ]);
+  const {
+    ref: containerRef,
+    gap,
+    padding,
+    cardWidth,
+  } = useCropTileListGap([activeCrops?.length, plannedCrops?.length, pastCrops?.length]);
 
   return (
     <Layout>
-      <PageTitle title={title} onGoBack={() => history.push('/map')} />
+      <PageTitle title={title} onGoBack={() => history.back()} />
       <RouterTab
         classes={{ container: { margin: '30px 0 26px 0' } }}
         history={history}


### PR DESCRIPTION
Access the variety detail page using the farm map as shown in 
https://lite-farm.atlassian.net/jira/software/c/projects/LF/boards/1?modal=detail&selectedIssue=LF-2318&assignee=626c0502a6d9be006abdad16&assignee=61f0981825edab006a0f0044
and press the back button and notice it goes back to the farm map.

Secondly access the variety detail page by clicking the menu icon on the top left and crops. Click any variety and then press the back button, you should return to the crop catalogue