### PR TITLE
fix: hide take me there when notification.ref is null

### DIFF
--- a/packages/webapp/src/components/Notifications/index.jsx
+++ b/packages/webapp/src/components/Notifications/index.jsx
@@ -35,6 +35,13 @@ function PureNotificationReadOnly({ onGoBack, notification }) {
     return options;
   }, {});
 
+  const hideTakeMeThere =
+    !notification.ref ||
+    (!notification.ref?.url &&
+      (!notification.ref?.entity ||
+        !notification.ref?.entity?.type ||
+        !notification.ref?.entity?.id));
+
   const onTakeMeThere = () => {
     const route =
       notification.ref.url ??
@@ -80,9 +87,11 @@ function PureNotificationReadOnly({ onGoBack, notification }) {
           ? t(notification.body.translation_key, tOptions)
           : notification.body[currentLang]}
       </Text>
-      <Button sm style={{ height: '32px', width: '150px' }} onClick={onTakeMeThere}>
-        {t('NOTIFICATION.TAKE_ME_THERE')}
-      </Button>
+      {!hideTakeMeThere && (
+        <Button sm style={{ height: '32px', width: '150px' }} onClick={onTakeMeThere}>
+          {t('NOTIFICATION.TAKE_ME_THERE')}
+        </Button>
+      )}
     </Layout>
   );
 }


### PR DESCRIPTION
Ticket: [F21-629](https://lite-farm.atlassian.net/browse/F21-629)

To test:
- Make sure you have at least on user in your database
- Open `notifyAllUsers.sql` in your code editor.
- Replace the value for ref in the `INSERT` command to either `NULL` or `'{}'::jsonb`
- Copy and paste commands one by one in postgres
- Login and go to notifications
- You should see the notification you just created with no "Take Me There" link