### PR TITLE
Lf 2484 structures to support sensors

### DIFF
--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -15,7 +15,7 @@ exports.up = function (knex) {
       table.uuid('reading_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
       table.timestamp('read_time').notNullable();
       table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
-      table.integer('sensor_id').references('sensor_id').inTable('sensor').notNullable();
+      table.uuid('sensor_id').references('sensor_id').inTable('sensor').notNullable();
       table.string('reading_type').notNullable();
       table.float('value').notNullable();
       table.string('unit').notNullable();

--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -7,7 +7,6 @@ exports.up = function (knex) {
       // table.float('latitude').notNullable();
       // table.float('longitude').notNullable();
       table.jsonb('grid_points').notNullable();
-      table.integer('type').notNullable();
       table.float('depth');
       table.float('elevation');
       table.integer('partner_id');

--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -15,7 +15,7 @@ exports.up = function (knex) {
       table.uuid('reading_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
       table.timestamp('read_time').notNullable();
       table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
-      table.uuid('sensor_id').references('sensor_id').inTable('sensor').notNullable();
+      table.string('sensor_id');
       table.string('reading_type').notNullable();
       table.float('value').notNullable();
       table.string('unit').notNullable();

--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -17,7 +17,7 @@ exports.up = function (knex) {
     knex.schema.createTable('sensor_reading', function (table) {
       table.uuid('reading_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
       table.timestamp('read_time').notNullable();
-      table.timestamp('transmit_time').notNullable().defaultTo(knex.fn.now());
+      table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
       table.integer('sensor_id').notNullable();
       table.string('reading_type').notNullable();
       table.float('value').notNullable();

--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -4,18 +4,23 @@ exports.up = function (knex) {
       table.uuid('sensor_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
       table.string('farm_id').notNullable();
       table.string('name').notNullable();
+      table
+        .integer('partner_id')
+        .references('partner_id')
+        .inTable('integratingPartners')
+        .notNullable();
+      table.string('external_id').notNullable();
+      table.uuid('location_id').references('location_id').inTable('location').notNullable();
       table.jsonb('grid_points').notNullable();
       table.float('depth');
       table.float('elevation');
-      table.integer('partner_id').references('partner_id').inTable('integratingPartners');
-      table.string('external_id');
     }),
 
     knex.schema.createTable('sensor_reading', function (table) {
       table.uuid('reading_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
+      table.string('sensor_id').notNullable();
       table.timestamp('read_time').notNullable();
       table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
-      table.string('sensor_id');
       table.string('reading_type').notNullable();
       table.float('value').notNullable();
       table.string('unit').notNullable();
@@ -25,9 +30,5 @@ exports.up = function (knex) {
 };
 
 exports.down = function (knex) {
-  return Promise.all([
-    knex.schema.dropTable('sensor'),
-    //   knex.schema.dropTable('sensor_parameter'),
-    knex.schema.dropTable('sensor_reading'),
-  ]);
+  return Promise.all([knex.schema.dropTable('sensor'), knex.schema.dropTable('sensor_reading')]);
 };

--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -4,8 +4,6 @@ exports.up = function (knex) {
       table.uuid('sensor_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
       table.string('farm_id').notNullable();
       table.string('name').notNullable();
-      // table.float('latitude').notNullable();
-      // table.float('longitude').notNullable();
       table.jsonb('grid_points').notNullable();
       table.float('depth');
       table.float('elevation');
@@ -17,7 +15,7 @@ exports.up = function (knex) {
       table.uuid('reading_id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v1()'));
       table.timestamp('read_time').notNullable();
       table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
-      table.integer('sensor_id').notNullable();
+      table.integer('sensor_id').references('sensor_id').inTable('sensor').notNullable();
       table.string('reading_type').notNullable();
       table.float('value').notNullable();
       table.string('unit').notNullable();

--- a/packages/api/db/migration/20220614195741_sensor_reading_types.js
+++ b/packages/api/db/migration/20220614195741_sensor_reading_types.js
@@ -56,16 +56,9 @@ exports.up = async function (knex) {
       .inTable('partner_reading_type');
     table.uuid('sensor_id').references('sensor_id').inTable('sensor');
   });
-
-  await knex.schema.alterTable('sensor', function (table) {
-    table.dropColumns('type');
-  });
 };
 
 exports.down = async function (knex) {
   await knex.schema.dropTable('sensor_reading_type');
   await knex.schema.dropTable('partner_reading_type');
-  await knex.schema.alterTable('sensor', function (table) {
-    table.integer('type');
-  });
 };

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -80,9 +80,7 @@ const sensorController = {
       const trx = await transaction.start(Model.knex());
       try {
         const infoBody = {
-          reading_id: req.body.reading_id,
           read_time: req.body.read_time,
-          //   transmit_time: req.body.transmit_time,
           sensor_id: req.body.sensor_id,
           reading_type: req.body.reading_type,
           value: req.body.value,

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -79,15 +79,29 @@ const sensorController = {
     return async (req, res) => {
       const trx = await transaction.start(Model.knex());
       try {
-        const infoBody = {
-          read_time: req.body.read_time,
-          sensor_id: req.body.sensor_id,
-          reading_type: req.body.reading_type,
-          value: req.body.value,
-          unit: req.body.unit,
-        };
+        // const infoBody = {
+        //   read_time: req.body.read_time,
+        //   sensor_id: req.body.sensor_id,
+        //   reading_type: req.body.reading_type,
+        //   value: req.body.value,
+        //   unit: req.body.unit,
+        // };
+        const infoBody = [];
+        for (const sensor of req.body) {
+          for (let i = 0; i < sensor.value.length; i++) {
+            const row = {
+              read_time: sensor.time[i],
+              sensor_id: sensor.sensor_esid,
+              reading_type: sensor.parameter_number,
+              value: sensor.value[i],
+              unit: sensor.unit,
+            };
+            infoBody.push(row);
+          }
+        }
 
-        if (!Object.values(infoBody).every((value) => value)) {
+        // Check if each field in each entry of infoBody populated
+        if (infoBody.every((entry) => !Object.values(entry).every((value) => value))) {
           res.status(400).send('Invalid reading');
         }
         const result = await baseController.postWithResponse(sensorReadingModel, infoBody, req, {

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -82,7 +82,6 @@ const sensorController = {
             .select('sensor_id')
             .where('external_id', sensor.sensor_esid)
             .where('partner_id', req.params.partner_id);
-          console.log(corresponding_sensor[0].sensor_id);
           for (let i = 0; i < sensor.value.length; i++) {
             const row = {
               read_time: sensor.time[i],
@@ -91,7 +90,6 @@ const sensorController = {
               value: sensor.value[i],
               unit: sensor.unit,
             };
-            console.log(row);
             // Only include this entry if all required values are poulated
             if (Object.values(row).every((value) => value)) {
               infoBody.push(row);

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -196,7 +196,7 @@ const sensorController = {
 
   addReading() {
     return async (req, res) => {
-      // const trx = await transaction.start(Model.knex());
+      const trx = await transaction.start(Model.knex());
       try {
         const infoBody = [];
         for (const sensor of req.body) {
@@ -219,12 +219,15 @@ const sensorController = {
             }
           }
         }
-
-        const result = await baseController.postWithResponse(sensorReadingModel, infoBody, req, {
-          trx,
-        });
-        await trx.commit();
-        res.status(200).send(result);
+        if (infoBody.length == 0) {
+          res.status(200).send(infoBody);
+        } else {
+          const result = await baseController.postWithResponse(sensorReadingModel, infoBody, req, {
+            trx,
+          });
+          await trx.commit();
+          res.status(200).send(result);
+        }
       } catch (error) {
         res.status(400).json({
           error,

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -91,6 +91,7 @@ const sensorController = {
               value: sensor.value[i],
               unit: sensor.unit,
             };
+            console.log(row);
             // Only include this entry if all required values are poulated
             if (Object.values(row).every((value) => value)) {
               infoBody.push(row);

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -17,7 +17,7 @@ const Model = require('objection').Model;
 
 class Sensor extends Model {
   static get tableName() {
-    return 'sensors';
+    return 'sensor';
   }
 
   static get idColumn() {

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -30,14 +30,19 @@ class Sensor extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['sensor_id', 'farm_id', 'name', 'latitude', 'longitude', 'type'],
+      required: ['sensor_id', 'farm_id', 'name', 'grid_points', 'type'],
 
       properties: {
         sensor_id: { type: 'string' },
         farm_id: { type: 'string', minLength: 1, maxLength: 255 },
         name: { type: 'string', minLength: 1, maxLength: 255 },
-        latitude: { type: 'float' },
-        longitude: { type: 'float' },
+        grid_points: {
+          type: 'object',
+          properties: {
+            lat: { type: 'number' },
+            lng: { type: 'number' },
+          },
+        },
         type: { type: 'string' },
         external_id: { type: 'string', minLength: 1, maxLength: 255 },
         depth: { type: 'float' },

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -30,7 +30,7 @@ class Sensor extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['sensor_id', 'farm_id', 'name', 'grid_points', 'type'],
+      required: ['sensor_id', 'farm_id', 'name', 'grid_points'],
 
       properties: {
         sensor_id: { type: 'string' },
@@ -43,7 +43,6 @@ class Sensor extends Model {
             lng: { type: 'number' },
           },
         },
-        type: { type: 'string' },
         external_id: { type: 'string', minLength: 1, maxLength: 255 },
         depth: { type: 'float' },
         elevation: { type: 'float' },

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -30,12 +30,23 @@ class Sensor extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['sensor_id', 'farm_id', 'name', 'grid_points'],
+      required: [
+        'sensor_id',
+        'farm_id',
+        'name',
+        'grid_points',
+        'partner_id',
+        'external_id',
+        'location_id',
+      ],
 
       properties: {
         sensor_id: { type: 'string' },
         farm_id: { type: 'string', minLength: 1, maxLength: 255 },
         name: { type: 'string', minLength: 1, maxLength: 255 },
+        partner_id: { type: 'integer' },
+        external_id: { type: 'string', minLength: 1, maxLength: 255 },
+        location_id: { type: 'string' },
         grid_points: {
           type: 'object',
           properties: {
@@ -43,8 +54,6 @@ class Sensor extends Model {
             lng: { type: 'number' },
           },
         },
-        external_id: { type: 'string', minLength: 1, maxLength: 255 },
-        partner_id: { type: 'integer' },
         depth: { type: 'float' },
         elevation: { type: 'float' },
       },

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -51,18 +51,6 @@ class Sensor extends Model {
       additionalProperties: false,
     };
   }
-  static get relationMappings() {
-    return {
-      sensor_id: {
-        relation: Model.HasManyRelation,
-        modelClass: require('./sensorReadingModel'),
-        join: {
-          from: 'sensor_reading',
-          to: 'sensor.sensor_id',
-        },
-      },
-    };
-  }
 }
 
 module.exports = Sensor;

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -44,14 +44,25 @@ class Sensor extends Model {
           },
         },
         external_id: { type: 'string', minLength: 1, maxLength: 255 },
+        partner_id: { type: 'integer' },
         depth: { type: 'float' },
         elevation: { type: 'float' },
       },
       additionalProperties: false,
     };
   }
+  static get relationMappings() {
+    return {
+      sensor_id: {
+        relation: Model.HasManyRelation,
+        modelClass: require('./sensorReadingModel'),
+        join: {
+          from: 'sensor_reading',
+          to: 'sensor.sensor_id',
+        },
+      },
+    };
+  }
 }
-
-// TODO: Create relationships with reading model
 
 module.exports = Sensor;

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -30,12 +30,12 @@ class SensorReading extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['reading_id', 'read_time', 'sensor_id', 'reading_type', 'value'],
+      required: ['read_time', 'sensor_id', 'reading_type', 'value', 'unit'],
       properties: {
-        reading_id: { type: 'integer' },
+        reading_id: { type: 'string' },
         read_time: { type: 'timestamp' },
-        transmit_time: { type: 'timestamp' },
-        sensor_id: { type: 'integer' },
+        created_at: { type: 'timestamp' },
+        sensor_id: { type: 'string' },
         reading_type: { type: 'string', minLength: 1, maxLength: 255 },
         value: { type: 'float' },
         unit: { type: 'string', minLength: 1, maxLength: 255 },

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -44,18 +44,6 @@ class SensorReading extends Model {
       additionalProperties: false,
     };
   }
-  static get relationMappings() {
-    return {
-      sensor_id: {
-        relation: Model.HasManyRelation,
-        modelClass: require('./sensorModel'),
-        join: {
-          from: 'sensor.sensor_id',
-          to: 'sensor_reading.sensor_id',
-        },
-      },
-    };
-  }
 }
 
 module.exports = SensorReading;

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -30,7 +30,17 @@ class SensorReading extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['read_time', 'sensor_id', 'reading_type', 'value', 'unit'],
+      required: [
+        'read_time',
+        'sensor_id',
+        'reading_type',
+        'value',
+        'unit',
+        'read_time',
+        'reading_type',
+        'value',
+        'unit',
+      ],
       properties: {
         reading_id: { type: 'string' },
         read_time: { type: 'timestamp' },

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -44,8 +44,18 @@ class SensorReading extends Model {
       additionalProperties: false,
     };
   }
+  static get relationMappings() {
+    return {
+      sensor_id: {
+        relation: Model.HasManyRelation,
+        modelClass: require('./sensorModel'),
+        join: {
+          from: 'sensor.sensor_id',
+          to: 'sensor_reading.sensor_id',
+        },
+      },
+    };
+  }
 }
-
-// TODO: Create relationships with sensor model
 
 module.exports = SensorReading;

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -17,7 +17,7 @@ const Model = require('objection').Model;
 
 class SensorReading extends Model {
   static get tableName() {
-    return 'sensor_readings';
+    return 'sensor_reading';
   }
 
   static get idColumn() {

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -20,7 +20,6 @@ const sensor_controller = require('../controllers/sensorController');
 router.post('/get_sensors/', sensor_controller.getSensorsByFarmId());
 router.post('/add_sensors', sensor_controller.addSensors());
 router.delete('/delete_sensor/:sensor_id', sensor_controller.deleteSensor());
-// router.post('/edit_sensor', sensor_controller.editSensor());
 router.post('/add_reading/:partner_id', sensor_controller.addReading());
 router.post('/get_readings', sensor_controller.getAllReadingsBySensorId());
 router.post('/invalidate_readings', sensor_controller.invalidateReadings());

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -21,7 +21,7 @@ router.post('/get_sensors/', sensor_controller.getSensorsByFarmId());
 router.post('/add_sensors', sensor_controller.addSensors());
 router.delete('/delete_sensor/:sensor_id', sensor_controller.deleteSensor());
 // router.post('/edit_sensor', sensor_controller.editSensor());
-router.post('/add_reading', sensor_controller.addReading());
+router.post('/add_reading/:partner_id', sensor_controller.addReading());
 router.post('/get_readings', sensor_controller.getAllReadingsBySensorId());
 router.post('/invalidate_readings', sensor_controller.invalidateReadings());
 

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -24,16 +24,16 @@ const upload = multer({ storage });
 
 const router = express.Router();
 
-router.post('/get_sensors/', sensor_controller.getSensorsByFarmId());
+router.post('/get_sensors/', SensorController.getSensorsByFarmId());
 router.post(
   '/add_sensors/',
   checkScope(['add:sensors']),
   upload.single('sensors'),
   SensorController.addSensors,
 );
-router.delete('/delete_sensor/:sensor_id', sensor_controller.deleteSensor());
-router.post('/add_reading/:partner_id', sensor_controller.addReading());
-router.post('/get_readings', sensor_controller.getAllReadingsBySensorId());
-router.post('/invalidate_readings', sensor_controller.invalidateReadings());
+router.delete('/delete_sensor/:sensor_id', SensorController.deleteSensor());
+router.post('/add_reading/:partner_id', SensorController.addReading());
+router.post('/get_readings', SensorController.getAllReadingsBySensorId());
+router.post('/invalidate_readings', SensorController.invalidateReadings());
 
 module.exports = router;

--- a/packages/api/src/util/ensemble.js
+++ b/packages/api/src/util/ensemble.js
@@ -82,7 +82,7 @@ async function registerOrganizationWebhook(farmId, organizationId, accessToken) 
     method: 'post',
     url: `${ensembleAPI}/organizations/${organizationId}/webhooks/`,
     data: {
-      url: `${baseUrl}/sensors/add_reading/:partner_id`,
+      url: `${baseUrl}/sensors/add_reading/1`,
       frequency: 15,
     },
   };
@@ -94,7 +94,7 @@ async function registerOrganizationWebhook(farmId, organizationId, accessToken) 
   const onResponse = async (response) => {
     await FarmExternalIntegrationsModel.updateWebhookAddress(
       farmId,
-      `${baseUrl}/sensors/add_reading/:partner_id`,
+      `${baseUrl}/sensors/add_reading/1`,
       response.data.id,
     );
     return { ...response.data, status: response.status };

--- a/packages/api/src/util/ensemble.js
+++ b/packages/api/src/util/ensemble.js
@@ -82,7 +82,7 @@ async function registerOrganizationWebhook(farmId, organizationId, accessToken) 
     method: 'post',
     url: `${ensembleAPI}/organizations/${organizationId}/webhooks/`,
     data: {
-      url: `${baseUrl}/sensors/add_reading/`,
+      url: `${baseUrl}/sensors/add_reading/:partner_id`,
       frequency: 15,
     },
   };
@@ -94,7 +94,7 @@ async function registerOrganizationWebhook(farmId, organizationId, accessToken) 
   const onResponse = async (response) => {
     await FarmExternalIntegrationsModel.updateWebhookAddress(
       farmId,
-      `${baseUrl}/sensors/add_reading/`,
+      `${baseUrl}/sensors/add_reading/:partner_id`,
       response.data.id,
     );
     return { ...response.data, status: response.status };


### PR DESCRIPTION
To test:

1. Run migrations from api folder, you should see two new db tables `sensor` and `sensor_reading`
2. Make calls to the sensor endpoints and ensure the data is stored in the db correctly.

Here is some general information to help you make the api calls
- To add a reading, the sensor that reading belongs to must exist in the db. I suggest creating sensors manually and adding readings through the api since the `add_sensor` endpoint is part of a different ticket
- Here is an example POST that ensemble may send to the `add_reading` endpoint
`[
  {
    "node_esid": "123",
    "sensor_esid": "124",
    "parameter_number": "Temperature",
    "unit": "ºC",
    "time": [
      "02-09-2022, 22:53:52",
      "02-09-2022, 22:54:07"
    ],
    "value": [
      1,
      2
    ],
    "validated": [
      false,
      false
    ]
  },
  {
    "node_esid": "123",
    "sensor_esid": "123",
    "parameter_number": "Soil Moisture",
    "unit": "kPa",
    "time": [
      "02-09-2022, 22:54:23"
    ],
    "value": [
      3
    ],
    "validated": [
      false
    ]
  }
]`
- Use '1' as the partner ID when you add a reading as this is the only partner ID we have at the moment
- When sending a request, make sure you include the appropriate JSON body