### PR TITLE
LF-2478/pseudo user conversion ui change

### DIFF
--- a/packages/api/src/controllers/userController.js
+++ b/packages/api/src/controllers/userController.js
@@ -271,7 +271,7 @@ const userController = {
         return res.status(400).send('Current app version only allows hourly wage');
       }
       /* End of input validation */
-      await baseController.post(userModel, req.body, req, { trx });
+      const user = await baseController.post(userModel, req.body, req, { trx });
       await userFarmModel.query(trx).insert({
         user_id,
         farm_id,
@@ -294,7 +294,7 @@ const userController = {
         .first()
         .select('*');
       await trx.commit();
-      res.status(201).send(userFarm);
+      res.status(201).send({ ...user, ...userFarm });
     } catch (error) {
       // handle more exceptions
       await trx.rollback();

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -497,7 +497,7 @@ const userFarmController = {
     };
   },
 
-  patchPseudoUserEmail() {
+  upgradePseudoUser() {
     return async (req, res) => {
       const { user_id, farm_id } = req.params;
       const { email, gender, birth_year, language, phone_number } = req.body;

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -598,7 +598,16 @@ const userFarmController = {
       }
       try {
         const { farm_name } = userFarm;
-        await emailModel.createTokenSendEmail(userFarm, userFarm, farm_name);
+        await emailModel.createTokenSendEmail(
+          {
+            email,
+            gender,
+            birth_year,
+            language,
+          },
+          userFarm,
+          farm_name,
+        );
       } catch (e) {
         console.log(e);
       }

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -500,7 +500,7 @@ const userFarmController = {
   patchPseudoUserEmail() {
     return async (req, res) => {
       const { user_id, farm_id } = req.params;
-      const { email } = req.body;
+      const { email, gender, birth_year, language, phone_number } = req.body;
       const roleIdAndWage = {};
       roleIdAndWage.role_id = !req.body.role_id || req.body.role_id === 4 ? 3 : req.body.role_id;
       if (req.body.wage) {
@@ -565,6 +565,10 @@ const userFarmController = {
               .patch({
                 email,
                 status_id: 2,
+                phone_number,
+                language_preference: language,
+                gender,
+                birth_year,
               })
               .returning('*');
             await userFarmModel
@@ -589,6 +593,7 @@ const userFarmController = {
           .select('*');
         res.status(201).send(userFarm);
       } catch (e) {
+        console.log(e);
         res.status(400).send(e);
       }
       try {

--- a/packages/api/src/routes/userFarmRoute.js
+++ b/packages/api/src/routes/userFarmRoute.js
@@ -98,7 +98,7 @@ router.post(
   '/invite/farm/:farm_id/user/:user_id',
   hasFarmAccess({ params: 'farm_id' }),
   checkScope(['edit:users']),
-  userFarmController.patchPseudoUserEmail(),
+  userFarmController.upgradePseudoUser(),
 );
 
 // Update wage of userFarm

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -45,11 +45,14 @@ export default function PureEditUser({
     { value: 'pt', label: t('PROFILE.ACCOUNT.PORTUGUESE') },
     { value: 'fr', label: t('PROFILE.ACCOUNT.FRENCH') },
   ];
+  const isPseudoUser = userFarm.role_id === 4;
   const roleOptions = Object.keys(dropDownMap).map((role_id) => ({
     value: role_id,
     label: dropDownMap[role_id],
   }));
-  const roleOption = { value: userFarm.role_id, label: dropDownMap[userFarm.role_id] };
+  const roleOption = isPseudoUser
+    ? { value: 3, label: dropDownMap[3] }
+    : { value: userFarm.role_id, label: dropDownMap[userFarm.role_id] };
 
   const getDefaultGender = () => {
     switch (userFarm.gender) {
@@ -62,7 +65,7 @@ export default function PureEditUser({
       case 'PREFER_NOT_TO_SAY':
         return genderOptions[3];
     }
-  }
+  };
 
   const getDefaultLanguage = () => {
     switch (userFarm.language_preference) {
@@ -75,7 +78,7 @@ export default function PureEditUser({
       case 'fr':
         return languageOptions[3];
     }
-  }
+  };
 
   const {
     register,
@@ -87,12 +90,11 @@ export default function PureEditUser({
     formState: { isValid, isDirty, errors },
   } = useForm({
     mode: 'onChange',
-    defaultValues: { ...userFarm, role_id: roleOption },
+    defaultValues: { ...userFarm, role_id: roleOption, gender: getDefaultGender() },
     shouldUnregister: true,
   });
 
   const [showRevokeUserAccessModal, setShowRevokeUserAccessModal] = useState();
-  const isPseudoUser = userFarm.role_id === 4;
   const [shouldInvitePseudoUser, setShouldInvitePseudoUser] = useState(false);
   const onInviteUserCheckboxClick = () => {
     setValue(EMAIL, shouldInvitePseudoUser ? userFarm.email : '');
@@ -201,7 +203,7 @@ export default function PureEditUser({
               options={genderOptions}
               toolTipContent={t('INVITE_USER.GENDER_TOOLTIP')}
               style={{ marginBottom: '24px' }}
-              defaultValue={getDefaultGender()}
+              defaultValue={genderOptions[3]}
               {...field}
               optional
             />
@@ -217,7 +219,10 @@ export default function PureEditUser({
               label={t('INVITE_USER.LANGUAGE_OF_INVITE')}
               options={languageOptions}
               style={{ marginBottom: '24px' }}
-              defaultValue={getDefaultLanguage()}
+              defaultValue={{
+                value: t('INVITE_USER.DEFAULT_LANGUAGE_VALUE'),
+                label: t('INVITE_USER.DEFAULT_LANGUAGE'),
+              }}
               {...field}
               required
             />

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -51,6 +51,32 @@ export default function PureEditUser({
   }));
   const roleOption = { value: userFarm.role_id, label: dropDownMap[userFarm.role_id] };
 
+  const getDefaultGender = () => {
+    switch (userFarm.gender) {
+      case 'MALE':
+        return genderOptions[0];
+      case 'FEMALE':
+        return genderOptions[1];
+      case 'OTHER':
+        return genderOptions[2];
+      case 'PREFER_NOT_TO_SAY':
+        return genderOptions[3];
+    }
+  }
+
+  const getDefaultLanguage = () => {
+    switch (userFarm.language_preference) {
+      case 'en':
+        return languageOptions[0];
+      case 'es':
+        return languageOptions[1];
+      case 'pt':
+        return languageOptions[2];
+      case 'fr':
+        return languageOptions[3];
+    }
+  }
+
   const {
     register,
     handleSubmit,
@@ -175,8 +201,9 @@ export default function PureEditUser({
               options={genderOptions}
               toolTipContent={t('INVITE_USER.GENDER_TOOLTIP')}
               style={{ marginBottom: '24px' }}
-              defaultValue={genderOptions[3]}
+              defaultValue={getDefaultGender()}
               {...field}
+              optional
             />
           )}
         />
@@ -190,10 +217,7 @@ export default function PureEditUser({
               label={t('INVITE_USER.LANGUAGE_OF_INVITE')}
               options={languageOptions}
               style={{ marginBottom: '24px' }}
-              defaultValue={{
-                value: t('INVITE_USER.DEFAULT_LANGUAGE_VALUE'),
-                label: t('INVITE_USER.DEFAULT_LANGUAGE'),
-              }}
+              defaultValue={getDefaultLanguage()}
               {...field}
               required
             />

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -1,4 +1,4 @@
-import Input, { getInputErrors } from '../../Form/Input';
+import Input, { getInputErrors, integerOnKeyDown } from '../../Form/Input';
 import { Controller, useForm } from 'react-hook-form';
 import ReactSelect from '../../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
@@ -10,18 +10,45 @@ import PageTitle from '../../PageTitle/v2';
 import RevokeUserAccessModal from '../../Modals/RevokeUserAccessModal';
 import Checkbox from '../../Form/Checkbox';
 
-export default function PureEditUser({ userFarm, onUpdate, history, isAdmin, onActivate, onRevoke, onInvite }) {
+export default function PureEditUser({
+  userFarm,
+  onUpdate,
+  history,
+  isAdmin,
+  onActivate,
+  onRevoke,
+  onInvite,
+}) {
   const { t } = useTranslation();
   const ROLE = 'role_id';
   const WAGE = 'wage.amount';
   const EMAIL = 'email';
+  const GENDER = 'gender';
+  const LANGUAGE = 'language';
+  const BIRTHYEAR = 'birth_year';
+  const PHONE = 'phone_number';
   const dropDownMap = {
     1: t('role:OWNER'),
     2: t('role:MANAGER'),
     3: t('role:WORKER'),
     5: t('role:EXTENSION_OFFICER'),
   };
-  const roleOptions = Object.keys(dropDownMap).map(role_id => ({ value: role_id, label: dropDownMap[role_id] }));
+  const genderOptions = [
+    { value: 'MALE', label: t('gender:MALE') },
+    { value: 'FEMALE', label: t('gender:FEMALE') },
+    { value: 'OTHER', label: t('gender:OTHER') },
+    { value: 'PREFER_NOT_TO_SAY', label: t('gender:PREFER_NOT_TO_SAY') },
+  ];
+  const languageOptions = [
+    { value: 'en', label: t('PROFILE.ACCOUNT.ENGLISH') },
+    { value: 'es', label: t('PROFILE.ACCOUNT.SPANISH') },
+    { value: 'pt', label: t('PROFILE.ACCOUNT.PORTUGUESE') },
+    { value: 'fr', label: t('PROFILE.ACCOUNT.FRENCH') },
+  ];
+  const roleOptions = Object.keys(dropDownMap).map((role_id) => ({
+    value: role_id,
+    label: dropDownMap[role_id],
+  }));
   const roleOption = { value: userFarm.role_id, label: dropDownMap[userFarm.role_id] };
 
   const {
@@ -38,40 +65,65 @@ export default function PureEditUser({ userFarm, onUpdate, history, isAdmin, onA
     shouldUnregister: true,
   });
 
-
   const [showRevokeUserAccessModal, setShowRevokeUserAccessModal] = useState();
   const isPseudoUser = userFarm.role_id === 4;
   const [shouldInvitePseudoUser, setShouldInvitePseudoUser] = useState(false);
   const onInviteUserCheckboxClick = () => {
     setValue(EMAIL, shouldInvitePseudoUser ? userFarm.email : '');
-    setShouldInvitePseudoUser(shouldInvitePseudoUser => !shouldInvitePseudoUser);
+    setShouldInvitePseudoUser((shouldInvitePseudoUser) => !shouldInvitePseudoUser);
     clearErrors(EMAIL);
   };
   const email = watch(EMAIL);
   const role = watch(ROLE);
   const wage = watch(WAGE);
-  const disabled = !isValid || (shouldInvitePseudoUser && (!email || !role?.label)) || (!shouldInvitePseudoUser && !isPseudoUser && Number(role?.value) === userFarm.role_id && (wage || 0) === Number(userFarm.wage?.amount))
-    || (!shouldInvitePseudoUser && isPseudoUser && (wage || 0) === Number(userFarm.wage?.amount));
+  const disabled =
+    !isValid ||
+    (shouldInvitePseudoUser && (!email || !role?.label)) ||
+    (!shouldInvitePseudoUser &&
+      !isPseudoUser &&
+      Number(role?.value) === userFarm.role_id &&
+      (wage || 0) === Number(userFarm.wage?.amount)) ||
+    (!shouldInvitePseudoUser && isPseudoUser && (wage || 0) === Number(userFarm.wage?.amount));
+
+  const onSubmit = (data) => {
+    data[GENDER] = data?.[GENDER]?.value || 'PREFER_NOT_TO_SAY';
+    data[ROLE] = data?.[ROLE]?.value;
+    data[LANGUAGE] = data?.[LANGUAGE]?.value || t('INVITE_USER.DEFAULT_LANGUAGE_VALUE');
+    onInvite({ ...data, email });
+  };
 
   return (
     <Form
-      onSubmit={handleSubmit(shouldInvitePseudoUser ? onInvite : onUpdate)}
-      buttonGroup={<>
-        {
-          userFarm.status === 'Inactive' ?
-            <Button type={'button'} onClick={onActivate} fullLength
-                    color={'success'}>{t('PROFILE.PEOPLE.RESTORE_ACCESS')}</Button>
-            : <Button type={'button'} onClick={() => {
-              setShowRevokeUserAccessModal(true);
-            }} fullLength color={'secondary'}>{t('PROFILE.PEOPLE.REVOKE_ACCESS')}</Button>}
-        <Button fullLength type={'submit'} disabled={disabled}>
-          {shouldInvitePseudoUser ? t('INVITE_USER.INVITE') : t('common:SAVE')}
-        </Button>
-      </>
+      onSubmit={handleSubmit(shouldInvitePseudoUser ? onSubmit : onUpdate)}
+      buttonGroup={
+        <>
+          {userFarm.status === 'Inactive' ? (
+            <Button type={'button'} onClick={onActivate} fullLength color={'success'}>
+              {t('PROFILE.PEOPLE.RESTORE_ACCESS')}
+            </Button>
+          ) : (
+            <Button
+              type={'button'}
+              onClick={() => {
+                setShowRevokeUserAccessModal(true);
+              }}
+              fullLength
+              color={'secondary'}
+            >
+              {t('PROFILE.PEOPLE.REVOKE_ACCESS')}
+            </Button>
+          )}
+          <Button fullLength type={'submit'} disabled={disabled}>
+            {shouldInvitePseudoUser ? t('INVITE_USER.INVITE') : t('common:SAVE')}
+          </Button>
+        </>
       }
     >
-      <PageTitle style={{ marginBottom: '32px' }} onGoBack={() => history.back()}
-                 title={t('PROFILE.ACCOUNT.EDIT_USER')} />
+      <PageTitle
+        style={{ marginBottom: '32px' }}
+        onGoBack={() => history.back()}
+        title={t('PROFILE.ACCOUNT.EDIT_USER')}
+      />
       <Input
         label={t('PROFILE.ACCOUNT.FIRST_NAME')}
         value={userFarm.first_name}
@@ -97,34 +149,113 @@ export default function PureEditUser({ userFarm, onUpdate, history, isAdmin, onA
         disabled={!shouldInvitePseudoUser}
         style={{ marginBottom: '24px' }}
       />
-      {(!isPseudoUser || shouldInvitePseudoUser) && <Controller
-        control={control}
-        name={ROLE}
-        render={({ field }) => (
-          <ReactSelect
-            {...field}
-            label={t('INVITE_USER.ROLE')}
-            options={roleOptions}
-            style={{ marginBottom: '24px' }}
-            placeholder={t('INVITE_USER.CHOOSE_ROLE')}
-          />
-        )}
-        rules={{ required: true }}
-      />}
+      {(!isPseudoUser || shouldInvitePseudoUser) && (
+        <Controller
+          control={control}
+          name={ROLE}
+          render={({ field }) => (
+            <ReactSelect
+              {...field}
+              label={t('INVITE_USER.ROLE')}
+              options={roleOptions}
+              style={{ marginBottom: '24px' }}
+              placeholder={t('INVITE_USER.CHOOSE_ROLE')}
+            />
+          )}
+          rules={{ required: true }}
+        />
+      )}
+      {isPseudoUser && shouldInvitePseudoUser && (
+        <Controller
+          control={control}
+          name={GENDER}
+          render={({ field }) => (
+            <ReactSelect
+              label={t('INVITE_USER.GENDER')}
+              options={genderOptions}
+              toolTipContent={t('INVITE_USER.GENDER_TOOLTIP')}
+              style={{ marginBottom: '24px' }}
+              defaultValue={genderOptions[3]}
+              {...field}
+            />
+          )}
+        />
+      )}
+      {isPseudoUser && shouldInvitePseudoUser && (
+        <Controller
+          control={control}
+          name={LANGUAGE}
+          render={({ field }) => (
+            <ReactSelect
+              label={t('INVITE_USER.LANGUAGE_OF_INVITE')}
+              options={languageOptions}
+              style={{ marginBottom: '24px' }}
+              defaultValue={{
+                value: t('INVITE_USER.DEFAULT_LANGUAGE_VALUE'),
+                label: t('INVITE_USER.DEFAULT_LANGUAGE'),
+              }}
+              {...field}
+              required
+            />
+          )}
+        />
+      )}
+      {isPseudoUser && shouldInvitePseudoUser && (
+        <Input
+          label={t('INVITE_USER.BIRTH_YEAR')}
+          type="number"
+          onKeyPress={integerOnKeyDown}
+          hookFormRegister={register(BIRTHYEAR, {
+            min: 1900,
+            max: new Date().getFullYear(),
+            valueAsNumber: true,
+          })}
+          toolTipContent={t('INVITE_USER.BIRTH_YEAR_TOOLTIP')}
+          style={{ marginBottom: '24px' }}
+          placeholder={'xxxx'}
+          errors={
+            errors[BIRTHYEAR] &&
+            (errors[BIRTHYEAR].message ||
+              `${t('INVITE_USER.BIRTH_YEAR_ERROR')} ${new Date().getFullYear()}`)
+          }
+          optional
+        />
+      )}
       <Input
         label={t('INVITE_USER.WAGE')}
-        step='0.01'
-        type='number'
+        step="0.01"
+        type="number"
         hookFormRegister={register(WAGE, { min: 0, valueAsNumber: true })}
         style={{ marginBottom: '40px' }}
         errors={errors[WAGE] && (errors[WAGE].message || t('INVITE_USER.WAGE_ERROR'))}
         optional
       />
-      {isPseudoUser && <Checkbox label={t('PROFILE.ACCOUNT.CONVERT_TO_HAVE_ACCOUNT')} value={shouldInvitePseudoUser}
-                                 onChange={onInviteUserCheckboxClick} />}
-      {showRevokeUserAccessModal && <RevokeUserAccessModal dismissModal={() => {
-        setShowRevokeUserAccessModal(false);
-      }} onRevoke={onRevoke} />}
+      {isPseudoUser && shouldInvitePseudoUser && (
+        <Input
+          style={{ marginBottom: '24px' }}
+          label={t('INVITE_USER.PHONE')}
+          type={'number'}
+          onKeyPress={integerOnKeyDown}
+          hookFormRegister={register(PHONE)}
+          errors={errors[PHONE] && (errors[PHONE].message || t('INVITE_USER.PHONE_ERROR'))}
+          optional
+        />
+      )}
+      {isPseudoUser && (
+        <Checkbox
+          label={t('PROFILE.ACCOUNT.CONVERT_TO_HAVE_ACCOUNT')}
+          value={shouldInvitePseudoUser}
+          onChange={onInviteUserCheckboxClick}
+        />
+      )}
+      {showRevokeUserAccessModal && (
+        <RevokeUserAccessModal
+          dismissModal={() => {
+            setShowRevokeUserAccessModal(false);
+          }}
+          onRevoke={onRevoke}
+        />
+      )}
     </Form>
   );
 }

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -67,19 +67,6 @@ export default function PureEditUser({
     }
   };
 
-  const getDefaultLanguage = () => {
-    switch (userFarm.language_preference) {
-      case 'en':
-        return languageOptions[0];
-      case 'es':
-        return languageOptions[1];
-      case 'pt':
-        return languageOptions[2];
-      case 'fr':
-        return languageOptions[3];
-    }
-  };
-
   const {
     register,
     handleSubmit,

--- a/packages/webapp/src/containers/Profile/EditUser.jsx
+++ b/packages/webapp/src/containers/Profile/EditUser.jsx
@@ -11,8 +11,8 @@ export default function EditUser({ history, match }) {
   const { user_id } = match.params;
   const userFarm = userFarmsEntities[farm_id]?.[user_id];
 
-  const getReqBody = data => {
-    const role_id = Number(data.role_id?.value);
+  const getReqBody = (data) => {
+    const role_id = Number(data.role_id);
     const reqBody = {
       ...data,
       user_id,
@@ -24,10 +24,10 @@ export default function EditUser({ history, match }) {
     return reqBody;
   };
 
-  const onUpdate = data => {
+  const onUpdate = (data) => {
     dispatch(updateUserFarm(getReqBody(data)));
   };
-  const onInvite = data => {
+  const onInvite = (data) => {
     dispatch(invitePseudoUser(getReqBody(data)));
   };
   const onRevoke = () => {
@@ -36,6 +36,15 @@ export default function EditUser({ history, match }) {
   const onActivate = () => {
     dispatch(reactivateUser(user_id));
   };
-  return <PureEditUser onActivate={onActivate} userFarm={userFarm} isAdmin={isAdmin} onUpdate={onUpdate}
-                       onRevoke={onRevoke} history={history} onInvite={onInvite} />;
+  return (
+    <PureEditUser
+      onActivate={onActivate}
+      userFarm={userFarm}
+      isAdmin={isAdmin}
+      onUpdate={onUpdate}
+      onRevoke={onRevoke}
+      history={history}
+      onInvite={onInvite}
+    />
+  );
 }


### PR DESCRIPTION
Ticket [LF-2478](https://lite-farm.atlassian.net/browse/LF-2478)

**To Test:**
1. Create a pseudo user (Go to people tab of the farm and invite a user without an email)
2. Click the pseudo user and click "Convert this worker to a user with account"
3. You should see all the fields same as regular invitation UI
4. Fill out the form and invite the user
5. Check in the users table from the database that the information has been correctly updated