### PR TITLE
Refactor task assign modal to not rely on task card contents

### DIFF
--- a/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
+++ b/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
@@ -6,6 +6,8 @@ import Button from '../../Form/Button';
 import ReactSelect from '../../Form/ReactSelect';
 import Checkbox from '../../Form/Checkbox';
 import { ReactComponent as Person } from '../../../assets/images/task/Person.svg';
+import { tasksSelector } from '../../../containers/taskSlice';
+import { useSelector } from 'react-redux';
 
 export default function TaskQuickAssignModal({
   dismissModal,
@@ -16,7 +18,6 @@ export default function TaskQuickAssignModal({
   onAssignTask,
   users,
   user,
-  taskCardContents,
 }) {
   const { t } = useTranslation();
   const selfOption = { label: `${user.first_name} ${user.last_name}`, value: user.user_id };
@@ -36,14 +37,18 @@ export default function TaskQuickAssignModal({
   const [selectedWorker, setWorker] = useState(isAssigned ? unAssignedOption : selfOption);
   const [assignAll, setAssignAll] = useState(false);
 
+  const tasks = useSelector(tasksSelector);
+
   const checkUnassignedTaskForSameDate = () => {
-    const selectedTask = taskCardContents.find((t) => t.task_id == task_id);
+    console.log(tasks);
+    const selectedTask = tasks.find((t) => t.task_id == task_id);
     let isUnassignedTaskPresent = false;
-    for (let task of taskCardContents) {
+    for (let task of tasks) {
       if (
-        task.completeOrDueDate === selectedTask.completeOrDueDate &&
+        task.due_date === selectedTask.due_date &&
         !task.assignee &&
-        task.task_id !== task_id
+        task.task_id !== task_id &&
+        task.complete_date === null
       ) {
         isUnassignedTaskPresent = true;
         break;

--- a/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
+++ b/packages/webapp/src/components/Modals/QuickAssignModal/index.jsx
@@ -58,7 +58,7 @@ export default function TaskQuickAssignModal({
   };
 
   const onAssign = () => {
-    assignAll && checkUnassignedTaskForSameDate()
+    assignAll && checkUnassignedTaskForSameDate() && selectedWorker.value !== null
       ? onAssignTasksOnDate({
           task_id: task_id,
           date: due_date,

--- a/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
+++ b/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
@@ -56,7 +56,6 @@ export default function ManagementTasks({ history, match }) {
             key={task.task_id}
             onClick={() => history.push(`/tasks/${task.task_id}/read_only`)}
             style={{ marginBottom: '14px' }}
-            taskCardContents={taskCardContents}
             {...task}
           />
         ))}

--- a/packages/webapp/src/containers/Task/TaskCard/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCard/index.jsx
@@ -20,7 +20,6 @@ const TaskCard = ({
   onClick = null,
   selected,
   happiness,
-  taskCardContents,
   classes = { card: {} },
   ...props
 }) => {
@@ -83,7 +82,6 @@ const TaskCard = ({
           onAssignTask={onAssignTask}
           users={users}
           user={user}
-          taskCardContents={taskCardContents}
           dismissModal={() => setShowTaskAssignModal(false)}
         />
       )}
@@ -113,7 +111,6 @@ TaskCard.propTypes = {
   onClickCompleteOrDueDate: PropTypes.func,
   selected: PropTypes.bool,
   task_id: PropTypes.number,
-  taskCardContents: PropTypes.array,
 };
 
 export default TaskCard;

--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -152,7 +152,6 @@ export default function TaskPage({ history }) {
             key={task.task_id}
             onClick={() => history.push(`/tasks/${task.task_id}/read_only`)}
             style={{ marginBottom: '14px' }}
-            taskCardContents={taskCardContents}
             {...task}
           />
         ))


### PR DESCRIPTION
Per recent discussion on Ticket [LF-2323](https://lite-farm.atlassian.net/browse/LF-2323). 

There was issue in the task assign modal where it was relying on task card contents. This was causing an issue when the modal was being used from the read only view rather than from a task card. I have refactored the quick assign modal to grab the tasks from state instead. 

To test:
- Create a few tasks, and play around with assigning, unassigning, and assigning all unassigned tasks on date. Make sure there are no additional bugs I missed. 