### PR TITLE
Fixed the page hang

### DIFF
--- a/packages/webapp/src/containers/Profile/People/saga.js
+++ b/packages/webapp/src/containers/Profile/People/saga.js
@@ -117,6 +117,7 @@ export function* invitePseudoUserSaga({ payload: user }) {
   const { user_id, farm_id } = yield select(loginSelector);
   const header = getHeader(user_id, farm_id);
   try {
+    history.back();
     delete user.user_id;
     const result = yield call(
       axios.post,
@@ -131,8 +132,8 @@ export function* invitePseudoUserSaga({ payload: user }) {
       }),
     );
     yield put(enqueueSuccessSnackbar(i18n.t('message:USER.SUCCESS.UPDATE')));
-    history.back();
   } catch (e) {
+    history.push(`/user/${target_user_id}`);
     yield put(enqueueErrorSnackbar(i18n.t('message:USER.ERROR.UPDATE')));
     console.error(e);
   }


### PR DESCRIPTION
This PR fixes https://lite-farm.atlassian.net/browse/F21-621 

The error was that when you convert a pseudo user account to a normal user account and use an email of an existing user for the new invitation, the page would hang. It turns out this was happening because we were relying on the `user_id` parameter in the url, which would no longer be associated with any user once the user is updated to an existing account (with a different user id). To fix this, we need to make sure we navigate back before updating any of the user info as otherwise the code will fail.