### PR TITLE
Added contextual navigation for wild crop plans

### DIFF
--- a/packages/webapp/src/components/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/components/Task/TaskLocations/index.jsx
@@ -23,6 +23,7 @@ export default function PureTaskLocations({
   maxZoomRef,
   getMaxZoom,
   defaultLocation,
+  targetsWildCrop,
 }) {
   const { t } = useTranslation();
   const progress = 43;
@@ -66,6 +67,10 @@ export default function PureTaskLocations({
       locations.some((location) => location.location_id === defaultLocation.location_id) &&
       onSelectLocation(defaultLocation.location_id);
   }, [defaultLocation]);
+
+  useEffect(() => {
+    setValue(SHOW_WILD_CROP, targetsWildCrop);
+  }, []);
 
   const getSelectedLocations = (location_id, selectedLocations) => {
     const isSelected = selectedLocations

--- a/packages/webapp/src/containers/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskLocations/index.jsx
@@ -134,7 +134,6 @@ function TaskLocations({
   const managementPlan = location?.state?.management_plan_id
     ? useSelector(managementPlanSelector(location.state.management_plan_id))
     : null;
-  console.log(managementPlan);
   return (
     <HookFormPersistProvider>
       <PureTaskLocations

--- a/packages/webapp/src/containers/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskLocations/index.jsx
@@ -18,6 +18,7 @@ import { useIsTaskType } from '../useIsTaskType';
 import { useTranslation } from 'react-i18next';
 import { useReadOnlyPinCoordinates } from '../useReadOnlyPinCoordinates';
 import { useMaxZoom } from '../../Map/useMaxZoom';
+import { managementPlanSelector } from '../../managementPlanSlice';
 
 export default function TaskLocationsSwitch({ history, match, location }) {
   const isCropLocation = useIsTaskType('HARVEST_TASK');
@@ -130,6 +131,10 @@ function TaskLocations({
 }) {
   const { grid_points } = useSelector(userFarmSelector);
   const { maxZoomRef, getMaxZoom } = useMaxZoom();
+  const managementPlan = location?.state?.management_plan_id
+    ? useSelector(managementPlanSelector(location.state.management_plan_id))
+    : null;
+  console.log(managementPlan);
   return (
     <HookFormPersistProvider>
       <PureTaskLocations
@@ -143,6 +148,7 @@ function TaskLocations({
         maxZoomRef={maxZoomRef}
         getMaxZoom={getMaxZoom}
         defaultLocation={location.state.location ?? null}
+        targetsWildCrop={managementPlan?.crop_management_plan?.is_wild ?? false}
       />
     </HookFormPersistProvider>
   );


### PR DESCRIPTION
This resolves https://lite-farm.atlassian.net/browse/F21-579

To test:
1. Create a wild crop plan. (When making the plan ensure you select "in ground" to be able to make it a wild crop)
2. Create a new task from the crop management plan
3. As you go through the task creation flow, the "This task targets a wild crop" checkbox should be checked automatically. Additionally, the crop plan should be pre-selected when you reach that page
4. When you finish creating the task, you should be returned to the management plan, not the tasks page 