### PR TITLE
F21 671/ignore "_" in search string fix

### DIFF
--- a/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
+++ b/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.js
@@ -10,6 +10,7 @@ export default function useStringFilteredCrops(crops, filterString) {
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
         .replace(/\W/g, '')
+        .replace(/_/g, '')
         .trim() || '';
     const check = (names) => {
       for (const name of names) {
@@ -19,6 +20,7 @@ export default function useStringFilteredCrops(crops, filterString) {
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
             .replace(/\W/g, '')
+            .replace(/_/g, '')
             .trim()
             .includes(lowerCaseFilter)
         )

--- a/packages/webapp/src/containers/Documents/util.js
+++ b/packages/webapp/src/containers/Documents/util.js
@@ -25,6 +25,7 @@ export function useStringFilteredDocuments(documents, filterString) {
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
         .replace(/\W/g, '')
+        .replace(/_/g, '')
         .trim() || '';
     const check = (names) => {
       for (const name of names) {
@@ -34,6 +35,7 @@ export function useStringFilteredDocuments(documents, filterString) {
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
             .replace(/\W/g, '')
+            .replace(/_/g, '')
             .trim()
             .includes(lowerCaseFilter)
         )


### PR DESCRIPTION
Ticket [F21-671](https://lite-farm.atlassian.net/browse/F21-671)

"_" underscore should be ignored from search strings.

To Test:
1. Go to Crop Catalogue and Documents
2. Search with underscore, the underscore should be ignored