### PR TITLE
Close Farm floater when other items in navbar are clicked

### DIFF
--- a/packages/webapp/src/components/Navigation/NavBar/index.jsx
+++ b/packages/webapp/src/components/Navigation/NavBar/index.jsx
@@ -149,6 +149,7 @@ export default function PureNavBar({
   };
   const farmButtonOnClick = () => setOpenFloater(isFarmFloaterOpen ? null : FARM);
   const notificationIconClick = () => {
+    closeFloater();
     const url = '/notifications';
     if (history.location.pathname === url) {
       // TODO click should update contents; is there better way than full page refresh?
@@ -158,6 +159,7 @@ export default function PureNavBar({
     }
   };
   const taskIconClick = () => {
+    closeFloater();
     history.push('/tasks');
   };
   const profileButtonOnClick = () => setOpenFloater(isProfileFloaterOpen ? null : PROFILE);


### PR DESCRIPTION
Ticket: [F21-633](https://lite-farm.atlassian.net/browse/F21-633)

To test:
1. Open the My Farm floater by clicking "My Farm" in the navbar
2. Click something else, including items in the navbar. You should see the My Farm floater disappear when you click do so.