### PR TITLE
Fixed various weird date problems

### DIFF
--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -37,10 +37,22 @@ export default function ActualRevenue({ history, match }) {
     shouldUnregister: true,
     defaultValues: {
       from_date: dateRange?.startDate
-        ? new Date(dateRange.startDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        ? new Date(
+            typeof dateRange.startDate === 'string'
+              ? dateRange.startDate.split('T')[0] + 'T00:00:00.000Z'
+              : dateRange.startDate,
+          )
+            .toISOString()
+            .split('T')[0]
         : `${year}-01-01`,
       to_date: dateRange?.endDate
-        ? new Date(dateRange.endDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        ? new Date(
+            typeof dateRange.endDate === 'string'
+              ? dateRange.endDate.split('T')[0] + 'T00:00:00.000Z'
+              : dateRange.endDate,
+          )
+            .toISOString()
+            .split('T')[0]
         : `${year}-12-31`,
     },
   });

--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -22,6 +22,10 @@ export default function ActualRevenue({ history, match }) {
   const dateRange = useSelector(dateRangeSelector);
   const dispatch = useDispatch();
 
+  console.log(dateRange);
+
+  const year = new Date().getFullYear();
+
   const {
     register,
     getValues,
@@ -32,13 +36,18 @@ export default function ActualRevenue({ history, match }) {
     mode: 'onBlur',
     shouldUnregister: true,
     defaultValues: {
-      from_date: dateRange.startDate,
-      to_date: dateRange.endDate,
+      from_date: dateRange?.startDate
+        ? new Date(dateRange.startDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        : `${year}-01-01`,
+      to_date: dateRange?.endDate
+        ? new Date(dateRange.endDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        : `${year}-12-31`,
     },
   });
 
   const fromDate = watch('from_date');
   const toDate = watch('to_date');
+
   const revenueForWholeFarm = useMemo(
     () => calcActualRevenue(sales, fromDate, toDate),
     [sales, fromDate, toDate],

--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -22,8 +22,6 @@ export default function ActualRevenue({ history, match }) {
   const dateRange = useSelector(dateRangeSelector);
   const dispatch = useDispatch();
 
-  console.log(dateRange);
-
   const year = new Date().getFullYear();
 
   const {

--- a/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
@@ -24,6 +24,8 @@ export default function EstimatedRevenue({ history, match }) {
   const dateRange = useSelector(dateRangeSelector);
   const dispatch = useDispatch();
 
+  const year = new Date().getFullYear();
+
   const {
     register,
     getValues,
@@ -34,8 +36,12 @@ export default function EstimatedRevenue({ history, match }) {
     mode: 'onBlur',
     shouldUnregister: true,
     defaultValues: {
-      from_date: dateRange.startDate,
-      to_date: dateRange.endDate,
+      from_date: dateRange?.startDate
+        ? new Date(dateRange.startDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        : `${year}-01-01`,
+      to_date: dateRange?.endDate
+        ? new Date(dateRange.endDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        : `${year}-12-31`,
     },
   });
 

--- a/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/EstimatedRevenue/index.jsx
@@ -37,10 +37,22 @@ export default function EstimatedRevenue({ history, match }) {
     shouldUnregister: true,
     defaultValues: {
       from_date: dateRange?.startDate
-        ? new Date(dateRange.startDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        ? new Date(
+            typeof dateRange.startDate === 'string'
+              ? dateRange.startDate.split('T')[0] + 'T00:00:00.000Z'
+              : dateRange.startDate,
+          )
+            .toISOString()
+            .split('T')[0]
         : `${year}-01-01`,
       to_date: dateRange?.endDate
-        ? new Date(dateRange.endDate.split('T')[0] + 'T00:00:00.000Z').toISOString().split('T')[0]
+        ? new Date(
+            typeof dateRange.endDate === 'string'
+              ? dateRange.endDate.split('T')[0] + 'T00:00:00.000Z'
+              : dateRange.endDate,
+          )
+            .toISOString()
+            .split('T')[0]
         : `${year}-12-31`,
     },
   });


### PR DESCRIPTION
This is a relatively messy bit of code to create the default values for the revenue date range, but the issue is that the `dateRange` object can have dates that are either a moment.js object, a string, or undefined. I did not have time to remove all of the moment.js instances throughout this part of the codebase, so I implemented a temporary fix here.

To test: 

1. Go to the "Finances" page
2. Set the date range to some initial value that is different from the default value
3. Go to both the "Actual Revenue" and "Estimated Revenue" pages and see if the date range there matches the value on the main finance page (it should)
4. Change the date range in the actual and estimated revenue pages and see if it updates on the main finances page (it should)
