### PR TITLE
Add utc offset to timed notification endpoints

### DIFF
--- a/packages/api/src/controllers/timeNotificationController.js
+++ b/packages/api/src/controllers/timeNotificationController.js
@@ -27,13 +27,17 @@ const timeNotificationController = {
    */
   async postWeeklyUnassignedTasks(req, res) {
     const { farm_id } = req.params;
+    const { utc_offset } = req.body;
     try {
       // All unassigned tasks at the farm associated with farm_id due this week that are
       // not completed or abandoned
       const tasksFromFarm = await getTasksForFarm(farm_id);
       const taskIds = tasksFromFarm.map(({ task_id }) => task_id);
 
-      const unassignedTasks = await TaskModel.getUnassignedTasksDueThiWeekFromIds(taskIds);
+      const unassignedTasks = await TaskModel.getUnassignedTasksDueThiWeekFromIds(
+        taskIds,
+        utc_offset,
+      );
       const farmManagementObjs = await UserFarmModel.getFarmManagementByFarmId(farm_id);
 
       const farmManagement = farmManagementObjs.map(

--- a/packages/api/src/models/taskModel.js
+++ b/packages/api/src/models/taskModel.js
@@ -237,15 +237,18 @@ class TaskModel extends BaseModel {
    * @async
    * @returns {Object} - Object {task_type_id, task_id}
    */
-  static async getUnassignedTasksDueThiWeekFromIds(taskIds) {
+  static async getUnassignedTasksDueThiWeekFromIds(taskIds, utcOffset) {
+    const startIntervalStr = `"${utcOffset} SECONDS"`;
+    const endIntervalStr = `"1 WEEK ${utcOffset} SECONDS"`;
     return await TaskModel.query().select('*').whereIn('task_id', taskIds).whereRaw(
       `
       task.assignee_user_id IS NULL
       AND task.complete_date IS NULL
       AND task.abandon_date IS NULL
-      AND task.due_date <= (now() + interval '1 week')::date
-      AND task.due_date >= now()::date
+      AND task.due_date <= ((NOW() AT TIME ZONE 'utc') + (?)::INTERVAL )::DATE
+      AND task.due_date >= ((NOW() AT TIME ZONE 'utc') + (?)::INTERVAL )::DATE
       `,
+      [endIntervalStr, startIntervalStr],
     );
   }
 

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -28,7 +28,7 @@ jest.mock('../src/middleware/acl/checkSchedulerJwt.js');
 describe('Time Based Notification Tests', () => {
   let farmOwner;
   let farm;
-  const utc_offset = 0;
+  const utc_offset = -14400;
 
   beforeEach(async () => {
     // Set up a farm with a farm owner
@@ -133,7 +133,11 @@ describe('Time Based Notification Tests', () => {
 
   function postDailyDueTodayTasks(data, callback) {
     const { farm_id } = data;
-    chai.request(server).post(`/time_notification/daily_due_today_tasks/${farm_id}`).end(callback);
+    chai
+      .request(server)
+      .post(`/time_notification/daily_due_today_tasks/${farm_id}`)
+      .send({ utc_offset })
+      .end(callback);
   }
 
   // Clean up after test finishes

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -28,6 +28,7 @@ jest.mock('../src/middleware/acl/checkSchedulerJwt.js');
 describe('Time Based Notification Tests', () => {
   let farmOwner;
   let farm;
+  const utc_offset = 0;
 
   beforeEach(async () => {
     // Set up a farm with a farm owner
@@ -126,6 +127,7 @@ describe('Time Based Notification Tests', () => {
     chai
       .request(server)
       .post(`/time_notification/weekly_unassigned_tasks/${farm_id}`)
+      .send({ utc_offset })
       .end(callback);
   }
 
@@ -163,7 +165,6 @@ describe('Time Based Notification Tests', () => {
       test('Farm Owners Should Receive Notification', async (done) => {
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).toContain(farmOwner.user_id);
           const notifications = await knex('notification_user')
             .join(
               'notification',
@@ -195,7 +196,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).toContain(farmManager.user_id);
           const notifications = await knex('notification_user')
             .join(
               'notification',
@@ -227,7 +227,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).toContain(extensionOfficer.user_id);
           const notifications = await knex('notification_user')
             .join(
               'notification',
@@ -259,7 +258,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).not.toContain(farmWorker.user_id);
           const notifications = await knex('notification_user').where({
             user_id: farmWorker.user_id,
             deleted: false,
@@ -282,7 +280,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).not.toContain(otherFarmManager.user_id);
           const notifications = await knex('notification_user').where({
             user_id: otherFarmManager.user_id,
             deleted: false,
@@ -296,7 +293,6 @@ describe('Time Based Notification Tests', () => {
       test('Not Sent When There Are No Unassigned Tasks', (done) => {
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(200);
-          // expect(res.body.unassignedTasks.length).toBe(0);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(0);
           done();
@@ -315,7 +311,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(200);
-          // expect(res.body.unassignedTasks.length).toBe(0);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(0);
           done();
@@ -330,7 +325,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(200);
-          // expect(res.body.unassignedTasks.length).toBe(0);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(0);
           done();
@@ -344,7 +338,6 @@ describe('Time Based Notification Tests', () => {
         });
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.unassignedTasks.length).toBe(1);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(1);
           done();


### PR DESCRIPTION
Added utc offsets to the request body of the timed notification endpoints.

NOTE: I did not add the utc offset where the requests are called in the actual job scheduler, since there is a range of timezone, so I wasn't sure if I should put the start or end.