### PR TITLE
F21 698 sticky pin based on gps location from farm creation flow on map until first area drawn

### DIFF
--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -66,6 +66,8 @@ export default function Map({ history }) {
   const [showZeroAreaWarning, setZeroAreaWarning] = useState(false);
   const successMessage = useSelector(setSuccessMessageSelector);
 
+  const [showingConfirmButtons, setShowingConfirmButtons] = useState(false);
+
   const initialLineData = {
     [locationEnum.watercourse]: {
       width: 1,
@@ -159,7 +161,7 @@ export default function Map({ history }) {
   const { drawAssets } = useMapAssetRenderer({
     isClickable: !drawingState.type,
     drawingState: drawingState,
-    reconstructOverlay: reconstructOverlay,
+    showingConfirmButtons: showingConfirmButtons,
   });
   const { getMaxZoom } = useMaxZoom();
   const handleGoogleMapApi = (map, maps) => {
@@ -212,6 +214,7 @@ export default function Map({ history }) {
       });
     });
     maps.event.addListener(drawingManagerInit, 'overlaycomplete', function (drawing) {
+      setShowingConfirmButtons(true);
       finishDrawing(drawing, maps, map);
       this.setDrawingMode();
     });
@@ -327,6 +330,7 @@ export default function Map({ history }) {
   };
 
   const handleConfirm = () => {
+    setShowingConfirmButtons(false);
     if (!isLineWithWidth()) {
       const locationData = getOverlayInfo();
       dispatch(upsertFormData(locationData));
@@ -335,6 +339,7 @@ export default function Map({ history }) {
   };
 
   const handleLineConfirm = (lineData) => {
+    setShowingConfirmButtons(false);
     const data = { ...getOverlayInfo(), ...lineData };
     dispatch(upsertFormData(data));
     history.push(`/create_location/${drawingState.type}`);
@@ -394,11 +399,13 @@ export default function Map({ history }) {
                   resetDrawing(true);
                   dispatch(resetAndUnLockFormData());
                   closeDrawer();
+                  setShowingConfirmButtons(false);
                 }}
                 onClickTryAgain={() => {
                   setZeroAreaWarning(false);
                   resetDrawing();
                   startDrawing(drawingState.type);
+                  setShowingConfirmButtons(false);
                 }}
                 onClickConfirm={handleConfirm}
                 showZeroAreaWarning={showZeroAreaWarning}

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -156,7 +156,11 @@ export default function Map({ history }) {
       fullscreenControl: false,
     };
   };
-  const { drawAssets } = useMapAssetRenderer({ isClickable: !drawingState.type });
+  const { drawAssets } = useMapAssetRenderer({
+    isClickable: !drawingState.type,
+    drawingState: drawingState,
+    reconstructOverlay: reconstructOverlay,
+  });
   const { getMaxZoom } = useMaxZoom();
   const handleGoogleMapApi = (map, maps) => {
     getMaxZoom(maps);

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -40,8 +40,7 @@ import { userFarmSelector } from '../userFarmSlice';
  *
  * Do not modify, copy or reuse
  */
-const useMapAssetRenderer = ({ isClickable, drawingState }) => {
-  console.log(drawingState);
+const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState }) => {
   const { handleSelection, dismissSelectionModal } = useSelectionHandler();
   const dispatch = useDispatch();
   const filterSettings = useSelector(mapFilterSettingSelector);
@@ -52,6 +51,9 @@ const useMapAssetRenderer = ({ isClickable, drawingState }) => {
     }
     return nextAssetGeometries;
   };
+
+  const [farmLocationMarker, setFarmLocationMarker] = useState(null);
+  const [farmMap, setFarmMap] = useState();
 
   const [assetGeometries, setAssetGeometries] = useState(initAssetGeometriesState());
   //TODO get prev filter state from redux
@@ -97,7 +99,7 @@ const useMapAssetRenderer = ({ isClickable, drawingState }) => {
   const areaAssets = useSelector(sortedAreaSelector);
   const lineAssets = useSelector(lineSelector);
   const pointAssets = useSelector(pointSelector);
-  const { grid_points, farm_name } = useSelector(userFarmSelector);
+  const { grid_points } = useSelector(userFarmSelector);
 
   const assetFunctionMap = (assetType) => {
     return isArea(assetType)
@@ -178,6 +180,18 @@ const useMapAssetRenderer = ({ isClickable, drawingState }) => {
     markerClusterRef.current = markerCluster;
   };
 
+  useEffect(() => {
+    if (farmMap !== null) {
+      if (drawingState.isActive) {
+        farmLocationMarker?.setMap(null);
+      } else if (showingConfirmButtons) {
+        farmLocationMarker?.setMap(null);
+      } else {
+        farmLocationMarker?.setMap(farmMap);
+      }
+    }
+  }, [drawingState.isActive, showingConfirmButtons]);
+
   const drawAssets = (map, maps, mapBounds) => {
     maps.event.addListenerOnce(map, 'idle', function () {
       markerClusterRef?.current?.repaint();
@@ -198,7 +212,8 @@ const useMapAssetRenderer = ({ isClickable, drawingState }) => {
     );
     hasLocation = assetsWithLocations.length > 0;
 
-    if (!hasLocation && !drawingState.isActive) {
+    if (!hasLocation) {
+      setFarmMap(map);
       const locationMarker = new maps.Marker({
         icon: MapPin,
         position: grid_points,
@@ -206,6 +221,7 @@ const useMapAssetRenderer = ({ isClickable, drawingState }) => {
         clickable: false,
         crossOnDrag: false,
       });
+      setFarmLocationMarker(locationMarker);
       mapBounds.extend(grid_points);
     }
 

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -40,7 +40,8 @@ import { userFarmSelector } from '../userFarmSlice';
  *
  * Do not modify, copy or reuse
  */
-const useMapAssetRenderer = ({ isClickable }) => {
+const useMapAssetRenderer = ({ isClickable, drawingState }) => {
+  console.log(drawingState);
   const { handleSelection, dismissSelectionModal } = useSelectionHandler();
   const dispatch = useDispatch();
   const filterSettings = useSelector(mapFilterSettingSelector);
@@ -197,19 +198,13 @@ const useMapAssetRenderer = ({ isClickable }) => {
     );
     hasLocation = assetsWithLocations.length > 0;
 
-    if (!hasLocation) {
+    if (!hasLocation && !drawingState.isActive) {
       const locationMarker = new maps.Marker({
         icon: MapPin,
         position: grid_points,
         map: map,
         clickable: false,
         crossOnDrag: false,
-        label: {
-          text: farm_name,
-          color: 'white',
-          fontSize: '16px',
-          className: styles.farmPointLabel,
-        },
       });
       mapBounds.extend(grid_points);
     }


### PR DESCRIPTION
Following up on the new desired behaviour described in the comments on https://lite-farm.atlassian.net/browse/F21-698

To test:
1. Create a new farm or retire all the existing locations on your current farm
2. You should see a pin (but no title) at the location of your farm
3. Add a location
4. As soon as you begin adding the location, the pin for your farm should go away
5. When there are 1+ locations on the farm, the pin should not appear