### PR TITLE
Removed download button for iOS users

### DIFF
--- a/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
+++ b/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
@@ -6,19 +6,23 @@ import { AiOutlineMail } from 'react-icons/all';
 import styles from './styles.module.scss';
 import { Main, Title } from '../../Typography';
 import Button from '../../Form/Button';
-import html2canvas from 'html2canvas';
+
+const isiOS = () => {
+  return (
+    ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(
+      navigator.platform,
+    ) ||
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  );
+};
 
 export function PureExportMapModal({
   onClickDownload: download,
   onClickShare: share,
   dismissModal,
-  currentMap,
-  farmName,
 }) {
   const { t } = useTranslation();
-  const [isEmailing, setEmailing] = useState();
-  const [isLoading, setIsLoading] = useState(false);
-  const [linkHref, setLinkHref] = useState();
+  const [isEmailing, setEmailing] = useState(false);
   const onClickEmail = () => {
     share();
     setEmailing(true);
@@ -36,39 +40,23 @@ export function PureExportMapModal({
     return () => clearTimeout(timer);
   }, [isEmailing]);
 
-  useEffect(() => {
-    setIsLoading(true);
-    html2canvas(currentMap, { useCORS: true }).then((canvas) => {
-      setLinkHref(canvas.toDataURL());
-      setIsLoading(false);
-    });
-  }, []);
-
   const onClickDownload = () => {
-    !isLoading && dismissModal();
+    download();
+    dismissModal();
   };
 
   return (
     <div className={styles.container}>
       <Title>{t('FARM_MAP.EXPORT_MODAL.TITLE')}</Title>
-      <Main>{t('FARM_MAP.EXPORT_MODAL.BODY')}</Main>
-      <a href={linkHref} download={`${farmName}-export-${new Date().toISOString()}.png`}>
-        <Button
-          color="secondary"
-          className={styles.button}
-          style={{ width: '100%' }}
-          onClick={onClickDownload}
-        >
-          {isLoading ? (
-            t('FARM_MAP.EXPORT_MODAL.LOADING')
-          ) : (
-            <>
-              <DownloadIcon className={styles.downloadSvg} />
-              <div>{t('FARM_MAP.EXPORT_MODAL.DOWNLOAD')}</div>
-            </>
-          )}
-        </Button>
-      </a>
+      {!isiOS() && (
+        <>
+          <Main>{t('FARM_MAP.EXPORT_MODAL.BODY')}</Main>
+          <Button color="secondary" className={styles.button} onClick={onClickDownload}>
+            <DownloadIcon className={styles.downloadSvg} />
+            <div>{t('FARM_MAP.EXPORT_MODAL.DOWNLOAD')}</div>
+          </Button>
+        </>
+      )}
       <Button
         color="secondary"
         disabled={isEmailing}
@@ -86,14 +74,13 @@ export function PureExportMapModal({
   );
 }
 
-export default function ExportMapModal({ onClickShare, dismissModal, currentMap, farmName }) {
+export default function ExportMapModal({ onClickDownload, onClickShare, dismissModal }) {
   return (
     <Modal dismissModal={dismissModal}>
       <PureExportMapModal
         onClickShare={onClickShare}
         dismissModal={dismissModal}
-        currentMap={currentMap}
-        farmName={farmName}
+        onClickDownload={onClickDownload}
       />
     </Modal>
   );

--- a/packages/webapp/src/components/Modals/ExportMapModal/styles.module.scss
+++ b/packages/webapp/src/components/Modals/ExportMapModal/styles.module.scss
@@ -24,17 +24,6 @@
   border-radius: 7.05466px;
   position: relative;
   padding: 24px;
-
-  a {
-    margin-top: 24px;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    text-decoration: none;
-    width: 100%;
-    align-self: stretch;
-  }
 }
 
 .button {

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import styles from './styles.module.scss';
@@ -298,10 +298,6 @@ export default function Map({ history }) {
 
   const mapWrapperRef = useRef();
 
-  const currentMap = useMemo(() => {
-    return mapWrapperRef.current;
-  }, [mapWrapperRef.current]);
-
   const handleShowVideo = () => {
     history.push('/map/videos');
   };
@@ -309,6 +305,14 @@ export default function Map({ history }) {
   const handleCloseSuccessHeader = () => {
     dispatch(canShowSuccessHeader(false));
     setShowSuccessHeader(false);
+  };
+
+  const handleDownload = () => {
+    html2canvas(mapWrapperRef.current, { useCORS: true }).then((canvas) => {
+      canvas.toBlob((blob) => {
+        saveAs(blob, `${farm_name}-export-${new Date().toISOString()}.png`);
+      });
+    });
   };
 
   const handleShare = () => {
@@ -426,10 +430,9 @@ export default function Map({ history }) {
         )}
         {showExportModal && (
           <ExportMapModal
+            onClickDownload={handleDownload}
             onClickShare={handleShare}
             dismissModal={() => setShowExportModal(false)}
-            currentMap={currentMap}
-            farmName={farm_name}
           />
         )}
         {showDrawAreaSpotlightModal && (


### PR DESCRIPTION
This PR makes the changes requested by Kevin on https://lite-farm.atlassian.net/browse/F21-639

This PR removes the option for iOS users to directly download the map as different methods of downloading the map work on different browsers/iOS versions. It also reverts to the previous method of downloading the map image because that did not have need of a "Loading..." text on the download button before the user had clicked on it