### PR TITLE
F21-671/Searching the crop catalogue should ignore non-alphabetical characters

### DIFF
--- a/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
+++ b/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
@@ -4,15 +4,16 @@ import { useTranslation } from 'react-i18next';
 export default function useStringFilteredCrops(crops, filterString) {
   const { t } = useTranslation();
   return useMemo(() => {
-    const lowerCaseFilter = filterString?.toLowerCase() || '';
+    const lowerCaseFilter = filterString?.toLowerCase().replace(/\W/g, '').trim() || '';
     const check = (names) => {
       for (const name of names) {
         if (
-          name?.toLowerCase().includes(lowerCaseFilter) ||
           name
             ?.toLowerCase()
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
+            .replace(/\W/g, '')
+            .trim()
             .includes(lowerCaseFilter)
         )
           return true;

--- a/packages/webapp/src/containers/Documents/util.js
+++ b/packages/webapp/src/containers/Documents/util.js
@@ -19,15 +19,16 @@ export function useSortByName(documents) {
 
 export function useStringFilteredDocuments(documents, filterString) {
   return useMemo(() => {
-    const lowerCaseFilter = filterString?.toLowerCase() || '';
+    const lowerCaseFilter = filterString?.toLowerCase().replace(/\W/g, '').trim() || '';
     const check = (names) => {
       for (const name of names) {
         if (
-          name?.toLowerCase().includes(lowerCaseFilter) ||
           name
             ?.toLowerCase()
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
+            .replace(/\W/g, '')
+            .trim()
             .includes(lowerCaseFilter)
         )
           return true;


### PR DESCRIPTION
Ticket [F21-671](https://lite-farm.atlassian.net/browse/F21-671)

**To Test:**
1. Go to Crop Catalogue.
2. Search crop names with non-alphabetical characters (i.e. spaces, commas, dashes, open and close parenthesis, and slashes).
3. You still should be able to search all the crops without typing all the non-alphabetical characters.
Examples: Chupa-chupa, Cabbage, Apple malay, etc.
