### PR TITLE
F21 686 canceling location creation not completed

### DIFF
--- a/packages/webapp/src/components/LocationDetailLayout/LocationPageHeader.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/LocationPageHeader.jsx
@@ -33,7 +33,7 @@ export default function LocationPageHeader({
   return (
     <PageTitle
       title={title}
-      onCancel={isCreateLocationPage && onCancel}
+      onCancel={isCreateLocationPage && onGoBack}
       cancelModalTitle={t('FARM_MAP.LOCATION_CREATION_FLOW')}
       onGoBack={onGoBack}
       style={{ marginBottom: '24px' }}

--- a/packages/webapp/src/components/LocationDetailLayout/LocationPageHeader.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/LocationPageHeader.jsx
@@ -33,7 +33,7 @@ export default function LocationPageHeader({
   return (
     <PageTitle
       title={title}
-      onCancel={isCreateLocationPage && onGoBack}
+      onCancel={isCreateLocationPage && onCancel}
       cancelModalTitle={t('FARM_MAP.LOCATION_CREATION_FLOW')}
       onGoBack={onGoBack}
       style={{ marginBottom: '24px' }}

--- a/packages/webapp/src/components/LocationDetailLayout/PureLocationDetailLayout.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/PureLocationDetailLayout.jsx
@@ -35,7 +35,8 @@ export function PureLocationDetailLayout({
     shouldUnregister: true,
     defaultValues: persistedFormData,
   });
-  const { historyCancel } = useHookFormPersist?.(formMethods.getValues) || {};
+  const historyCancel = () => history.push('/map');
+
   const onError = (data) => {};
   const disabled = !formMethods.formState.isValid;
 


### PR DESCRIPTION
This PR fixes a bug that was causing the "cancel" button in the location creation flow to behave incorrectly.

Ticket: [F21-686](https://lite-farm.atlassian.net/browse/F21-686)

To test:
1. Go to the farm map in my farm
2. Draw a new location
3. Click confirm
5. Click the back button
6. Click confirm again
7. In the details page, click cancel

You should be brought back to the farm map without the location you just drew.