### PR TITLE
F21-673/search without typing accented or non alphabet char

### DIFF
--- a/packages/webapp/src/components/Profile/People/index.jsx
+++ b/packages/webapp/src/components/Profile/People/index.jsx
@@ -61,7 +61,19 @@ export default function PurePeople({ users, history, isAdmin }) {
     };
 
     const filteredUsers = users.filter((user) => {
-      return getName(user).includes(searchString.trim().toLowerCase());
+      return getName(user)
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replace(/\W/g, '')
+        .trim()
+        .includes(
+          searchString
+            .normalize('NFD')
+            .replace(/\p{Diacritic}/gu, '')
+            .toLowerCase()
+            .replace(/\W/g, '')
+            .trim(),
+        );
     });
     return filteredUsers.map((user) => ({
       name: getName(user),

--- a/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
+++ b/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
@@ -4,7 +4,13 @@ import { useTranslation } from 'react-i18next';
 export default function useStringFilteredCrops(crops, filterString) {
   const { t } = useTranslation();
   return useMemo(() => {
-    const lowerCaseFilter = filterString?.toLowerCase().replace(/\W/g, '').trim() || '';
+    const lowerCaseFilter =
+      filterString
+        ?.toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replace(/\W/g, '')
+        .trim() || '';
     const check = (names) => {
       for (const name of names) {
         if (

--- a/packages/webapp/src/containers/Documents/util.js
+++ b/packages/webapp/src/containers/Documents/util.js
@@ -19,7 +19,13 @@ export function useSortByName(documents) {
 
 export function useStringFilteredDocuments(documents, filterString) {
   return useMemo(() => {
-    const lowerCaseFilter = filterString?.toLowerCase().replace(/\W/g, '').trim() || '';
+    const lowerCaseFilter =
+      filterString
+        ?.toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replace(/\W/g, '')
+        .trim() || '';
     const check = (names) => {
       for (const name of names) {
         if (


### PR DESCRIPTION
Ticket [F21-673](https://lite-farm.atlassian.net/browse/F21-673)

Users can now search people with accented or non-alphabetical character names.
Also this PR updated previous accented or non-alphabetical crop, document names search.

**To Test:**
1. Go to People tab of the farm.
2. Make sure you have people with accented and non-alphabetical character names.
3. Search without typing accented or non-alphabetical characters. The results should still be the same.