### PR TITLE
F21-630 : Fix: Area unit dropdowns not disabled on location detail page

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -371,7 +371,7 @@ const Unit = ({
               styles={reactSelectStyles}
               isSearchable={false}
               options={options}
-              isDisabled={isSelectDisabled}
+              isDisabled={isSelectDisabled || disabled}
             />
           )}
         />


### PR DESCRIPTION
To Test:

1. go to farm maps
2. select any farm and navigate to the farm details page.
3. check if the unit component's dropdown is disabled or not.

For more details: 
https://lite-farm.atlassian.net/browse/F21-630

Before: 
<img width="300" alt="Screen Shot 2022-06-07 at 10 44 21 AM" src="https://user-images.githubusercontent.com/20675885/172450109-20a5477a-2bdc-4219-8a03-916ab3ef7b32.png">

After: 
<img width="300" alt="Screen Shot 2022-06-07 at 10 43 53 AM" src="https://user-images.githubusercontent.com/20675885/172450141-c71e7bc3-9578-4aca-bfdc-ed7728533452.png">



