### PR TITLE
F21-630: Fix: Update snackbar for locations is missing a space and has wrong capitalization

### DIFF
--- a/packages/webapp/src/containers/mapSlice.js
+++ b/packages/webapp/src/containers/mapSlice.js
@@ -14,7 +14,7 @@ const mapLocationReducer = createSlice({
   initialState,
   reducers: {
     setSuccessMessage: (state, { payload: [locationType, action] }) => {
-      state.successMessage = `${locationType}${action}`;
+      state.successMessage = `${locationType} ${action?.toString()?.toLowerCase()}`;
     },
     canShowSuccessHeader: (state, { payload: showHeader }) => {
       state.canShowSuccessHeader = showHeader;


### PR DESCRIPTION
To test: 

1. On the farm map, select an existing location
2. Click “Edit”
3. Change some of the attributes
4. Click “Update”

Fix Results: 
e.g. “Surface water successfully updated”

Before Fix Results: 
e.g. “Surface waterSuccessfully updated”

For more details: 
https://lite-farm.atlassian.net/browse/F21-611

Before:
<img width="392" alt="Screen Shot 2022-06-07 at 10 24 17 AM" src="https://user-images.githubusercontent.com/20675885/172445040-7410a294-0eaf-4cfb-8f49-601dc2c74574.png">

After: 
<img width="393" alt="Screen Shot 2022-06-07 at 10 19 56 AM" src="https://user-images.githubusercontent.com/20675885/172444493-8dc1b0c2-9507-43fd-b79e-1f238761adc5.png">