### PR TITLE
F21-600 iphone landing page not detecting french

### DIFF
--- a/packages/webapp/src/locales/i18n.js
+++ b/packages/webapp/src/locales/i18n.js
@@ -15,6 +15,7 @@ i18n
     locales: ['en', 'pt', 'es', 'fr'],
     debug: false,
     detection: {
+      order: ['localStorage', 'navigator', 'querystring'],
       lookupLocalStorage: 'litefarm_lang',
     },
 


### PR DESCRIPTION
Ticket: [F21-600](https://lite-farm.atlassian.net/browse/F21-600)

Fixed issue where landing page was not detecting french on iOS.

To test (If you have an iPhone):
- Set Up [Ngrok](https://ngrok.com/signup)
- After running both the backend and frontend servers, run `ngrok http 3000`
- Switch phone language to French (Canada)
- Set default language in Chrome to French (Canada)
- Go to ngrok tunnel link
- See if the landing page is french