### PR TITLE
Lf 2393 - Disable unit conversion on changing the value of unit selection dropdown component

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -238,15 +238,16 @@ const Unit = ({
     hookFormSetHiddenValue(hookFormValue, { shouldValidate: true, shouldDirty: false });
   }, []);
 
-  useEffect(() => {
-    if (hookFormUnit && hookFormValue !== undefined) {
-      setVisibleInputValue(
-        roundToTwoDecimal(convert(hookFormValue).from(databaseUnit).to(hookFormUnit)),
-      );
-      //Trigger validation
-      (hookFormValue === 0 || hookFormValue > 0) && hookFormSetHiddenValue(hookFormValue);
-    }
-  }, [hookFormUnit]);
+  // disabled to unit conversion
+  // useEffect(() => {
+  //   if (hookFormUnit && hookFormValue !== undefined) {
+  //     setVisibleInputValue(
+  //       roundToTwoDecimal(convert(hookFormValue).from(databaseUnit).to(hookFormUnit)),
+  //     );
+  //     //Trigger validation
+  //     (hookFormValue === 0 || hookFormValue > 0) && hookFormSetHiddenValue(hookFormValue);
+  //   }
+  // }, [hookFormUnit]);
 
   const inputOnChange = (e) => {
     setVisibleInputValue(e.target.value);

--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -238,7 +238,7 @@ const Unit = ({
     hookFormSetHiddenValue(hookFormValue, { shouldValidate: true, shouldDirty: false });
   }, []);
 
-  // disabled to unit conversion
+  // uncomment the code to enable the unit conversion feature.
   // useEffect(() => {
   //   if (hookFormUnit && hookFormValue !== undefined) {
   //     setVisibleInputValue(

--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -238,17 +238,6 @@ const Unit = ({
     hookFormSetHiddenValue(hookFormValue, { shouldValidate: true, shouldDirty: false });
   }, []);
 
-  // uncomment the code to enable the unit conversion feature.
-  // useEffect(() => {
-  //   if (hookFormUnit && hookFormValue !== undefined) {
-  //     setVisibleInputValue(
-  //       roundToTwoDecimal(convert(hookFormValue).from(databaseUnit).to(hookFormUnit)),
-  //     );
-  //     //Trigger validation
-  //     (hookFormValue === 0 || hookFormValue > 0) && hookFormSetHiddenValue(hookFormValue);
-  //   }
-  // }, [hookFormUnit]);
-
   const inputOnChange = (e) => {
     setVisibleInputValue(e.target.value);
     mode === 'onChange' && inputOnBlur(e);


### PR DESCRIPTION
To test:

1. start with the create a task flow.
2. in the forms, look for the unit conversion dropdown.
3. add a value to the input field.
4. make changes in the drop-down unit field.
5. check if the value in the input field remains the same after selecting a different unit field.
