### PR TITLE
Lf 2322 modify survey stack export document

### DIFF
--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,2 +1,3 @@
 src/jobs/locales/*/crop.json
 src/jobs/locales/*/*_old.json
+/exports/temp

--- a/packages/api/src/jobs/certification/recordD.js
+++ b/packages/api/src/jobs/certification/recordD.js
@@ -28,7 +28,7 @@ module.exports = (nextQueue, zipQueue, emailQueue) => (job) => {
         recordAGenerator(recordA, exportId, from_date, to_date, farm_name, measurement),
         recordIGeneration(recordICleaners, exportId, from_date, to_date, farm_name, measurement),
         readmeGeneration(exportId, language_preference),
-        surveyRecordGeneration(submission),
+        surveyRecordGeneration(submission, exportId),
       ]),
     )
     .then(() => {

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -87,6 +87,18 @@ module.exports = async (submission, exportId) => {
     return col, row;
   };
 
+  const writeMatrixQs = (sheet, col, row, data) => {
+    sheet.cell(`${col}${row}`).value(data['Question']).style({ fontFamily: 'Calibri', bold: true });
+    const categories = Object.keys(data['Answer'][0]);
+    row += 1;
+    for (let i = 0; i < categories.length; i++) {
+      sheet
+        .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
+        .value(categories[i])
+        .style({ fontFamily: 'Calibri', bold: true, border: { color: '000000' } });
+    }
+  };
+
   const typeToFuncMap = {
     string: writeSimpleQs, // Text
     number: writeSimpleQs,
@@ -95,7 +107,7 @@ module.exports = async (submission, exportId) => {
     selectSingle: writeMultiOptionQs, // Multiple choice
     selectMultiple: writeMultiOptionQs, // Checkbox
     ontology: writeSimpleQs, //Dropdown
-    //   'matrix': func6
+    matrix: writeMatrixQs,
     instructions: writeInstructions,
   };
 

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -61,6 +61,7 @@ module.exports = async (submission, exportId) => {
     return questionAnswerList
       .map(({ label, name, type, hint, options, moreInfo, children }) => ({
         Question: label,
+        Name: name,
         Answer: submissionData.data[name].value,
         Type: type,
         Hint: hint,
@@ -194,14 +195,12 @@ module.exports = async (submission, exportId) => {
           }
         }
       }
-      return [col, row + 1];
     }
-    return [col, row];
+    return [col, row + 1];
   };
 
   const writeGroupOrPage = (sheet, col, row, data) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style(groupHeaderStyle);
-    // console.log("THIS IS THE CHILDREN: ", data['Children']);
     // const childInfo = data['Children']
     //     .map(({ label, name, type, hint, options, moreInfo, children }) => ({
     //     Question: label,
@@ -218,7 +217,7 @@ module.exports = async (submission, exportId) => {
     //     row += 1;
     // }
 
-    // return [col, row + 1];
+    return [col, row + 1];
   };
 
   const typeToFuncMap = {
@@ -257,7 +256,7 @@ module.exports = async (submission, exportId) => {
     }, 0);
 
     // For the default font settings in Excel, 1 char -> 1 pt is a pretty good estimate.
-    mainSheet.column('A').width(maxStringLength);
+    mainSheet.column('A').width(maxStringLength * (titleStyle.fontSize / 12));
 
     // Write to file.
     return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/${surveyName}.xlsx`);

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -27,9 +27,26 @@ module.exports = async (submission, exportId) => {
     survey.revisions[survey.revisions.length - 1].controls,
   );
 
-  const defaultStyles = {
-    verticalAlignment: 'center',
-    fontFamily: 'Calibri',
+  /**
+   * Writes the question in bold and answer without bolding to Excel sheet at the position specified by col and row
+   */
+  const simpleQuestionProcess = (sheet, col, row, data) => {
+    sheet.cell(`${col}${row}`).value(data['Question']).style({ fontFamily: 'Calibri', bold: true });
+
+    sheet
+      .cell(`${col}${(row += 1)}`)
+      .value(data['Answer'])
+      .style({ fontFamily: 'Calibri' });
+  };
+
+  const typeToFuncMap = {
+    string: simpleQuestionProcess, // Text
+    number: simpleQuestionProcess,
+    //   'date': func3,
+    location: simpleQuestionProcess,
+    //   'selectSingle': func4, // Multiple choice
+    //   'ontology': func5, //Dropdown
+    //   'matrix': func6
   };
 
   console.log('THIS IS THE QUESITON & ANSWERS', questionAnswerMap);
@@ -37,16 +54,19 @@ module.exports = async (submission, exportId) => {
   return XlsxPopulate.fromBlankAsync().then((workbook) => {
     // Populate the workbook.
     const sheet1 = workbook.sheet(0);
+    var currentCol = 'A';
     var currentRow = 1;
     for (const qa of questionAnswerMap) {
-      sheet1
-        .cell(`A${currentRow++}`)
-        .value(qa['Question'])
-        .style(defaultStyles);
-      sheet1
-        .cell(`A${currentRow++}`)
-        .value(qa['Answer'])
-        .style(defaultStyles);
+      //   sheet1
+      //     .cell(`${currentCol}${currentRow++}`)
+      //     .value(qa['Question'])
+      //     .style(defaultStyles);
+      //   sheet1
+      //     .cell(`${currentCol}${currentRow++}`)
+      //     .value(qa['Answer'])
+      //     .style(defaultStyles);
+      typeToFuncMap[qa['Type']](sheet1, currentCol, currentRow, qa);
+      currentRow += 2;
     }
     // Write to file.
     return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/Survey Record.xlsx`);

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -96,7 +96,7 @@ module.exports = async (submission, exportId) => {
       sheet
         .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
         .value(categories[i])
-        .style({ fontFamily: 'Calibri', bold: true, border: { color: '000000' } });
+        .style({ fontFamily: 'Calibri', bold: true, border: { color: '000000', style: 'thick' } });
     }
 
     // Fill in the matrix
@@ -106,7 +106,7 @@ module.exports = async (submission, exportId) => {
         sheet
           .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
           .value(answer[categories[i]]['value'])
-          .style({ fontFamily: 'Calibri', border: { color: '000000' } });
+          .style({ fontFamily: 'Calibri', border: { color: '000000', style: 'thin' } });
       }
     }
 

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -13,12 +13,20 @@ module.exports = async (submission, exportId) => {
     json: true,
   });
 
