### PR TITLE
F21 657 able to have end date before start date in the finances page

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -332,7 +332,8 @@
   "DATE_RANGE": {
     "HELP_BODY": "Select the date range to create a financial report for your farm for a given time window.",
     "HELP_TITLE": "Date Range Help",
-    "TITLE": "Filter Report by Date"
+    "TITLE": "Filter Report by Date",
+    "INVALID_RANGE_MESSAGE": "End date must be after start date to return results"
   },
   "DATE_RANGE_PICKER": {
     "FROM": "From",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -331,7 +331,8 @@
   "DATE_RANGE": {
     "HELP_BODY": "Selecciona el rango de fechas para crear un reporte financiero para su granja en ese rango.",
     "HELP_TITLE": "Ayuda con el rango de fechas",
-    "TITLE": "Filtrar reporte por fecha"
+    "TITLE": "Filtrar reporte por fecha",
+    "INVALID_RANGE_MESSAGE": "MISSING"
   },
   "DATE_RANGE_PICKER": {
     "FROM": "Desde",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -332,7 +332,8 @@
   "DATE_RANGE": {
     "HELP_BODY": "Sélectionnez la plage de dates pour créer un rapport financier pour votre ferme pour une fenêtre de temps donnée.",
     "HELP_TITLE": "Aide sur la plage de dates",
-    "TITLE": "Filtrer le rapport par date"
+    "TITLE": "Filtrer le rapport par date",
+    "INVALID_RANGE_MESSAGE": "MISSING"
   },
   "DATE_RANGE_PICKER": {
     "FROM": "De",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -331,7 +331,8 @@
   "DATE_RANGE": {
     "HELP_BODY": "Selecione as datas para criar um relatório financeiro para sua fazenda para um determinado intervalo de tempo.",
     "HELP_TITLE": "Ajuda",
-    "TITLE": "Filtrar relatório por data"
+    "TITLE": "Filtrar relatório por data",
+    "INVALID_RANGE_MESSAGE": "MISSING"
   },
   "DATE_RANGE_PICKER": {
     "FROM": "De",

--- a/packages/webapp/src/components/Finances/DateRangeSelector/index.jsx
+++ b/packages/webapp/src/components/Finances/DateRangeSelector/index.jsx
@@ -12,7 +12,7 @@ import { withTranslation } from 'react-i18next';
 class DateRangeSelector extends Component {
   constructor(props) {
     super(props);
-    let startDate, endDate;
+    let startDate, endDate, validRange;
     const { dateRange } = this.props;
     if (dateRange && dateRange.startDate && dateRange.endDate) {
       startDate = moment(dateRange.startDate);
@@ -21,16 +21,23 @@ class DateRangeSelector extends Component {
       startDate = moment().startOf('year');
       endDate = moment().endOf('year');
     }
+    startDate <= endDate ? (validRange = true) : (validRange = false);
 
     this.state = {
       startDate,
       endDate,
+      validRange,
     };
     this.changeStartDate.bind(this);
     this.changeEndDate.bind(this);
   }
 
   changeStartDate = (date) => {
+    if (date > this.state.endDate) {
+      this.setState({ validRange: false });
+      return;
+    }
+    this.setState({ validRange: true });
     this.setState({ startDate: date });
     const endDate = this.state.endDate;
     this.props.dispatch(setDateRange({ startDate: date, endDate }));
@@ -38,6 +45,11 @@ class DateRangeSelector extends Component {
   };
 
   changeEndDate = (date) => {
+    if (date < this.state.startDate) {
+      this.setState({ validRange: false });
+      return;
+    }
+    this.setState({ validRange: true });
     this.setState({ endDate: date });
     const startDate = this.state.startDate;
     this.props.dispatch(setDateRange({ startDate, endDate: date }));
@@ -69,6 +81,11 @@ class DateRangeSelector extends Component {
           endDate={this.state.endDate}
           startDate={this.state.startDate}
         />
+        {!this.state.validRange && (
+          <Semibold style={{ textAlign: 'center', color: 'red' }}>
+            {this.props.t('DATE_RANGE.INVALID_RANGE_MESSAGE')}
+          </Semibold>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
This PR gives the user an error message when they select an invalid date range in the "Finances" section

To test:

1. Navigate to the finances section
2. Play around with the "Filter Report by Date" date picker. When the end date is before the start date, or the start date is after the end date, you should see an error message warning you of this.