### PR TITLE
Fix code, English for incorrect wording

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -106,7 +106,7 @@ const taskController = {
           available_tasks.map(async (task) => {
             await sendTaskNotification(
               newAssigneeUserId,
-              null,
+              user_id,
               task.task_id,
               TaskNotificationTypes.TASK_ASSIGNED,
               task.task_translation_key,
@@ -266,7 +266,7 @@ const taskController = {
           const { assignee_user_id, task_id, taskType } = result;
           await sendTaskNotification(
             assignee_user_id,
-            null,
+            user_id,
             task_id,
             TaskNotificationTypes.TASK_ASSIGNED,
             taskType.task_translation_key,
@@ -661,7 +661,7 @@ const TaskNotificationTypes = {
 };
 
 const TaskNotificationUserTypes = {
-  TASK_ASSIGNED: 'assignee',
+  TASK_ASSIGNED: 'assigner',
   TASK_ABANDONED: 'abandoner',
   TASK_REASSIGNED: 'assigner',
   TASK_COMPLETED_BY_OTHER_USER: 'assigner',
@@ -720,7 +720,7 @@ async function sendTaskReassignedNotifications(
   await Promise.all([
     sendTaskNotification(
       newAssigneeUserId,
-      null,
+      assignerUserId,
       taskId,
       TaskNotificationTypes.TASK_ASSIGNED,
       taskTranslationKey,

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1094,7 +1094,7 @@
       "TITLE": "Task abandoned"
     },
     "TASK_ASSIGNED": {
-      "BODY": "A {{taskType}} task has been assigned to {{assignee}}.",
+      "BODY": "A {{taskType}} task has been assigned to you by {{assigner}}.",
       "TITLE": "Assigned task"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1097,7 +1097,7 @@
       "TITLE": "Tarea abandonada"
     },
     "TASK_ASSIGNED": {
-      "BODY": "Se ha asignado una tarea {{taskType}} a MISSING {{assigner}}.",
+      "BODY": "Una tarea {{taskType}} fue asignado para ti por {{assigner}}.",
       "TITLE": "Tarea asignada"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1097,7 +1097,7 @@
       "TITLE": "Tarea abandonada"
     },
     "TASK_ASSIGNED": {
-      "BODY": "Se ha asignado una tarea {{taskType}} a {{assignee}}.",
+      "BODY": "Se ha asignado una tarea {{taskType}} a MISSING {{assigner}}.",
       "TITLE": "Tarea asignada"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1098,7 +1098,7 @@
       "TITLE": "Tâche abandonnée"
     },
     "TASK_ASSIGNED": {
-      "BODY": "Une tâche de {{taskType}} a été assignée à MISSING {{assigner}}.",
+      "BODY": "Une tâche de {{taskType}} a été assignée à vous par {{assigner}}.",
       "TITLE": "Tâche assignée"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1098,7 +1098,7 @@
       "TITLE": "Tâche abandonnée"
     },
     "TASK_ASSIGNED": {
-      "BODY": "Une tâche de {{taskType}} a été assignée à {{assignee}}.",
+      "BODY": "Une tâche de {{taskType}} a été assignée à MISSING {{assigner}}.",
       "TITLE": "Tâche assignée"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1098,7 +1098,7 @@
       "TITLE": "Tarefa abandonada"
     },
     "TASK_ASSIGNED": {
-      "BODY": "A tarefa {{taskType}} foi atribuída a MISSING {{assigner}}.",
+      "BODY": "A tarefa {{taskType}} atribuída a você por {{assigner}}.",
       "TITLE": "Tarefa atribuída"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1098,7 +1098,7 @@
       "TITLE": "Tarefa abandonada"
     },
     "TASK_ASSIGNED": {
-      "BODY": "A tarefa {{taskType}} foi atribuída a {{assignee}}. ",
+      "BODY": "A tarefa {{taskType}} foi atribuída a MISSING {{assigner}}.",
       "TITLE": "Tarefa atribuída"
     },
     "TASK_COMPLETED_BY_OTHER_USER": {


### PR DESCRIPTION
Note that this intentionally inserts `MISSING` as a substring in a key for non-English languages where words are missing from the otherwise correct translation.