### PR TITLE
Added check for variables being null

### DIFF
--- a/packages/webapp/src/containers/Notification/useStringFilteredNotifications.js
+++ b/packages/webapp/src/containers/Notification/useStringFilteredNotifications.js
@@ -13,7 +13,7 @@ export default function useStringFilteredNotifications(notifications, filterStri
     };
 
     return notifications.filter((notification) => {
-      const tOptions = notification.variables.reduce((optionsSoFar, currentOption) => {
+      const tOptions = notification.variables?.reduce((optionsSoFar, currentOption) => {
         let options = { ...optionsSoFar };
         options[currentOption.name] = currentOption.translate
           ? t(currentOption.value)


### PR DESCRIPTION
There was an error occurring because we were try to use `notification.variables.reduce` when variables are not always present. This fix just adds a check for whether variables is undefined.