### PR TITLE
F21 693 product and supplier not persisted when creating soil amendment task

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskAssignment/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskAssignment/index.jsx
@@ -23,7 +23,6 @@ const PureTaskAssignment = ({
   persistedFormData,
 }) => {
   const { t } = useTranslation();
-  console.log(userFarmOptions);
   const OVERRIDE_HOURLY_WAGE = 'override_hourly_wage';
   const ASSIGNEE = 'assignee_user_id';
   const WAGE_OVERRIDE = 'wage_at_moment';

--- a/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
+++ b/packages/webapp/src/containers/Crop/ManagementDetail/ManagementTasks.jsx
@@ -9,9 +9,10 @@ import {
   tasksByManagementPlanIdSelector,
 } from '../../taskSlice';
 import TaskCard from '../../Task/TaskCard';
-import React, { useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { taskCardContentByManagementPlanSelector } from '../../Task/taskCardContentSelector';
 import { onAddTask } from '../../Task/onAddTask';
+import { getManagementPlansAndTasks } from '../../saga';
 
 export default function ManagementTasks({ history, match, location }) {
   const dispatch = useDispatch();
@@ -21,6 +22,10 @@ export default function ManagementTasks({ history, match, location }) {
   const management_plan_id = match.params.management_plan_id;
   const plan = useSelector(managementPlanSelector(management_plan_id));
   const isAdmin = useSelector(isAdminSelector);
+
+  useEffect(() => {
+    dispatch(getManagementPlansAndTasks());
+  }, []);
 
   const onBack = () => {
     history.push(`/crop/${variety_id}/management`, location?.state);

--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -60,14 +60,6 @@ export default function TaskPage({ history }) {
     setIsFilterOpen(true);
   };
 
-  // useEffect(() => {
-  //   dispatch(getManagementPlansAndTasks());
-  // }, []);
-
-  // useEffect(() => {
-  //   dispatch(resetAndUnLockFormData());
-  // }, []);
-
   useEffect(() => {
     dispatch(getManagementPlansAndTasks());
     dispatch(resetAndUnLockFormData());
@@ -99,12 +91,6 @@ export default function TaskPage({ history }) {
         break;
     }
   }, []);
-
-  // useEffect(() => {
-  //   if (history.location.state?.notification_type === DAILY_TASKS_DUE_TODAY) {
-  //     dispatch(setTasksFilterDueToday({ user_id, first_name, last_name, date: history.location.state.notification_date }));
-  //   }
-  // }, []);
 
   const assigneeValue = useMemo(() => {
     let unassigned;

--- a/packages/webapp/src/util/convert-units/unit.js
+++ b/packages/webapp/src/util/convert-units/unit.js
@@ -173,7 +173,7 @@ export const soilAmounts = {
   metric: {
     units: ['g', 'kg', 'mt'],
     defaultUnit: 'kg',
-    breakpoints: [1000],
+    breakpoints: [1, 1000],
   },
   imperial: {
     units: ['oz', 'lb', 't'],
@@ -306,6 +306,7 @@ export const getDefaultUnit = (unitType = area_total_area, value, system, unit) 
     const defaultDisplayValue =
       defaultDisplayUnit === from ? value : convert(value).from(from).to(defaultDisplayUnit);
     let i = 0;
+    console.log(unitType[system]);
     for (; i < unitType[system].breakpoints.length; i++) {
       if (defaultDisplayValue < unitType[system].breakpoints[i]) {
         displayUnit = unitType[system].units[i];

--- a/packages/webapp/src/util/convert-units/unit.js
+++ b/packages/webapp/src/util/convert-units/unit.js
@@ -306,7 +306,6 @@ export const getDefaultUnit = (unitType = area_total_area, value, system, unit) 
     const defaultDisplayValue =
       defaultDisplayUnit === from ? value : convert(value).from(from).to(defaultDisplayUnit);
     let i = 0;
-    console.log(unitType[system]);
     for (; i < unitType[system].breakpoints.length; i++) {
       if (defaultDisplayValue < unitType[system].breakpoints[i]) {
         displayUnit = unitType[system].units[i];


### PR DESCRIPTION
Ticket: [F21-693](https://lite-farm.atlassian.net/browse/F21-693)

To test:
- Create a new soil amendment task from a crop plan
  - Create a new product and supplier
- Immediately go to task read only page of the new task from the crop plan
- Ensure that the new product and supplier are showing up correctly