+  console.log('THIS IS THE SUBMISSION DATA: ', submissionData);
+  console.log(
+    'THIS IS THE WHOLE SURVEY INFORMATION: ',
+    survey.revisions[survey.revisions.length - 1].controls,
+  );
+
   const getQuestionsInfo = (questionAnswerList) => {
     return questionAnswerList
-      .map(({ label, name, type }) => ({
+      .map(({ label, name, type, hint, options }) => ({
         Question: label,
         Answer: submissionData.data[name].value,
         Type: type,
+        Hint: hint,
+        Instructions: type == 'instructions' ? options.source.replace(/<p>|<\/p>/g, '') : null,
       }))
       .filter((entry) => !['geoJSON', 'script', 'farmOsField'].includes(entry['Type']));
   };
@@ -39,14 +47,22 @@ module.exports = async (submission, exportId) => {
       .style({ fontFamily: 'Calibri' });
   };
 
+  const writeInstructions = (sheet, col, row, data) => {
+    sheet
+      .cell(`${col}${row}`)
+      .value(data['Instructions'])
+      .style({ fontFamily: 'Calibri', italic: true });
+  };
+
   const typeToFuncMap = {
     string: simpleQuestionProcess, // Text
     number: simpleQuestionProcess,
     //   'date': func3,
     location: simpleQuestionProcess,
     //   'selectSingle': func4, // Multiple choice
-    //   'ontology': func5, //Dropdown
+    ontology: simpleQuestionProcess, //Dropdown
     //   'matrix': func6
+    instructions: writeInstructions,
   };
 
   console.log('THIS IS THE QUESITON & ANSWERS', questionAnswerMap);

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -1,304 +1,3 @@
-// const XlsxPopulate = require('xlsx-populate');
-
-// const rp = require('request-promise');
-// const surveyStackURL = 'https://app.surveystack.io/api/';
-// module.exports = async (submission, exportId) => {
-//   const submissionData = await rp({
-//     uri: `${surveyStackURL}/submissions/${submission}`,
-//     json: true,
-//     headers: { Authorization: 'ashaikh@litefarm.org' },
-//   });
-
-//   const survey = await rp({
-//     uri: `${surveyStackURL}/surveys/${submissionData.meta.survey.id}`,
-//     json: true,
-//     headers: { Authorization: '<user-email> <user-token>' },
-//   });
-
-// //   console.log('THIS IS THE SUBMISSION DATA: ', submissionData);
-// //   console.log(
-// //     'THIS IS THE WHOLE SURVEY INFORMATION: ',
-// //     survey.revisions[survey.revisions.length - 1].controls,
-// //   );
-
-//   const ignoredQuestions = [
-//     'geoJSON',
-//     'script',
-//     'FarmOS Field',
-//     'farmOsField',
-//     'farmOsPlanting',
-//     'farmOsFarm',
-//     'FarmOS Planting',
-//     'instructionsImageSplit',
-//   ];
-//   const questionStyle = {
-//     fontFamily: 'Calibri',
-//     bold: true,
-//     fontSize: 14,
-//     horizontalAlignment: 'left',
-//   };
-//   const groupHeaderStyle = {
-//     fontFamily: 'Calibri',
-//     bold: true,
-//     fontSize: 18,
-//     horizontalAlignment: 'center',
-//   };
-//   const defaultStyle = {
-//     fontFamily: 'Calibri',
-//     fontSize: 12,
-//     horizontalAlignment: 'left',
-//   };
-//   const titleStyle = {
-//     fontFamily: 'Calibri',
-//     fontSize: 20,
-//     bold: true,
-//     horizontalAlignment: 'center',
-//   };
-
-//   const getQuestionInfo = (questionAnswerList, groupName = null) => {
-//     return questionAnswerList
-//       .map(({ label, name, type, hint, options, moreInfo, children }) => ({
-//         Question: label,
-//         Name: name,
-//         Answer:
-//           groupName == null
-//             ? submissionData.data[name].value
-//             : submissionData.data[groupName][name].value,
-//         Type: type,
-//         Hint: hint,
-//         Options: options,
-//         MoreInfo: moreInfo,
-//         Children: ['group', 'page'].includes(type) ? children : null,
-//       }))
-//       .filter((entry) => !ignoredQuestions.includes(entry['Type']));
-//   };
-
-//   const questionAnswerMap = getQuestionInfo(survey.revisions[survey.revisions.length - 1].controls);
-
-//   /**
-//    * Writes the question in bold and answer without bolding to Excel sheet at the position specified by col and row
-//    */
-//   const writeSimpleQs = (sheet, col, row, data) => {
-//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
-
-//     sheet
-//       .cell(`${col}${(row += 1)}`)
-//       .value(data['Answer'])
-//       .style(defaultStyle);
-//     return [col, row];
-//   };
-
-//   /**
-//    * Write all the selected options from the dropdown question as subsequent rows
-//    */
-//   const writeDropdownQs = (sheet, col, row, data) => {
-//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
-
-//     if (data['Answer'] != null) {
-//       for (const answer of data['Answer']) {
-//         sheet
-//           .cell(`${col}${(row += 1)}`)
-//           .value(answer)
-//           .style(defaultStyle);
-//       }
-//     }
-//     return [col, row];
-//   };
-
-//   /**
-//    * Write date questions in the full format
-//    */
-//   const writeDateQs = (sheet, col, row, data) => {
-//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
-//     if (data['Answer'] != null) {
-//       const date = new Date(data['Answer']).toDateString();
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(date)
-//         .style(defaultStyle);
-//     }
-//     return [col, row];
-//   };
-
-//   /**
-//    * Write instructions in italics
-//    */
-//   const writeInstructions = (sheet, col, row, data) => {
-//     const instructions = data['Options']['source'].replace(/<p>|<\/p>/g, '');
-//     sheet
-//       .cell(`${col}${row}`)
-//       .value(instructions)
-//       .style({ ...defaultStyle, italic: true });
-//     return [col, row + 1];
-//   };
-
-//   /**
-//    * Write multiple choice/checkbox type questions to the Excel Sheet.
-//    * Label is in the left column and a 'X' is placed in the immediate right column if this option was selected
-//    */
-//   const writeMultiOptionQs = (sheet, col, row, data) => {
-//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
-//     if (data['Hint'] != null) {
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(`Hint: ${data['Hint']}`)
-//         .style({ ...defaultStyle, italic: true });
-//     }
-//     if (data['MoreInfo'] != null) {
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(`Extra Info: ${data['MoreInfo']}`)
-//         .style({ ...defaultStyle, italic: true });
-//     }
-//     const nonCustomAnswers = data['Options']['source'];
-//     for (const ncAnswer of nonCustomAnswers) {
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(ncAnswer['label'])
-//         .style(defaultStyle);
-//       if (data['Answer'] != null && data['Answer'].includes(ncAnswer['value'])) {
-//         sheet
-//           .cell(`${String.fromCharCode(col.charCodeAt(0) + 1)}${row}`)
-//           .value('X')
-//           .style(defaultStyle); // Write 'X' to the right column
-//       }
-//     }
-
-//     // Get the difference between given answers and all non-custom answers.
-//     // If this list is non-empty, we know the user gave a custom answer
-//     const customEntry = data['Answer'].filter(
-//       (answer) => !nonCustomAnswers.map((ncAnswer) => ncAnswer['value']).includes(answer),
-//     );
-
-//     if (customEntry.length != 0) {
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(customEntry[0])
-//         .style(defaultStyle);
-
-//       sheet
-//         .cell(`${String.fromCharCode(col.charCodeAt(0) + 1)}${row}`)
-//         .value('X')
-//         .style(defaultStyle);
-//     }
-
-//     return [col, row + 1];
-//   };
-
-//   /**
-//    * Write a matrix question to the sheet in the same format as the matrix.
-//    * Only include the valid question types
-//    */
-//   const writeMatrixQs = (sheet, col, row, data) => {
-//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
-//     if (data['Hint'] != null) {
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(`Hint: ${data['Hint']}`)
-//         .style({ ...defaultStyle, italic: true });
-//     }
-
-//     if (data['MoreInfo'] != null) {
-//       sheet
-//         .cell(`${col}${(row += 1)}`)
-//         .value(`Extra Info: ${data['MoreInfo']}`)
-//         .style({ ...defaultStyle, italic: true });
-//     }
-//     // Get all the valid types of questions in the matrix
-//     const categories = data['Options']['source']['content']
-//       .map((c) => c['value'])
-//       .filter((c) => !ignoredQuestions.includes(c));
-
-//     const labels = data['Options']['source']['content']
-//       .map((c) => c['label'])
-//       .filter((c) => !ignoredQuestions.includes(c));
-
-//     row += 1;
-//     // Write column headers
-//     for (let i = 0; i < categories.length; i++) {
-//       sheet
-//         .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
-//         .value(labels[i])
-//         .style({ ...defaultStyle, bold: true, border: { color: '000000', style: 'thick' } });
-//     }
-
-//     // Fill in the matrix
-//     if (data['Answer'] != null) {
-//       for (const answer of data['Answer']) {
-//         row += 1;
-//         for (let i = 0; i < categories.length; i++) {
-//           if (answer[categories[i]]) {
-//             // Check if this answer has valid type
-//             sheet
-//               .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
-//               .value(answer[categories[i]]['value'])
-//               .style({ ...defaultStyle, border: { color: '000000', style: 'thin' } });
-//           }
-//         }
-//       }
-//     }
-//     return [col, row + 1];
-//   };
-
-//   const writeCollection = (sheet, col, row, data) => {
-//     sheet
-//       .cell(`${col}${row}`)
-//       .value(data['Question'])
-//       .style({ ...groupHeaderStyle, topBorder: { color: '000000', style: 'thin' } });
-//     const childInfo = getQuestionInfo(data['Children'], data['Name']);
-//     for (const child of childInfo) {
-//       [col, row] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
-//     }
-//     sheet
-//       .cell(`${col}${row}`)
-//       .style({ ...groupHeaderStyle, bottomBorder: { color: '000000', style: 'thin' } });
-
-//     return [col, row + 1];
-//   };
-
-//   const typeToFuncMap = {
-//     string: writeSimpleQs, // Text
-//     number: writeSimpleQs,
-//     ontology: writeDropdownQs, //Dropdown
-//     location: writeSimpleQs,
-//     date: writeDateQs,
-//     selectSingle: writeMultiOptionQs, // Multiple choice
-//     selectMultiple: writeMultiOptionQs, // Checkbox
-//     matrix: writeMatrixQs,
-//     instructions: writeInstructions,
-//     page: writeCollection,
-//     group: writeCollection,
-//   };
-
-//   console.log('THIS IS THE QUESTION & ANSWERS', questionAnswerMap);
-
-//   return XlsxPopulate.fromBlankAsync().then((workbook) => {
-//     // Populate the workbook.
-//     const mainSheet = workbook.sheet(0);
-//     const surveyName = survey['name'];
-//     var currentCol = 'A';
-//     var currentRow = 1;
-//     mainSheet.cell(`${currentCol}${currentRow}`).value(surveyName).style(titleStyle);
-//     currentRow += 1;
-//     for (const qa of questionAnswerMap) {
-//       [currentCol, currentRow] = typeToFuncMap[qa['Type']](mainSheet, currentCol, currentRow, qa);
-//       currentRow += 1;
-//     }
-//     // Resize cells
-//     const maxStringLength = mainSheet.range(`A1:A${currentRow}`).reduce((max, cell) => {
-//       const value = cell.value() == null ? '' : cell.value();
-//       if (value === undefined) return max;
-//       return Math.max(max, value.toString().length);
-//     }, 0);
-
-//     // For the default font settings in Excel, 1 char -> 1 pt is a pretty good estimate.
-//     mainSheet.column('A').width(maxStringLength * (titleStyle.fontSize / 12));
-
-//     // Write to file.
-//     return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/${surveyName}.xlsx`);
-//   });
-// };
-
 const XlsxPopulate = require('xlsx-populate');
 
 const rp = require('request-promise');
@@ -386,7 +85,7 @@ module.exports = async (submission, exportId) => {
       .cell(`${col}${(row += 1)}`)
       .value(data['Answer'])
       .style(defaultStyle);
-    return [col, row];
+    return [col, row + 1, 1];
   };
 
   /**
@@ -403,7 +102,7 @@ module.exports = async (submission, exportId) => {
           .style(defaultStyle);
       }
     }
-    return [col, row];
+    return [col, row + 1, 1];
   };
 
   /**
@@ -418,7 +117,7 @@ module.exports = async (submission, exportId) => {
         .value(date)
         .style(defaultStyle);
     }
-    return [col, row];
+    return [col, row + 1, 1];
   };
 
   /**
@@ -430,7 +129,7 @@ module.exports = async (submission, exportId) => {
       .cell(`${col}${row}`)
       .value(instructions)
       .style({ ...defaultStyle, italic: true });
-    return [col, row + 1];
+    return [col, row + 1, 1];
   };
 
   /**
@@ -483,7 +182,7 @@ module.exports = async (submission, exportId) => {
         .style(defaultStyle);
     }
 
-    return [col, row + 1];
+    return [col, row + 1, 2];
   };
 
   /**
@@ -538,23 +237,26 @@ module.exports = async (submission, exportId) => {
         }
       }
     }
-    return [categories.length, row + 1];
+    return [col, row + 1, categories.length];
   };
 
+  /**
+   * Write groups or pages to the Excel sheet with special formatting
+   */
   const writeCollection = (sheet, col, row, data) => {
     sheet
       .cell(`${col}${row}`)
       .value(data['Question'])
       .style({ ...groupHeaderStyle, topBorder: { color: '000000', style: 'thin' } });
     const childInfo = getQuestionInfo(data['Children'], data['Name']);
+    var [currentFarthestCol, farthestCol] = [1, 1];
     for (const child of childInfo) {
-      [col, row] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
+      [col, row, currentFarthestCol] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
+      farthestCol = Math.max(currentFarthestCol, farthestCol);
     }
-    sheet
-      .cell(`${col}${row}`)
-      .style({ ...groupHeaderStyle, bottomBorder: { color: '000000', style: 'thin' } });
+    sheet.cell(`${col}${row}`).style({ bottomBorder: { color: '000000', style: 'thin' } });
 
-    return [col, row + 1];
+    return [col, row + 1, farthestCol];
   };
 
   const typeToFuncMap = {
@@ -577,15 +279,18 @@ module.exports = async (submission, exportId) => {
     // Populate the workbook.
     const mainSheet = workbook.sheet(0);
     const surveyName = survey['name'];
-    var currentCol = 1;
-    var currentRow = 1;
-    var farthestCol = 1;
+    var [currentCol, currentRow, farthestCol, currentFarthestCol] = ['A', 1, 1, 1];
     mainSheet.cell(`A${currentRow}`).value(surveyName).style(titleStyle);
     currentRow += 1;
     for (const qa of questionAnswerMap) {
-      [currentCol, currentRow] = typeToFuncMap[qa['Type']](mainSheet, 'A', currentRow, qa);
+      [currentCol, currentRow, currentFarthestCol] = typeToFuncMap[qa['Type']](
+        mainSheet,
+        currentCol,
+        currentRow,
+        qa,
+      );
       currentRow += 1;
-      farthestCol = Math.max(currentCol, farthestCol);
+      farthestCol = Math.max(currentFarthestCol, farthestCol);
     }
     // Resize cells
     for (let i = 0; i < farthestCol; i++) {
@@ -599,7 +304,6 @@ module.exports = async (submission, exportId) => {
         }, 0);
 
       mainSheet.column(colToResize).width(maxStringLength * (titleStyle.fontSize / 12));
-      console.log('Resized column:', colToResize);
     }
 
     // Write to file.

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -82,7 +82,7 @@ module.exports = async (submission, exportId) => {
 
     sheet
       .cell(`${col}${(row += 1)}`)
-      .value(typeof data['Answer'] == 'string' ? data['Answer'] : data['Answer'][0]) // Lists in case of ontology
+      .value(typeof data['Answer'] != 'object' ? data['Answer'] : data['Answer'][0]) // Lists in case of ontology
       .style(defaultStyle);
     return [col, row];
   };
@@ -201,21 +201,23 @@ module.exports = async (submission, exportId) => {
 
   const writeGroupOrPage = (sheet, col, row, data) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style(groupHeaderStyle);
-    // const childInfo = data['Children']
-    //     .map(({ label, name, type, hint, options, moreInfo, children }) => ({
-    //     Question: label,
-    //     Answer: submissionData.data[name].value,
-    //     Type: type,
-    //     Hint: hint,
-    //     Options: options,
-    //     MoreInfo: moreInfo,
-    //     Children: ['group', 'page'].includes(type) ? children : null,
-    //   }))
-    //   .filter((entry) => !ignoredQuestions.includes(entry['Type']))
-    // for (child in childInfo){
-    //     [col, row] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
-    //     row += 1;
-    // }
+    const groupName = data['Name'];
+    const childInfo = data['Children']
+      .map(({ label, name, type, hint, options, moreInfo, children }) => ({
+        Question: label,
+        Answer: submissionData.data[groupName][name].value,
+        Type: type,
+        Hint: hint,
+        Options: options,
+        MoreInfo: moreInfo,
+        Children: ['group', 'page'].includes(type) ? children : null,
+      }))
+      .filter((entry) => !ignoredQuestions.includes(entry['Type']));
+    // console.log("THESE ARE THE CHILDREN: ", childInfo);
+    for (const child of childInfo) {
+      [col, row] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
+      // row += 1;
+    }
 
     return [col, row + 1];
   };

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -1,0 +1,34 @@
+// const puppeteer = require('puppeteer');
+// const fs = require('fs');
+const rp = require('request-promise');
+const surveyStackURL = 'https://app.surveystack.io/api/';
+module.exports = async (submission) => {
+  console.log('STEP X > SURVEY RECORD');
+  const submissionData = await rp({
+    uri: `${surveyStackURL}/submissions/${submission}`,
+    json: true,
+  });
+  const survey = await rp({
+    uri: `${surveyStackURL}/surveys/${submissionData.meta.survey.id}`,
+    json: true,
+  });
+
+  //   if (!submissionData || !survey) {
+  //     emailQueue.add({ fail: true });
+  //     return Promise.resolve();
+  //   }
+
+  const getQuestionsInfo = (questionAnswerList) => {
+    return questionAnswerList.map(({ label, name, type }) => ({
+      Question: label,
+      Answer: submissionData.data[name].value,
+      Type: type,
+    }));
+  };
+
+  const questionAnswerMap = getQuestionsInfo(
+    survey.revisions[survey.revisions.length - 1].controls,
+  );
+
+  console.log('THIS IS THE QUESITON & ANSWERS', questionAnswerMap);
+};

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -19,26 +19,26 @@ module.exports = async (submission, exportId) => {
     survey.revisions[survey.revisions.length - 1].controls,
   );
 
-  const getQuestionsInfo = (questionAnswerList) => {
+  const getQuestionInfo = (questionAnswerList) => {
     return questionAnswerList
-      .map(({ label, name, type, hint, options }) => ({
+      .map(({ label, name, type, hint, options, moreInfo }) => ({
         Question: label,
         Answer: submissionData.data[name].value,
         Type: type,
         Hint: hint,
-        Instructions: type == 'instructions' ? options.source.replace(/<p>|<\/p>/g, '') : null,
+        Instructions: type == 'instructions' ? options.source.replace(/<p>|<\/p>/g, '') : null, // Replace the <p> and </p> tags from the string
+        Options: ['selectSingle', 'selectMultiple'].includes(type) ? options.source : null,
+        MoreInfo: moreInfo,
       }))
       .filter((entry) => !['geoJSON', 'script', 'farmOsField'].includes(entry['Type']));
   };
 
-  const questionAnswerMap = getQuestionsInfo(
-    survey.revisions[survey.revisions.length - 1].controls,
-  );
+  const questionAnswerMap = getQuestionInfo(survey.revisions[survey.revisions.length - 1].controls);
 
   /**
    * Writes the question in bold and answer without bolding to Excel sheet at the position specified by col and row
    */
-  const simpleQuestionProcess = (sheet, col, row, data) => {
+  const writeSimpleQs = (sheet, col, row, data) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style({ fontFamily: 'Calibri', bold: true });
 
     sheet
@@ -54,18 +54,47 @@ module.exports = async (submission, exportId) => {
       .style({ fontFamily: 'Calibri', italic: true });
   };
 
+  const writeMultiOptionQs = (sheet, col, row, data) => {
+    sheet.cell(`${col}${row}`).value(data['Question']).style({ fontFamily: 'Calibri', bold: true });
+    if (data.Hint != null) {
+      sheet
+        .cell(`${col}${(row += 1)}`)
+        .value(data['Hint'])
+        .style({ fontFamily: 'Calibri', italic: true });
+    }
+    if (data.MoreInfo != null) {
+      sheet
+        .cell(`${col}${(row += 1)}`)
+        .value(data['MoreInfo'])
+        .style({ fontFamily: 'Calibri', italic: true });
+    }
+    for (const option of data['Options']) {
+      sheet
+        .cell(`${col}${(row += 1)}`)
+        .value(option['value'])
+        .style({ fontFamily: 'Calibri' });
+      if (data['Answer'].includes(option['value'])) {
+        sheet
+          .cell(`${String.fromCharCode(col.charCodeAt(0) + 1)}${row}`)
+          .value('X')
+          .style({ fontFamily: 'Calibri' }); // Write 'X' to the right column
+      }
+    }
+  };
+
   const typeToFuncMap = {
-    string: simpleQuestionProcess, // Text
-    number: simpleQuestionProcess,
+    string: writeSimpleQs, // Text
+    number: writeSimpleQs,
     //   'date': func3,
-    location: simpleQuestionProcess,
-    //   'selectSingle': func4, // Multiple choice
-    ontology: simpleQuestionProcess, //Dropdown
+    location: writeSimpleQs,
+    selectSingle: writeMultiOptionQs, // Multiple choice
+    selectMultiple: writeMultiOptionQs, // Multiple choice
+    ontology: writeSimpleQs, //Dropdown
     //   'matrix': func6
     instructions: writeInstructions,
   };
 
-  console.log('THIS IS THE QUESITON & ANSWERS', questionAnswerMap);
+  console.log('THIS IS THE QUESITON & ANSWERS', questionAnswerMap[0]);
 
   return XlsxPopulate.fromBlankAsync().then((workbook) => {
     // Populate the workbook.
@@ -73,16 +102,8 @@ module.exports = async (submission, exportId) => {
     var currentCol = 'A';
     var currentRow = 1;
     for (const qa of questionAnswerMap) {
-      //   sheet1
-      //     .cell(`${currentCol}${currentRow++}`)
-      //     .value(qa['Question'])
-      //     .style(defaultStyles);
-      //   sheet1
-      //     .cell(`${currentCol}${currentRow++}`)
-      //     .value(qa['Answer'])
-      //     .style(defaultStyles);
       typeToFuncMap[qa['Type']](sheet1, currentCol, currentRow, qa);
-      currentRow += 2;
+      currentRow += 2; // Have each function return a new current postion
     }
     // Write to file.
     return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/Survey Record.xlsx`);

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -1,8 +1,8 @@
-// const puppeteer = require('puppeteer');
-// const fs = require('fs');
+const XlsxPopulate = require('xlsx-populate');
+
 const rp = require('request-promise');
 const surveyStackURL = 'https://app.surveystack.io/api/';
-module.exports = async (submission) => {
+module.exports = async (submission, exportId) => {
   console.log('STEP X > SURVEY RECORD');
   const submissionData = await rp({
     uri: `${surveyStackURL}/submissions/${submission}`,
@@ -13,22 +13,42 @@ module.exports = async (submission) => {
     json: true,
   });
 
-  //   if (!submissionData || !survey) {
-  //     emailQueue.add({ fail: true });
-  //     return Promise.resolve();
-  //   }
-
   const getQuestionsInfo = (questionAnswerList) => {
-    return questionAnswerList.map(({ label, name, type }) => ({
-      Question: label,
-      Answer: submissionData.data[name].value,
-      Type: type,
-    }));
+    return questionAnswerList
+      .map(({ label, name, type }) => ({
+        Question: label,
+        Answer: submissionData.data[name].value,
+        Type: type,
+      }))
+      .filter((entry) => !['geoJSON', 'script', 'farmOsField'].includes(entry['Type']));
   };
 
   const questionAnswerMap = getQuestionsInfo(
     survey.revisions[survey.revisions.length - 1].controls,
   );
 
+  const defaultStyles = {
+    verticalAlignment: 'center',
+    fontFamily: 'Calibri',
+  };
+
   console.log('THIS IS THE QUESITON & ANSWERS', questionAnswerMap);
+
+  return XlsxPopulate.fromBlankAsync().then((workbook) => {
+    // Populate the workbook.
+    const sheet1 = workbook.sheet(0);
+    var currentRow = 1;
+    for (const qa of questionAnswerMap) {
+      sheet1
+        .cell(`A${currentRow++}`)
+        .value(qa['Question'])
+        .style(defaultStyles);
+      sheet1
+        .cell(`A${currentRow++}`)
+        .value(qa['Answer'])
+        .style(defaultStyles);
+    }
+    // Write to file.
+    return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/Survey Record.xlsx`);
+  });
 };

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -1,3 +1,304 @@
+// const XlsxPopulate = require('xlsx-populate');
+
+// const rp = require('request-promise');
+// const surveyStackURL = 'https://app.surveystack.io/api/';
+// module.exports = async (submission, exportId) => {
+//   const submissionData = await rp({
+//     uri: `${surveyStackURL}/submissions/${submission}`,
+//     json: true,
+//     headers: { Authorization: 'ashaikh@litefarm.org' },
+//   });
+
+//   const survey = await rp({
+//     uri: `${surveyStackURL}/surveys/${submissionData.meta.survey.id}`,
+//     json: true,
+//     headers: { Authorization: '<user-email> <user-token>' },
+//   });
+
+// //   console.log('THIS IS THE SUBMISSION DATA: ', submissionData);
+// //   console.log(
+// //     'THIS IS THE WHOLE SURVEY INFORMATION: ',
+// //     survey.revisions[survey.revisions.length - 1].controls,
+// //   );
+
+//   const ignoredQuestions = [
+//     'geoJSON',
+//     'script',
+//     'FarmOS Field',
+//     'farmOsField',
+//     'farmOsPlanting',
+//     'farmOsFarm',
+//     'FarmOS Planting',
+//     'instructionsImageSplit',
+//   ];
+//   const questionStyle = {
+//     fontFamily: 'Calibri',
+//     bold: true,
+//     fontSize: 14,
+//     horizontalAlignment: 'left',
+//   };
+//   const groupHeaderStyle = {
+//     fontFamily: 'Calibri',
+//     bold: true,
+//     fontSize: 18,
+//     horizontalAlignment: 'center',
+//   };
+//   const defaultStyle = {
+//     fontFamily: 'Calibri',
+//     fontSize: 12,
+//     horizontalAlignment: 'left',
+//   };
+//   const titleStyle = {
+//     fontFamily: 'Calibri',
+//     fontSize: 20,
+//     bold: true,
+//     horizontalAlignment: 'center',
+//   };
+
+//   const getQuestionInfo = (questionAnswerList, groupName = null) => {
+//     return questionAnswerList
+//       .map(({ label, name, type, hint, options, moreInfo, children }) => ({
+//         Question: label,
+//         Name: name,
+//         Answer:
+//           groupName == null
+//             ? submissionData.data[name].value
+//             : submissionData.data[groupName][name].value,
+//         Type: type,
+//         Hint: hint,
+//         Options: options,
+//         MoreInfo: moreInfo,
+//         Children: ['group', 'page'].includes(type) ? children : null,
+//       }))
+//       .filter((entry) => !ignoredQuestions.includes(entry['Type']));
+//   };
+
+//   const questionAnswerMap = getQuestionInfo(survey.revisions[survey.revisions.length - 1].controls);
+
+//   /**
+//    * Writes the question in bold and answer without bolding to Excel sheet at the position specified by col and row
+//    */
+//   const writeSimpleQs = (sheet, col, row, data) => {
+//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+
+//     sheet
+//       .cell(`${col}${(row += 1)}`)
+//       .value(data['Answer'])
+//       .style(defaultStyle);
+//     return [col, row];
+//   };
+
+//   /**
+//    * Write all the selected options from the dropdown question as subsequent rows
+//    */
+//   const writeDropdownQs = (sheet, col, row, data) => {
+//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+
+//     if (data['Answer'] != null) {
+//       for (const answer of data['Answer']) {
+//         sheet
+//           .cell(`${col}${(row += 1)}`)
+//           .value(answer)
+//           .style(defaultStyle);
+//       }
+//     }
+//     return [col, row];
+//   };
+
+//   /**
+//    * Write date questions in the full format
+//    */
+//   const writeDateQs = (sheet, col, row, data) => {
+//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+//     if (data['Answer'] != null) {
+//       const date = new Date(data['Answer']).toDateString();
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(date)
+//         .style(defaultStyle);
+//     }
+//     return [col, row];
+//   };
+
+//   /**
+//    * Write instructions in italics
+//    */
+//   const writeInstructions = (sheet, col, row, data) => {
+//     const instructions = data['Options']['source'].replace(/<p>|<\/p>/g, '');
+//     sheet
+//       .cell(`${col}${row}`)
+//       .value(instructions)
+//       .style({ ...defaultStyle, italic: true });
+//     return [col, row + 1];
+//   };
+
+//   /**
+//    * Write multiple choice/checkbox type questions to the Excel Sheet.
+//    * Label is in the left column and a 'X' is placed in the immediate right column if this option was selected
+//    */
+//   const writeMultiOptionQs = (sheet, col, row, data) => {
+//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+//     if (data['Hint'] != null) {
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(`Hint: ${data['Hint']}`)
+//         .style({ ...defaultStyle, italic: true });
+//     }
+//     if (data['MoreInfo'] != null) {
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(`Extra Info: ${data['MoreInfo']}`)
+//         .style({ ...defaultStyle, italic: true });
+//     }
+//     const nonCustomAnswers = data['Options']['source'];
+//     for (const ncAnswer of nonCustomAnswers) {
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(ncAnswer['label'])
+//         .style(defaultStyle);
+//       if (data['Answer'] != null && data['Answer'].includes(ncAnswer['value'])) {
+//         sheet
+//           .cell(`${String.fromCharCode(col.charCodeAt(0) + 1)}${row}`)
+//           .value('X')
+//           .style(defaultStyle); // Write 'X' to the right column
+//       }
+//     }
+
+//     // Get the difference between given answers and all non-custom answers.
+//     // If this list is non-empty, we know the user gave a custom answer
+//     const customEntry = data['Answer'].filter(
+//       (answer) => !nonCustomAnswers.map((ncAnswer) => ncAnswer['value']).includes(answer),
+//     );
+
+//     if (customEntry.length != 0) {
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(customEntry[0])
+//         .style(defaultStyle);
+
+//       sheet
+//         .cell(`${String.fromCharCode(col.charCodeAt(0) + 1)}${row}`)
+//         .value('X')
+//         .style(defaultStyle);
+//     }
+
+//     return [col, row + 1];
+//   };
+
+//   /**
+//    * Write a matrix question to the sheet in the same format as the matrix.
+//    * Only include the valid question types
+//    */
+//   const writeMatrixQs = (sheet, col, row, data) => {
+//     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+//     if (data['Hint'] != null) {
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(`Hint: ${data['Hint']}`)
+//         .style({ ...defaultStyle, italic: true });
+//     }
+
+//     if (data['MoreInfo'] != null) {
+//       sheet
+//         .cell(`${col}${(row += 1)}`)
+//         .value(`Extra Info: ${data['MoreInfo']}`)
+//         .style({ ...defaultStyle, italic: true });
+//     }
+//     // Get all the valid types of questions in the matrix
+//     const categories = data['Options']['source']['content']
+//       .map((c) => c['value'])
+//       .filter((c) => !ignoredQuestions.includes(c));
+
+//     const labels = data['Options']['source']['content']
+//       .map((c) => c['label'])
+//       .filter((c) => !ignoredQuestions.includes(c));
+
+//     row += 1;
+//     // Write column headers
+//     for (let i = 0; i < categories.length; i++) {
+//       sheet
+//         .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
+//         .value(labels[i])
+//         .style({ ...defaultStyle, bold: true, border: { color: '000000', style: 'thick' } });
+//     }
+
+//     // Fill in the matrix
+//     if (data['Answer'] != null) {
+//       for (const answer of data['Answer']) {
+//         row += 1;
+//         for (let i = 0; i < categories.length; i++) {
+//           if (answer[categories[i]]) {
+//             // Check if this answer has valid type
+//             sheet
+//               .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
+//               .value(answer[categories[i]]['value'])
+//               .style({ ...defaultStyle, border: { color: '000000', style: 'thin' } });
+//           }
+//         }
+//       }
+//     }
+//     return [col, row + 1];
+//   };
+
+//   const writeCollection = (sheet, col, row, data) => {
+//     sheet
+//       .cell(`${col}${row}`)
+//       .value(data['Question'])
+//       .style({ ...groupHeaderStyle, topBorder: { color: '000000', style: 'thin' } });
+//     const childInfo = getQuestionInfo(data['Children'], data['Name']);
+//     for (const child of childInfo) {
+//       [col, row] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
+//     }
+//     sheet
+//       .cell(`${col}${row}`)
+//       .style({ ...groupHeaderStyle, bottomBorder: { color: '000000', style: 'thin' } });
+
+//     return [col, row + 1];
+//   };
+
+//   const typeToFuncMap = {
+//     string: writeSimpleQs, // Text
+//     number: writeSimpleQs,
+//     ontology: writeDropdownQs, //Dropdown
+//     location: writeSimpleQs,
+//     date: writeDateQs,
+//     selectSingle: writeMultiOptionQs, // Multiple choice
+//     selectMultiple: writeMultiOptionQs, // Checkbox
+//     matrix: writeMatrixQs,
+//     instructions: writeInstructions,
+//     page: writeCollection,
+//     group: writeCollection,
+//   };
+
+//   console.log('THIS IS THE QUESTION & ANSWERS', questionAnswerMap);
+
+//   return XlsxPopulate.fromBlankAsync().then((workbook) => {
+//     // Populate the workbook.
+//     const mainSheet = workbook.sheet(0);
+//     const surveyName = survey['name'];
+//     var currentCol = 'A';
+//     var currentRow = 1;
+//     mainSheet.cell(`${currentCol}${currentRow}`).value(surveyName).style(titleStyle);
+//     currentRow += 1;
+//     for (const qa of questionAnswerMap) {
+//       [currentCol, currentRow] = typeToFuncMap[qa['Type']](mainSheet, currentCol, currentRow, qa);
+//       currentRow += 1;
+//     }
+//     // Resize cells
+//     const maxStringLength = mainSheet.range(`A1:A${currentRow}`).reduce((max, cell) => {
+//       const value = cell.value() == null ? '' : cell.value();
+//       if (value === undefined) return max;
+//       return Math.max(max, value.toString().length);
+//     }, 0);
+
+//     // For the default font settings in Excel, 1 char -> 1 pt is a pretty good estimate.
+//     mainSheet.column('A').width(maxStringLength * (titleStyle.fontSize / 12));
+
+//     // Write to file.
+//     return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/${surveyName}.xlsx`);
+//   });
+// };
+
 const XlsxPopulate = require('xlsx-populate');
 
 const rp = require('request-promise');
@@ -15,11 +316,11 @@ module.exports = async (submission, exportId) => {
     headers: { Authorization: '<user-email> <user-token>' },
   });
 
-  console.log('THIS IS THE SUBMISSION DATA: ', submissionData);
-  console.log(
-    'THIS IS THE WHOLE SURVEY INFORMATION: ',
-    survey.revisions[survey.revisions.length - 1].controls,
-  );
+  //   console.log('THIS IS THE SUBMISSION DATA: ', submissionData);
+  //   console.log(
+  //     'THIS IS THE WHOLE SURVEY INFORMATION: ',
+  //     survey.revisions[survey.revisions.length - 1].controls,
+  //   );
 
   const ignoredQuestions = [
     'geoJSON',
@@ -104,6 +405,7 @@ module.exports = async (submission, exportId) => {
     }
     return [col, row];
   };
+
   /**
    * Write date questions in the full format
    */
@@ -169,9 +471,6 @@ module.exports = async (submission, exportId) => {
       (answer) => !nonCustomAnswers.map((ncAnswer) => ncAnswer['value']).includes(answer),
     );
 
-    console.log(`THIS IS THE CUSTOM LIST FOR ${data['Name']}: ${customEntry}`);
-    console.log(`THE CUSTOM LIST FOR ${data['Name']} has type ${typeof customEntry}`);
-
     if (customEntry.length != 0) {
       sheet
         .cell(`${col}${(row += 1)}`)
@@ -223,6 +522,7 @@ module.exports = async (submission, exportId) => {
         .value(labels[i])
         .style({ ...defaultStyle, bold: true, border: { color: '000000', style: 'thick' } });
     }
+
     // Fill in the matrix
     if (data['Answer'] != null) {
       for (const answer of data['Answer']) {
@@ -238,7 +538,7 @@ module.exports = async (submission, exportId) => {
         }
       }
     }
-    return [col, row + 1];
+    return [categories.length, row + 1];
   };
 
   const writeCollection = (sheet, col, row, data) => {
@@ -277,23 +577,30 @@ module.exports = async (submission, exportId) => {
     // Populate the workbook.
     const mainSheet = workbook.sheet(0);
     const surveyName = survey['name'];
-    var currentCol = 'A';
+    var currentCol = 1;
     var currentRow = 1;
-    mainSheet.cell(`${currentCol}${currentRow}`).value(surveyName).style(titleStyle);
+    var farthestCol = 1;
+    mainSheet.cell(`A${currentRow}`).value(surveyName).style(titleStyle);
     currentRow += 1;
     for (const qa of questionAnswerMap) {
-      [currentCol, currentRow] = typeToFuncMap[qa['Type']](mainSheet, currentCol, currentRow, qa);
+      [currentCol, currentRow] = typeToFuncMap[qa['Type']](mainSheet, 'A', currentRow, qa);
       currentRow += 1;
+      farthestCol = Math.max(currentCol, farthestCol);
     }
     // Resize cells
-    const maxStringLength = mainSheet.range(`A1:A${currentRow}`).reduce((max, cell) => {
-      const value = cell.value() == null ? '' : cell.value();
-      if (value === undefined) return max;
-      return Math.max(max, value.toString().length);
-    }, 0);
+    for (let i = 0; i < farthestCol; i++) {
+      const colToResize = String.fromCharCode('A'.charCodeAt(0) + i);
+      const maxStringLength = mainSheet
+        .range(`${colToResize}1:${colToResize}${currentRow}`)
+        .reduce((max, cell) => {
+          const value = cell.value() == null ? '' : cell.value();
+          if (value === undefined) return max;
+          return Math.max(max, value.toString().length);
+        }, 0);
 
-    // For the default font settings in Excel, 1 char -> 1 pt is a pretty good estimate.
-    mainSheet.column('A').width(maxStringLength * (titleStyle.fontSize / 12));
+      mainSheet.column(colToResize).width(maxStringLength * (titleStyle.fontSize / 12));
+      console.log('Resized column:', colToResize);
+    }
 
     // Write to file.
     return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/${surveyName}.xlsx`);

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -43,6 +43,23 @@ module.exports = async (submission, exportId) => {
     fontSize: 18,
     horizontalAlignment: 'center',
   };
+
+  const getGroupBorder = (direction) => {
+    return {
+      [`${direction}Border`]: {
+        color: '000000',
+        style: 'thin',
+      },
+      leftBorder: {
+        color: '000000',
+        style: 'thin',
+      },
+      rightBorder: {
+        color: '000000',
+        style: 'thin',
+      },
+    };
+  };
   const defaultStyle = {
     fontFamily: 'Calibri',
     fontSize: 12,
@@ -53,6 +70,7 @@ module.exports = async (submission, exportId) => {
     fontSize: 20,
     bold: true,
     horizontalAlignment: 'center',
+    border: { color: '000000', style: 'thick' },
   };
 
   const getQuestionInfo = (questionAnswerList, groupName = null) => {
@@ -85,7 +103,7 @@ module.exports = async (submission, exportId) => {
       .cell(`${col}${(row += 1)}`)
       .value(data['Answer'])
       .style(defaultStyle);
-    return [col, row + 1, 1];
+    return [col, row, 1];
   };
 
   /**
@@ -102,7 +120,7 @@ module.exports = async (submission, exportId) => {
           .style(defaultStyle);
       }
     }
-    return [col, row + 1, 1];
+    return [col, row, 1];
   };
 
   /**
@@ -117,7 +135,7 @@ module.exports = async (submission, exportId) => {
         .value(date)
         .style(defaultStyle);
     }
-    return [col, row + 1, 1];
+    return [col, row, 1];
   };
 
   /**
@@ -129,7 +147,7 @@ module.exports = async (submission, exportId) => {
       .cell(`${col}${row}`)
       .value(instructions)
       .style({ ...defaultStyle, italic: true });
-    return [col, row + 1, 1];
+    return [col, row, 1];
   };
 
   /**
@@ -182,7 +200,7 @@ module.exports = async (submission, exportId) => {
         .style(defaultStyle);
     }
 
-    return [col, row + 1, 2];
+    return [col, row, 2];
   };
 
   /**
@@ -237,7 +255,7 @@ module.exports = async (submission, exportId) => {
         }
       }
     }
-    return [col, row + 1, categories.length];
+    return [col, row, categories.length];
   };
 
   /**
@@ -247,16 +265,16 @@ module.exports = async (submission, exportId) => {
     sheet
       .cell(`${col}${row}`)
       .value(data['Question'])
-      .style({ ...groupHeaderStyle, topBorder: { color: '000000', style: 'thin' } });
+      .style({ ...groupHeaderStyle, ...getGroupBorder('top') });
     const childInfo = getQuestionInfo(data['Children'], data['Name']);
     var [currentFarthestCol, farthestCol] = [1, 1];
     for (const child of childInfo) {
       [col, row, currentFarthestCol] = typeToFuncMap[child['Type']](sheet, col, row + 1, child);
       farthestCol = Math.max(currentFarthestCol, farthestCol);
     }
-    sheet.cell(`${col}${row}`).style({ bottomBorder: { color: '000000', style: 'thin' } });
+    sheet.cell(`${col}${row}`).style(getGroupBorder('bottom'));
 
-    return [col, row + 1, farthestCol];
+    return [col, row, farthestCol];
   };
 
   const typeToFuncMap = {
@@ -280,6 +298,8 @@ module.exports = async (submission, exportId) => {
     const mainSheet = workbook.sheet(0);
     const surveyName = survey['name'];
     var [currentCol, currentRow, farthestCol, currentFarthestCol] = ['A', 1, 1, 1];
+
+    // Write the title
     mainSheet.cell(`A${currentRow}`).value(surveyName).style(titleStyle);
     currentRow += 1;
     for (const qa of questionAnswerMap) {
@@ -289,7 +309,7 @@ module.exports = async (submission, exportId) => {
         currentRow,
         qa,
       );
-      currentRow += 1;
+      currentRow += 2;
       farthestCol = Math.max(currentFarthestCol, farthestCol);
     }
     // Resize cells

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -91,22 +91,36 @@ module.exports = async (submission, exportId) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style({ fontFamily: 'Calibri', bold: true });
     const categories = Object.keys(data['Answer'][0]);
     row += 1;
+    // Write column headers
     for (let i = 0; i < categories.length; i++) {
       sheet
         .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
         .value(categories[i])
         .style({ fontFamily: 'Calibri', bold: true, border: { color: '000000' } });
     }
+
+    // Fill in the matrix
+    for (const answer of data['Answer']) {
+      row += 1;
+      for (let i = 0; i < categories.length; i++) {
+        sheet
+          .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
+          .value(answer[categories[i]]['value'])
+          .style({ fontFamily: 'Calibri', border: { color: '000000' } });
+      }
+    }
+
+    return col, row;
   };
 
   const typeToFuncMap = {
     string: writeSimpleQs, // Text
     number: writeSimpleQs,
-    //   'date': func3,
+    ontology: writeSimpleQs, //Dropdown
     location: writeSimpleQs,
+    //   'date': func3,
     selectSingle: writeMultiOptionQs, // Multiple choice
     selectMultiple: writeMultiOptionQs, // Checkbox
-    ontology: writeSimpleQs, //Dropdown
     matrix: writeMatrixQs,
     instructions: writeInstructions,
   };

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -6,13 +6,11 @@ module.exports = async (submission, exportId) => {
   const submissionData = await rp({
     uri: `${surveyStackURL}/submissions/${submission}`,
     json: true,
-    headers: { Authorization: 'ashaikh@litefarm.org' },
   });
 
   const survey = await rp({
     uri: `${surveyStackURL}/surveys/${submissionData.meta.survey.id}`,
     json: true,
-    headers: { Authorization: '<user-email> <user-token>' },
   });
 
   const ignoredQuestions = [

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -82,11 +82,35 @@ module.exports = async (submission, exportId) => {
 
     sheet
       .cell(`${col}${(row += 1)}`)
-      .value(typeof data['Answer'] != 'object' ? data['Answer'] : data['Answer'][0]) // Lists in case of ontology
+      .value(data['Answer'])
       .style(defaultStyle);
     return [col, row];
   };
 
+  const writeDropdownQs = (sheet, col, row, data) => {
+    sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+
+    for (const answer of data['Answer']) {
+      sheet
+        .cell(`${col}${(row += 1)}`)
+        .value(answer)
+        .style(defaultStyle);
+    }
+    return [col, row];
+  };
+
+  const writeDateQs = (sheet, col, row, data) => {
+    sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+
+    const date = new Date(data['Answer']).toDateString();
+    sheet
+      .cell(`${col}${(row += 1)}`)
+      .value(date)
+      .style(defaultStyle);
+    return [col, row];
+  };
+
+  // Write instructions in italics
   const writeInstructions = (sheet, col, row, data) => {
     const instructions = data['Options']['source'].replace(/<p>|<\/p>/g, '');
     sheet
@@ -96,6 +120,8 @@ module.exports = async (submission, exportId) => {
     return [col, row + 1];
   };
 
+  // Write multiple choice/checkbox type questions to the Excel Sheet.
+  // Option is in the left column and a 'X' is placed in the immediate right column if this option was selected
   const writeMultiOptionQs = (sheet, col, row, data) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
     if (data['Hint'] != null) {
@@ -199,7 +225,7 @@ module.exports = async (submission, exportId) => {
     return [col, row + 1];
   };
 
-  const writeGroupOrPage = (sheet, col, row, data) => {
+  const writeCollection = (sheet, col, row, data) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style(groupHeaderStyle);
     const groupName = data['Name'];
     const childInfo = data['Children']
@@ -225,15 +251,15 @@ module.exports = async (submission, exportId) => {
   const typeToFuncMap = {
     string: writeSimpleQs, // Text
     number: writeSimpleQs,
-    ontology: writeSimpleQs, //Dropdown
+    ontology: writeDropdownQs, //Dropdown
     location: writeSimpleQs,
-    date: writeSimpleQs,
+    date: writeDateQs,
     selectSingle: writeMultiOptionQs, // Multiple choice
     selectMultiple: writeMultiOptionQs, // Checkbox
     matrix: writeMatrixQs,
     instructions: writeInstructions,
-    page: writeGroupOrPage,
-    group: writeGroupOrPage,
+    page: writeCollection,
+    group: writeCollection,
   };
 
   console.log('THIS IS THE QUESTION & ANSWERS', questionAnswerMap);

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -84,16 +84,37 @@ module.exports = async (submission, exportId) => {
           .style({ fontFamily: 'Calibri' }); // Write 'X' to the right column
       }
     }
+    // Get the difference between given answers and all non-custom answers.
+    // If this list is non-empty, we know the user gave a custom answer
+    const customEntry = data['Answer'].filter(
+      (a) => !data['Options']['source'].map((s) => s['value']).includes(a),
+    );
+
+    if (customEntry != []) {
+      sheet
+        .cell(`${col}${(row += 1)}`)
+        .value(customEntry[0])
+        .style({ fontFamily: 'Calibri' });
+
+      sheet
+        .cell(`${String.fromCharCode(col.charCodeAt(0) + 1)}${row}`)
+        .value('X')
+        .style({ fontFamily: 'Calibri' });
+    }
+
     return [col, row + 1];
   };
 
+  /**
+   * Write a matrix question to the sheet in the same format as the matrix.
+   * Only include the valid question types
+   */
   const writeMatrixQs = (sheet, col, row, data) => {
     sheet.cell(`${col}${row}`).value(data['Question']).style({ fontFamily: 'Calibri', bold: true });
+    // Get all the valid types of questions in the matrix
     const categories = data['Options']['source']['content']
       .map((c) => c['label'])
-      .filter((c) => !ignoredQuestions.includes(c)); // Get all the valid types of questions in the matrix
-
-    console.log('CATEGORIES: ', categories);
+      .filter((c) => !ignoredQuestions.includes(c));
 
     row += 1;
     // Write column headers
@@ -103,6 +124,7 @@ module.exports = async (submission, exportId) => {
         .value(categories[i])
         .style({ fontFamily: 'Calibri', bold: true, border: { color: '000000', style: 'thick' } });
     }
+
     row += 1;
     // Fill in the matrix
     for (const answer of data['Answer']) {

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -98,16 +98,16 @@ module.exports = async (submission, exportId) => {
         .value(categories[i])
         .style({ fontFamily: 'Calibri', bold: true, border: { color: '000000', style: 'thick' } });
     }
-
+    row += 1;
     // Fill in the matrix
     for (const answer of data['Answer']) {
-      row += 1;
       for (let i = 0; i < categories.length; i++) {
         sheet
           .cell(`${String.fromCharCode(col.charCodeAt(0) + i)}${row}`)
           .value(answer[categories[i]]['value'])
           .style({ fontFamily: 'Calibri', border: { color: '000000', style: 'thin' } });
       }
+      row += 1;
     }
 
     return col, row;

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -277,11 +277,23 @@ module.exports = async (submission, exportId) => {
     return [col, row, farthestCol];
   };
 
+  const writeLocationQs = (sheet, col, row, data) => {
+    sheet.cell(`${col}${row}`).value(data['Question']).style(questionStyle);
+    if (data['Answer'] != null) {
+      const longLat = data['Answer']['geometry']['coordinates'];
+      sheet
+        .cell(`${col}${(row += 1)}`)
+        .value(`Longitude:${longLat[0]}, Latitude:${longLat[1]}`)
+        .style(defaultStyle);
+    }
+    return [col, row, 1];
+  };
+
   const typeToFuncMap = {
     string: writeSimpleQs, // Text
     number: writeSimpleQs,
     ontology: writeDropdownQs, //Dropdown
-    location: writeSimpleQs,
+    location: writeLocationQs,
     date: writeDateQs,
     selectSingle: writeMultiOptionQs, // Multiple choice
     selectMultiple: writeMultiOptionQs, // Checkbox

--- a/packages/webapp/src/components/CertificationSurvey/RegisteredCertifierQuestions/index.jsx
+++ b/packages/webapp/src/components/CertificationSurvey/RegisteredCertifierQuestions/index.jsx
@@ -7,7 +7,13 @@ import { Info, Main, Semibold } from '../../Typography';
 import { colors } from '../../../assets/theme';
 import { ReactComponent as PostSurveySplash } from '../../../assets/images/certification/CompleteSurveySplash.svg';
 
-const RegisteredCertifierQuestionsSurvey = ({ certiferAcronym, surveyId, submissionId, isSurveySkipped, email }) => {
+const RegisteredCertifierQuestionsSurvey = ({
+  certiferAcronym,
+  surveyId,
+  submissionId,
+  isSurveySkipped,
+  email,
+}) => {
   const { t } = useTranslation();
 
   return (
@@ -30,7 +36,11 @@ const RegisteredCertifierQuestionsSurvey = ({ certiferAcronym, surveyId, submiss
 
       <Info style={{ marginBottom: '24px' }}>{t('CERTIFICATIONS.NOTE_CANNOT_RESUBMIT')}</Info>
 
-      {submissionId || isSurveySkipped ? <PostSurveyBody email={email} /> : <PreSurveyBody surveyId={surveyId} />}
+      {submissionId || isSurveySkipped ? (
+        <PostSurveyBody email={email} />
+      ) : (
+        <PreSurveyBody surveyId={surveyId} />
+      )}
     </>
   );
 };
@@ -41,6 +51,7 @@ const PreSurveyBody = ({ surveyId }) => {
       title="temp iframe title"
       src={`https://app.surveystack.io/surveys/${surveyId}?minimal_ui=true`}
       className={styles.surveyFrame}
+      allow="geolocation"
     />
   );
 };


### PR DESCRIPTION
This PR exports the answers to the questions asked during a certification document as an Excel sheet.

To Test:
First we need to set up the database to pull the correct surveys. In the psql client...
1. Connect to the 'pg-litefarm' database
2. run the following command `update certifiers set survey_id='627bdbff5b5f71000118f47c'`. This will update the surveys for all certifiers

Then we need to set up the Redis service

1. Under packages/api, you have to create a directory called exports
2. Install the aws cli https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
3. Authenticate the aws cli by running aws configure in your terminal, and using the DO_SPACES_ACCES_KEY_ID and DO_SPACES_SECRET_ACCESS_KEY values from the packages/api/.env file for the access key id and secret access key fields

Then start the service in a new terminal by typing `npm run scheduler` in the api folder

Then on localhost...
1. Navigate to the certifications page and select any certifier
4. Continue through the flow and fill in the survey
5. After completing the flow, check your email for the documents. You should see an Excel sheet with all of your answers in a format that fits the question