### PR TITLE
text overflow on crop type varietal hybrid view

### DIFF
--- a/packages/webapp/src/components/Crop/CropHeader.jsx
+++ b/packages/webapp/src/components/Crop/CropHeader.jsx
@@ -15,7 +15,7 @@ function CropHeader({
   return (
     <div className={styles.headerContainer}>
       <div className={styles.headerTitleContainer} onClick={onBackClick}>
-        <Back style={{ verticalAlign: 'text-bottom' }} />
+        <Back style={{ verticalAlign: 'text-bottom', marginBottom: '20px' }} />
         <Title className={styles.headerTitle}>{t(`crop:${crop_translation_key}`)}</Title>
       </div>
       <div className={styles.headerAttributesContainer}>

--- a/packages/webapp/src/components/Crop/styles.module.scss
+++ b/packages/webapp/src/components/Crop/styles.module.scss
@@ -7,19 +7,33 @@
   cursor: pointer;
 }
 
+@media only screen and (max-width: 650px) {
+  .headerTitle {
+    width: 55vw; 
+  }
+}
+
+@media only screen and (max-width: 450px) {
+  .headerTitle {
+    width: 40vw; 
+  }
+}
+
 .headerTitle {
   color: var(--teal900);
   font-weight: 600;
   font-size: 24px;
   line-height: 32px;
   display: inline-block;
-  margin-bottom: 14px
+  margin-bottom: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
 .headerTitleContainer {
   margin-top: 15px;
   padding-left: 25px;
-  white-space: nowrap;
-  overflow: hidden;
 }
 
 .headerAttributesContainer {

--- a/packages/webapp/src/components/Crop/styles.module.scss
+++ b/packages/webapp/src/components/Crop/styles.module.scss
@@ -18,6 +18,8 @@
 .headerTitleContainer {
   margin-top: 15px;
   padding-left: 25px;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .headerAttributesContainer {


### PR DESCRIPTION
[Jira Ticket](https://lite-farm.atlassian.net/jira/software/c/projects/F21/boards/3?modal=detail&selectedIssue=F21-599)
Set the litefarm application to responsive view on dev tools
Select a crop variety with a large name (I used Big Leaf Mahogany (Mogno brasileiro) for testing purposes)

Decrease the width of the view and the large name should hide behind the picture instead of it shifting downwards and resizing the picture on the right

