### PR TITLE
LF-2478/pseudo user invite email language bug fix

### DIFF
--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -603,7 +603,7 @@ const userFarmController = {
             email,
             gender,
             birth_year,
-            language,
+            language_preference: language,
           },
           userFarm,
           farm_name,

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -242,7 +242,7 @@ export default function PureEditUser({
         step="0.01"
         type="number"
         hookFormRegister={register(WAGE, { min: 0, valueAsNumber: true })}
-        style={{ marginBottom: '40px' }}
+        style={{ marginBottom: '24px' }}
         errors={errors[WAGE] && (errors[WAGE].message || t('INVITE_USER.WAGE_ERROR'))}
         optional
       />

--- a/packages/webapp/src/containers/Profile/People/saga.js
+++ b/packages/webapp/src/containers/Profile/People/saga.js
@@ -125,6 +125,7 @@ export function* invitePseudoUserSaga({ payload: user }) {
       user,
       header,
     );
+    localStorage.setItem('litefarm_lang', user.language);
     yield put(
       invitePseudoUserSuccess({
         newUserFarm: result.data,


### PR DESCRIPTION
Ticket [LF-2478 comments](https://lite-farm.atlassian.net/browse/LF-2478?focusedCommentId=13522)

To Test:
1. Create a pseudo user without an email account.
2. Convert the user to an account with email.
3. Try different language of invitation.
4. The invitation email must be in the correct language and when you click the link, the app should be in the correct language.