### PR TITLE
LF-2330 skip crop plans when non-crop locations are selected (task creation flow)

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
@@ -26,6 +26,8 @@ const PureTaskCrops = ({
   isMulti = true,
   isRequired,
   defaultManagementPlanId,
+  history,
+  location
 }) => {
   const { t } = useTranslation();
 
@@ -50,6 +52,12 @@ const PureTaskCrops = ({
   };
 
   const locationIds = Object.keys(managementPlansByLocationIds);
+
+  if (!locationIds.length) {
+    history.replace('/add_task/task_locations', location.state);
+    onContinue();
+  }
+
   const filterManagementPlansByCropVarietyName = (mp) =>
     mp.crop_variety_name.toLowerCase().includes(filter?.toLowerCase()) ||
     mp.crop_common_name.toLowerCase().includes(filter?.toLowerCase());

--- a/packages/webapp/src/containers/Task/TaskCrops/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCrops/index.jsx
@@ -78,6 +78,8 @@ function TaskCrops({
         isRequired={isRequired}
         wildManagementPlanTiles={showWildCrops ? wildManagementPlanTiles : undefined}
         defaultManagementPlanId={location.state.management_plan_id ?? null}
+        history={history}
+        location={location}
       />
     </HookFormPersistProvider>
   );


### PR DESCRIPTION
**Description:**
- Ticket [LF-2330](https://lite-farm.atlassian.net/browse/LF-2330)
- When creating a task, if locations selected by the user are not referenced by active crop plans, bypass the "affect any plans" page

**To Test:**
1. Create one area with no crop plans associated with, one area with abandoned crop plans, and one area with active crop plans.
2. Create a task for the area with no crop plans. Upon selecting that location, you will be directed to the task details page rather than "affect any plans?" page.
3. Repeat for the area with abandoned crop plans (same result) and the area with active crop plans (should be redirected to "affect any plans?" page after location selection.
