### PR TITLE
F21-612 - Fix: long farm name overflow on the farm selection page 

### DIFF
--- a/packages/webapp/src/components/ChooseFarm/ChooseFarmMenu/ChooseFarmMenuItem/chooseFarmMenuItem.module.scss
+++ b/packages/webapp/src/components/ChooseFarm/ChooseFarmMenu/ChooseFarmMenuItem/chooseFarmMenuItem.module.scss
@@ -1,16 +1,18 @@
 @import '../../../../assets/mixin';
 .leftColumn {
   margin-left: 18px;
+  margin-right: 12px;
   margin-bottom: 3px;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  flex: 1.3;
 }
 .rightColumn {
   display: flex;
   flex-direction: row;
   justify-content: center;
-  width: 42.3%;
+  flex: 1;
 }
 .farmName {
   color: var(--fontColor);

--- a/packages/webapp/src/components/ChooseFarm/ChooseFarmMenu/ChooseFarmMenuItem/index.jsx
+++ b/packages/webapp/src/components/ChooseFarm/ChooseFarmMenu/ChooseFarmMenuItem/index.jsx
@@ -25,6 +25,8 @@ const ChooseFarmMenuItem = ({
         minHeight: '63px',
         justifyContent: 'space-between',
         cursor: color === 'secondary' ? 'pointer' : 'default',
+        wordBreak: 'break-word',
+        padding: '8px 0',
         ...style,
       }}
       {...props}

--- a/packages/webapp/src/components/ChooseFarm/ChooseFarmMenu/ChooseFarmMenuItem/index.jsx
+++ b/packages/webapp/src/components/ChooseFarm/ChooseFarmMenu/ChooseFarmMenuItem/index.jsx
@@ -32,7 +32,9 @@ const ChooseFarmMenuItem = ({
       {...props}
     >
       <div className={clsx(styles.leftColumn, styles[color])}>
-        <h5 className={clsx(styles.farmName)}>{farmName}</h5>
+        <h5 className={clsx(styles.farmName)}>
+          {farmName.length > 77 ? `${farmName.substring(0, 77).trim()}...` : farmName}
+        </h5>
         {ownerName && <p className={clsx(styles.address)}>{ownerName}</p>}
       </div>
       <div className={clsx(styles.rightColumn, styles[color])}>


### PR DESCRIPTION
To Test: 

1. Go to http://localhost:3000/farm_selection page.
2. Inspect the page in your browser:-
3. Add some dummy text as shown below. 


<img width="1091" alt="Screen Shot 2022-06-01 at 12 17 25 PM" src="https://user-images.githubusercontent.com/20675885/171486830-c74cc897-680e-493f-8a7d-1d4efee936bb.png">

<img width="392" alt="Screen Shot 2022-06-01 at 12 39 09 PM" src="https://user-images.githubusercontent.com/20675885/171487928-e2501846-17b2-42e5-995f-2cd0bc9cd781.png">

For details: https://lite-farm.atlassian.net/browse/F21-612

Please check the CSS compatibility of word-break: https://caniuse.com/?search=word-break