### PR TITLE
Unit Indicators are not dynamic

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -226,6 +226,8 @@ const Unit = ({
   }, [hookFormUnit]);
 
   useEffect(() => {
+    !hookFormGetValue(displayUnitName) &&
+      hookFormSetValue(displayUnitName, getUnitOptionMap()[displayUnit]);
     if (hookFormGetValue(displayUnitName)) {
       hookFormSetValue(displayUnitName, getUnitOptionMap()[displayUnit]);
     }

--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -226,7 +226,7 @@ const Unit = ({
   }, [hookFormUnit]);
 
   useEffect(() => {
-    if (!hookFormGetValue(displayUnitName)) {
+    if (hookFormGetValue(displayUnitName)) {
       hookFormSetValue(displayUnitName, getUnitOptionMap()[displayUnit]);
     }
   }, []);


### PR DESCRIPTION
[Jira Ticket:](https://lite-farm.atlassian.net/jira/software/c/projects/LF/boards/1?modal=detail&selectedIssue=LF-2491)
Create a crop plan and input values higher than the threshold that would convert the numbers to a smaller value. 
For example, input at least 100cm in plant spacing/depth etc in order for the values to be converted into meters. Do the same thing for estimated annual harvest (At least 1000kg to convert to mt). 

Once the crop plan has created open the details page of the plan and make sure the conversion occurred and the units are now in mt. Similarly check the plan spacing/depth etc in the planting task and make sure the cm have converted to meters. 