### PR TITLE
F21-575/spotlight twice bug fix

### DIFF
--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -56,15 +56,17 @@ export function* sendMapToEmailSaga({ payload: fileDataURL }) {
 
 export const setSpotlightToShown = createAction(`setSpotlightToShownSaga`);
 
-export function* setSpotlightToShownSaga({ payload: spotlight }) {
+export function* setSpotlightToShownSaga({ payload: spotlights }) {
   try {
     const { user_id } = yield select(loginSelector);
     const header = getHeader(user_id);
     let patchContent = {};
-    patchContent[spotlight] = true;
-    patchContent[`${spotlight}_end`] = new Date().toISOString();
-    yield put(spotlightLoading());
-    yield put(patchSpotlightFlagsSuccess({ [spotlight]: true }));
+    for (const spotlight of spotlights) {
+      patchContent[spotlight] = true;
+      patchContent[`${spotlight}_end`] = new Date().toISOString();
+      yield put(spotlightLoading());
+      yield put(patchSpotlightFlagsSuccess({ [spotlight]: true }));
+    }
     yield call(axios.patch, showedSpotlightUrl(), patchContent, header);
   } catch (error) {
     yield put(patchSpotlightFlagsFailure());

--- a/packages/webapp/src/containers/Navigation/index.jsx
+++ b/packages/webapp/src/containers/Navigation/index.jsx
@@ -31,8 +31,7 @@ const NavBar = (props) => {
   const isFarmSelected =
     isAuthenticated() && farm && farm.has_consent && farm?.step_five === true && !isInvitationFlow;
   const resetSpotlight = () => {
-    dispatch(setSpotlightToShown('notification'));
-    dispatch(setSpotlightToShown('navigation'));
+    dispatch(setSpotlightToShown(['notification', 'navigation']));
   };
 
   return isFarmSelected ? (

--- a/packages/webapp/src/containers/Navigation/index.jsx
+++ b/packages/webapp/src/containers/Navigation/index.jsx
@@ -31,7 +31,8 @@ const NavBar = (props) => {
   const isFarmSelected =
     isAuthenticated() && farm && farm.has_consent && farm?.step_five === true && !isInvitationFlow;
   const resetSpotlight = () => {
-    dispatch(setSpotlightToShown(!navigation ? 'navigation' : 'notification'));
+    dispatch(setSpotlightToShown('notification'));
+    dispatch(setSpotlightToShown('navigation'));
   };
 
   return isFarmSelected ? (


### PR DESCRIPTION
Ticket [F21-575](https://lite-farm.atlassian.net/browse/F21-575)

Please look at the discussion.

The bug:
1. User creates a new account
2. They see the navigation bar spotlight
3. They see the notification spotlight

To Test:
1. Create a new account
2. Go through the navigation bar spotlight
3. There shouldn't be notification spotlight anymore