### PR TITLE
Updated dates to mirror those on the other finance pages

### DIFF
--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -32,8 +32,8 @@ export default function ActualRevenue({ history, match }) {
     mode: 'onBlur',
     shouldUnregister: true,
     defaultValues: {
-      from_date: new Date(dateRange.startDate).toISOString().split('T')[0],
-      to_date: new Date(dateRange.endDate).toISOString().split('T')[0],
+      from_date: dateRange.startDate,
+      to_date: dateRange.endDate,
     },
   });
 

--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -1,17 +1,17 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import Layout from '../../../components/Layout';
 import PageTitle from '../../../components/PageTitle/v2';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
-import moment from 'moment';
-import { salesSelector } from '../selectors';
+import { dateRangeSelector, salesSelector } from '../selectors';
 import WholeFarmRevenue from '../../../components/Finances/WholeFarmRevenue';
 import { AddLink, Semibold } from '../../../components/Typography';
 import DateRangePicker from '../../../components/Form/DateRangePicker';
 import ActualCropRevenue from '../ActualCropRevenue';
 import FinanceListHeader from '../../../components/Finances/FinanceListHeader';
 import { calcActualRevenue, filterSalesByDateRange } from '../util';
+import { setDateRange } from '../actions';
 
 export default function ActualRevenue({ history, match }) {
   const { t } = useTranslation();
@@ -19,6 +19,8 @@ export default function ActualRevenue({ history, match }) {
   const onAddRevenue = () => history.push(`/add_sale`);
   // TODO: refactor sale data after finance reducer is remade
   const sales = useSelector(salesSelector);
+  const dateRange = useSelector(dateRangeSelector);
+  const dispatch = useDispatch();
 
   const {
     register,
@@ -30,8 +32,8 @@ export default function ActualRevenue({ history, match }) {
     mode: 'onBlur',
     shouldUnregister: true,
     defaultValues: {
-      from_date: moment().startOf('year').format('YYYY-MM-DD'),
-      to_date: moment().endOf('year').format('YYYY-MM-DD'),
+      from_date: new Date(dateRange.startDate).toISOString().split('T')[0],
+      to_date: new Date(dateRange.endDate).toISOString().split('T')[0],
     },
   });
 
@@ -45,6 +47,10 @@ export default function ActualRevenue({ history, match }) {
     () => filterSalesByDateRange(sales, fromDate, toDate),
     [sales, fromDate, toDate],
   );
+
+  useEffect(() => {
+    dispatch(setDateRange({ startDate: fromDate, endDate: toDate }));
+  }, [fromDate, toDate]);
 
   return (
     <Layout>

--- a/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import Layout from '../../../components/Layout';
 import PageTitle from '../../../components/PageTitle/v2';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import moment from 'moment';
@@ -13,12 +13,16 @@ import FinanceListHeader from '../../../components/Finances/FinanceListHeader';
 import { managementPlansSelector } from '../../managementPlanSlice';
 import { taskEntitiesByManagementPlanIdSelector } from '../../taskSlice';
 import { isTaskType } from '../../Task/useIsTaskType';
+import { dateRangeSelector } from '../selectors';
+import { setDateRange } from '../actions';
 
 export default function EstimatedRevenue({ history, match }) {
   const { t } = useTranslation();
   const onGoBack = () => history.push(`/finances`);
   const managementPlans = useSelector(managementPlansSelector);
   const tasksByManagementPlanId = useSelector(taskEntitiesByManagementPlanIdSelector);
+  const dateRange = useSelector(dateRangeSelector);
+  const dispatch = useDispatch();
 
   const {
     register,
@@ -30,13 +34,17 @@ export default function EstimatedRevenue({ history, match }) {
     mode: 'onBlur',
     shouldUnregister: true,
     defaultValues: {
-      from_date: moment().startOf('year').format('YYYY-MM-DD'),
-      to_date: moment().endOf('year').format('YYYY-MM-DD'),
+      from_date: new Date(dateRange.startDate).toISOString().split('T')[0],
+      to_date: new Date(dateRange.endDate).toISOString().split('T')[0],
     },
   });
 
   const fromDate = watch('from_date');
   const toDate = watch('to_date');
+
+  useEffect(() => {
+    dispatch(setDateRange({ startDate: fromDate, endDate: toDate }));
+  }, [fromDate, toDate]);
 
   const estimatedRevenueItems = useMemo(() => {
     return managementPlans

--- a/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
@@ -34,8 +34,8 @@ export default function EstimatedRevenue({ history, match }) {
     mode: 'onBlur',
     shouldUnregister: true,
     defaultValues: {
-      from_date: new Date(dateRange.startDate).toISOString().split('T')[0],
-      to_date: new Date(dateRange.endDate).toISOString().split('T')[0],
+      from_date: dateRange.startDate,
+      to_date: dateRange.endDate,
     },
   });
 


### PR DESCRIPTION
This PR resolves https://lite-farm.atlassian.net/browse/F21-669

To test:
1. Go to the "Finances" page
2. Set the date range to some initial value that is different from the default value
3. Go to both the "Actual Revenue" and "Estimated Revenue" pages and see if the date range there matches the value on the main finance page (it should)
4. Change the date range in the actual and estimated revenue pages and see if it updates on the main finances page (it should)