### PR TITLE
Notifications-are-sorted-in-the-wrong-order

### DIFF
--- a/packages/webapp/src/containers/Notification/index.jsx
+++ b/packages/webapp/src/containers/Notification/index.jsx
@@ -66,6 +66,7 @@ export default function NotificationPage() {
               />
             );
           })
+          .reverse()
       ) : (
         <Semibold style={{ color: 'var(--teal700)', marginLeft: '24px' }}>
           {t('NOTIFICATION.NONE_TO_DISPLAY')}

--- a/packages/webapp/src/containers/Notification/index.jsx
+++ b/packages/webapp/src/containers/Notification/index.jsx
@@ -53,7 +53,7 @@ export default function NotificationPage() {
       {notifications.length > 0 ? (
         notifications
           .sort((a, b) => {
-            if (a.alert !== b.alert) return a.alert ? -1 : 1;
+            // if (a.alert !== b.alert) return a.alert ? -1 : 1;
             return new Date(a.created_at) - new Date(b.created_at);
           })
           .map((notification) => {

--- a/packages/webapp/src/containers/Notification/index.jsx
+++ b/packages/webapp/src/containers/Notification/index.jsx
@@ -53,8 +53,7 @@ export default function NotificationPage() {
       {notifications.length > 0 ? (
         notifications
           .sort((a, b) => {
-            // if (a.alert !== b.alert) return a.alert ? -1 : 1;
-            return new Date(a.created_at) - new Date(b.created_at);
+            return new Date(b.created_at) - new Date(a.created_at);
           })
           .map((notification) => {
             return (
@@ -66,7 +65,6 @@ export default function NotificationPage() {
               />
             );
           })
-          .reverse()
       ) : (
         <Semibold style={{ color: 'var(--teal700)', marginLeft: '24px' }}>
           {t('NOTIFICATION.NONE_TO_DISPLAY')}


### PR DESCRIPTION
[Jira Ticket](https://lite-farm.atlassian.net/jira/software/c/projects/F21/boards/3?modal=detail&selectedIssue=F21-697)


To test: 
Go to the notifications page and check to see if the notifications are sorted in descending order. (ie. June 6 should be on top while June 5th notification should be below the June 6th notification)