### PR TITLE
Fix: Stretching of weather board on Litefarm homepage

### DIFF
--- a/packages/webapp/src/components/WeatherBoard/assets/weatherBoard.module.scss
+++ b/packages/webapp/src/components/WeatherBoard/assets/weatherBoard.module.scss
@@ -7,14 +7,12 @@
   padding: 4.44% 9.44%;
   width: 84%;
   display: grid;
-  grid-template-columns: 78fr 25fr 11fr 11fr 25fr 78fr;
-  grid-template-rows: 24fr 24fr 80fr 24fr;
-  gap: 0px 0px;
   grid-template-areas:
-    'city city city city city city'
-    'date date date date date date'
-    'temperature temperature temperature temperature . icon'
-    'wind wind wind humidity humidity humidity';
+    'city city'
+    'date date'
+    'temperature icon'
+    'wind humidity';
+  word-break: break-word;    
   background-color: var(--overlay);
   font-size: 3.88vw;
   line-height: 6.66vw;
@@ -39,6 +37,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-top: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .icon {
@@ -46,14 +48,18 @@
   display: flex;
   align-items: center;
   font-size: 15.55vw;
+  justify-content: center;
+  padding-top: 16px;
 }
 
 .wind {
   grid-area: wind;
+  padding-top: 16px;
 }
 
 .humidity {
   grid-area: humidity;
+  padding-top: 16px;
 }
 
 @media only screen and (min-width: 960px) {
@@ -73,9 +79,19 @@
   .temperature {
     font-size: 136.5px;
     line-height: 126px;
+    padding-top: 20px;
   }
 
   .icon {
     font-size: 144.375px;
+    padding-top: 20px;
+  }
+  
+  .wind {
+    padding-top: 20px;
+  }
+
+  .humidity {
+    padding-top: 20px;
   }
 }


### PR DESCRIPTION
To test: 

1. go to http://localhost:3000/
2. open the safari browser and check if the weather board is not stretching for all screen sizes.

For more details: https://lite-farm.atlassian.net/browse/F21-589


Before: 
<img width="332" alt="Screen Shot 2022-06-06 at 1 29 09 PM" src="https://user-images.githubusercontent.com/20675885/172243493-5a3b5628-3efe-4fd3-9ca0-c3810fb292d7.png">

After: 
<img width="320" alt="Screen Shot 2022-06-06 at 1 29 33 PM" src="https://user-images.githubusercontent.com/20675885/172243582-8c202524-35dc-4676-9caf-e0cd25fad1dd.png">

