### PR TITLE
F21-606 Fix : resolved the Incorrect capitalization on "People" tab

### DIFF
--- a/packages/webapp/src/components/Profile/People/index.jsx
+++ b/packages/webapp/src/components/Profile/People/index.jsx
@@ -55,13 +55,13 @@ export default function PurePeople({ users, history, isAdmin }) {
     };
 
     const getName = (user) => {
-      const firstName = user.first_name.toLowerCase();
-      const lastName = user.last_name.toLowerCase();
+      const firstName = user.first_name;
+      const lastName = user.last_name;
       return firstName.concat(' ', lastName);
     };
 
     const filteredUsers = users.filter((user) => {
-      return getName(user).includes(searchString.trim().toLowerCase());
+      return getName(user).toLowerCase().includes(searchString.trim().toLowerCase());
     });
     return filteredUsers.map((user) => ({
       name: getName(user),


### PR DESCRIPTION
To Test:

1. go to http://localhost:3000/people.
2. check the names displayed in the name column are retaining the capitalization.
3. check the search functionality based on the name.


<img width="400" alt="Screen Shot 2022-06-03 at 1 21 02 PM" src="https://user-images.githubusercontent.com/20675885/171946179-7335c977-16b1-4677-ab4e-9bdaad78f1b0.png">

For more details: 
https://lite-farm.atlassian.net/browse/F21-606


  