### PR TITLE
F21-690 - fix: 'this task targets a wild crop' doesn't allow bypass of task crops page

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
@@ -19,7 +19,7 @@ const PureTaskCrops = ({
   onError,
   persistedFormData,
   onContinue,
-
+  bypass,
   useHookFormPersist,
   managementPlansByLocationIds,
   wildManagementPlanTiles,
@@ -53,7 +53,7 @@ const PureTaskCrops = ({
 
   const locationIds = Object.keys(managementPlansByLocationIds);
 
-  if (!locationIds.length) {
+  if (bypass) {
     history.replace('/add_task/task_locations', location.state);
     onContinue();
   }

--- a/packages/webapp/src/containers/Task/TaskCrops/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCrops/index.jsx
@@ -63,6 +63,11 @@ function TaskCrops({
       locations || persistedFormData.locations,
       showWildCrops,
     );
+
+  const bypass =
+    !Object.keys(activeAndCurrentManagementPlansByLocationIds).length &&
+    !persistedFormData.show_wild_crop;
+
   const isRequired =
     isHarvestTask || isTransplantTask || (showWildCrops && !persistedFormData.locations?.length);
   return (
@@ -80,6 +85,7 @@ function TaskCrops({
         defaultManagementPlanId={location?.state?.management_plan_id ?? null}
         history={history}
         location={location}
+        bypass={bypass}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskLocations/index.jsx
@@ -93,7 +93,10 @@ function TaskAllLocations({ history, location }) {
   const readOnlyPinCoordinates = useReadOnlyPinCoordinates();
 
   const onContinue = () => {
-    if (taskTypesBypassCrops.includes(persistedFormData.task_type_id)) {
+    if (
+      taskTypesBypassCrops.includes(persistedFormData.task_type_id) &&
+      !readOnlyPinCoordinates?.length
+    ) {
       dispatch(setManagementPlansData([]));
       return history.push('/add_task/task_details', location?.state);
     }


### PR DESCRIPTION
Ticket: [F21-690](https://lite-farm.atlassian.net/browse/F21-690)

Linked Ticket: [F21-692](https://lite-farm.atlassian.net/browse/F21-692)

Added logic so that the “Will this task affect any plans” page will not be bypassed if "This task targets a wild crop" is selected.

To test:
- Create a new wild crop plan with a pin dropped
  - "Will you be planting this crop or is it already in the ground?" --> "In Ground"
  - "Are you harvesting a wild crop?" --> "Yes"
  - "Select the crop's current location" --> Click the button below the map to drop a pin
- Create a new task for the plan
- Do not select any areas, and click "This task targets a wild crop"
- The next page should be “Will this task affect any plans"