### PR TITLE
F21 608 creation flow for location (barn, greenhouse, field, farm boundary, potentially others ) loops 

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/BarnDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/BarnDetailForm/saga.js
@@ -36,7 +36,8 @@ export function* postBarnLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.BARN'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/BarnDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/BarnDetailForm/saga.js
@@ -36,7 +36,6 @@ export function* postBarnLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.BARN'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/CeremonialAreaDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/CeremonialAreaDetailForm/saga.js
@@ -36,7 +36,6 @@ export function* postCeremonialLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.CA'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/CeremonialAreaDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/CeremonialAreaDetailForm/saga.js
@@ -36,7 +36,8 @@ export function* postCeremonialLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.CA'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/FarmSiteBoundaryDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/FarmSiteBoundaryDetailForm/saga.js
@@ -36,7 +36,7 @@ export function* postFarmSiteBoundaryLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.FSB'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/FieldDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/FieldDetailForm/saga.js
@@ -36,7 +36,8 @@ export function* postFieldLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.FIELD'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/FieldDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/FieldDetailForm/saga.js
@@ -36,7 +36,6 @@ export function* postFieldLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.FIELD'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/GardenDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/GardenDetailForm/saga.js
@@ -35,7 +35,8 @@ export function* postGardenLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.GARDEN'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/GardenDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/GardenDetailForm/saga.js
@@ -35,7 +35,6 @@ export function* postGardenLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.GARDEN'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/GreenhouseDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/GreenhouseDetailForm/saga.js
@@ -39,7 +39,6 @@ export function* postGreenhouseLocationSaga({ payload: data }) {
       ]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/GreenhouseDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/GreenhouseDetailForm/saga.js
@@ -39,7 +39,8 @@ export function* postGreenhouseLocationSaga({ payload: data }) {
       ]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/NaturalAreaDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/NaturalAreaDetailForm/saga.js
@@ -36,7 +36,8 @@ export function* postNaturalAreaLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.NA'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/NaturalAreaDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/NaturalAreaDetailForm/saga.js
@@ -36,7 +36,6 @@ export function* postNaturalAreaLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.NA'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/ResidenceDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/ResidenceDetailForm/saga.js
@@ -39,7 +39,6 @@ export function* postResidenceLocationSaga({ payload: data }) {
       ]),
     );
     yield put(canShowSuccessHeader(true));
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/ResidenceDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/ResidenceDetailForm/saga.js
@@ -39,7 +39,8 @@ export function* postResidenceLocationSaga({ payload: data }) {
       ]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/SurfaceWaterDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/SurfaceWaterDetailForm/saga.js
@@ -39,7 +39,8 @@ export function* postSurfaceWaterLocationSaga({ payload: data }) {
     );
     yield put(canShowSuccessHeader(true));
 
-    history.back();
+    // history.back();
+    history.push({ pathname: '/map' });
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/AreaDetails/SurfaceWaterDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/AreaDetails/SurfaceWaterDetailForm/saga.js
@@ -39,7 +39,6 @@ export function* postSurfaceWaterLocationSaga({ payload: data }) {
     );
     yield put(canShowSuccessHeader(true));
 
-    // history.back();
     history.push({ pathname: '/map' });
   } catch (e) {
     history.push(


### PR DESCRIPTION
This fix addresses an unwanted loop in the location creation flow

To test:
1. Log in to system
2. Go to “my farm” > “farm map”
3. Click “+”
4. Select a type
5. Draw shape
6. Click redraw and redraw
8. Click “Confirm”
9. Click “<“
10. Click “Confirm” again
11. Enter all required attributes for barn and click “Save”

After all of that, you should arrive at your farm map with the new addition.

**Note:** This issue was originally discovered on Barns and Greenhouses. I noticed the same issue in other area types and I extended the fix to them as well.