### PR TITLE
F21 167 able to have a value of 0 for expense

### DIFF
--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -12,7 +12,7 @@ import {
 } from '../../selectors';
 import history from '../../../../history';
 import DateContainer from '../../../../components/Inputs/DateContainer';
-import { actions, Control, Field, Form } from 'react-redux-form';
+import { actions, Control, Field, Form, Errors } from 'react-redux-form';
 import footerStyles from '../../../../components/LogFooter/styles.module.scss';
 import { addExpenses } from '../../actions';
 import { userFarmSelector } from '../../../userFarmSlice';
@@ -93,7 +93,7 @@ class AddExpense extends Component {
       let values = currentExpenseDetail[k];
 
       for (let v of values) {
-        if (v.note !== '' && !isNaN(v.value) && v.value >= 0) {
+        if (v.note !== '' && !isNaN(v.value) && v.value > 0) {
           let value = parseFloat(parseFloat(v.value).toFixed(2));
           let temp = {
             farm_id,
@@ -109,7 +109,7 @@ class AddExpense extends Component {
 
     if (data.length < 1) {
       alert(this.props.t('EXPENSE.ADD_EXPENSE.REQUIRED_ERROR'));
-    } else if (data.filter((d) => d.value <= 0).length > 0) {
+    } else if (data.filter((d) => d.value <= 0 || isNaN(d.value)).length > 0) {
       alert(this.props.t('EXPENSE.ADD_EXPENSE.MIN_ERROR') + '0');
     } else {
       this.props.dispatch(addExpenses(data));
@@ -182,6 +182,7 @@ class AddExpense extends Component {
                               maxLength="25"
                             />
                           </div>
+
                           <div className={styles.labelInput}>
                             <label>
                               {this.props.t('EXPENSE.VALUE')} ({this.state.currencySymbol})
@@ -190,11 +191,19 @@ class AddExpense extends Component {
                               type="number"
                               onKeyDown={numberOnKeyDown}
                               model={`.expenseDetail[${k}][${i}].value`}
-                              validators={{ required: this.required, min: this.min }}
+                              validators={{ min: (val) => val > 0 }}
                               min="0.01"
                               step="0.01"
                             />
                           </div>
+                          <Errors
+                            className="required"
+                            model={`.expenseDetail[${k}][${i}].value`}
+                            show={{ touched: true, focus: false }}
+                            messages={{
+                              min: this.props.t('EXPENSE.ADD_EXPENSE.MIN_ERROR') + '0',
+                            }}
+                          />
                         </Field>
                         {i !== 0 && (
                           <div className={styles.removeButton}>

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -109,6 +109,8 @@ class AddExpense extends Component {
 
     if (data.length < 1) {
       alert(this.props.t('EXPENSE.ADD_EXPENSE.REQUIRED_ERROR'));
+    } else if (data.filter((d) => d.value <= 0).length > 0) {
+      alert(this.props.t('EXPENSE.ADD_EXPENSE.MIN_ERROR') + '0');
     } else {
       this.props.dispatch(addExpenses(data));
       history.push('/finances');

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -93,7 +93,7 @@ class AddExpense extends Component {
       let values = currentExpenseDetail[k];
 
       for (let v of values) {
-        if (v.note !== '' && !isNaN(v.value) && v.value > 0) {
+        if (v.note !== '') {
           let value = parseFloat(parseFloat(v.value).toFixed(2));
           let temp = {
             farm_id,


### PR DESCRIPTION
This PR prevents users from providing 0 as a value when adding a new expense

Ticket: [F21-167](https://lite-farm.atlassian.net/browse/F21-167)

To test:
1. Navigate to the finances page
2. Click 'Add new expense' and pick an expense type and proceed to the form
3. Here you should enter various different inputs for the "value" field. When you enter 0, or when the field is empty, you should see an inline error message. When you try to submit the form with invalid values, you should see an alert that prevents you from proceeding until you enter valid inputs.