### PR TITLE
Lf 2412 user should be able to enter in wages input to delimit dollars from cents

### DIFF
--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -193,6 +193,11 @@ export default Input;
 
 export const numberOnKeyDown = (e) => ['e', 'E', '+', '-'].includes(e.key) && e.preventDefault();
 export const integerOnKeyDown = (e) => /[^0-9]/.test(e.key) && e.preventDefault();
+export const validateWage = (e) => {
+  console.log(e.target.value);
+  // new RegExp('(^\d)(^\.?)(^[\b])').test(e.target.value) && e.preventDefault();
+  new RegExp('[^0-9]^.?').test(e.key) && e.preventDefault();
+};
 export const preventNumberScrolling = (e) => e.target.blur();
 
 export const getInputErrors = (errors, name) => {

--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -194,8 +194,15 @@ export default Input;
 export const numberOnKeyDown = (e) => ['e', 'E', '+', '-'].includes(e.key) && e.preventDefault();
 export const integerOnKeyDown = (e) => /[^0-9]/.test(e.key) && e.preventDefault();
 export const validateWage = (e) => {
-  console.log(e.target.value);
-  new RegExp('[^0-9]^.?').test(e.key) && e.preventDefault();
+  // 1. First character should be a number
+  // 2. Following characters can be either a number or a period
+  //    a. If there is a period in the field already, it can only be a number
+  //    b. If not, it can be either one
+  if (e.target.value.length == 0 || /\./.test(e.target.value)) {
+    !/[0-9]/.test(e.key) && e.preventDefault();
+  } else {
+    !/[0-9]|\./.test(e.key) && e.preventDefault();
+  }
 };
 export const preventNumberScrolling = (e) => e.target.blur();
 

--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -195,7 +195,6 @@ export const numberOnKeyDown = (e) => ['e', 'E', '+', '-'].includes(e.key) && e.
 export const integerOnKeyDown = (e) => /[^0-9]/.test(e.key) && e.preventDefault();
 export const validateWage = (e) => {
   console.log(e.target.value);
-  // new RegExp('(^\d)(^\.?)(^[\b])').test(e.target.value) && e.preventDefault();
   new RegExp('[^0-9]^.?').test(e.key) && e.preventDefault();
 };
 export const preventNumberScrolling = (e) => e.target.blur();

--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -1,6 +1,6 @@
 import Form from '../Form';
 import Button from '../Form/Button';
-import Input, { getInputErrors, integerOnKeyDown } from '../Form/Input';
+import Input, { getInputErrors, integerOnKeyDown, validateWage } from '../Form/Input';
 import React, { useEffect } from 'react';
 import { Title } from '../Typography';
 import PropTypes from 'prop-types';
@@ -142,7 +142,7 @@ export default function PureInviteUser({ onInvite, onGoBack, roleOptions = [] })
         label={t('INVITE_USER.WAGE')}
         step="0.01"
         type="number"
-        onKeyPress={integerOnKeyDown}
+        onKeyPress={validateWage}
         hookFormRegister={register(WAGE, { min: 0, valueAsNumber: true })}
         style={{ marginBottom: '24px' }}
         errors={errors[WAGE] && (errors[WAGE].message || t('INVITE_USER.WAGE_ERROR'))}


### PR DESCRIPTION
This PR allows users to input periods into the wage input in the 'invite user' page.

To test:

1. Begin the process to invite a new user
2. In the wage field, you should only be able to enter a single period. Additionally, periods cannot be the first character