### PR TITLE
LF-2526 successfully created sensors notification

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -331,7 +331,10 @@ async function sendSensorNotification(receiverId, farmId, notifyTranslationKey) 
       },
       variables: [],
       ref: { url: '/map' },
-      context: { icon_translation_key: 'SENSOR' },
+      context: {
+        icon_translation_key: 'SENSOR',
+        notification_type: SensorNotificationTypes[notifyTranslationKey],
+      },
       farm_id: farmId,
     },
     [receiverId],

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -31,7 +31,6 @@ const sensorController = {
   async addSensors(req, res) {
     try {
       const { farm_id } = req.headers;
-      const { user_id } = req.user;
       const { access_token } = await IntegratingPartnersModel.getAccessAndRefreshTokens(
         'Ensemble Scientific',
       );
@@ -151,7 +150,6 @@ const sensorController = {
             registeredSensors,
           });
         } else {
-          sendSensorNotification(user_id, farm_id, SensorNotificationTypes.SENSOR_BULK_UPLOAD);
           res.status(200).send({ message: 'Successfully uploaded!' });
         }
       }
@@ -319,6 +317,7 @@ const SensorNotificationTypes = {
  * @param {string} notifyTranslationKey notification translation key
  * @async
  */
+// eslint-disable-next-line no-unused-vars
 async function sendSensorNotification(receiverId, farmId, notifyTranslationKey) {
   if (!receiverId) return;
 

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1125,6 +1125,10 @@
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "You have unassigned tasks due this week.",
       "TITLE": "Unassigned tasks"
+    },
+    "SENSOR_BULK_UPLOAD": {
+      "BODY": "Your sensor upload has completed successfully.",
+      "TITLE": "Sensor upload completed"
     }
   },
   "OUTRO": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1128,6 +1128,10 @@
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "Tiene tareas sin asignar que vencen esta semana.",
       "TITLE": "Tareas sin responables"
+    },
+    "SENSOR_BULK_UPLOAD": {
+      "BODY": "MISSING",
+      "TITLE": "MISSING"
     }
   },
   "OUTRO": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1129,6 +1129,10 @@
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "Vous avez des tâches non attribuées à accomplir cette semaine.",
       "TITLE": "Tâches non attribuées"
+    },
+    "SENSOR_BULK_UPLOAD": {
+      "BODY": "MISSING",
+      "TITLE": "MISSING"
     }
   },
   "OUTRO": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1129,6 +1129,10 @@
     "WEEKLY_UNASSIGNED_TASKS": {
       "BODY": "Você tem tarefas não atribuídas para esta semana.",
       "TITLE": "Tarefas não atribuídas"
+    },
+    "SENSOR_BULK_UPLOAD": {
+      "BODY": "MISSING",
+      "TITLE": "MISSING"
     }
   },
   "OUTRO": {

--- a/packages/webapp/src/components/Card/NotificationCard/NotificationCard.jsx
+++ b/packages/webapp/src/components/Card/NotificationCard/NotificationCard.jsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { colors } from '../../../assets/theme';
 import { ReactComponent as AlertIcon } from '../../../assets/images/alert.svg';
 import getTaskTypeIcon from '../../util/getTaskTypeIcon';
+import getNotificationTypeIcon from '../../util/getNotificationTypeIcon';
 import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 
 /**
@@ -37,6 +38,7 @@ export function PureNotificationCard({
   let Icon;
   // The "context" can indicate that a particular type of task icon is appropriate.
   if (context?.task_translation_key) Icon = getTaskTypeIcon(context.task_translation_key);
+  if (context?.icon_translation_key) Icon = getNotificationTypeIcon(context.icon_translation_key);
 
   return (
     <Card

--- a/packages/webapp/src/components/util/getNotificationTypeIcon.js
+++ b/packages/webapp/src/components/util/getNotificationTypeIcon.js
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ReactComponent as SensorIcon } from '../../assets/images/farmMapFilter/Sensor.svg';
+
+/**
+ * Provides the appropriate icon for a specified notification type.
+ * @param {string} key - A translation key that specifies a notification type.
+ * @returns {ReactComponent | undefined} The icon for the specified notification type.
+ */
+export default function getTaskTypeIcon(key) {
+  const iconDict = {
+    SENSOR: SensorIcon,
+  };
+
+  return iconDict[key];
+}

--- a/packages/webapp/src/components/util/getNotificationTypeIcon.js
+++ b/packages/webapp/src/components/util/getNotificationTypeIcon.js
@@ -20,7 +20,7 @@ import { ReactComponent as SensorIcon } from '../../assets/images/farmMapFilter/
  * @param {string} key - A translation key that specifies a notification type.
  * @returns {ReactComponent | undefined} The icon for the specified notification type.
  */
-export default function getTaskTypeIcon(key) {
+export default function getNotificationTypeIcon(key) {
   const iconDict = {
     SENSOR: SensorIcon,
   };

--- a/packages/webapp/src/containers/Map/constants.js
+++ b/packages/webapp/src/containers/Map/constants.js
@@ -75,6 +75,8 @@ export const polygonPath = (path, width, maps) => {
   return leftPoints.concat(rightPoints.reverse());
 };
 
+export const SENSOR_BULK_UPLOAD = 'SENSOR_BULK_UPLOAD';
+
 const linePathPolygonConstructor = (innerState, point, i, path) => {
   const { bearings, leftPoints, rightPoints, width, maps } = innerState;
   const {

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -4,7 +4,14 @@ import { useTranslation } from 'react-i18next';
 import styles from './styles.module.scss';
 import GoogleMap from 'google-map-react';
 import { saveAs } from 'file-saver';
-import { DEFAULT_ZOOM, GMAPS_API_KEY, isArea, isLine, locationEnum } from './constants';
+import {
+  DEFAULT_ZOOM,
+  GMAPS_API_KEY,
+  isArea,
+  isLine,
+  locationEnum,
+  SENSOR_BULK_UPLOAD,
+} from './constants';
 import { useDispatch, useSelector } from 'react-redux';
 import { measurementSelector, userFarmSelector } from '../userFarmSlice';
 import html2canvas from 'html2canvas';
@@ -105,6 +112,12 @@ export default function Map({ history }) {
       setShowBulkSensorUploadModal(false);
     }
   }, [bulkSensorsUploadResponse?.isBulkUploadSuccessful]);
+
+  useEffect(() => {
+    if (history.location.state?.notification_type === SENSOR_BULK_UPLOAD) {
+      dispatch(setMapFilterShowAll(farm_id));
+    }
+  }, []);
 
   const [
     drawingState,


### PR DESCRIPTION
This PR should be merged into `collab/sensors` branch after `feature/ensemble-communications` is merged into `collab/sensors`

Ticket [LF-2526](https://lite-farm.atlassian.net/browse/LF-2526)

To Test:
1. Call `sensors/add_sensors` endpoint (you can comment out the actual functionality in `sensorController` if you only want to test the notification without actually uploading sensors)
2. A new notification should be created in the notification center
3. "Take me there" will take you to the map with all locations visible (you can set your map filters before clicking "Take me there" and see if the filter settings are gone)