### PR TITLE
F21-582/switch farms reset notification reducer state

### DIFF
--- a/packages/webapp/src/containers/notificationSlice.js
+++ b/packages/webapp/src/containers/notificationSlice.js
@@ -43,10 +43,11 @@ export const { onLoadingNotificationStart, onLoadingNotificationFail, getNotific
   notificationSlice.actions;
 export default notificationSlice.reducer;
 
-export const notificationReducerSelector = (state) => state.entitiesReducer[notificationSlice.name];
+export const notificationReducerSelector = (state) =>
+  state.farmStateReducer[notificationSlice.name];
 
 const notificationSelectors = notificationAdapter.getSelectors(
-  (state) => state.entitiesReducer[notificationSlice.name],
+  (state) => state.farmStateReducer[notificationSlice.name],
 );
 
 export const notificationEntitiesSelector = notificationSelectors.selectEntities;

--- a/packages/webapp/src/store/actionTypes.js
+++ b/packages/webapp/src/store/actionTypes.js
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const ActionTypes = {
+  SWITCH_FARMS: 'chooseFarmFlowReducer/startSwitchFarmModal',
+};

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -75,6 +75,7 @@ import certificationReducer from '../containers/OrganicCertifierSurvey/certifica
 import certifierReducer from '../containers/OrganicCertifierSurvey/certifierSlice';
 import snackbarReducer from '../containers/Snackbar/snackbarSlice';
 import appSettingReducer from '../containers/appSettingSlice';
+import { ActionTypes } from './actionTypes';
 // all the initial state for the forms
 const initialFarmState = {
   farm_name: '',
@@ -152,7 +153,6 @@ const entitiesReducer = combineReducers({
   cropVarietyReducer,
   weatherReducer,
   alertReducer,
-  notificationReducer,
   barnReducer,
   ceremonialReducer,
   farmSiteBoundaryReducer,
@@ -191,6 +191,10 @@ const entitiesReducer = combineReducers({
   productReducer,
 });
 
+const farmStateReducer = combineReducers({
+  notificationReducer,
+});
+
 const persistedStateReducer = combineReducers({
   userLogReducer,
   chooseFarmFlowReducer,
@@ -222,6 +226,7 @@ const appReducer = combineReducers({
     'profileForms',
   ),
   entitiesReducer,
+  farmStateReducer,
   persistedStateReducer,
   tempStateReducer,
   baseReducer,
@@ -230,6 +235,11 @@ const appReducer = combineReducers({
 });
 
 const rootReducer = (state, action) => {
+  if (state && action.type === ActionTypes.SWITCH_FARMS) {
+    // selectively only reset farmStateReducer state when switching farms
+    const { farmStateReducer, ...otherReducers } = state;
+    state = otherReducers;
+  }
   if (action.type === PURGE) {
     // clear redux state
     state = undefined;


### PR DESCRIPTION
Ticket [F21-582](https://lite-farm.atlassian.net/browse/F21-582) and [F21-583](https://lite-farm.atlassian.net/browse/F21-583)

**Description:**
This PR fixes the bug where a user was seeing notifications from multiple farms on notification center when switching farms.
When a user switches farms, the notification reducer state will be reseted. [Selective reset redux state](https://webdev99.com/resetting-redux-state-with-a-root-reducer-completely-selectively/)

**To Test:**
1. You need a user with multiple farms (create one or use the one you have if you already have one).
2. Please either clear site data or log out before you test this out.
3. Log into the user's account and select one of the farms.
4. Create a notification for yourself (by assigning a task, etc.).
5. You should see the notification in the notification center.
6. Now, switch to a different farm.
7. Check the notification center and you should not be able to see the notification from another farm (step 5).

As discussed in the meeting, this PR will also solve [F21-583](https://lite-farm.atlassian.net/browse/F21-583). Users will still be able to access tasks from another farm since they have access to those tasks (by manually typing in the url) but the application's UI will not give any ways for them to navigate as such.