### PR TITLE
Update searchbar and filter on notifications listview

### DIFF
--- a/packages/webapp/src/components/PopupFilter/PureSearchbarAndFilter/index.jsx
+++ b/packages/webapp/src/components/PopupFilter/PureSearchbarAndFilter/index.jsx
@@ -34,7 +34,13 @@ const useStyles = makeStyles({
   },
 });
 
-export default function PureSearchbarAndFilter({ onFilterOpen, value, onChange, isFilterActive }) {
+export default function PureSearchbarAndFilter({
+  onFilterOpen,
+  value,
+  onChange,
+  isFilterActive,
+  disableFilter = false,
+}) {
   const classes = useStyles();
   return (
     <>
@@ -45,9 +51,11 @@ export default function PureSearchbarAndFilter({ onFilterOpen, value, onChange, 
           value={value}
           onChange={onChange}
         />
-        {isFilterActive && <div className={classes.circle} />}
-        {isFilterActive && (
-          <FiFilter data-cy="tasks-filter" className={classes.filter} onClick={onFilterOpen} />
+        {!disableFilter && (
+          <>
+            {isFilterActive && <div className={classes.circle} />}
+            <FiFilter data-cy="tasks-filter" className={classes.filter} onClick={onFilterOpen} />
+          </>
         )}
       </div>
     </>

--- a/packages/webapp/src/components/PopupFilter/PureSearchbarAndFilter/index.jsx
+++ b/packages/webapp/src/components/PopupFilter/PureSearchbarAndFilter/index.jsx
@@ -67,4 +67,5 @@ PureSearchbarAndFilter.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
   isFilterActive: PropTypes.bool,
+  disableFilter: PropTypes.bool,
 };

--- a/packages/webapp/src/components/PopupFilter/PureSearchbarAndFilter/index.jsx
+++ b/packages/webapp/src/components/PopupFilter/PureSearchbarAndFilter/index.jsx
@@ -46,7 +46,9 @@ export default function PureSearchbarAndFilter({ onFilterOpen, value, onChange, 
           onChange={onChange}
         />
         {isFilterActive && <div className={classes.circle} />}
-        <FiFilter data-cy="tasks-filter" className={classes.filter} onClick={onFilterOpen} />
+        {isFilterActive && (
+          <FiFilter data-cy="tasks-filter" className={classes.filter} onClick={onFilterOpen} />
+        )}
       </div>
     </>
   );

--- a/packages/webapp/src/containers/Notification/index.jsx
+++ b/packages/webapp/src/containers/Notification/index.jsx
@@ -47,6 +47,7 @@ export default function NotificationPage() {
           value={filterString}
           onChange={filterStringOnChange}
           isFilterActive={false}
+          disableFilter={true}
         />
       </div>
 

--- a/packages/webapp/src/containers/Notification/useStringFilteredNotifications.js
+++ b/packages/webapp/src/containers/Notification/useStringFilteredNotifications.js
@@ -7,7 +7,14 @@ export default function useStringFilteredNotifications(notifications, filterStri
     const lowerCaseFilter = filterString?.toLowerCase() || '';
     const check = (names) => {
       for (const name of names) {
-        if (name?.toLowerCase().includes(lowerCaseFilter)) return true;
+        if (
+          name
+            ?.toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .includes(lowerCaseFilter)
+        )
+          return true;
       }
       return false;
     };
@@ -21,8 +28,8 @@ export default function useStringFilteredNotifications(notifications, filterStri
         return options;
       }, {});
       return check([
-        t(`NOTIFICATION.${notification.translation_key}.TITLE`),
-        t(`NOTIFICATION.${notification.translation_key}.BODY`, tOptions),
+        t(notification.title.translation_key),
+        t(notification.body.translation_key, tOptions),
       ]);
     });
   }, [notifications, filterString]);


### PR DESCRIPTION
This PR fixes the search functionality in the notifications centre. It also allows users to receive accented character outputs from non accented search inputs. Additionally, the "filter" icon is no longer visible beside the search bar because filtering is not applicable here.

Ticket: [F21-695](https://lite-farm.atlassian.net/browse/F21-695)

To test:
1. Navigate to the notifications centre where all notifications are displayed
2. Ensure the "filter" icon is not appearing beside the search bar
3. Enter a search term into the search bar and ensure the appropriate notifications are appearing. Try testing searches against both the body and the title of the notification

To thoroughly test this functionality, try changing the language and searching for terms with accented characters in them. For example, you should find that searching for "a" will match with notifications that have "à" or "â" in their title/body.