### PR TITLE
F21 639 download map fails silently on iPhone

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -462,7 +462,8 @@
       "DOWNLOAD": "Download",
       "EMAIL_TO_ME": "Email to me",
       "EMAILING": "Emailing",
-      "TITLE": "Export your farm map"
+      "TITLE": "Export your farm map",
+      "LOADING": "Loading..."
     },
     "FARM_SITE_BOUNDARY": {
       "EDIT_TITLE": "Edit farm site boundary",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -461,7 +461,8 @@
       "DOWNLOAD": "Descargar",
       "EMAIL_TO_ME": "Enviar a mi correo",
       "EMAILING": "Enviando",
-      "TITLE": "Exporta su mapa"
+      "TITLE": "Exporta su mapa",
+      "LOADING": "Cargando..."
     },
     "FARM_SITE_BOUNDARY": {
       "EDIT_TITLE": "Editar limites de la granja",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -462,7 +462,8 @@
       "DOWNLOAD": "Télécharger",
       "EMAIL_TO_ME": "Envoyez-moi une courriel",
       "EMAILING": "Envoi en cours",
-      "TITLE": "Exportez votre carte de ferme"
+      "TITLE": "Exportez votre carte de ferme",
+      "LOADING": "Chargement..."
     },
     "FARM_SITE_BOUNDARY": {
       "EDIT_TITLE": "Modifier les limites du site de la ferme",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -461,7 +461,8 @@
       "DOWNLOAD": "Download",
       "EMAIL_TO_ME": "Enviar email para mim",
       "EMAILING": "Enviando...",
-      "TITLE": "Exporte o mapa do seu sítio/fazenda"
+      "TITLE": "Exporte o mapa do seu sítio/fazenda",
+      "LOADING": "Carregando..."
     },
     "FARM_SITE_BOUNDARY": {
       "EDIT_TITLE": "Editar limites do sítio/fazenda",

--- a/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
+++ b/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
@@ -45,7 +45,7 @@ export function PureExportMapModal({
   }, []);
 
   const onClickDownload = () => {
-    dismissModal();
+    !isLoading && dismissModal();
   };
 
   return (

--- a/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
+++ b/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
@@ -6,14 +6,19 @@ import { AiOutlineMail } from 'react-icons/all';
 import styles from './styles.module.scss';
 import { Main, Title } from '../../Typography';
 import Button from '../../Form/Button';
+import html2canvas from 'html2canvas';
 
 export function PureExportMapModal({
   onClickDownload: download,
   onClickShare: share,
   dismissModal,
+  currentMap,
+  farmName,
 }) {
   const { t } = useTranslation();
   const [isEmailing, setEmailing] = useState();
+  const [isLoading, setIsLoading] = useState(false);
+  const [linkHref, setLinkHref] = useState();
   const onClickEmail = () => {
     share();
     setEmailing(true);
@@ -31,8 +36,16 @@ export function PureExportMapModal({
     return () => clearTimeout(timer);
   }, [isEmailing]);
 
+  useEffect(() => {
+    console.log(currentMap);
+    setIsLoading(true);
+    html2canvas(currentMap, { useCORS: true }).then((canvas) => {
+      setLinkHref(canvas.toDataURL());
+      setIsLoading(false);
+    });
+  }, []);
+
   const onClickDownload = () => {
-    download();
     dismissModal();
   };
 
@@ -40,10 +53,23 @@ export function PureExportMapModal({
     <div className={styles.container}>
       <Title>{t('FARM_MAP.EXPORT_MODAL.TITLE')}</Title>
       <Main>{t('FARM_MAP.EXPORT_MODAL.BODY')}</Main>
-      <Button color="secondary" className={styles.button} onClick={onClickDownload}>
-        <DownloadIcon className={styles.downloadSvg} />
-        <div>{t('FARM_MAP.EXPORT_MODAL.DOWNLOAD')}</div>
-      </Button>
+      <a href={linkHref} download={`${farmName}-export-${new Date().toISOString()}.png`}>
+        <Button
+          color="secondary"
+          className={styles.button}
+          style={{ width: '100%' }}
+          onClick={onClickDownload}
+        >
+          {isLoading ? (
+            'Loading...'
+          ) : (
+            <>
+              <DownloadIcon className={styles.downloadSvg} />
+              <div>{t('FARM_MAP.EXPORT_MODAL.DOWNLOAD')}</div>
+            </>
+          )}
+        </Button>
+      </a>
       <Button
         color="secondary"
         disabled={isEmailing}
@@ -61,13 +87,14 @@ export function PureExportMapModal({
   );
 }
 
-export default function ExportMapModal({ onClickDownload, onClickShare, dismissModal }) {
+export default function ExportMapModal({ onClickShare, dismissModal, currentMap, farmName }) {
   return (
     <Modal dismissModal={dismissModal}>
       <PureExportMapModal
-        onClickDownload={onClickDownload}
         onClickShare={onClickShare}
         dismissModal={dismissModal}
+        currentMap={currentMap}
+        farmName={farmName}
       />
     </Modal>
   );

--- a/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
+++ b/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
@@ -37,7 +37,6 @@ export function PureExportMapModal({
   }, [isEmailing]);
 
   useEffect(() => {
-    console.log(currentMap);
     setIsLoading(true);
     html2canvas(currentMap, { useCORS: true }).then((canvas) => {
       setLinkHref(canvas.toDataURL());

--- a/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
+++ b/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
@@ -61,7 +61,7 @@ export function PureExportMapModal({
           onClick={onClickDownload}
         >
           {isLoading ? (
-            'Loading...'
+            t('FARM_MAP.EXPORT_MODAL.LOADING')
           ) : (
             <>
               <DownloadIcon className={styles.downloadSvg} />

--- a/packages/webapp/src/components/Modals/ExportMapModal/styles.module.scss
+++ b/packages/webapp/src/components/Modals/ExportMapModal/styles.module.scss
@@ -24,6 +24,17 @@
   border-radius: 7.05466px;
   position: relative;
   padding: 24px;
+
+  a {
+    margin-top: 24px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    text-decoration: none;
+    width: 100%;
+    align-self: stretch;
+  }
 }
 
 .button {

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import styles from './styles.module.scss';
@@ -298,6 +298,10 @@ export default function Map({ history }) {
 
   const mapWrapperRef = useRef();
 
+  const currentMap = useMemo(() => {
+    return mapWrapperRef.current;
+  }, [mapWrapperRef.current]);
+
   const handleShowVideo = () => {
     history.push('/map/videos');
   };
@@ -305,14 +309,6 @@ export default function Map({ history }) {
   const handleCloseSuccessHeader = () => {
     dispatch(canShowSuccessHeader(false));
     setShowSuccessHeader(false);
-  };
-
-  const handleDownload = () => {
-    html2canvas(mapWrapperRef.current, { useCORS: true }).then((canvas) => {
-      canvas.toBlob((blob) => {
-        saveAs(blob, `${farm_name}-export-${new Date().toISOString()}.png`);
-      });
-    });
   };
 
   const handleShare = () => {
@@ -430,9 +426,10 @@ export default function Map({ history }) {
         )}
         {showExportModal && (
           <ExportMapModal
-            onClickDownload={handleDownload}
             onClickShare={handleShare}
             dismissModal={() => setShowExportModal(false)}
+            currentMap={currentMap}
+            farmName={farm_name}
           />
         )}
         {showDrawAreaSpotlightModal && (


### PR DESCRIPTION
The issue we were experiencing with the map downloads may have been caused by the fact that we were  generating and clicking an `a` tag in the code. I have verified that in Chrome for iOS, `a` tags with the proper `download` and `href` attributes generally download fine.

To test:
1. Go to your map
2. Download it