### PR TITLE
F21-664/accented characters allowed from search inputs

### DIFF
--- a/packages/webapp/src/containers/CropCatalogue/index.jsx
+++ b/packages/webapp/src/containers/CropCatalogue/index.jsx
@@ -105,7 +105,7 @@ export default function CropCatalogue({ history }) {
       )}
 
       <div ref={containerRef}>
-        {!!(sum + filteredCropsWithoutManagementPlan.length) ? (
+        {sum + filteredCropsWithoutManagementPlan.length ? (
           <>
             <PageBreak style={{ paddingBottom: '16px' }} label={t('CROP_CATALOGUE.ON_YOUR_FARM')} />
             <CropStatusInfoBox

--- a/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
+++ b/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
@@ -7,7 +7,15 @@ export default function useStringFilteredCrops(crops, filterString) {
     const lowerCaseFilter = filterString?.toLowerCase() || '';
     const check = (names) => {
       for (const name of names) {
-        if (name?.toLowerCase().includes(lowerCaseFilter)) return true;
+        if (
+          name?.toLowerCase().includes(lowerCaseFilter) ||
+          name
+            ?.toLowerCase()
+            .normalize('NFD')
+            .replace(/\p{Diacritic}/gu, '')
+            .includes(lowerCaseFilter)
+        )
+          return true;
       }
       return false;
     };

--- a/packages/webapp/src/containers/Documents/util.js
+++ b/packages/webapp/src/containers/Documents/util.js
@@ -22,7 +22,15 @@ export function useStringFilteredDocuments(documents, filterString) {
     const lowerCaseFilter = filterString?.toLowerCase() || '';
     const check = (names) => {
       for (const name of names) {
-        if (name?.toLowerCase().includes(lowerCaseFilter)) return true;
+        if (
+          name?.toLowerCase().includes(lowerCaseFilter) ||
+          name
+            ?.toLowerCase()
+            .normalize('NFD')
+            .replace(/\p{Diacritic}/gu, '')
+            .includes(lowerCaseFilter)
+        )
+          return true;
       }
       return false;
     };


### PR DESCRIPTION
Ticket [F21-664](https://lite-farm.atlassian.net/browse/F21-664)

**To Test:**
1. Go to Crops page and type in crops with accented characters without actually typing in accented characters (you can try it in different languages other than English) i.e. Guaraná, Acácia mangium, etc.
2. You should still get the appropriate crops in the search results.