### PR TITLE
LF-2462 - feat: created notification timeline

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1073,7 +1073,7 @@
   },
   "ENTITY_TYPES": {
     "TASK": "task",
-    "location": "location"
+    "LOCATION": "location"
   },
   "NOTIFICATION": {
     "TIMELINE": {

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1071,7 +1071,16 @@
       "YOU_WILL_FIND": "Here you will find:"
     }
   },
+  "ENTITY_TYPES": {
+    "TASK": "task",
+    "location": "location"
+  },
   "NOTIFICATION": {
+    "TIMELINE": {
+      "HEADING": "Notification timeline",
+      "VIEW_NOW": "View now",
+      "MORE_RECENT_NOTIFICATION": "There are more recent notifications about this {{entityType}}."
+    },
     "DAILY_TASKS_DUE_TODAY": {
       "BODY": "You have tasks due today.",
       "TITLE": "Tasks due today"

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1074,7 +1074,16 @@
       "YOU_WILL_FIND": "Aquí encontrará:"
     }
   },
+  "ENTITY_TYPES": {
+    "TASK": "tarea",
+    "location": "ubicación"
+  },
   "NOTIFICATION": {
+    "TIMELINE": {
+      "HEADING": "MISSING",
+      "VIEW_NOW": "MISSING",
+      "MORE_RECENT_NOTIFICATION": "MISSING"
+    },
     "DAILY_TASKS_DUE_TODAY": {
       "BODY": "Tienes tareas para hoy.",
       "TITLE": "Tareas para hoy"

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1076,7 +1076,7 @@
   },
   "ENTITY_TYPES": {
     "TASK": "tarea",
-    "location": "ubicación"
+    "LOCATION": "ubicación"
   },
   "NOTIFICATION": {
     "TIMELINE": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1075,7 +1075,16 @@
       "YOU_WILL_FIND": "Vous trouverez ici:"
     }
   },
+  "ENTITY_TYPES": {
+    "TASK": "tâche",
+    "location": "emplacement"
+  },
   "NOTIFICATION": {
+    "TIMELINE": {
+      "HEADING": "MISSING",
+      "VIEW_NOW": "MISSING",
+      "MORE_RECENT_NOTIFICATION": "MISSING"
+    },
     "DAILY_TASKS_DUE_TODAY": {
       "BODY": "Vous avez des tâches à accomplir aujourd'hui.",
       "TITLE": "Tâches à accomplir aujourd'hui"

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1077,7 +1077,7 @@
   },
   "ENTITY_TYPES": {
     "TASK": "tâche",
-    "location": "emplacement"
+    "LOCATION": "emplacement"
   },
   "NOTIFICATION": {
     "TIMELINE": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1077,7 +1077,7 @@
   },
   "ENTITY_TYPES": {
     "TASK": "tarefa",
-    "location": "localização"
+    "LOCATION": "localização"
   },
   "NOTIFICATION": {
     "TIMELINE": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1075,7 +1075,16 @@
       "YOU_WILL_FIND": "Aqui você encontrará:"
     }
   },
