### PR TITLE
fix: adding one day later flag to timed notification endpoints

### DIFF
--- a/packages/api/src/controllers/timeNotificationController.js
+++ b/packages/api/src/controllers/timeNotificationController.js
@@ -27,13 +27,18 @@ const timeNotificationController = {
    */
   async postWeeklyUnassignedTasks(req, res) {
     const { farm_id } = req.params;
+    const { is_day_later_than_utc } = req.body;
+
     try {
       // All unassigned tasks at the farm associated with farm_id due this week that are
       // not completed or abandoned
       const tasksFromFarm = await getTasksForFarm(farm_id);
       const taskIds = tasksFromFarm.map(({ task_id }) => task_id);
 
-      const unassignedTasks = await TaskModel.getUnassignedTasksDueThiWeekFromIds(taskIds);
+      const unassignedTasks = await TaskModel.getUnassignedTasksDueThiWeekFromIds(
+        taskIds,
+        is_day_later_than_utc,
+      );
       const farmManagementObjs = await UserFarmModel.getFarmManagementByFarmId(farm_id);
 
       const farmManagement = farmManagementObjs.map(
@@ -62,6 +67,7 @@ const timeNotificationController = {
    */
   async postDailyDueTodayTasks(req, res) {
     const { farm_id } = req.params;
+    const { is_day_later_than_utc } = req.body;
     try {
       let notificationsSent = 0;
       const activeUsers = await UserFarmModel.getActiveUsersFromFarmId(farm_id);
@@ -72,6 +78,7 @@ const timeNotificationController = {
         const hasTasksDueToday = await TaskModel.hasTasksDueTodayForUserFromFarm(
           user_id,
           taskIdsFromFarm,
+          is_day_later_than_utc,
         );
 
         if (hasTasksDueToday) {

--- a/packages/api/src/controllers/timeNotificationController.js
+++ b/packages/api/src/controllers/timeNotificationController.js
@@ -27,7 +27,7 @@ const timeNotificationController = {
    */
   async postWeeklyUnassignedTasks(req, res) {
     const { farm_id } = req.params;
-    const { is_day_later_than_utc } = req.body;
+    const { isDayLaterThanUtc } = req.body;
 
     try {
       // All unassigned tasks at the farm associated with farm_id due this week that are
@@ -35,9 +35,9 @@ const timeNotificationController = {
       const tasksFromFarm = await getTasksForFarm(farm_id);
       const taskIds = tasksFromFarm.map(({ task_id }) => task_id);
 
-      const unassignedTasks = await TaskModel.getUnassignedTasksDueThiWeekFromIds(
+      const unassignedTasks = await TaskModel.getUnassignedTasksDueThisWeekFromIds(
         taskIds,
-        is_day_later_than_utc,
+        isDayLaterThanUtc,
       );
       const farmManagementObjs = await UserFarmModel.getFarmManagementByFarmId(farm_id);
 
@@ -67,7 +67,7 @@ const timeNotificationController = {
    */
   async postDailyDueTodayTasks(req, res) {
     const { farm_id } = req.params;
-    const { is_day_later_than_utc } = req.body;
+    const { isDayLaterThanUtc } = req.body;
     try {
       let notificationsSent = 0;
       const activeUsers = await UserFarmModel.getActiveUsersFromFarmId(farm_id);
@@ -78,7 +78,7 @@ const timeNotificationController = {
         const hasTasksDueToday = await TaskModel.hasTasksDueTodayForUserFromFarm(
           user_id,
           taskIdsFromFarm,
-          is_day_later_than_utc,
+          isDayLaterThanUtc,
         );
 
         if (hasTasksDueToday) {

--- a/packages/api/src/jobs/notifications/index.js
+++ b/packages/api/src/jobs/notifications/index.js
@@ -84,8 +84,8 @@ const sendOnSchedule = (queueConfig) => {
           for (const farmId of res.data) {
             // ... send daily 6am notifications ...
             apiQueue.add(
-              { farmId, type: 'Daily', reqConfig, is_day_later_than_utc: timeZone >= 7 },
-              { jobId: `${farmId}-Daily-${utcDay}-${utcHour}` },
+              { farmId, type: 'Daily', reqConfig, isDayLaterThanUtc: timeZone >= 7 },
+              { jobId: `Daily-${utcDay}-${utcHour}-${farmId}` },
             );
 
             // ... and weekly 6am notifications if appropriate.
@@ -94,8 +94,8 @@ const sendOnSchedule = (queueConfig) => {
               (utcDay === WEEKLY_NOTIFICATION_DAY_EARLIER_ZONES && timeZone >= 7)
             ) {
               apiQueue.add(
-                { farmId, type: 'Weekly', reqConfig, is_day_later_than_utc: timeZone >= 7 },
-                { jobId: `${farmId}-Weekly-${utcDay}-${utcHour}` },
+                { farmId, type: 'Weekly', reqConfig, isDayLaterThanUtc: timeZone >= 7 },
+                { jobId: `Weekly-${utcDay}-${utcHour}-${farmId}` },
               );
             }
           }
@@ -115,13 +115,13 @@ const sendOnSchedule = (queueConfig) => {
 
   // Process a job for each API request.
   apiQueue.process((job, done) => {
-    const { type, farmId, reqConfig, is_day_later_than_utc } = job.data;
+    const { type, farmId, reqConfig, isDayLaterThanUtc } = job.data;
     const urls = {
       Daily: 'time_notification/daily_due_today_tasks',
       Weekly: 'time_notification/weekly_unassigned_tasks',
     };
     axios
-      .post(`${apiUrl}/${urls[type]}/${farmId}`, { is_day_later_than_utc }, reqConfig)
+      .post(`${apiUrl}/${urls[type]}/${farmId}`, { isDayLaterThanUtc }, reqConfig)
       .then(function (res) {
         if ([200, 201].includes(res.status)) {
           console.log(

--- a/packages/api/src/models/taskModel.js
+++ b/packages/api/src/models/taskModel.js
@@ -237,15 +237,17 @@ class TaskModel extends BaseModel {
    * @async
    * @returns {Object} - Object {task_type_id, task_id}
    */
-  static async getUnassignedTasksDueThiWeekFromIds(taskIds) {
+  static async getUnassignedTasksDueThiWeekFromIds(taskIds, isDayLaterThanUTC = false) {
+    const dayLaterInterval = isDayLaterThanUTC ? '"1 day"' : '"0 days"';
     return await TaskModel.query().select('*').whereIn('task_id', taskIds).whereRaw(
       `
       task.assignee_user_id IS NULL
       AND task.complete_date IS NULL
       AND task.abandon_date IS NULL
-      AND task.due_date <= (now() + interval '1 week')::date
-      AND task.due_date >= now()::date
+      AND task.due_date <= (now() + ('1 week')::interval + (?)::interval)::date
+      AND task.due_date >= (now() + (?)::interval)::date
       `,
+      [dayLaterInterval, dayLaterInterval],
     );
   }
 
@@ -306,13 +308,15 @@ class TaskModel extends BaseModel {
    * @async
    * @returns {boolean} true if the user has tasks due today or false if not
    */
-  static async hasTasksDueTodayForUserFromFarm(userId, taskIds) {
+  static async hasTasksDueTodayForUserFromFarm(userId, taskIds, isDayLaterThanUTC = false) {
+    const today = new Date();
+    if (isDayLaterThanUTC) today.setDate(today.getDate() + 1);
     const tasksDueToday = await TaskModel.query()
       .select('*')
       .whereIn('task_id', taskIds)
       .whereNotDeleted()
       .andWhere('task.assignee_user_id', userId)
-      .andWhere('task.due_date', new Date());
+      .andWhere('task.due_date', today);
 
     return tasksDueToday && tasksDueToday.length;
   }

--- a/packages/api/src/models/taskModel.js
+++ b/packages/api/src/models/taskModel.js
@@ -237,7 +237,7 @@ class TaskModel extends BaseModel {
    * @async
    * @returns {Object} - Object {task_type_id, task_id}
    */
-  static async getUnassignedTasksDueThiWeekFromIds(taskIds, isDayLaterThanUTC = false) {
+  static async getUnassignedTasksDueThisWeekFromIds(taskIds, isDayLaterThanUTC = false) {
     const dayLaterInterval = isDayLaterThanUTC ? '"1 day"' : '"0 days"';
     return await TaskModel.query().select('*').whereIn('task_id', taskIds).whereRaw(
       `

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -28,11 +28,16 @@ jest.mock('../src/middleware/acl/checkSchedulerJwt.js');
 describe('Time Based Notification Tests', () => {
   let farmOwner;
   let farm;
+  let isDayLaterThanUTC;
+  let fakeToday;
 
   beforeEach(async () => {
     // Set up a farm with a farm owner
     [farmOwner] = await mocks.usersFactory();
     [farm] = await mocks.farmFactory();
+    isDayLaterThanUTC = faker.datatype.boolean();
+    fakeToday = new Date();
+    if (isDayLaterThanUTC) fakeToday.setDate(fakeToday.getDate() + 1);
 
     await mocks.userFarmFactory(
       {
@@ -126,12 +131,17 @@ describe('Time Based Notification Tests', () => {
     chai
       .request(server)
       .post(`/time_notification/weekly_unassigned_tasks/${farm_id}`)
+      .send({ is_day_later_than_utc: isDayLaterThanUTC })
       .end(callback);
   }
 
   function postDailyDueTodayTasks(data, callback) {
     const { farm_id } = data;
-    chai.request(server).post(`/time_notification/daily_due_today_tasks/${farm_id}`).end(callback);
+    chai
+      .request(server)
+      .post(`/time_notification/daily_due_today_tasks/${farm_id}`)
+      .send({ is_day_later_than_utc: isDayLaterThanUTC })
+      .end(callback);
   }
 
   // Clean up after test finishes
@@ -155,7 +165,7 @@ describe('Time Based Notification Tests', () => {
       beforeEach(async () => {
         // Set up such that there are unassigned tasks due within the next week
         await createFullTask({
-          due_date: faker.date.soon(6).toISOString().split('T')[0],
+          due_date: faker.date.soon(6, fakeToday).toISOString().split('T')[0],
           assignee_user_id: null,
         });
       });
@@ -163,7 +173,6 @@ describe('Time Based Notification Tests', () => {
       test('Farm Owners Should Receive Notification', async (done) => {
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).toContain(farmOwner.user_id);
           const notifications = await knex('notification_user')
             .join(
               'notification',
@@ -195,7 +204,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).toContain(farmManager.user_id);
           const notifications = await knex('notification_user')
             .join(
               'notification',
@@ -227,7 +235,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).toContain(extensionOfficer.user_id);
           const notifications = await knex('notification_user')
             .join(
               'notification',
@@ -259,7 +266,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).not.toContain(farmWorker.user_id);
           const notifications = await knex('notification_user').where({
             user_id: farmWorker.user_id,
             deleted: false,
@@ -282,7 +288,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.farmManagement).not.toContain(otherFarmManager.user_id);
           const notifications = await knex('notification_user').where({
             user_id: otherFarmManager.user_id,
             deleted: false,
@@ -296,7 +301,6 @@ describe('Time Based Notification Tests', () => {
       test('Not Sent When There Are No Unassigned Tasks', (done) => {
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(200);
-          // expect(res.body.unassignedTasks.length).toBe(0);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(0);
           done();
@@ -304,7 +308,7 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('Not Sent When The Only Unassigned Tasks Are Due Later Then 7 Days', async (done) => {
-        const laterThanOneWeekFromNow = new Date();
+        const laterThanOneWeekFromNow = fakeToday;
         laterThanOneWeekFromNow.setDate(laterThanOneWeekFromNow.getDate() + 8);
         const laterThanOneWeekFromNowStr = laterThanOneWeekFromNow.toISOString().split('T')[0];
 
@@ -315,7 +319,6 @@ describe('Time Based Notification Tests', () => {
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(200);
-          // expect(res.body.unassignedTasks.length).toBe(0);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(0);
           done();
@@ -324,13 +327,12 @@ describe('Time Based Notification Tests', () => {
 
       test('Not Sent When The Only Tasks Due This Week Are Assigned', async (done) => {
         await createFullTask({
-          due_date: faker.date.soon(6).toISOString().split('T')[0],
+          due_date: faker.date.soon(6, fakeToday).toISOString().split('T')[0],
           assignee_user_id: farmOwner.user_id,
         });
 
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(200);
-          // expect(res.body.unassignedTasks.length).toBe(0);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(0);
           done();
@@ -339,12 +341,11 @@ describe('Time Based Notification Tests', () => {
 
       test('Sent When There Are Unassigned Tasks Due Within The Next 7 days', async (done) => {
         await createFullTask({
-          due_date: faker.date.soon(6).toISOString().split('T')[0],
+          due_date: faker.date.soon(6, fakeToday).toISOString().split('T')[0],
           assignee_user_id: null,
         });
         postWeeklyUnassignedTasksRequest({ farm_id: farm.farm_id }, async (err, res) => {
           expect(res.status).toBe(201);
-          // expect(res.body.unassignedTasks.length).toBe(1);
           const notifications = await knex('notification').where({ deleted: false });
           expect(notifications.length).toBe(1);
           done();
@@ -370,7 +371,7 @@ describe('Time Based Notification Tests', () => {
     describe('Notification sent tests', () => {
       test('Farm worker should receive a due today notification', async (done) => {
         await createFullTask({
-          due_date: new Date().toISOString().split('T')[0],
+          due_date: fakeToday.toISOString().split('T')[0],
           assignee_user_id: farmWorker.user_id,
         });
 
@@ -390,7 +391,7 @@ describe('Time Based Notification Tests', () => {
 
       test('Farm owner should receive a due today notification', async (done) => {
         await createFullTask({
-          due_date: new Date().toISOString().split('T')[0],
+          due_date: fakeToday.toISOString().split('T')[0],
           assignee_user_id: farmOwner.user_id,
         });
 
@@ -410,12 +411,12 @@ describe('Time Based Notification Tests', () => {
 
       test('Multiple farm workers in the same farm should receive a due today notification', async (done) => {
         await createFullTask({
-          due_date: new Date().toISOString().split('T')[0],
+          due_date: fakeToday.toISOString().split('T')[0],
           assignee_user_id: farmOwner.user_id,
         });
 
         await createFullTask({
-          due_date: new Date().toISOString().split('T')[0],
+          due_date: fakeToday.toISOString().split('T')[0],
           assignee_user_id: farmWorker.user_id,
         });
 
@@ -438,7 +439,7 @@ describe('Time Based Notification Tests', () => {
       test('Notification not sent if no active workers in a farm', async (done) => {
         const [farm2] = await mocks.farmFactory();
         await createFullTask({
-          due_date: faker.date.soon(2).toISOString().split('T')[0],
+          due_date: faker.date.soon(2, fakeToday).toISOString().split('T')[0],
           assignee_user_id: farmWorker.user_id,
         });
 
@@ -464,7 +465,7 @@ describe('Time Based Notification Tests', () => {
         );
 
         await createFullTask({
-          due_date: new Date().toISOString().split('T')[0],
+          due_date: fakeToday.toISOString().split('T')[0],
           assignee_user_id: farmWorker.user_id,
         });
 
@@ -488,7 +489,7 @@ describe('Time Based Notification Tests', () => {
 
       test('Farm workers should not receive a due today notification of unassigned tasks', async (done) => {
         await createFullTask({
-          due_date: new Date().toISOString().split('T')[0],
+          due_date: fakeToday.toISOString().split('T')[0],
           assignee_user_id: null,
         });
 

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -28,16 +28,16 @@ jest.mock('../src/middleware/acl/checkSchedulerJwt.js');
 describe('Time Based Notification Tests', () => {
   let farmOwner;
   let farm;
-  let isDayLaterThanUTC;
+  let isDayLaterThanUtc;
   let fakeToday;
 
   beforeEach(async () => {
     // Set up a farm with a farm owner
     [farmOwner] = await mocks.usersFactory();
     [farm] = await mocks.farmFactory();
-    isDayLaterThanUTC = faker.datatype.boolean();
+    isDayLaterThanUtc = faker.datatype.boolean();
     fakeToday = new Date();
-    if (isDayLaterThanUTC) fakeToday.setDate(fakeToday.getDate() + 1);
+    if (isDayLaterThanUtc) fakeToday.setDate(fakeToday.getDate() + 1);
 
     await mocks.userFarmFactory(
       {
@@ -131,7 +131,7 @@ describe('Time Based Notification Tests', () => {
     chai
       .request(server)
       .post(`/time_notification/weekly_unassigned_tasks/${farm_id}`)
-      .send({ is_day_later_than_utc: isDayLaterThanUTC })
+      .send({ isDayLaterThanUtc })
       .end(callback);
   }
 
@@ -140,7 +140,7 @@ describe('Time Based Notification Tests', () => {
     chai
       .request(server)
       .post(`/time_notification/daily_due_today_tasks/${farm_id}`)
-      .send({ is_day_later_than_utc: isDayLaterThanUTC })
+      .send({ isDayLaterThanUtc })
       .end(callback);
   }
 


### PR DESCRIPTION
Related to [F21-578](https://lite-farm.atlassian.net/browse/F21-578) - Notification driver/scheduler.

Added a flag to the notification endpoints to indicate whether "today" should be thought of as a day later than UTC time. 

To test:
- run tests in "timeNotification.test.js"