### PR TITLE
Crop plan loop bug fix

### DIFF
--- a/packages/webapp/src/components/Crop/Detail.jsx
+++ b/packages/webapp/src/components/Crop/Detail.jsx
@@ -54,7 +54,7 @@ function PureCropDetail({
       }
     >
       <CropHeader
-        onBackClick={onBack}
+        onBackClick={() => history.back()}
         crop_translation_key={variety.crop_translation_key}
         crop_variety_name={variety.crop_variety_name}
         crop_variety_photo_url={variety.crop_variety_photo_url}

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -92,7 +92,7 @@ export default function PureManagementDetail({
       }
     >
       <CropHeader
-        onBackClick={onBack}
+        onBackClick={() => history.back()}
         crop_translation_key={variety.crop_translation_key}
         crop_variety_name={variety.crop_variety_name}
         crop_variety_photo_url={variety.crop_variety_photo_url}

--- a/packages/webapp/src/components/RouterTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/index.jsx
@@ -11,7 +11,7 @@ export default function RouterTab({ tabs, history, classes }) {
         <Semibold
           key={index}
           className={clsx(styles.pill, isSelected(tab.path) && styles.selected)}
-          onClick={() => !isSelected(tab.path) && history.push(tab.path)}
+          onClick={() => !isSelected(tab.path) && history.replace(tab.path)}
           id={tab.label + index}
         >
           {tab.label}


### PR DESCRIPTION
[Jira Ticket](https://lite-farm.atlassian.net/jira/software/c/projects/F21/boards/3?modal=detail&selectedIssue=F21-585)

Access the management plans page via the crop catalogue or the farm map and select a crop variety and then a plan. Go to the details page of the crop plan and press the back button to go back to the page you accesses the crop plans from.  If you accessed the crop plans from the farm map you should return to the farm map, similar behaviour should show when accesses crop plans via the crop catalogue. Also there should not be any looping behaviour when pressing the back buttons.