### PR TITLE
F21-692/wild crops tasks displayed on the task list

### DIFF
--- a/packages/webapp/src/containers/Task/tasksFilter.js
+++ b/packages/webapp/src/containers/Task/tasksFilter.js
@@ -50,7 +50,8 @@ export function filterTasks(tasks, filters) {
     .filter(
       (t) =>
         !activeLocations.size ||
-        t.locations.find(({ location_id }) => activeLocations.has(location_id)),
+        t.locations.find(({ location_id }) => activeLocations.has(location_id)) ||
+        !t.locations.length
     )
     .filter(
       (t) =>


### PR DESCRIPTION
Ticket [F21-692](https://lite-farm.atlassian.net/browse/F21-692)

Currently, the tasks that target wild crops only appear in the wild crop plans page. (They don't appear on the main general task list)

To Test:

1. Create at least one crop plan which is for a wild crop
2. Create a task and on the location page, select “This task targets a wild crop”
3. Finish creating the task
4. Check that the task appears on the main task list