### PR TITLE
Remove redundant env var

### DIFF
--- a/packages/api/.env.default
+++ b/packages/api/.env.default
@@ -50,5 +50,4 @@ REDIS_PASSWORD=test
 REPORT_URL=http://localhost:3000/render_survey
 EXPORT_WD=exports
 
-GOOGLE_MAPS_API_KEY=?
 API_HOST=localhost

--- a/packages/api/src/controllers/farmController.js
+++ b/packages/api/src/controllers/farmController.js
@@ -257,7 +257,7 @@ const farmController = {
         params: {
           location: gridPoints,
           timestamp: new Date(Date.now()),
-          key: process.env.GOOGLE_MAPS_API_KEY,
+          key: process.env.GOOGLE_API_KEY,
         },
       });
       return timeZone.data.rawOffset;
@@ -271,7 +271,7 @@ const farmController = {
               params: {
                 location: gridPoints,
                 timestamp: new Date(Date.now()),
-                key: process.env.GOOGLE_MAPS_API_KEY,
+                key: process.env.GOOGLE_API_KEY,
               },
             });
             return timeZone.data.rawOffset;

--- a/packages/api/src/jobs/station_sync/updateTimeZoneOffsets.js
+++ b/packages/api/src/jobs/station_sync/updateTimeZoneOffsets.js
@@ -26,7 +26,7 @@ async function mapTimeZoneOffsetsToFarms(knex) {
         params: {
           location: farm.grid_points,
           timestamp: date,
-          key: process.env.GOOGLE_MAPS_API_KEY,
+          key: process.env.GOOGLE_API_KEY,
         },
       });
       await knex('farm')
@@ -42,7 +42,7 @@ async function mapTimeZoneOffsetsToFarms(knex) {
               params: {
                 location: farm.grid_points,
                 timestamp: new Date(Date.now()),
-                key: process.env.GOOGLE_MAPS_API_KEY,
+                key: process.env.GOOGLE_API_KEY,
               },
             });
             await knex('farm')


### PR DESCRIPTION
We recently added `GOOGLE_MAPS_API_KEY` to the api package. That is the name used by the webapp package. api already had `GOOGLE_API_KEY`, which is the same value. This removes the new, redundant environment variable.