### PR TITLE
Fixed displaying crops in french

### DIFF
--- a/packages/webapp/public/locales/fr/crop.json
+++ b/packages/webapp/public/locales/fr/crop.json
@@ -36,7 +36,7 @@
   "BROAD_BEAN": "Fève",
   "BROAD_BEAN_DRY": "Fève sec, Gourgane",
   "BROAD_BEAN_HARVESTED_GREEN": "Gourgane vertes",
-  "BROCCOLI": "Brocoli"
+  "BROCCOLI": "Brocoli",
   "BROOM_MILLET": "Millet Commun",
   "BROOM_SORGHUM": "Sorgho Commun",
   "BRUSSELS_SPROUTS": "Chou de Bruxelles",


### PR DESCRIPTION
French crops were not displaying before because of a syntax error in the translation file. This PR fixes the file