### PR TITLE
fix: sensor map filter when sensor is in point cluster

### DIFF
--- a/packages/webapp/src/components/Map/Footer/index.jsx
+++ b/packages/webapp/src/components/Map/Footer/index.jsx
@@ -40,7 +40,7 @@ export default function PureMapFooter({
       locationEnum.residence,
     ],
     line: [locationEnum.buffer_zone, locationEnum.watercourse, locationEnum.fence],
-    point: [locationEnum.gate, locationEnum.water_valve],
+    point: [locationEnum.gate, locationEnum.water_valve, locationEnum.sensor],
   },
 }) {
   const { t } = useTranslation();
@@ -78,7 +78,7 @@ export default function PureMapFooter({
     >
       <div className={clsx(container)} style={style}>
         {isAdmin && (
-          <button 
+          <button
             data-cy="map-addFeature"
             className={clsx(button, (stepSpotlighted === 0 || showAddDrawer) && spotlighted)}
             id="mapFirstStep"

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -116,7 +116,7 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
   useEffect(() => {
     dismissSelectionModal();
     markerClusterRef?.current?.repaint();
-  }, [filterSettings?.gate, filterSettings?.water_valve]);
+  }, [filterSettings?.gate, filterSettings?.water_valve, filterSettings?.sensor]);
   useEffect(() => {
     markerClusterRef?.current?.setOptions({ zoomOnClick: isClickable });
   }, [isClickable]);


### PR DESCRIPTION
Ticket: [LF-2510](https://lite-farm.atlassian.net/browse/LF-2510)

This PR fixes a specific issue where the sensor map filter was not properly working with clusters.

To test:
- Comment out line 103 in `sensorController.js` (or just all code related to ensemble for now)
- Create new sensors through bulk upload (you can use this file for testing: [testBulkUpload.csv](https://github.com/LiteFarmOrg/LiteFarm/files/8980405/testBulkUpload.csv)
- If you zoom out enough, some points will be group together in "clusters" and are represented by a green box with a number inside denoting the number of points near that area
- Use the map filter to hide and show the sensor points and make sure those clusters react accordingly as well.
- NOTE: make sure to unclaim all sensors at `https://api.esci.io/organizations/<INSERT_ORG_ID>/devices/unclaim/`
