### PR TITLE
F21-694/fix where quantity and unit are incorrectly displayed

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -214,16 +214,24 @@ const Unit = ({
 
   const hookFormUnitOption = hookFromWatch(displayUnitName);
   const hookFormUnit = hookFormUnitOption?.value;
+
   useEffect(() => {
     if (typeof hookFormUnitOption === 'string' && getUnitOptionMap()[hookFormUnitOption]) {
       hookFormSetValue(displayUnitName, getUnitOptionMap()[hookFormUnitOption]);
     }
   }, []);
+
   useEffect(() => {
     if (hookFormUnit && convert().describe(hookFormUnit)?.system !== system && measure !== 'time') {
       hookFormSetValue(displayUnitName, getUnitOptionMap()[displayUnit]);
     }
   }, [hookFormUnit]);
+
+  useEffect(() => {
+    if (hookFormUnit !== displayUnit) {
+      setVisibleInputValue(hookFormValue);
+    }
+  }, [displayUnit]);
 
   useEffect(() => {
     if (!hookFormGetValue(displayUnitName)) {


### PR DESCRIPTION
Ticket [F21-694](https://lite-farm.atlassian.net/browse/F21-694)

Please note that this bug originated from a commonly used <Unit/> component so this change might affect many different places (theoretically shouldn't)

**To Test:**
1. Create a cleaning task, a pest control task, and a soil amendment task (when creating these tasks, make sure to select appropriate options so that you can put in the quantity of products used for this task). For example, choose any spray method for pest control and choose cleaner for cleaning task, etc.
2. Once you create the tasks, go to the task details page and make sure that the quantity and unit are displayed as you entered.

Also, feel free to test around crop plans, etc that utilize this component (anywhere that users can input quantity and unit)
