### PR TITLE
F21 592: Fix: farm name character limit error handling

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -11,7 +11,8 @@
     "INVALID_FARM_LOCATION": "No country for this location",
     "LOCATING": "Locating...",
     "NO_ADDRESS": "No location found! Try latitude and longitude",
-    "TELL_US_ABOUT_YOUR_FARM": "Tell us about your farm"
+    "TELL_US_ABOUT_YOUR_FARM": "Tell us about your farm",
+    "FARM_NAME_ERROR": "Farm name character limit exceeded"
   },
   "ADD_PRODUCT": {
     "PRESS_ENTER": "Type and press enter to add...",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -11,7 +11,8 @@
     "INVALID_FARM_LOCATION": "Ningún país para esta ubicación",
     "LOCATING": "Localizando...",
     "NO_ADDRESS": "Ubicación no encontrada! Trate latitud y longitud",
-    "TELL_US_ABOUT_YOUR_FARM": "Cuéntenos sobre su finca"
+    "TELL_US_ABOUT_YOUR_FARM": "Cuéntenos sobre su finca",
+    "FARM_NAME_ERROR": "MISSING"
   },
   "ADD_PRODUCT": {
     "PRESS_ENTER": "Escriba y presione enter para agregar...",
@@ -698,8 +699,8 @@
         "PREVIEW": "Indisponible",
         "TITLE": "Había un problema",
         "BODY": "LiteFarm genera información sobre la biodiversidad basada en varias fuentes y no pudo hacerlo en este momento. Vuelva a intentarlo después de {{minutos}} minutos."
-    }
-  }, 
+      }
+    },
     "CURRENT": "Actual",
     "INFO": "Las reflexiones son caracteristicas de datos de que esta pasando en su granja. Mientras mas data proveas en la aplicacion mas reflexiones pueden ser generadas. Mira las reflexiones individuales para mas informacion.",
     "LABOUR_HAPPINESS": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -11,7 +11,8 @@
     "INVALID_FARM_LOCATION": "Aucun pays pour cet emplacement",
     "LOCATING": "Localisation...",
     "NO_ADDRESS": "Emplacement entré n'a pas été trouvé! Veuillez essayer d'entrer la longitude et la latitude",
-    "TELL_US_ABOUT_YOUR_FARM": "Parlez-nous de votre ferme"
+    "TELL_US_ABOUT_YOUR_FARM": "Parlez-nous de votre ferme",
+    "FARM_NAME_ERROR": "MISSING"
   },
   "ADD_PRODUCT": {
     "PRESS_ENTER": "Tapez et appuyez sur Entrée pour ajouter...",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -11,7 +11,8 @@
     "INVALID_FARM_LOCATION": "Nenhum país para esta localização",
     "LOCATING": "Localizando...",
     "NO_ADDRESS": "Localização não encontrada. Tente inserir latitue e longitude",
-    "TELL_US_ABOUT_YOUR_FARM": "Conte-nos sobre seu sítio/fazenda"
+    "TELL_US_ABOUT_YOUR_FARM": "Conte-nos sobre seu sítio/fazenda",
+    "FARM_NAME_ERROR": "MISSING"
   },
   "ADD_PRODUCT": {
     "PRESS_ENTER": "Digite e pressione enter para adicionar...",

--- a/packages/webapp/src/containers/AddFarm/index.jsx
+++ b/packages/webapp/src/containers/AddFarm/index.jsx
@@ -71,11 +71,19 @@ const AddFarm = () => {
     errors[COUNTRY]?.message ||
     errorMessage[errors[ADDRESS]?.type];
 
+  const showFarmNameCharacterLimitExceededError = () => {
+    setError(FARMNAME, {
+      type: 'manual',
+      message: t('ADD_FARM.FARM_NAME_ERROR'),
+    });
+  };
+
   const onSubmit = (data) => {
     const farmInfo = {
       ...data,
       gridPoints,
       farm_id: farm ? farm.farm_id : undefined,
+      showFarmNameCharacterLimitExceededError: showFarmNameCharacterLimitExceededError,
     };
     farm.farm_id ? dispatch(patchFarm(farmInfo)) : dispatch(postFarm(farmInfo));
   };

--- a/packages/webapp/src/containers/AddFarm/saga.js
+++ b/packages/webapp/src/containers/AddFarm/saga.js
@@ -117,7 +117,6 @@ export function* patchFarmSaga({ payload: { showFarmNameCharacterLimitExceededEr
       e?.response?.status === 400 &&
       typeof e?.response?.data?.error === 'string' &&
       e?.response?.data?.error?.includes('farm_name:');
-
     if (isFarmNameError) {
       showFarmNameCharacterLimitExceededError();
     } else {


### PR DESCRIPTION
To Test:

1. Go to create a farm page in a frame name input field fill in characters more than 255.
2. check the error message.

"Scenario 1" - For the first time, it will call the post API of addFarm. 

3. Therefore, fill in a valid farm name and go to the next form page.
4. Now, come back to the same page and add a farm name having more than 255 characters.

"Scenario 2" - This time it will show the error from the update/patch API of the farm. 

match the error message from both scenarios.  

For more details: 
https://lite-farm.atlassian.net/browse/F21-592