### PR TITLE
fix: made dates for time notifications static

### DIFF
--- a/packages/api/src/controllers/timeNotificationController.js
+++ b/packages/api/src/controllers/timeNotificationController.js
@@ -46,7 +46,7 @@ const timeNotificationController = {
       );
 
       if (unassignedTasks.length > 0 && farmManagement.length > 0) {
-        await sendWeeklyUnassignedTaskNotifications(farm_id, farmManagement);
+        await sendWeeklyUnassignedTaskNotifications(farm_id, farmManagement, isDayLaterThanUtc);
       }
 
       const status = unassignedTasks.length > 0 && farmManagement.length > 0 ? 201 : 200;
@@ -103,7 +103,10 @@ const timeNotificationController = {
  * @param {String} firstTaskTranslationKey - task translation key of the first unassigned task
  * @async
  */
-async function sendWeeklyUnassignedTaskNotifications(farmId, farmManagement) {
+async function sendWeeklyUnassignedTaskNotifications(farmId, farmManagement, isDayLaterThanUtc) {
+  const today = new Date();
+  if (isDayLaterThanUtc) today.setDate(today.getDate() + 1);
+  const todayStr = today.toISOString().split('T')[0];
   await NotificationUser.notify(
     {
       title: { translation_key: 'NOTIFICATION.WEEKLY_UNASSIGNED_TASKS.TITLE' },
@@ -113,6 +116,7 @@ async function sendWeeklyUnassignedTaskNotifications(farmId, farmManagement) {
       context: {
         task_translation_key: 'FIELD_WORK_TASK',
         notification_type: 'WEEKLY_UNASSIGNED_TASKS',
+        notification_date: todayStr,
       },
       farm_id: farmId,
     },
@@ -126,7 +130,10 @@ async function sendWeeklyUnassignedTaskNotifications(farmId, farmManagement) {
  * @param {String} userId
  * @async
  */
-async function sendDailyDueTodayTaskNotification(farmId, userId) {
+async function sendDailyDueTodayTaskNotification(farmId, userId, isDayLaterThanUtc) {
+  const today = new Date();
+  if (isDayLaterThanUtc) today.setDate(today.getDate() + 1);
+  const todayStr = today.toISOString().split('T')[0];
   await NotificationUser.notify(
     {
       title: { translation_key: 'NOTIFICATION.DAILY_TASKS_DUE_TODAY.TITLE' },
@@ -136,6 +143,7 @@ async function sendDailyDueTodayTaskNotification(farmId, userId) {
       context: {
         task_translation_key: 'FIELD_WORK_TASK',
         notification_type: 'DAILY_TASKS_DUE_TODAY',
+        notification_date: todayStr,
       },
       farm_id: farmId,
     },

--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -60,25 +60,51 @@ export default function TaskPage({ history }) {
     setIsFilterOpen(true);
   };
 
+  // useEffect(() => {
+  //   dispatch(getManagementPlansAndTasks());
+  // }, []);
+
+  // useEffect(() => {
+  //   dispatch(resetAndUnLockFormData());
+  // }, []);
+
   useEffect(() => {
     dispatch(getManagementPlansAndTasks());
-  }, []);
-
-  useEffect(() => {
     dispatch(resetAndUnLockFormData());
-  }, []);
 
-  useEffect(() => {
-    if (history.location.state?.notification_type === WEEKLY_UNASSIGNED_TASKS) {
-      dispatch(setTasksFilterUnassignedDueThisWeek());
+    const context = history.location?.state;
+
+    let notificationDate;
+    if (context?.notification_date) {
+      const tempDate = new Date(context?.notification_date);
+      notificationDate = new Date(
+        tempDate.getUTCFullYear(),
+        tempDate.getUTCMonth(),
+        tempDate.getUTCDate(),
+      );
+    } else {
+      notificationDate = new Date();
+    }
+
+    switch (context?.notification_type) {
+      case WEEKLY_UNASSIGNED_TASKS:
+        dispatch(setTasksFilterUnassignedDueThisWeek({ date: notificationDate }));
+        break;
+      case DAILY_TASKS_DUE_TODAY:
+        dispatch(
+          setTasksFilterDueToday({ user_id, first_name, last_name, date: notificationDate }),
+        );
+        break;
+      default:
+        break;
     }
   }, []);
 
-  useEffect(() => {
-    if (history.location.state?.notification_type === DAILY_TASKS_DUE_TODAY) {
-      dispatch(setTasksFilterDueToday({ user_id, first_name, last_name }));
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (history.location.state?.notification_type === DAILY_TASKS_DUE_TODAY) {
+  //     dispatch(setTasksFilterDueToday({ user_id, first_name, last_name, date: history.location.state.notification_date }));
+  //   }
+  // }, []);
 
   const assigneeValue = useMemo(() => {
     let unassigned;

--- a/packages/webapp/src/containers/filterSlice.js
+++ b/packages/webapp/src/containers/filterSlice.js
@@ -97,10 +97,9 @@ const filterSliceReducer = createSlice({
     setTasksFilter: (state, { payload: tasksFilter }) => {
       Object.assign(state.tasks, tasksFilter);
     },
-    setTasksFilterUnassignedDueThisWeek: (state) => {
-      const today = new Date();
-      const oneWeekFromNow = new Date();
-      oneWeekFromNow.setDate(today.getDate() + 6);
+    setTasksFilterUnassignedDueThisWeek: (state, { payload: { date = new Date() } }) => {
+      const oneWeekFromDate = new Date(date.valueOf());
+      oneWeekFromDate.setDate(date.getDate() + 6);
       state.tasks = {
         ...intialTasksFilter,
         ASSIGNEE: Object.keys(state.tasks.ASSIGNEE).reduce((assignees, assigneeUserId) => {
@@ -110,18 +109,20 @@ const filterSliceReducer = createSlice({
           };
           return assignees;
         }, {}),
-        FROM_DATE: getDateInputFormat(today),
-        TO_DATE: getDateInputFormat(oneWeekFromNow),
+        FROM_DATE: getDateInputFormat(date),
+        TO_DATE: getDateInputFormat(oneWeekFromDate),
       };
       state.tasks.ASSIGNEE['unassigned'] = {
         active: true,
         label: i18n.t('TASK.UNASSIGNED'),
       };
     },
-    setTasksFilterDueToday: (state, { payload: { user_id, first_name, last_name } }) => {
-      const today = new Date();
-      const yesterday = new Date();
-      yesterday.setDate(today.getDate() - 1);
+    setTasksFilterDueToday: (
+      state,
+      { payload: { user_id, first_name, last_name, date = new Date() } },
+    ) => {
+      const dayBefore = new Date(date.valueOf());
+      dayBefore.setDate(date.getDate() - 1);
       state.tasks = {
         ...intialTasksFilter,
         ASSIGNEE: Object.keys(state.tasks.ASSIGNEE).reduce((assignees, assigneeUserId) => {
@@ -130,8 +131,8 @@ const filterSliceReducer = createSlice({
           };
           return assignees;
         }, {}),
-        FROM_DATE: getDateInputFormat(yesterday),
-        TO_DATE: getDateInputFormat(today),
+        FROM_DATE: getDateInputFormat(dayBefore),
+        TO_DATE: getDateInputFormat(date),
       };
       state.tasks.ASSIGNEE[user_id].active = true;
       state.tasks.ASSIGNEE[user_id].label = `${first_name} ${last_name}`;


### PR DESCRIPTION
See latest comments on this ticket: [F21-560](https://lite-farm.atlassian.net/browse/F21-560)

To test: see instuctions on this pull request ([1912](https://github.com/LiteFarmOrg/LiteFarm/pull/1912))

You can also try manually changing the notification.context.date object in postgres, to test if you view a notification later than it was created, it will still filter by the date sent. 