### PR TITLE
F21-623 - fix: invalidate negative values for units

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -400,6 +400,7 @@ const Unit = ({
           required: required && t('common:REQUIRED'),
           valueAsNumber: true,
           max: { value: getMax(), message: t('UNIT.VALID_VALUE') + max },
+          min: { value: 0, message: t('UNIT.VALID_VALUE') + max },
         })}
       />
       {info && !showError && <Info style={classes.info}>{info}</Info>}


### PR DESCRIPTION
Ticket: [F21-623](https://lite-farm.atlassian.net/browse/F21-623)

Fix for making sure only non-negative values are excepted in Unit input. 

To test:
- Create a new area location in the map
- Copy a negative number and paste it into the "Total area" field (may need to right click, then paste)
- Ensure that an error appears below the "Total area" field
- I looked through the current units that our Unit input supports and it doesn't seem like any of them can be negative logically. If the reviewer can also verify this that would be great:
<img width="466" alt="Screen Shot 2022-06-07 at 1 43 14 PM" src="https://user-images.githubusercontent.com/104768598/172448082-a8cda7e7-08b1-4e9c-aec5-4c0d0c32eed8.png">

