### PR TITLE
 F21-660 finances date range doesnt filter revenues appropriately

### DIFF
--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -11,7 +11,7 @@ import { AddLink, Semibold } from '../../../components/Typography';
 import DateRangePicker from '../../../components/Form/DateRangePicker';
 import ActualCropRevenue from '../ActualCropRevenue';
 import FinanceListHeader from '../../../components/Finances/FinanceListHeader';
-import { calcRevenue, filterSalesByDateRange } from '../util';
+import { calcActualRevenue, filterSalesByDateRange } from '../util';
 
 export default function ActualRevenue({ history, match }) {
   const { t } = useTranslation();
@@ -38,7 +38,7 @@ export default function ActualRevenue({ history, match }) {
   const fromDate = watch('from_date');
   const toDate = watch('to_date');
   const revenueForWholeFarm = useMemo(
-    () => calcRevenue(sales, fromDate, toDate),
+    () => calcActualRevenue(sales, fromDate, toDate),
     [sales, fromDate, toDate],
   );
   const filteredSales = useMemo(

--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -11,6 +11,7 @@ import { AddLink, Semibold } from '../../../components/Typography';
 import DateRangePicker from '../../../components/Form/DateRangePicker';
 import ActualCropRevenue from '../ActualCropRevenue';
 import FinanceListHeader from '../../../components/Finances/FinanceListHeader';
+import { calcRevenue, filterSalesByDateRange } from '../util';
 
 export default function ActualRevenue({ history, match }) {
   const { t } = useTranslation();
@@ -36,22 +37,14 @@ export default function ActualRevenue({ history, match }) {
 
   const fromDate = watch('from_date');
   const toDate = watch('to_date');
-
-  const filteredSales = useMemo(() => {
-    return sales
-      .filter((sale) => {
-        const saleDate = moment(new Date(sale.sale_date)).utc().format('YYYY-MM-DD');
-        return new Date(saleDate) >= new Date(fromDate) && new Date(saleDate) <= new Date(toDate);
-      })
-      .sort((a, b) => {
-        return new Date(a.sale_date) - new Date(b.sale_date);
-      });
-  }, [sales, fromDate, toDate]);
-
-  const total = filteredSales.reduce((acc, sale) => {
-    const { crop_variety_sale } = sale;
-    return acc + crop_variety_sale.reduce((acc, cvs) => acc + cvs.sale_value, 0);
-  }, 0);
+  const revenueForWholeFarm = useMemo(
+    () => calcRevenue(sales, fromDate, toDate),
+    [sales, fromDate, toDate],
+  );
+  const filteredSales = useMemo(
+    () => filterSalesByDateRange(sales, fromDate, toDate),
+    [sales, fromDate, toDate],
+  );
 
   return (
     <Layout>
@@ -61,7 +54,7 @@ export default function ActualRevenue({ history, match }) {
         onGoBack={onGoBack}
       />
 
-      <WholeFarmRevenue amount={total} style={{ marginBottom: '14px' }} />
+      <WholeFarmRevenue amount={revenueForWholeFarm} style={{ marginBottom: '14px' }} />
       <AddLink onClick={onAddRevenue} style={{ marginBottom: '32px' }}>
         {t('FINANCES.ACTUAL_REVENUE.ADD_REVENUE')}
       </AddLink>

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -360,10 +360,10 @@ class Finances extends Component {
 
   render() {
     const totalRevenue = calcActualRevenue(
-      this.props.sale,
+      this.props.sales,
       this.state.startDate,
       this.state.endDate,
-    );
+    ).toFixed(2);
     const estimatedRevenue = this.getEstimatedRevenue(this.props.managementPlans);
     const { tasks, expenses } = this.props;
     const { balanceByCrop, startDate, endDate, hasUnAllocated, showUnTip, unTipButton } =

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -20,7 +20,7 @@ import DescriptiveButton from '../../components/Inputs/DescriptiveButton';
 import history from '../../history';
 import { dateRangeSelector, expenseSelector, salesSelector, shiftSelector } from './selectors';
 import { getDefaultExpenseType, getExpense, getSales, setDateRange } from './actions';
-import { calcOtherExpense, calcTotalLabour, calcRevenue } from './util';
+import { calcOtherExpense, calcTotalLabour, calcActualRevenue } from './util';
 import Moment from 'moment';
 import { roundToTwoDecimal } from '../../util';
 import DateRangeSelector from '../../components/Finances/DateRangeSelector';
@@ -359,7 +359,11 @@ class Finances extends Component {
   }
 
   render() {
-    const totalRevenue = calcRevenue(this.props.sale, this.state.startDate, this.state.endDate);
+    const totalRevenue = calcActualRevenue(
+      this.props.sale,
+      this.state.startDate,
+      this.state.endDate,
+    );
     const estimatedRevenue = this.getEstimatedRevenue(this.props.managementPlans);
     const { tasks, expenses } = this.props;
     const { balanceByCrop, startDate, endDate, hasUnAllocated, showUnTip, unTipButton } =

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -59,19 +59,11 @@ class Finances extends Component {
       unTipButton: this.props.t('SALE.FINANCES.UNALLOCATED_TIP'),
       currencySymbol: grabCurrencySymbol(),
     };
-    this.getRevenue = this.getRevenue.bind(this);
     this.getEstimatedRevenue = this.getEstimatedRevenue.bind(this);
     // this.calcBalanceByCrop = this.calcBalanceByCrop.bind(this);
     this.getShiftCropOnField = this.getShiftCropOnField.bind(this);
     this.toggleTip = this.toggleTip.bind(this);
     this.changeDate = this.changeDate.bind(this);
-  }
-
-  getRevenue() {
-    if (this.props.sales && Array.isArray(this.props.sales)) {
-      return calcRevenue(this.props.sales, this.state.startDate, this.state.endDate);
-    }
-    return 0;
   }
 
   componentDidMount() {
@@ -94,7 +86,6 @@ class Finances extends Component {
         }),
       );
     }
-    console.log(this.state);
     // this.calcBalanceByCrop();
   }
 
@@ -368,7 +359,7 @@ class Finances extends Component {
   }
 
   render() {
-    const totalRevenue = this.getRevenue();
+    const totalRevenue = calcRevenue(this.props.sale, this.state.startDate, this.state.endDate);
     const estimatedRevenue = this.getEstimatedRevenue(this.props.managementPlans);
     const { tasks, expenses } = this.props;
     const { balanceByCrop, startDate, endDate, hasUnAllocated, showUnTip, unTipButton } =

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -20,7 +20,7 @@ import DescriptiveButton from '../../components/Inputs/DescriptiveButton';
 import history from '../../history';
 import { dateRangeSelector, expenseSelector, salesSelector, shiftSelector } from './selectors';
 import { getDefaultExpenseType, getExpense, getSales, setDateRange } from './actions';
-import { calcOtherExpense, calcTotalLabour, calcSales } from './util';
+import { calcOtherExpense, calcTotalLabour, calcRevenue } from './util';
 import Moment from 'moment';
 import { roundToTwoDecimal } from '../../util';
 import DateRangeSelector from '../../components/Finances/DateRangeSelector';
@@ -69,7 +69,7 @@ class Finances extends Component {
 
   getRevenue() {
     if (this.props.sales && Array.isArray(this.props.sales)) {
-      return calcSales(this.props.sales, this.state.startDate, this.state.endDate);
+      return calcRevenue(this.props.sales, this.state.startDate, this.state.endDate);
     }
     return 0;
   }

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- *  This file (index.js) is part of LiteFarm.
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@ import DescriptiveButton from '../../components/Inputs/DescriptiveButton';
 import history from '../../history';
 import { dateRangeSelector, expenseSelector, salesSelector, shiftSelector } from './selectors';
 import { getDefaultExpenseType, getExpense, getSales, setDateRange } from './actions';
-import { calcOtherExpense, calcTotalLabour, filterSalesByCurrentYear } from './util';
+import { calcOtherExpense, calcTotalLabour, calcSales } from './util';
 import Moment from 'moment';
 import { roundToTwoDecimal } from '../../util';
 import DateRangeSelector from '../../components/Finances/DateRangeSelector';
@@ -67,21 +67,11 @@ class Finances extends Component {
     this.changeDate = this.changeDate.bind(this);
   }
 
-  //TODO: filter revenue of cropSales for the current year?
   getRevenue() {
-    let cropVarietySale = [];
     if (this.props.sales && Array.isArray(this.props.sales)) {
-      filterSalesByCurrentYear(this.props.sales).map((s) => {
-        return s.crop_variety_sale.map((cvs) => {
-          return cropVarietySale.push(cvs);
-        });
-      });
+      return calcSales(this.props.sales, this.state.startDate, this.state.endDate);
     }
-    let totalRevenue = 0;
-    cropVarietySale.map((cvs) => {
-      return (totalRevenue += cvs.sale_value || 0);
-    });
-    return totalRevenue.toFixed(2);
+    return 0;
   }
 
   componentDidMount() {
@@ -104,6 +94,7 @@ class Finances extends Component {
         }),
       );
     }
+    console.log(this.state);
     // this.calcBalanceByCrop();
   }
 

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -74,7 +74,7 @@ export function calcOtherExpense(expenses, startDate, endDate) {
 }
 
 export function filterSalesByDateRange(sales, startDate, endDate) {
-  if (sales & Array.isArray(sales)) {
+  if (sales && Array.isArray(sales)) {
     return sales.filter((s) => {
       const saleDate = moment(s.sale_date);
       return saleDate.isSameOrAfter(startDate, 'day') && saleDate.isSameOrBefore(endDate, 'day');

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -73,7 +73,7 @@ export function calcOtherExpense(expenses, startDate, endDate) {
   return total;
 }
 
-export function calcSales(sales, startDate, endDate) {
+export function calcRevenue(sales, startDate, endDate) {
   let total = 0.0;
 
   if (Array.isArray(sales)) {

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -83,7 +83,7 @@ export function filterSalesByDateRange(sales, startDate, endDate) {
   return [];
 }
 
-export function calcRevenue(sales, startDate, endDate) {
+export function calcActualRevenue(sales, startDate, endDate) {
   let total = 0.0;
 
   if (sales && Array.isArray(sales)) {

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019-2022 LiteFarm.org
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@ import moment from 'moment';
 import { roundToTwoDecimal } from '../../util';
 
 export function calcTotalLabour(tasks, startDate, endDate) {
-  let total = 0.00;
+  let total = 0.0;
   if (Array.isArray(tasks)) {
     for (const t of tasks) {
       const completedTime = moment(t.complete_date);
@@ -58,7 +58,7 @@ export const filterSalesByCurrentYear = (sales) => {
 };
 
 export function calcOtherExpense(expenses, startDate, endDate) {
-  let total = 0.00;
+  let total = 0.0;
   if (Array.isArray(expenses)) {
     for (const e of expenses) {
       const expenseDate = moment(e.expense_date);
@@ -74,16 +74,13 @@ export function calcOtherExpense(expenses, startDate, endDate) {
 }
 
 export function calcSales(sales, startDate, endDate) {
-  let total = 0.00;
+  let total = 0.0;
 
   if (Array.isArray(sales)) {
     for (const s of sales) {
       const saleDate = moment(s.sale_date);
-      if (
-        saleDate.isSameOrAfter(startDate, 'day') &&
-        saleDate.isSameOrBefore(endDate, 'day')
-      ) {
-        for (const c of s.cropSale) {
+      if (saleDate.isSameOrAfter(startDate, 'day') && saleDate.isSameOrBefore(endDate, 'day')) {
+        for (const c of s.crop_variety_sale) {
           total = roundToTwoDecimal(roundToTwoDecimal(total) + roundToTwoDecimal(c.sale_value));
         }
       }
@@ -98,13 +95,12 @@ export function calcBalanceByCrop(shifts, sales, expenses, startDate, endDate) {
   if (shifts && shifts.length) {
     for (const s of shifts) {
       const cid = s.crop_id;
-      const cost = roundToTwoDecimal(roundToTwoDecimal(s.wage_at_moment) * roundToTwoDecimal(s.duration / 60));
+      const cost = roundToTwoDecimal(
+        roundToTwoDecimal(s.wage_at_moment) * roundToTwoDecimal(s.duration / 60),
+      );
       if (cid) {
         const shiftDate = moment(s.shift_date);
-        if (
-          shiftDate.isSameOrAfter(startDate, 'day') &&
-          shiftDate.isSameOrBefore(endDate, 'day')
-        ) {
+        if (shiftDate.isSameOrAfter(startDate, 'day') && shiftDate.isSameOrBefore(endDate, 'day')) {
           if (sortObj.hasOwnProperty(cid)) {
             sortObj[cid].cost = roundToTwoDecimal(roundToTwoDecimal(sortObj[cid].cost) + cost);
           } else {
@@ -118,7 +114,9 @@ export function calcBalanceByCrop(shifts, sales, expenses, startDate, endDate) {
       } else {
         if (s.location_id && s.is_field) {
           if (unAllocated.hasOwnProperty(s.location_id)) {
-            unAllocated[s.location_id] = roundToTwoDecimal(roundToTwoDecimal(unAllocated[s.location_id] + cost));
+            unAllocated[s.location_id] = roundToTwoDecimal(
+              roundToTwoDecimal(unAllocated[s.location_id] + cost),
+            );
           } else {
             unAllocated[s.location_id] = cost;
           }
@@ -133,7 +131,9 @@ export function calcBalanceByCrop(shifts, sales, expenses, startDate, endDate) {
     const shiftCropOnField = getShiftCropOnField(fk, shifts);
     let isAllocated = false;
     if (shiftCropOnField.length) {
-      const avgCost = roundToTwoDecimal(roundToTwoDecimal(unAllocated[fk]) / shiftCropOnField.length);
+      const avgCost = roundToTwoDecimal(
+        roundToTwoDecimal(unAllocated[fk]) / shiftCropOnField.length,
+      );
       for (const c of shiftCropOnField) {
         if (sortObj.hasOwnProperty(c)) {
           isAllocated = true;
@@ -166,7 +166,9 @@ export function calcBalanceByCrop(shifts, sales, expenses, startDate, endDate) {
 
   let keys = Object.keys(sortObj);
   const numOfCrops = keys.length;
-  const expensePerCrop = roundToTwoDecimal(calcOtherExpense(expenses, startDate, endDate) / numOfCrops);
+  const expensePerCrop = roundToTwoDecimal(
+    calcOtherExpense(expenses, startDate, endDate) / numOfCrops,
+  );
 
   for (const k of keys) {
     sortObj[k].cost = roundToTwoDecimal(roundToTwoDecimal(sortObj[k].cost) + expensePerCrop);
@@ -175,15 +177,14 @@ export function calcBalanceByCrop(shifts, sales, expenses, startDate, endDate) {
   if (sales && sales.length) {
     for (const s of sales) {
       const saleDate = moment(s.sale_date);
-      if (
-        saleDate.isSameOrAfter(startDate, 'day') &&
-        saleDate.isSameOrBefore(endDate, 'day')
-      ) {
+      if (saleDate.isSameOrAfter(startDate, 'day') && saleDate.isSameOrBefore(endDate, 'day')) {
         for (const cropSale of s.cropSale) {
           const cid = cropSale.managementPlan.crop_id;
           const revenue = roundToTwoDecimal(cropSale.sale_value);
           if (sortObj.hasOwnProperty(cid)) {
-            sortObj[cid].revenue = roundToTwoDecimal(roundToTwoDecimal(sortObj[cid].revenue) + revenue);
+            sortObj[cid].revenue = roundToTwoDecimal(
+              roundToTwoDecimal(sortObj[cid].revenue) + revenue,
+            );
           } else {
             sortObj[cid] = {
               cost: 0,
@@ -201,7 +202,9 @@ export function calcBalanceByCrop(shifts, sales, expenses, startDate, endDate) {
   for (const k of keys) {
     final.push({
       crop: sortObj[k].crop,
-      profit: roundToTwoDecimal(roundToTwoDecimal(sortObj[k].revenue) - roundToTwoDecimal(sortObj[k].cost)),
+      profit: roundToTwoDecimal(
+        roundToTwoDecimal(sortObj[k].revenue) - roundToTwoDecimal(sortObj[k].cost),
+      ),
     });
   }
 

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -73,10 +73,20 @@ export function calcOtherExpense(expenses, startDate, endDate) {
   return total;
 }
 
+export function filterSalesByDateRange(sales, startDate, endDate) {
+  if (sales & Array.isArray(sales)) {
+    return sales.filter((s) => {
+      const saleDate = moment(s.sale_date);
+      return saleDate.isSameOrAfter(startDate, 'day') && saleDate.isSameOrBefore(endDate, 'day');
+    });
+  }
+  return [];
+}
+
 export function calcRevenue(sales, startDate, endDate) {
   let total = 0.0;
 
-  if (Array.isArray(sales)) {
+  if (sales && Array.isArray(sales)) {
     for (const s of sales) {
       const saleDate = moment(s.sale_date);
       if (saleDate.isSameOrAfter(startDate, 'day') && saleDate.isSameOrBefore(endDate, 'day')) {


### PR DESCRIPTION
Ticket: [F21-660](https://lite-farm.atlassian.net/browse/F21-660)

FIxed finance page so that the revenue changes with the date range. 

To test:
- Make sure you have a crop variety with an active crop plan (not complete or abandoned);
- Got to Finances
- Click "Add new sale" and fill this out a couple times for different dates
- Make you are getting correct values for Actual Revenue where filtering by those date ranges
- Try making the start date after the end date, make sure the Actual Revenue is 0