### PR TITLE
Bug fix for map and crop variety detail page

### DIFF
--- a/packages/webapp/src/containers/Crop/CropVarietySpotlight/index.jsx
+++ b/packages/webapp/src/containers/Crop/CropVarietySpotlight/index.jsx
@@ -9,7 +9,7 @@ export default function CropVarietySpotlight({ children }) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { crop_variety_detail } = useSelector(showedSpotlightSelector);
-  const onFinish = () => dispatch(setSpotlightToShown(['crop_variety_detail']));
+  const onFinish = () => dispatch(setSpotlightToShown('crop_variety_detail'));
   const managementId = `#${t('CROP_DETAIL.MANAGEMENT_TAB')}0`;
   const detailId = `#${t('CROP_DETAIL.DETAIL_TAB')}1`;
 

--- a/packages/webapp/src/containers/Crop/CropVarietySpotlight/index.jsx
+++ b/packages/webapp/src/containers/Crop/CropVarietySpotlight/index.jsx
@@ -9,32 +9,36 @@ export default function CropVarietySpotlight({ children }) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { crop_variety_detail } = useSelector(showedSpotlightSelector);
-  const onFinish = () => dispatch(setSpotlightToShown('crop_variety_detail'));
+  const onFinish = () => dispatch(setSpotlightToShown(['crop_variety_detail']));
   const managementId = `#${t('CROP_DETAIL.MANAGEMENT_TAB')}0`;
   const detailId = `#${t('CROP_DETAIL.DETAIL_TAB')}1`;
 
-  return <TourProviderWrapper
-    open={!crop_variety_detail}
-    steps={[
-      {
-        title: t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_TITLE'),
-        contents: [t('MANAGEMENT_PLAN.SPOTLIGHT_HERE_YOU_CAN')],
-        list: [
-          t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_1'),
-          t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_2'),
-          t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_3'),
-        ],
-        selector: managementId,
-        position: 'bottom',
-      },
-      {
-        title: t('MANAGEMENT_PLAN.DETAIL_SPOTLIGHT_TITLE'),
-        contents: [t('MANAGEMENT_PLAN.DETAIL_SPOTLIGHT_CONTENTS')],
-        selector: detailId,
-        position: 'bottom',
-        buttonText: t('MANAGEMENT_PLAN.STARTED'),
-      },
-    ]}
-    onFinish={onFinish}
-  >{children}</TourProviderWrapper>;
+  return (
+    <TourProviderWrapper
+      open={!crop_variety_detail}
+      steps={[
+        {
+          title: t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_TITLE'),
+          contents: [t('MANAGEMENT_PLAN.SPOTLIGHT_HERE_YOU_CAN')],
+          list: [
+            t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_1'),
+            t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_2'),
+            t('MANAGEMENT_PLAN.MANAGEMENT_SPOTLIGHT_3'),
+          ],
+          selector: managementId,
+          position: 'bottom',
+        },
+        {
+          title: t('MANAGEMENT_PLAN.DETAIL_SPOTLIGHT_TITLE'),
+          contents: [t('MANAGEMENT_PLAN.DETAIL_SPOTLIGHT_CONTENTS')],
+          selector: detailId,
+          position: 'bottom',
+          buttonText: t('MANAGEMENT_PLAN.STARTED'),
+        },
+      ]}
+      onFinish={onFinish}
+    >
+      {children}
+    </TourProviderWrapper>
+  );
 }

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -426,7 +426,7 @@ export default function Map({ history }) {
           <PureMapFooter
             isAdmin={is_admin}
             showSpotlight={!showedSpotlight.map}
-            resetSpotlight={() => dispatch(setSpotlightToShown(['map']))}
+            resetSpotlight={() => dispatch(setSpotlightToShown('map'))}
             onClickAdd={handleClickAdd}
             onClickExport={handleClickExport}
             showModal={showExportModal}

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -426,7 +426,7 @@ export default function Map({ history }) {
           <PureMapFooter
             isAdmin={is_admin}
             showSpotlight={!showedSpotlight.map}
-            resetSpotlight={() => dispatch(setSpotlightToShown('map'))}
+            resetSpotlight={() => dispatch(setSpotlightToShown(['map']))}
             onClickAdd={handleClickAdd}
             onClickExport={handleClickExport}
             showModal={showExportModal}

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -61,6 +61,9 @@ export function* setSpotlightToShownSaga({ payload: spotlights }) {
     const { user_id } = yield select(loginSelector);
     const header = getHeader(user_id);
     let patchContent = {};
+    if (typeof spotlights == 'string') {
+      spotlights = [spotlights];
+    }
     for (const spotlight of spotlights) {
       patchContent[spotlight] = true;
       patchContent[`${spotlight}_end`] = new Date().toISOString();


### PR DESCRIPTION
To test:


1. If you don't already have one, create a crop plan on your farm
2. Invite a farm worker from your current farm. Make sure the invitee would be making a fresh account when they receive the invitation
3. Sign in from this new worker and navigate to the crop plan you made.
4. You should see the appropriate spotlight only once. Click the details tab and ensure you do not see the spotlight again. You can also re-navigate to this same page to ensure you do not see the spotlight again
5. Navigate to the map and ensure you only see the spotlight once. Try creating an area or re-navigating to the map to make sure of this as well.