+  "ENTITY_TYPES": {
+    "TASK": "tarefa",
+    "location": "localização"
+  },
   "NOTIFICATION": {
+    "TIMELINE": {
+      "HEADING": "MISSING",
+      "VIEW_NOW": "MISSING",
+      "MORE_RECENT_NOTIFICATION": "MISSING"
+    },
     "DAILY_TASKS_DUE_TODAY": {
       "BODY": "Você tem tarefas para vencer hoje.",
       "TITLE": "Tarefas para hoje"

--- a/packages/webapp/src/components/Notifications/MoreRecentNotificationWarning/index.jsx
+++ b/packages/webapp/src/components/Notifications/MoreRecentNotificationWarning/index.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Text } from '../../Typography';
+import PureWarningBox from '../../WarningBox';
+import history from '../../../history';
+import styles from './styles.module.scss';
+import { useTranslation } from 'react-i18next';
+
+function MoreRecentNotificationWarning({ notificationId, entityType }) {
+  const { t } = useTranslation();
+  const translatedEntityType = t(`ENTITY_TYPES.${entityType.toUpperCase()}`);
+  return (
+    <PureWarningBox className={styles.warningBox} iconClassName={styles.warningIcon}>
+      <Text>
+        {t('NOTIFICATION.TIMELINE.MORE_RECENT_NOTIFICATION', { entityType: translatedEntityType })}
+      </Text>
+      <a
+        className={styles.viewNowLink}
+        onClick={() => history.push(`/notifications/${notificationId}/read_only`)}
+      >
+        {t('NOTIFICATION.TIMELINE.VIEW_NOW')}
+      </a>
+    </PureWarningBox>
+  );
+}
+
+export default MoreRecentNotificationWarning;

--- a/packages/webapp/src/components/Notifications/MoreRecentNotificationWarning/styles.module.scss
+++ b/packages/webapp/src/components/Notifications/MoreRecentNotificationWarning/styles.module.scss
@@ -1,0 +1,13 @@
+.warningBox {
+    border-color: var(--brown700);
+}
+
+.warningIcon {
+    color: var(--brown700);
+}
+
+.viewNowLink {
+    color: var(--brown700);
+    text-decoration: underline;
+    cursor: pointer;
+}

--- a/packages/webapp/src/components/Notifications/NotificationTimeline/index.jsx
+++ b/packages/webapp/src/components/Notifications/NotificationTimeline/index.jsx
@@ -69,4 +69,5 @@ export default NotificationTimeline;
 NotificationTimeline.prototype = {
   notificationId: PropTypes.string,
   relatedNotifications: PropTypes.arrayOf(PropTypes.object),
+  style: PropTypes.object,
 };

--- a/packages/webapp/src/components/Notifications/NotificationTimeline/index.jsx
+++ b/packages/webapp/src/components/Notifications/NotificationTimeline/index.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import styles from './styles.module.scss';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import { getNotificationCardDate } from '../../../util/moment';
+import useTranslationUtil from '../../../util/useTranslationUtil';
+import { useTranslation } from 'react-i18next';
+import history from '../../../history';
+import MoreRecentNotificationWarning from '../MoreRecentNotificationWarning';
+
+function NotificationTimeline({ activeNotificationId, relatedNotifications, style }) {
+  const { t } = useTranslation();
+  const { getNotificationTitle } = useTranslationUtil();
+  const [sortedRelatedNotifications, setSortedRelatedNotifications] = useState([]);
+  const [mostRecentNotification, setMostRecentNotification] = useState(null);
+
+  useEffect(() => {
+    setMostRecentNotification(null);
+    setSortedRelatedNotifications(
+      relatedNotifications.sort((a, b) => {
+        return new Date(b.created_at) - new Date(a.created_at);
+      }),
+    );
+  }, [activeNotificationId]);
+
+  useEffect(() => {
+    if (
+      sortedRelatedNotifications &&
+      sortedRelatedNotifications[0]?.notification_id !== activeNotificationId
+    ) {
+      setMostRecentNotification(sortedRelatedNotifications[0]);
+    }
+  }, [sortedRelatedNotifications]);
+
+  return (
+    <div className={styles.container} style={style}>
+      <header className={styles.header}>
+        <h2 className={styles.heading}>{t('NOTIFICATION.TIMELINE.HEADING')}</h2>
+        <hr className={styles.headerLine} />
+      </header>
+      {mostRecentNotification && (
+        <MoreRecentNotificationWarning
+          notificationId={mostRecentNotification?.notification_id}
+          entityType={mostRecentNotification?.ref?.entity?.type}
+        />
+      )}
+      <ul className={styles.timeline}>
+        {sortedRelatedNotifications.map((notification) => (
+          <li
+            role="link"
+            tabIndex="0"
+            key={notification.notification_id}
+            className={clsx(
+              styles.timelineItem,
+              activeNotificationId === notification.notification_id && styles.activeItem,
+            )}
+            onClick={() => history.push(`/notifications/${notification.notification_id}/read_only`)}
+          >
+            {getNotificationCardDate(notification.created_at)} |{' '}
+            {getNotificationTitle(notification.title)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default NotificationTimeline;
+NotificationTimeline.prototype = {
+  notificationId: PropTypes.string,
+  relatedNotifications: PropTypes.arrayOf(PropTypes.object),
+};

--- a/packages/webapp/src/components/Notifications/NotificationTimeline/index.jsx
+++ b/packages/webapp/src/components/Notifications/NotificationTimeline/index.jsx
@@ -40,8 +40,8 @@ function NotificationTimeline({ activeNotificationId, relatedNotifications, styl
       </header>
       {mostRecentNotification && (
         <MoreRecentNotificationWarning
-          notificationId={mostRecentNotification?.notification_id}
-          entityType={mostRecentNotification?.ref?.entity?.type}
+          notificationId={mostRecentNotification.notification_id}
+          entityType={mostRecentNotification.ref?.entity?.type}
         />
       )}
       <ul className={styles.timeline}>

--- a/packages/webapp/src/components/Notifications/NotificationTimeline/styles.module.scss
+++ b/packages/webapp/src/components/Notifications/NotificationTimeline/styles.module.scss
@@ -1,0 +1,84 @@
+.container {
+    width: 100%;
+    --active-dot-w: 12px;
+    --dot-w: 8px;
+    --item-fs: 12px;
+    --active-item-fs: 14px;
+    --heading-fs: 14px;
+    --line-w: 1px;
+    --spacing: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing)
+}
+
+.headerLine {
+    flex-grow: 1;
+    height: var(--line-w);
+    background: inherit;
+    background-color: var(--grey600);
+    border: none;
+    margin: 0;
+}
+
+.heading {
+    flex-basis: fit-content;
+    font-size: 14px;
+    color: var(--grey600);
+}
+
+.header {
+    width: 100%;
+    display: flex;
+    gap: 1em;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.timelineItem {
+    width: fit-content;
+    font-size: var(--item-fs);
+    color: var(--grey600);
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--spacing);
+    cursor: pointer;
+}
+
+.timelineItem::before {
+    content: '';
+    display: block;
+    background-color: var(--grey500);
+    width: var(--dot-w);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    margin-left: calc((var(--active-dot-w) - var(--dot-w)) / 2);
+    margin-right: calc(1em + (var(--active-dot-w) - var(--dot-w)));
+}
+
+.timelineItem:not(:last-child)::after {
+    content: '';
+    display: block;
+    position: absolute;
+    background-color: var(--grey500);
+    width: var(--line-w);
+    height: calc(var(--spacing) + (var(--item-fs) - var(--dot-w)) + 1px);
+    transform: translate(calc((var(--active-dot-w) / 2) - 0.5px), calc(50% + (var(--dot-w) / 2) + 2px));
+}
+
+.activeItem {
+    font-size: var(--active-item-fs);
+    color: var(--teal700);
+    font-weight: 600;
+} 
+
+.activeItem::before {
+    background-color: var(--teal700);
+    width: var(--active-dot-w);
+    margin-left: 0;
+    margin-right: 1em;
+}
+
+.activeItem:not(:last-child)::after {
+    transform: translate(calc((var(--active-dot-w) / 2) - 0.5px), calc(50% + (var(--active-dot-w) / 2) + 2px));
+}

--- a/packages/webapp/src/components/Notifications/index.jsx
+++ b/packages/webapp/src/components/Notifications/index.jsx
@@ -22,18 +22,12 @@ import Button from '../../components/Form/Button';
 import { Semibold, Text } from '../Typography';
 import { getNotificationCardDate } from '../../util/moment.js';
 import history from '../../history';
-import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
+import useTranslationUtil from '../../util/useTranslationUtil';
+import NotificationTimeline from './NotificationTimeline';
 
-function PureNotificationReadOnly({ onGoBack, notification }) {
+function PureNotificationReadOnly({ onGoBack, notification, relatedNotifications }) {
   const { t } = useTranslation();
-  const currentLang = getLanguageFromLocalStorage();
-  const tOptions = notification.variables.reduce((optionsSoFar, currentOption) => {
-    let options = { ...optionsSoFar };
-    options[currentOption.name] = currentOption.translate
-      ? t(currentOption.value)
-      : currentOption.value;
-    return options;
-  }, {});
+  const { getNotificationTitle, getNotificationBody } = useTranslationUtil();
 
   const hideTakeMeThere =
     !notification.ref ||
@@ -78,19 +72,22 @@ function PureNotificationReadOnly({ onGoBack, notification }) {
       </div>
 
       <Semibold style={{ color: colors.teal700, marginBottom: '16px' }}>
-        {notification.title.translation_key
-          ? t(notification.title.translation_key)
-          : notification.title[currentLang]}
+        {getNotificationTitle(notification.title)}
       </Semibold>
       <Text style={{ fontSize: '16px', marginBottom: '16px' }}>
-        {notification.body.translation_key
-          ? t(notification.body.translation_key, tOptions)
-          : notification.body[currentLang]}
+        {getNotificationBody(notification.body, notification.variables)}
       </Text>
       {!hideTakeMeThere && (
         <Button sm style={{ height: '32px', width: '150px' }} onClick={onTakeMeThere}>
           {t('NOTIFICATION.TAKE_ME_THERE')}
         </Button>
+      )}
+      {relatedNotifications?.length > 1 && (
+        <NotificationTimeline
+          style={{ marginTop: '30px' }}
+          activeNotificationId={notification.notification_id}
+          relatedNotifications={relatedNotifications}
+        />
       )}
     </Layout>
   );

--- a/packages/webapp/src/components/WarningBox/index.jsx
+++ b/packages/webapp/src/components/WarningBox/index.jsx
@@ -3,10 +3,10 @@ import styles from './styles.module.scss';
 import clsx from 'clsx';
 import { VscWarning } from 'react-icons/all';
 
-export default function PureWarningBox({ children, className, ...props }) {
+export default function PureWarningBox({ children, className, iconClassName, ...props }) {
   return (
     <div className={clsx(styles.warningBox, className)} {...props}>
-      <VscWarning className={styles.icon} />
+      <VscWarning className={clsx(styles.icon, iconClassName)} />
       {children}
     </div>
   );

--- a/packages/webapp/src/containers/Notification/NotificationCard/index.jsx
+++ b/packages/webapp/src/containers/Notification/NotificationCard/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PureNotificationCard } from '../../../components/Card/NotificationCard/NotificationCard';
+import { getNotificationCardDate } from '../../../util/moment';
 
 const NotificationCard = ({
   alert,
@@ -23,7 +24,7 @@ const NotificationCard = ({
         body={body}
         variables={variables}
         context={context}
-        created_at={created_at}
+        created_at={getNotificationCardDate(created_at)}
         onClick={onClick}
       />
     </>

--- a/packages/webapp/src/containers/Notification/NotificationReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Notification/NotificationReadOnly/index.jsx
@@ -1,30 +1,22 @@
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import PureNotificationReadOnly from '../../../components/Notifications';
 import { notificationSelector, relatedNotificationSelector } from '../../notificationSlice';
-import { getNotification } from '../saga';
 
 export default function NotificationReadOnly({ history, match }) {
-  const dispatch = useDispatch();
   const { notification_id } = match.params;
   const notification = useSelector(notificationSelector(notification_id));
-  const relatedNotifications = useSelector(relatedNotificationSelector(notification.ref?.entity));
-
-  useEffect(() => {
-    dispatch(getNotification());
-  }, []);
+  const relatedNotifications = useSelector(relatedNotificationSelector(notification?.ref?.entity));
 
   const onGoBack = () => {
     history.push('/notifications');
   };
 
   return (
-    <>
-      <PureNotificationReadOnly
-        onGoBack={onGoBack}
-        notification={notification}
-        relatedNotifications={relatedNotifications}
-      />
-    </>
+    <PureNotificationReadOnly
+      onGoBack={onGoBack}
+      notification={notification}
+      relatedNotifications={relatedNotifications}
+    />
   );
 }

--- a/packages/webapp/src/containers/Notification/NotificationReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Notification/NotificationReadOnly/index.jsx
@@ -1,12 +1,19 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import PureNotificationReadOnly from '../../../components/Notifications';
 import { notificationSelector, relatedNotificationSelector } from '../../notificationSlice';
+import { getNotification } from '../saga';
 
 export default function NotificationReadOnly({ history, match }) {
+  const dispatch = useDispatch();
   const { notification_id } = match.params;
   const notification = useSelector(notificationSelector(notification_id));
   const relatedNotifications = useSelector(relatedNotificationSelector(notification.ref?.entity));
+
+  useEffect(() => {
+    dispatch(getNotification());
+  }, []);
+
   const onGoBack = () => {
     history.push('/notifications');
   };

--- a/packages/webapp/src/containers/Notification/NotificationReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Notification/NotificationReadOnly/index.jsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import PureNotificationReadOnly from '../../../components/Notifications';
-import { notificationSelector } from '../../notificationSlice';
+import { notificationSelector, relatedNotificationSelector } from '../../notificationSlice';
 
 export default function NotificationReadOnly({ history, match }) {
   const { notification_id } = match.params;
   const notification = useSelector(notificationSelector(notification_id));
+  const relatedNotifications = useSelector(relatedNotificationSelector(notification.ref?.entity));
   const onGoBack = () => {
     history.push('/notifications');
   };
 
   return (
     <>
-      <PureNotificationReadOnly onGoBack={onGoBack} notification={notification} />
+      <PureNotificationReadOnly
+        onGoBack={onGoBack}
+        notification={notification}
+        relatedNotifications={relatedNotifications}
+      />
     </>
   );
 }

--- a/packages/webapp/src/containers/notificationSlice.js
+++ b/packages/webapp/src/containers/notificationSlice.js
@@ -1,6 +1,5 @@
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
-import { getNotificationCardDate } from '../util/moment';
 
 /**
  * Generate action creators and action types that correspond to a specified initial state and a specified set of reducers.
@@ -66,7 +65,6 @@ export const notificationsSelector = createSelector(
       return {
         ...notification,
         ...notification.variables,
-        created_at: getNotificationCardDate(notification.created_at),
       };
     });
   },

--- a/packages/webapp/src/containers/notificationSlice.js
+++ b/packages/webapp/src/containers/notificationSlice.js
@@ -1,4 +1,4 @@
-import { createEntityAdapter, createSlice, current } from '@reduxjs/toolkit';
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { getNotificationCardDate } from '../util/moment';
 

--- a/packages/webapp/src/containers/notificationSlice.js
+++ b/packages/webapp/src/containers/notificationSlice.js
@@ -81,7 +81,7 @@ export const relatedNotificationSelector = (entity) => (state) => {
   const { type, id } = entity;
   if (!!type && !!id) {
     return notificationSelectors.selectAll(state).filter((n) => {
-      return n.ref?.entity?.type === type && n.ref?.entity?.id === id;
+      return n.ref?.entity?.type === type && n.ref?.entity?.id.toString() === id.toString();
     });
   } else {
     return [];

--- a/packages/webapp/src/containers/notificationSlice.js
+++ b/packages/webapp/src/containers/notificationSlice.js
@@ -1,4 +1,4 @@
-import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import { createEntityAdapter, createSlice, current } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { getNotificationCardDate } from '../util/moment';
 
@@ -74,4 +74,16 @@ export const notificationsSelector = createSelector(
 
 export const notificationSelector = (notification_id) => (state) => {
   return notificationSelectors.selectById(state, notification_id);
+};
+
+export const relatedNotificationSelector = (entity) => (state) => {
+  if (!entity) return [];
+  const { type, id } = entity;
+  if (!!type && !!id) {
+    return notificationSelectors.selectAll(state).filter((n) => {
+      return n.ref?.entity?.type === type && n.ref?.entity?.id === id;
+    });
+  } else {
+    return [];
+  }
 };

--- a/packages/webapp/src/stories/Notification/NotificationTimeline.stories.jsx
+++ b/packages/webapp/src/stories/Notification/NotificationTimeline.stories.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import NotificationTimeline from '../../components/Notifications/NotificationTimeline';
+
+export default {
+  title: 'Components/NotificationTimeline',
+  component: NotificationTimeline,
+};
+
+const Template = (args) => <NotificationTimeline {...args} />;
+
+export const Primary = Template.bind({});
+localStorage.setItem('litefarm_lang', 'en');
+Primary.args = {
+  activeNotificationId: 4,
+  relatedNotifications: [
+    {
+      created_at: new Date(2022, 6, 9).toISOString(),
+      title: { en: 'Assigned Task' },
+      notification_id: 1,
+    },
+    {
+      created_at: new Date(2022, 6, 11).toISOString(),
+      title: { en: 'Unassigned Task' },
+      notification_id: 2,
+    },
+    {
+      created_at: new Date(2022, 6, 10).toISOString(),
+      title: { en: 'Assigned Task' },
+      notification_id: 3,
+    },
+    {
+      created_at: new Date(2022, 6, 13).toISOString(),
+      title: { en: 'Completed Task' },
+      notification_id: 4,
+    },
+  ],
+};

--- a/packages/webapp/src/util/useTranslationUtil.js
+++ b/packages/webapp/src/util/useTranslationUtil.js
@@ -1,0 +1,30 @@
+import { getLanguageFromLocalStorage } from './getLanguageFromLocalStorage';
+import { useTranslation } from 'react-i18next';
+
+const useTranslationUtil = () => {
+  const { t } = useTranslation();
+  const currentLang = getLanguageFromLocalStorage();
+
+  const getNotificationTitle = (title) => {
+    return title.translation_key ? t(title.translation_key) : title[currentLang];
+  };
+
+  const getTranslationOptions = (variables) => {
+    return variables?.reduce((optionsSoFar, currentOption) => {
+      let options = { ...optionsSoFar };
+      options[currentOption.name] = currentOption.translate
+        ? t(currentOption.value)
+        : currentOption.value;
+      return options;
+    }, {});
+  };
+
+  const getNotificationBody = (body, variables) => {
+    const tOptions = getTranslationOptions(variables);
+    return body.translation_key ? t(body.translation_key, tOptions) : body[currentLang];
+  };
+
+  return { getNotificationTitle, getNotificationBody, getTranslationOptions };
+};
+
+export default useTranslationUtil;


### PR DESCRIPTION
Ticket: [LF-2462](https://lite-farm.atlassian.net/browse/LF-2462)

Created a notification timeline for viewing notifications related to the same entity (eg. a task).

To test:
- See [Figma](https://www.figma.com/file/F3f6DpGcxAaEsxfl7OZkI2/Litefarm?node-id=27547%3A88602&properties-panel-tab=code) for design expectations.
- Assign a task to yourself, then reassign/unassign it (we want to trigger two notifications);
- Go to the notification related to the above event, make sure that we see the notification timeline with the two notifications
- If you are viewing the "Assigned task" notification, make sure that the warning box shows up
- In the timeline, you should be able to click the different items to switch between related notifications