### PR TITLE
F21 587 non usd denominated farms show hardcoded throughout the finances section

### DIFF
--- a/packages/webapp/src/components/Finances/FinanceGroup/GroupItem/index.jsx
+++ b/packages/webapp/src/components/Finances/FinanceGroup/GroupItem/index.jsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { BsChevronRight } from 'react-icons/bs';
 import { Text } from '../../../Typography';
 import { ReactComponent as CalendarIcon } from '../../../../assets/images/managementPlans/calendar.svg';
+import grabCurrencySymbol from '../../../../util/grabCurrencySymbol';
 
 const FinanceItem = ({ title, subtitle, amount, isPlan, onClickForward }) => {
   return (
@@ -22,7 +23,7 @@ const FinanceItem = ({ title, subtitle, amount, isPlan, onClickForward }) => {
           </div>
         )}
       </div>
-      <Text className={styles.gridItem}>{`$${amount.toFixed(2)}`}</Text>
+      <Text className={styles.gridItem}>{`${grabCurrencySymbol()}${amount.toFixed(2)}`}</Text>
       {onClickForward && (
         <BsChevronRight
           className={clsx(styles.itemChevron, styles.rightChevron, styles.gridItem)}

--- a/packages/webapp/src/components/Finances/FinanceGroup/Header/index.jsx
+++ b/packages/webapp/src/components/Finances/FinanceGroup/Header/index.jsx
@@ -4,6 +4,7 @@ import styles from '../styles.module.scss';
 import clsx from 'clsx';
 import { BsChevronDown, BsChevronRight } from 'react-icons/bs';
 import { Semibold, Text } from '../../../Typography';
+import grabCurrencySymbol from '../../../../util/grabCurrencySymbol';
 
 const FinanceGroupHeader = ({
   title,
@@ -23,7 +24,9 @@ const FinanceGroupHeader = ({
         <Semibold sm>{title}</Semibold>
         {subtitle && <div className={clsx(styles.subtitle)}>{subtitle}</div>}
       </div>
-      <Text className={styles.gridItem}>{`$${currencyAmount.toFixed(2)}`}</Text>
+      <Text className={styles.gridItem}>{`${grabCurrencySymbol()}${currencyAmount.toFixed(
+        2,
+      )}`}</Text>
       {isDropDown ? (
         <BsChevronDown
           className={clsx(styles.headerChevron, styles.gridItem)}

--- a/packages/webapp/src/components/Finances/UpdateEstimatedCropRevenue/index.jsx
+++ b/packages/webapp/src/components/Finances/UpdateEstimatedCropRevenue/index.jsx
@@ -11,6 +11,7 @@ import Unit from '../../Form/Unit';
 import { seedYield } from '../../../util/convert-units/unit';
 import { convert } from '../../../util/convert-units/convert';
 import { roundToTwoDecimal } from '../../../util';
+import grabCurrencySymbol from '../../../util/grabCurrencySymbol';
 
 function PureUpdateEstimatedCropRevenue({ system, managementPlan, onGoBack, onSubmit }) {
   const { t } = useTranslation();
@@ -142,7 +143,7 @@ function PureUpdateEstimatedCropRevenue({ system, managementPlan, onGoBack, onSu
           valueAsNumber: true,
         })}
         // todo: make currency variable
-        currency={'$'}
+        currency={grabCurrencySymbol()}
         errors={getInputErrors(errors, ESTIMATED_ANNUAL_REVENUE)}
         style={{ marginBottom: '40px' }}
       />

--- a/packages/webapp/src/components/Finances/UpdateEstimatedCropRevenue/index.jsx
+++ b/packages/webapp/src/components/Finances/UpdateEstimatedCropRevenue/index.jsx
@@ -142,7 +142,6 @@ function PureUpdateEstimatedCropRevenue({ system, managementPlan, onGoBack, onSu
           required: true,
           valueAsNumber: true,
         })}
-        // todo: make currency variable
         currency={grabCurrencySymbol()}
         errors={getInputErrors(errors, ESTIMATED_ANNUAL_REVENUE)}
         style={{ marginBottom: '40px' }}

--- a/packages/webapp/src/components/Finances/WholeFarmRevenue/index.jsx
+++ b/packages/webapp/src/components/Finances/WholeFarmRevenue/index.jsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { gridContainer, gridItem } from '../FinanceGroup/styles.module.scss';
 import { useTranslation } from 'react-i18next';
 import { Semibold } from '../../Typography';
+import grabCurrencySymbol from '../../../util/grabCurrencySymbol';
 
 const WholeFarmRevenue = ({ amount, className, ...props }) => {
   const { t } = useTranslation();
@@ -15,7 +16,7 @@ const WholeFarmRevenue = ({ amount, className, ...props }) => {
         {t('FINANCES.WHOLE_FARM_REVENUE')}
       </Semibold>
       <Semibold className={clsx(gridItem, styles.textColor)} sm>
-        {`$${amount.toFixed(2)}`}
+        {`${grabCurrencySymbol()}${amount.toFixed(2)}`}
       </Semibold>
     </div>
   );

--- a/packages/webapp/src/containers/Finances/AddSale/index.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/index.jsx
@@ -22,7 +22,7 @@ class AddSale extends Component {
       date: moment(),
       chosenOptions: [],
       quantity_unit: getUnit(this.props.farm, 'kg', 'lb'),
-      currencySymbol: grabCurrencySymbol(this.props.farm),
+      currencySymbol: grabCurrencySymbol(),
     };
     this.props.dispatch(actions.reset('financeReducer.forms.addSale'));
     this.handleSubmit = this.handleSubmit.bind(this);

--- a/packages/webapp/src/containers/Finances/EditSale/index.jsx
+++ b/packages/webapp/src/containers/Finances/EditSale/index.jsx
@@ -42,7 +42,7 @@ class EditSale extends Component {
       date: moment.utc(sale && sale.sale_date),
       quantity_unit,
       chosenOptions,
-      currencySymbol: grabCurrencySymbol(this.props.farm),
+      currencySymbol: grabCurrencySymbol(),
     };
     sale?.crop_variety_sale.forEach((cvs) => {
       const { crop_variety_name, crop_id } = this.props.cropVarietyEntities[cvs.crop_variety_id];

--- a/packages/webapp/src/containers/Finances/ExpenseDetail/index.jsx
+++ b/packages/webapp/src/containers/Finances/ExpenseDetail/index.jsx
@@ -34,7 +34,7 @@ class ExpenseDetail extends Component {
 
   componentDidMount() {
     const { farm, expense } = this.props;
-    this.setState({ currencySymbol: grabCurrencySymbol(farm) });
+    this.setState({ currencySymbol: grabCurrencySymbol() });
     const language = getLanguageFromLocalStorage();
     const date = moment(expense.expense_date).locale(language).format('MMM DD, YYYY');
     this.setState({

--- a/packages/webapp/src/containers/Finances/Labour/index.jsx
+++ b/packages/webapp/src/containers/Finances/Labour/index.jsx
@@ -67,7 +67,7 @@ class Labour extends Component {
     const i = 1;
     const { dropDownTitle, dButtonStyle } = this.state;
     const { farm } = this.props;
-    const symbol = grabCurrencySymbol(farm);
+    const symbol = grabCurrencySymbol();
     const options = [
       {
         text: this.props.t('SALE.LABOUR.EMPLOYEES'),

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -27,7 +27,7 @@ class AddExpense extends Component {
       date: moment(),
       expenseDetail: {},
       expenseNames: {},
-      currencySymbol: grabCurrencySymbol(this.props.farm),
+      currencySymbol: grabCurrencySymbol(),
     };
     this.setDate = this.setDate.bind(this);
     this.getTypeName = this.getTypeName.bind(this);

--- a/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
@@ -43,7 +43,7 @@ class OtherExpense extends Component {
         width: '100%',
         marginBottom: '10px',
       },
-      currencySymbol: grabCurrencySymbol(this.props.farm),
+      currencySymbol: grabCurrencySymbol(),
     };
     this.computeTable = this.computeTable.bind(this);
     this.getExpenseType = this.getExpenseType.bind(this);

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -57,7 +57,7 @@ class Finances extends Component {
       hasUnAllocated: false,
       showUnTip: 'none',
       unTipButton: this.props.t('SALE.FINANCES.UNALLOCATED_TIP'),
-      currencySymbol: grabCurrencySymbol(this.props.farm),
+      currencySymbol: grabCurrencySymbol(),
     };
     this.getRevenue = this.getRevenue.bind(this);
     this.getEstimatedRevenue = this.getEstimatedRevenue.bind(this);


### PR DESCRIPTION
This PR has the "finances" page display the correct currency based on the user's location.

Ticket: [F21-587](https://lite-farm.atlassian.net/browse/F21-587)

To test:
1. Go to the finances page
2. Add some expenses and sales
3. Explore the "Expenses" and "Revenue" tabs and ensure the correct currency is being displayed in every part

To thoroughly test this, I suggest testing with 2 or more farms that are in different locations so they use different currencies.