### PR TITLE
Fixed language of invitation

### DIFF
--- a/packages/api/src/controllers/userController.js
+++ b/packages/api/src/controllers/userController.js
@@ -204,11 +204,7 @@ const userController = {
       await trx.commit();
       res.status(201).send({ ...user, ...userFarm });
       try {
-        const { language_preference } =
-          isUserAlreadyCreated ?? language
-            ? { language_preference: language }
-            : await userModel.query().findById(req.user.user_id);
-
+        const { language_preference } = isUserAlreadyCreated ?? { language_preference: language };
         await emailTokenModel.createTokenSendEmail(
           {
             email,


### PR DESCRIPTION
This fixes the language of invitations

To test:
1. Create 2 users on an existing farm
2. Create a new farm with one of those users
3. Invite the second user to the new farm and select for the language drop down a language that is different than the preferred language of the second user (e.g. if the second user's preferred language is spanish, select english)
4. The email to the second user should be in their preferred language, not the language selected from the drop down
5. Invite a new user who does not yet have an account
6. The language of this invitation should be the one selected in the drop down

It is worth noting that any emails that should be in french will be in english because there are no existing french translations of the emails