### PR TITLE
Fixed filtering on crop management plans

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/LocationManagementPlan/index.jsx
+++ b/packages/webapp/src/containers/LocationDetails/LocationManagementPlan/index.jsx
@@ -8,6 +8,7 @@ import {
   expiredManagementPlansByLocationIdSelector,
   plannedManagementPlansByLocationIdSelector,
 } from '../../Task/TaskCrops/managementPlansWithLocationSelector';
+import { useTranslation } from 'react-i18next';
 
 function LocationManagementPlan({ history, match }) {
   const [filter, setFilter] = useState();
@@ -16,6 +17,7 @@ function LocationManagementPlan({ history, match }) {
   const activeCrops = useSelector(currentManagementPlansByLocationIdSelector(location_id));
   const pastCrops = useSelector(expiredManagementPlansByLocationIdSelector(location_id));
   const plannedCrops = useSelector(plannedManagementPlansByLocationIdSelector(location_id));
+  const { t } = useTranslation();
 
   const onFilterChange = (e) => {
     setFilter(e.target.value.toLowerCase());
@@ -31,9 +33,9 @@ function LocationManagementPlan({ history, match }) {
       <PureCropList
         onFilterChange={onFilterChange}
         onAddCrop={onAddCrop}
-        activeCrops={filteredManagementPlans(filter, activeCrops)}
-        pastCrops={filteredManagementPlans(filter, pastCrops)}
-        plannedCrops={filteredManagementPlans(filter, plannedCrops)}
+        activeCrops={filteredManagementPlans(filter, activeCrops, t)}
+        pastCrops={filteredManagementPlans(filter, pastCrops, t)}
+        plannedCrops={filteredManagementPlans(filter, plannedCrops, t)}
         isAdmin={isAdmin}
         history={history}
         match={match}
@@ -43,15 +45,16 @@ function LocationManagementPlan({ history, match }) {
   );
 }
 
-const filteredManagementPlans = (filter, managementPlans) => {
-  const filtered = filter
+const filteredManagementPlans = (filter, managementPlans, t) => {
+  return filter
     ? managementPlans.filter(
         (managementPlan) =>
-          managementPlan?.crop_variety?.toLowerCase()?.includes(filter) ||
-          managementPlan?.crop_common_name?.toLowerCase()?.includes(filter),
+          managementPlan?.crop_variety?.crop_variety_name?.toLowerCase()?.includes(filter) ||
+          t(`crop:${managementPlan?.crop_variety?.crop_translation_key}`)
+            .toLowerCase()
+            ?.includes(filter),
       )
     : managementPlans;
-  return filtered;
 };
 
 export default LocationManagementPlan;

--- a/packages/webapp/src/containers/LocationDetails/LocationManagementPlan/index.jsx
+++ b/packages/webapp/src/containers/LocationDetails/LocationManagementPlan/index.jsx
@@ -45,14 +45,23 @@ function LocationManagementPlan({ history, match }) {
   );
 }
 
+const check = (name, filter) => {
+  return (
+    name?.toLowerCase().includes(filter) ||
+    name
+      ?.toLowerCase()
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .includes(filter)
+  );
+};
+
 const filteredManagementPlans = (filter, managementPlans, t) => {
   return filter
     ? managementPlans.filter(
         (managementPlan) =>
-          managementPlan?.crop_variety?.crop_variety_name?.toLowerCase()?.includes(filter) ||
-          t(`crop:${managementPlan?.crop_variety?.crop_translation_key}`)
-            .toLowerCase()
-            ?.includes(filter),
+          check(managementPlan?.crop_variety?.crop_variety_name, filter) ||
+          check(t(`crop:${managementPlan?.crop_variety?.crop_translation_key}`), filter),
       )
     : managementPlans;
 };


### PR DESCRIPTION
This was fixing https://lite-farm.atlassian.net/browse/F21-651 

This sentry error was caused when someone tried to search on the "crop" page associated with a location. I fixed the error, and also updated the filtering to filter the crops by the appropriate language.

To test:
1. Have at least one crop plan associated with a location. 
2. Go to map view, and click on that location
3. Go to the crops tab, and search. It should correctly filter out the crops based on the search term, and also on the language you are currently using