### PR TITLE
Added unassigned notification, did small refactor

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -59,6 +59,19 @@ const taskController = {
         user_id,
       );
 
+      if (newAssigneeUserId === null) {
+        const farmManagementObjs = await userFarmModel.getFarmManagementByFarmId(farm_id);
+        const farmManagement = farmManagementObjs.map((obj) => obj.user_id);
+        await sendTaskNotification(
+          farmManagement,
+          oldAssigneeUserId,
+          task_id,
+          TaskNotificationTypes.TASK_UNASSIGNED,
+          task_translation_key,
+          farm_id,
+        );
+      }
+
       return res.sendStatus(200);
     } catch (error) {
       console.log(error);
@@ -105,7 +118,7 @@ const taskController = {
         await Promise.all(
           available_tasks.map(async (task) => {
             await sendTaskNotification(
-              newAssigneeUserId,
+              [newAssigneeUserId],
               null,
               task.task_id,
               TaskNotificationTypes.TASK_ASSIGNED,
@@ -218,7 +231,7 @@ const taskController = {
       if (!result) return res.status(404).send('Task not found');
 
       await sendTaskNotification(
-        assignee_user_id,
+        [assignee_user_id],
         user_id,
         task_id,
         TaskNotificationTypes.TASK_ABANDONED,
@@ -265,7 +278,7 @@ const taskController = {
         if (result.assignee_user_id) {
           const { assignee_user_id, task_id, taskType } = result;
           await sendTaskNotification(
-            assignee_user_id,
+            [assignee_user_id],
             null,
             task_id,
             TaskNotificationTypes.TASK_ASSIGNED,
@@ -403,7 +416,7 @@ const taskController = {
         if (result) {
           const taskType = await TaskModel.getTaskType(task_id);
           await sendTaskNotification(
-            assignee_user_id,
+            [assignee_user_id],
             user_id,
             task_id,
             TaskNotificationTypes.TASK_COMPLETED_BY_OTHER_USER,
@@ -466,7 +479,7 @@ const taskController = {
       if (Object.keys(result).length > 0) {
         const { task_translation_key } = await TaskModel.getTaskType(task_id);
         await sendTaskNotification(
-          assignee_user_id,
+          [assignee_user_id],
           user_id,
           task_id,
           TaskNotificationTypes.TASK_COMPLETED_BY_OTHER_USER,
@@ -658,6 +671,7 @@ const TaskNotificationTypes = {
   TASK_ABANDONED: 'TASK_ABANDONED',
   TASK_REASSIGNED: 'TASK_REASSIGNED',
   TASK_COMPLETED_BY_OTHER_USER: 'TASK_COMPLETED_BY_OTHER_USER',
+  TASK_UNASSIGNED: 'TASK_UNASSIGNED',
 };
 
 const TaskNotificationUserTypes = {
@@ -665,19 +679,31 @@ const TaskNotificationUserTypes = {
   TASK_ABANDONED: 'abandoner',
   TASK_REASSIGNED: 'assigner',
   TASK_COMPLETED_BY_OTHER_USER: 'assigner',
+  TASK_UNASSIGNED: 'editor',
 };
 
+/**
+ * Sends a notification to the specified receivers about a task
+ * @param {Array<String>} receiverIds
+ * @param {String} senderId
+ * @param {String} taskId
+ * @param {String} notifyTranslationKey
+ * @param {String} taskTranslationKey
+ * @param {String} farmId
+ * @return {Promise<void>}
+ */
+
 async function sendTaskNotification(
-  receiverId,
+  receiverIds,
   senderId,
   taskId,
   notifyTranslationKey,
   taskTranslationKey,
   farmId,
 ) {
-  if (!receiverId) return;
+  if (receiverIds.includes(null) || receiverIds.includes(undefined)) return;
 
-  const userName = await User.getNameFromUserId(senderId ? senderId : receiverId);
+  const userName = await User.getNameFromUserId(senderId ? senderId : receiverIds[0]);
   await NotificationUser.notify(
     {
       title: {
@@ -696,7 +722,7 @@ async function sendTaskNotification(
       context: { task_translation_key: taskTranslationKey },
       farm_id: farmId,
     },
-    [receiverId],
+    receiverIds,
   );
 }
 
@@ -719,7 +745,7 @@ async function sendTaskReassignedNotifications(
 ) {
   await Promise.all([
     sendTaskNotification(
-      newAssigneeUserId,
+      [newAssigneeUserId],
       null,
       taskId,
       TaskNotificationTypes.TASK_ASSIGNED,
@@ -727,7 +753,7 @@ async function sendTaskReassignedNotifications(
       farmId,
     ),
     sendTaskNotification(
-      oldAssigneeUserId,
+      [oldAssigneeUserId],
       assignerUserId,
       taskId,
       TaskNotificationTypes.TASK_REASSIGNED,

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -684,7 +684,7 @@ const TaskNotificationUserTypes = {
 
 /**
  * Sends a notification to the specified receivers about a task
- * @param {Array<String>} receiverIds
+ * @param {Array<uuid>} receiverIds
  * @param {String} senderId
  * @param {String} taskId
  * @param {String} notifyTranslationKey
@@ -701,9 +701,10 @@ async function sendTaskNotification(
   taskTranslationKey,
   farmId,
 ) {
-  if (receiverIds.includes(null) || receiverIds.includes(undefined)) return;
+  const filteredReceiverIds = receiverIds.filter((id) => id !== null && id !== undefined);
+  if (filteredReceiverIds.length === 0) return;
 
-  const userName = await User.getNameFromUserId(senderId ? senderId : receiverIds[0]);
+  const userName = await User.getNameFromUserId(senderId ?? receiverIds[0]);
   await NotificationUser.notify(
     {
       title: {
@@ -722,7 +723,7 @@ async function sendTaskNotification(
       context: { task_translation_key: taskTranslationKey },
       farm_id: farmId,
     },
-    receiverIds,
+    filteredReceiverIds,
   );
 }
 

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -64,7 +64,7 @@ const taskController = {
         const farmManagement = farmManagementObjs.map((obj) => obj.user_id);
         await sendTaskNotification(
           farmManagement,
-          oldAssigneeUserId,
+          user_id,
           task_id,
           TaskNotificationTypes.TASK_UNASSIGNED,
           task_translation_key,

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -685,7 +685,7 @@ const TaskNotificationUserTypes = {
 /**
  * Sends a notification to the specified receivers about a task
  * @param {Array<uuid>} receiverIds
- * @param {String} senderId
+ * @param {String} usernameVariableId
  * @param {String} taskId
  * @param {String} notifyTranslationKey
  * @param {String} taskTranslationKey
@@ -695,7 +695,7 @@ const TaskNotificationUserTypes = {
 
 async function sendTaskNotification(
   receiverIds,
-  senderId,
+  usernameVariableId,
   taskId,
   notifyTranslationKey,
   taskTranslationKey,
@@ -704,7 +704,7 @@ async function sendTaskNotification(
   const filteredReceiverIds = receiverIds.filter((id) => id !== null && id !== undefined);
   if (filteredReceiverIds.length === 0) return;
 
-  const userName = await User.getNameFromUserId(senderId);
+  const userName = await User.getNameFromUserId(usernameVariableId);
   await NotificationUser.notify(
     {
       title: {

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -119,7 +119,7 @@ const taskController = {
           available_tasks.map(async (task) => {
             await sendTaskNotification(
               [newAssigneeUserId],
-              null,
+              newAssigneeUserId,
               task.task_id,
               TaskNotificationTypes.TASK_ASSIGNED,
               task.task_translation_key,
@@ -279,7 +279,7 @@ const taskController = {
           const { assignee_user_id, task_id, taskType } = result;
           await sendTaskNotification(
             [assignee_user_id],
-            null,
+            assignee_user_id,
             task_id,
             TaskNotificationTypes.TASK_ASSIGNED,
             taskType.task_translation_key,
@@ -704,7 +704,7 @@ async function sendTaskNotification(
   const filteredReceiverIds = receiverIds.filter((id) => id !== null && id !== undefined);
   if (filteredReceiverIds.length === 0) return;
 
-  const userName = await User.getNameFromUserId(senderId ?? receiverIds[0]);
+  const userName = await User.getNameFromUserId(senderId);
   await NotificationUser.notify(
     {
       title: {
@@ -747,7 +747,7 @@ async function sendTaskReassignedNotifications(
   await Promise.all([
     sendTaskNotification(
       [newAssigneeUserId],
-      null,
+      newAssigneeUserId,
       taskId,
       TaskNotificationTypes.TASK_ASSIGNED,
       taskTranslationKey,

--- a/packages/api/src/models/userFarmModel.js
+++ b/packages/api/src/models/userFarmModel.js
@@ -182,7 +182,7 @@ class userFarm extends Model {
    * @returns {Object} Object {userId} of FM/FO/EO
    */
   static async getFarmManagementByFarmId(farmId) {
-    return await userFarm
+    return userFarm
       .query()
       .select('user_id')
       .whereIn('role_id', [1, 2, 5])
@@ -197,7 +197,7 @@ class userFarm extends Model {
    * @returns {Array} Array [user_id]
    */
   static async getActiveUsersFromFarmId(farmId) {
-    return await userFarm
+    return userFarm
       .query()
       .select('userFarm.user_id')
       .join('users', 'userFarm.user_id', 'users.user_id')

--- a/packages/api/tests/taskNotification.test.js
+++ b/packages/api/tests/taskNotification.test.js
@@ -235,6 +235,96 @@ describe('Task Notification Tests', () => {
         },
       );
     });
+
+    test('Owner will receive a notification when a task in unassigned', async (done) => {
+      const [{ task_type_id }] = await mocks.task_typeFactory({
+        promisedFarm: [{ farm_id: farm.farm_id }],
+      });
+      const [{ location_id }] = await mocks.locationFactory({
+        promisedFarm: [{ farm_id: farm.farm_id }],
+      });
+
+      const [{ task_id }] = await mocks.taskFactory(
+        { promisedUser: [{ user_id: farmOwner.user_id }], promisedTaskType: [{ task_type_id }] },
+        mocks.fakeTask({
+          assignee_user_id: farmWorker.user_id,
+        }),
+      );
+
+      await mocks.location_tasksFactory({
+        promisedTask: [{ task_id }],
+        promisedField: [{ location_id }],
+      });
+
+      patchAssignTaskRequest(
+        { user_id: farmOwner.user_id, farm_id: farm.farm_id },
+        { assignee_user_id: null },
+        task_id,
+        async (err, res) => {
+          expect(res.status).toBe(200);
+          const notifications = await knex('notification_user')
+            .join(
+              'notification',
+              'notification.notification_id',
+              'notification_user.notification_id',
+            )
+            .where({
+              'notification_user.user_id': farmOwner.user_id,
+              'notification_user.deleted': false,
+              'notification.deleted': false,
+            });
+          expect(notifications.length).toBe(1);
+          expect(notifications[0].title.translation_key).toBe('NOTIFICATION.TASK_UNASSIGNED.TITLE');
+          expect(notifications[0].body.translation_key).toBe('NOTIFICATION.TASK_UNASSIGNED.BODY');
+          done();
+        },
+      );
+    });
+
+    test('Worker does not receive a task unassigned notification', async (done) => {
+      const [{ task_type_id }] = await mocks.task_typeFactory({
+        promisedFarm: [{ farm_id: farm.farm_id }],
+      });
+      const [{ location_id }] = await mocks.locationFactory({
+        promisedFarm: [{ farm_id: farm.farm_id }],
+      });
+
+      const [{ task_id }] = await mocks.taskFactory(
+        { promisedUser: [{ user_id: farmOwner.user_id }], promisedTaskType: [{ task_type_id }] },
+        mocks.fakeTask({
+          assignee_user_id: farmWorker.user_id,
+        }),
+      );
+
+      await mocks.location_tasksFactory({
+        promisedTask: [{ task_id }],
+        promisedField: [{ location_id }],
+      });
+
+      patchAssignTaskRequest(
+        { user_id: farmOwner.user_id, farm_id: farm.farm_id },
+        { assignee_user_id: null },
+        task_id,
+        async (err, res) => {
+          expect(res.status).toBe(200);
+          const notifications = await knex('notification_user')
+            .join(
+              'notification',
+              'notification.notification_id',
+              'notification_user.notification_id',
+            )
+            .where({
+              'notification_user.user_id': farmWorker.user_id,
+              'notification_user.deleted': false,
+              'notification.deleted': false,
+            });
+          expect(notifications.length).toBe(1);
+          expect(notifications[0].title.translation_key).toBe('NOTIFICATION.TASK_REASSIGNED.TITLE');
+          expect(notifications[0].body.translation_key).toBe('NOTIFICATION.TASK_REASSIGNED.BODY');
+          done();
+        },
+      );
+    });
   });
 
   describe('Task Abandonment Notification Tests', () => {

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1096,6 +1096,10 @@
       "BODY": "A {{taskType}} task previously assigned to you has been assigned to someone else by {{assigner}}.",
       "TITLE": "Task re-assigned"
     },
+    "TASK_UNASSIGNED": {
+      "BODY": "{{editor}} has marked a {{taskType}} task as unassigned.",
+      "TITLE": "Task unassigned"
+    },
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "You have unassigned tasks due this week.",
       "TITLE": "Unassigned tasks"

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1099,6 +1099,10 @@
       "BODY": "Una {{taskType}} tarea que te asignó previamente ha sido asignada a otra persona por {{assigner}}.",
       "TITLE": "Tarea reasignada"
     },
+    "TASK_UNASSIGNED": {
+      "BODY": "MISSING",
+      "TITLE": "MISSING"
+    },
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "Tiene tareas sin asignar que vencen esta semana.",
       "TITLE": "Tareas sin responables"

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1100,6 +1100,10 @@
       "BODY": "Une tâche de {{taskType}} qui vous était assignée a été attribuée à quelqu'un d'autre par {{assigner}}.",
       "TITLE": "Tâche réattribuée"
     },
+    "TASK_UNASSIGNED": {
+      "BODY": "{{editor}} a marqué une tâche de {{taskType}} comme non attribuée.",
+      "TITLE": "Tâche non attribuée"
+    },
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "Vous avez des tâches non attribuées à accomplir cette semaine.",
       "TITLE": "Tâches non attribuées"

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1100,6 +1100,10 @@
       "BODY": "Uma tarefa {{taskType}} atribuída anteriormente a você foi atribuída a outra pessoa por {{assigner}}.",
       "TITLE": "Tarefa reatribuída"
     },
+    "TASK_UNASSIGNED": {
+      "BODY": "MISSING",
+      "TITLE": "MISSING"
+    },
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "Você tem tarefas não atribuídas para esta semana.",
       "TITLE": "Tarefas não atribuídas"


### PR DESCRIPTION
This PR addresses https://lite-farm.atlassian.net/browse/LF-2463

To test:
1. Create a task and assign it someone (you should be on an account with farm management permissions)
2. Unassign that task
3. You should get a notification on all management accounts for that farm that the task has been unassigned
4. The notification should not appear for any worker accounts
5. Because I did a little refactoring in the code that sends notifications based on tasks, test some other use cases of task notifications and ensure they are still sending properly