### PR TITLE
fix: border and icon colour override for warning box

### DIFF
--- a/packages/webapp/src/components/WarningBox/index.jsx
+++ b/packages/webapp/src/components/WarningBox/index.jsx
@@ -5,8 +5,8 @@ import { VscWarning } from 'react-icons/all';
 
 export default function PureWarningBox({ children, className, iconClassName, ...props }) {
   return (
-    <div className={clsx(styles.warningBox, className)} {...props}>
-      <VscWarning className={clsx(styles.icon, iconClassName)} />
+    <div className={clsx(className, styles.warningBox)} {...props}>
+      <VscWarning className={clsx(iconClassName, styles.icon)} />
       {children}
     </div>
   );


### PR DESCRIPTION
Fix for the colour of the notification timeline warning box. The border, icon, and hyperlink should all be the same colour. 

<img width="1270" alt="Screen Shot 2022-06-16 at 10 08 01 AM" src="https://user-images.githubusercontent.com/104768598/174088508-424beba9-dd65-4e9e-b7b7-c02782ae633e.png">
 