### PR TITLE
Lf 2533 refresh store with last x days sensor readings when opening farm map

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -237,19 +237,7 @@ const sensorController = {
       if (!farm_id) {
         return res.status(400).send('Invalid farm id');
       }
-      let result;
-      if (!days) {
-        result = await SensorReadingModel.query()
-          .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
-          .where('farm_id', farm_id);
-      } else {
-        const pastDate = new Date();
-        pastDate.setDate(pastDate.getDate() - days);
-        result = await SensorReadingModel.query()
-          .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
-          .where('farm_id', farm_id)
-          .andWhere('created_at', '>=', pastDate);
-      }
+      const result = await SensorReadingModel.getSensorReadingsByFarmId(farm_id, days);
       res.status(200).send(result);
     } catch (error) {
       res.status(400).send(error);

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -237,7 +237,7 @@ const sensorController = {
       if (!farm_id) {
         return res.status(400).send('Invalid farm id');
       }
-      const result = await SensorReadingModel.getSensorReadingsByFarmId(farm_id, days);
+      const result = await SensorReadingModel.getSensorReadingsInDaysByFarmId(farm_id, days);
       res.status(200).send(result);
     } catch (error) {
       res.status(400).send(error);

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -235,14 +235,13 @@ const sensorController = {
     try {
       const { farm_id, days } = req.params;
       if (!farm_id) {
-        res.status(400).send('Invalid farm id');
+        return res.status(400).send('Invalid farm id');
       }
       let result;
       if (!days) {
         result = await SensorReadingModel.query()
           .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
-          .where('farm_id', farm_id)
-          .debug();
+          .where('farm_id', farm_id);
       } else {
         const pastDate = new Date();
         pastDate.setDate(pastDate.getDate() - days);
@@ -253,9 +252,7 @@ const sensorController = {
       }
       res.status(200).send(result);
     } catch (error) {
-      res.status(400).json({
-        error,
-      });
+      res.status(400).send(error);
     }
   },
 

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -250,14 +250,20 @@ const sensorController = {
 
   async getReadingsByFarmId(req, res) {
     try {
-      const { farm_id } = req.params;
+      const { farm_id, days } = req.params;
       if (!farm_id) {
         res.status(400).send('Invalid farm id');
       }
+      if (!days) {
+        res.status(400).send('Invalid days');
+      }
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - days);
       const result = await sensorReadingModel
         .query()
         .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
-        .where('farm_id', farm_id);
+        .where('farm_id', farm_id)
+        .andWhere('created_at', '>=', pastDate);
       res.status(200).send(result);
     } catch (error) {
       res.status(400).json({

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -258,14 +258,14 @@ const sensorController = {
       if (!days) {
         result = await sensorReadingModel
           .query()
-          .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
-          .where('farm_id', farm_id);
+          .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
+          .where('farm_id', farm_id).debug();
       } else {
         const pastDate = new Date();
         pastDate.setDate(pastDate.getDate() - days);
         result = await sensorReadingModel
           .query()
-          .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
+          .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
           .where('farm_id', farm_id)
           .andWhere('created_at', '>=', pastDate);
       }

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -248,6 +248,24 @@ const sensorController = {
     }
   },
 
+  async getReadingsByFarmId(req, res) {
+    try {
+      const { farm_id } = req.params;
+      if (!farm_id) {
+        res.status(400).send('Invalid farm id');
+      }
+      const result = await sensorReadingModel
+        .query()
+        .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
+        .where('farm_id', farm_id);
+      res.status(200).send(result);
+    } catch (error) {
+      res.status(400).json({
+        error,
+      });
+    }
+  },
+
   async invalidateReadings(req, res) {
     try {
       const { start_time, end_time } = req.body;

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -254,16 +254,21 @@ const sensorController = {
       if (!farm_id) {
         res.status(400).send('Invalid farm id');
       }
+      let result;
       if (!days) {
-        res.status(400).send('Invalid days');
+        result = await sensorReadingModel
+          .query()
+          .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
+          .where('farm_id', farm_id);
+      } else {
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - days);
+        result = await sensorReadingModel
+          .query()
+          .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
+          .where('farm_id', farm_id)
+          .andWhere('created_at', '>=', pastDate);
       }
-      const pastDate = new Date();
-      pastDate.setDate(pastDate.getDate() - days);
-      const result = await sensorReadingModel
-        .query()
-        .join('sensor', 'sensor_reading.sensor_id', 'sensor.sensor_id')
-        .where('farm_id', farm_id)
-        .andWhere('created_at', '>=', pastDate);
       res.status(200).send(result);
     } catch (error) {
       res.status(400).json({

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -54,6 +54,27 @@ class SensorReading extends Model {
       additionalProperties: false,
     };
   }
+
+  /**
+   * Returns sensor readings for a farm for the past given number of days
+   * @param {uuid} farmId farm id
+   * @param {number} days number of days of sensor readings
+   * @returns {Object} Sensor Reading Object
+   */
+  static async getSensorReadingsByFarmId(farmId, days) {
+    if (!days) {
+      return await SensorReading.query()
+        .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
+        .where('farm_id', farmId);
+    } else {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - days);
+      return await SensorReading.query()
+        .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
+        .where('farm_id', farmId)
+        .andWhere('created_at', '>=', pastDate);
+    }
+  }
 }
 
 module.exports = SensorReading;

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -61,19 +61,13 @@ class SensorReading extends Model {
    * @param {number} days number of days of sensor readings
    * @returns {Object} Sensor Reading Object
    */
-  static async getSensorReadingsByFarmId(farmId, days) {
-    if (!days) {
-      return await SensorReading.query()
-        .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
-        .where('farm_id', farmId);
-    } else {
-      const pastDate = new Date();
-      pastDate.setDate(pastDate.getDate() - days);
-      return await SensorReading.query()
-        .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
-        .where('farm_id', farmId)
-        .andWhere('created_at', '>=', pastDate);
-    }
+  static async getSensorReadingsInDaysByFarmId(farmId, days) {
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - days);
+    return await SensorReading.query()
+      .joinRaw('JOIN sensor ON sensor_reading.sensor_id::uuid = sensor.sensor_id')
+      .where('farm_id', farmId)
+      .andWhere('created_at', '>=', pastDate);
   }
 }
 

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -34,7 +34,7 @@ router.post(
 router.delete('/delete_sensor/:sensor_id', SensorController.deleteSensor);
 router.post('/add_reading/:partner_id', SensorController.addReading);
 router.post('/get_readings', SensorController.getAllReadingsBySensorId);
-router.get('/sensor_readings/:farm_id/:days?', SensorController.getReadingsByFarmId);
+router.get('/sensor_readings/:farm_id/:days', SensorController.getReadingsByFarmId);
 router.post('/invalidate_readings', SensorController.invalidateReadings);
 
 module.exports = router;

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -34,7 +34,7 @@ router.post(
 router.delete('/delete_sensor/:sensor_id', SensorController.deleteSensor);
 router.post('/add_reading/:partner_id', SensorController.addReading);
 router.post('/get_readings', SensorController.getAllReadingsBySensorId);
-router.get('/sensor_readings/:farm_id', SensorController.getReadingsByFarmId);
+router.get('/sensor_readings/:farm_id/:days?', SensorController.getReadingsByFarmId);
 router.post('/invalidate_readings', SensorController.invalidateReadings);
 
 module.exports = router;

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -34,6 +34,7 @@ router.post(
 router.delete('/delete_sensor/:sensor_id', SensorController.deleteSensor);
 router.post('/add_reading/:partner_id', SensorController.addReading);
 router.post('/get_readings', SensorController.getAllReadingsBySensorId);
+router.get('/sensor_readings/:farm_id', SensorController.getReadingsByFarmId);
 router.post('/invalidate_readings', SensorController.invalidateReadings);
 
 module.exports = router;

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -8,7 +8,12 @@ import { DEFAULT_ZOOM, GMAPS_API_KEY, isArea, isLine, locationEnum } from './con
 import { useDispatch, useSelector } from 'react-redux';
 import { measurementSelector, userFarmSelector } from '../userFarmSlice';
 import html2canvas from 'html2canvas';
-import { sendMapToEmail, setSpotlightToShown, bulkUploadSensorsInfoFile, getSensorReadings } from './saga';
+import {
+  sendMapToEmail,
+  setSpotlightToShown,
+  bulkUploadSensorsInfoFile,
+  getSensorReadings,
+} from './saga';
 import {
   canShowSuccessHeader,
   setShowSuccessHeaderSelector,
@@ -40,9 +45,7 @@ import {
   setMapFilterSetting,
   setMapFilterShowAll,
 } from './mapFilterSettingSlice';
-import {
-  mapSensorSelector
-} from './mapSensorSlice';
+import { mapSensorSelector } from './mapSensorSlice';
 import {
   hookFormPersistedPathsSetSelector,
   hookFormPersistSelector,
@@ -306,9 +309,9 @@ export default function Map({ history }) {
   const availableFilterSettings = useSelector(availableFilterSettingsSelector);
   const mapSensorReadings = useSelector(mapSensorSelector);
 
-  // useEffect(() => {
-  //   dispatch(getSensorReadings()); //todo need to pass in sensor_id
-  // }, []);
+  useEffect(() => {
+    dispatch(getSensorReadings());
+  }, []);
 
   const handleAddMenuClick = (locationType) => {
     setZeroAreaWarning(false);
@@ -397,7 +400,7 @@ export default function Map({ history }) {
         />
       )}
       <div
-         data-cy="map-selection"
+        data-cy="map-selection"
         className={styles.pageWrapper}
         style={{ height: windowInnerHeight }}
       >

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -8,7 +8,7 @@ import { DEFAULT_ZOOM, GMAPS_API_KEY, isArea, isLine, locationEnum } from './con
 import { useDispatch, useSelector } from 'react-redux';
 import { measurementSelector, userFarmSelector } from '../userFarmSlice';
 import html2canvas from 'html2canvas';
-import { sendMapToEmail, setSpotlightToShown, bulkUploadSensorsInfoFile } from './saga';
+import { sendMapToEmail, setSpotlightToShown, bulkUploadSensorsInfoFile, getSensorReadings } from './saga';
 import {
   canShowSuccessHeader,
   setShowSuccessHeaderSelector,
@@ -40,6 +40,9 @@ import {
   setMapFilterSetting,
   setMapFilterShowAll,
 } from './mapFilterSettingSlice';
+import {
+  mapSensorSelector
+} from './mapSensorSlice';
 import {
   hookFormPersistedPathsSetSelector,
   hookFormPersistSelector,
@@ -302,6 +305,11 @@ export default function Map({ history }) {
   };
 
   const availableFilterSettings = useSelector(availableFilterSettingsSelector);
+  const mapSensorReadings = useSelector(mapSensorSelector);
+
+  // useEffect(() => {
+  //   dispatch(getSensorReadings()); //todo need to pass in sensor_id
+  // }, []);
 
   const handleAddMenuClick = (locationType) => {
     setZeroAreaWarning(false);
@@ -390,7 +398,7 @@ export default function Map({ history }) {
         />
       )}
       <div
-        data-cy="map-selection"
+         data-cy="map-selection"
         className={styles.pageWrapper}
         style={{ height: windowInnerHeight }}
       >

--- a/packages/webapp/src/containers/Map/mapSensorSlice.js
+++ b/packages/webapp/src/containers/Map/mapSensorSlice.js
@@ -15,7 +15,6 @@
 
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
-import { loginSelector } from '../userFarmSlice';
 
 const addManySensorReadings = (state, { payload: sensorReadings }) => {
   mapSensorAdapter.upsertMany(state, sensorReadings);

--- a/packages/webapp/src/containers/Map/mapSensorSlice.js
+++ b/packages/webapp/src/containers/Map/mapSensorSlice.js
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import { createSelector } from 'reselect';
+import { loginSelector } from '../userFarmSlice';
+
+const addManySensorReadings = (state, { payload: sensorReadings }) => {
+  mapSensorAdapter.upsertMany(state, sensorReadings);
+};
+
+const mapSensorAdapter = createEntityAdapter({
+  selectId: (farmState) => farmState.farm_id,
+});
+
+const mapSensorSlice = createSlice({
+  name: 'mapSensorReducer',
+  initialState: mapSensorAdapter.getInitialState({
+    loading: false,
+    loaded: false,
+    error: undefined,
+  }),
+  reducers: {
+    onLoadingSensorReadingStart: (state) => {
+      state.loading = true;
+    },
+    onLoadingSensorReadingFail: (state, { payload: error }) => {
+      state.loading = false;
+      state.error = error;
+      state.loaded = true;
+    },
+    getSensorReadingSuccess: (state, { payload: sensorReadings }) => {
+      addManySensorReadings(state, { payload: sensorReadings });
+      state.loading = false;
+      state.loaded = true;
+      state.error = null;
+    },
+  },
+});
+
+export const {
+  onLoadingSensorReadingStart,
+  onLoadingSensorReadingFail,
+  getSensorReadingSuccess,
+} = mapSensorSlice.actions;
+export default mapSensorSlice.reducer;
+
+export const mapSensorReducerSelector = (state) =>
+  state.persistedStateReducer[mapSensorSlice.name];
+
+const mapSensorSelectors = mapSensorAdapter.getSelectors(
+  (state) => state.persistedStateReducer[mapSensorSlice.name],
+);
+
+export const mapSensorSelector = createSelector(
+  [mapSensorSelectors.selectEntities, loginSelector],
+  (mapSensorEntities, { farm_id }) => {
+    return mapSensorEntities[farm_id];
+  },
+);
+
+

--- a/packages/webapp/src/containers/Map/mapSensorSlice.js
+++ b/packages/webapp/src/containers/Map/mapSensorSlice.js
@@ -22,7 +22,7 @@ const addManySensorReadings = (state, { payload: sensorReadings }) => {
 };
 
 const mapSensorAdapter = createEntityAdapter({
-  selectId: (farmState) => farmState.farm_id,
+  selectId: (sensorReading) => sensorReading.sensor_id,
 });
 
 const mapSensorSlice = createSlice({
@@ -50,25 +50,19 @@ const mapSensorSlice = createSlice({
   },
 });
 
-export const {
-  onLoadingSensorReadingStart,
-  onLoadingSensorReadingFail,
-  getSensorReadingSuccess,
-} = mapSensorSlice.actions;
+export const { onLoadingSensorReadingStart, onLoadingSensorReadingFail, getSensorReadingSuccess } =
+  mapSensorSlice.actions;
 export default mapSensorSlice.reducer;
 
-export const mapSensorReducerSelector = (state) =>
-  state.persistedStateReducer[mapSensorSlice.name];
+export const mapSensorReducerSelector = (state) => state.persistedStateReducer[mapSensorSlice.name];
 
 const mapSensorSelectors = mapSensorAdapter.getSelectors(
   (state) => state.persistedStateReducer[mapSensorSlice.name],
 );
 
 export const mapSensorSelector = createSelector(
-  [mapSensorSelectors.selectEntities, loginSelector],
-  (mapSensorEntities, { farm_id }) => {
-    return mapSensorEntities[farm_id];
+  [mapSensorSelectors.selectEntities],
+  (mapSensorEntities) => {
+    return mapSensorEntities;
   },
 );
-
-

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -36,7 +36,7 @@ import {
 import { bulkSenorUploadErrorTypeEnum } from './constants';
 
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
-import { getSensorReadingSuccess, onLoadingSensorReadingStart } from './mapSensorSlice';
+import { getSensorReadingSuccess, onLoadingSensorReadingStart, onLoadingSensorReadingFail } from './mapSensorSlice';
 
 const sendMapToEmailUrl = (farm_id) => `${url}/export/map/farm/${farm_id}`;
 const showedSpotlightUrl = () => `${url}/showed_spotlight`;
@@ -171,8 +171,10 @@ export function* getSensorReadingsSaga() {
   try {
     yield put(onLoadingSensorReadingStart(user_id, farm_id));
     const result = yield call(axios.get, `${sensorUrl}/sensor_readings/${farm_id}/7`, header);
-    yield put(getSensorReadingSuccess(result.data));
+    if (result.status === 200) yield put(getSensorReadingSuccess(result.data));
+    yield put(onLoadingSensorReadingFail(result.error));
   } catch (e) {
+    yield put(onLoadingSensorReadingFail(e));
     console.error(e);
   }
 }

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -128,11 +128,9 @@ export const getSensorReadings = createAction('getSensorReadingsSaga');
 export function* getSensorReadingsSaga() {
   const { user_id, farm_id } = yield select(userFarmSelector);
   const header = getHeader(user_id, farm_id);
-  const formData = new FormData();
-  //todo get sensor_id and send it as the body
   try {
     yield put(onLoadingSensorReadingStart(user_id, farm_id));
-    const result = yield call(axios.post, sensorUrl + '/get_readings', formData, header);
+    const result = yield call(axios.get, `${sensorUrl}/sensor_readings/${farm_id}/7`, header);
     yield put(getSensorReadingSuccess(result.data));
   } catch (e) {
     console.error(e);

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -32,6 +32,7 @@ import {
 } from '../bulkSensorUploadSlice';
 
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
+import { getSensorReadingSuccess, onLoadingSensorReadingStart } from './mapSensorSlice';
 
 const sendMapToEmailUrl = (farm_id) => `${url}/export/map/farm/${farm_id}`;
 const showedSpotlightUrl = () => `${url}/showed_spotlight`;
@@ -122,8 +123,25 @@ export function* bulkUploadSensorsInfoFileSaga({ payload: { file } }) {
   }
 }
 
+export const getSensorReadings = createAction('getSensorReadingsSaga');
+
+export function* getSensorReadingsSaga() {
+  const { user_id, farm_id } = yield select(userFarmSelector);
+  const header = getHeader(user_id, farm_id);
+  const formData = new FormData();
+  //todo get sensor_id and send it as the body
+  try {
+    yield put(onLoadingSensorReadingStart(user_id, farm_id));
+    const result = yield call(axios.post, sensorUrl + '/get_readings', formData, header);
+    yield put(getSensorReadingSuccess(result.data));
+  } catch (e) {
+    console.error(e);
+  }
+}
+
 export default function* supportSaga() {
   yield takeLeading(sendMapToEmail.type, sendMapToEmailSaga);
   yield takeLeading(setSpotlightToShown.type, setSpotlightToShownSaga);
   yield takeLeading(bulkUploadSensorsInfoFile.type, bulkUploadSensorsInfoFileSaga);
+  yield takeLeading(getSensorReadings.type, getSensorReadingsSaga);
 }

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -60,6 +60,7 @@ import homeReducer from '../containers/Home/homeSlice';
 import mapLocationReducer from '../containers/mapSlice';
 import mapFilterSettingReducer from '../containers/Map/mapFilterSettingSlice';
 import mapCacheReducer from '../containers/Map/mapCacheSlice';
+import mapSensorReducer from '../containers/Map/mapSensorSlice';
 import showedSpotlightReducer from '../containers/showedSpotlightSlice';
 import bulkSensorsUploadReducer from '../containers/bulkSensorUploadSlice';
 import hookFormPersistReducer from '../containers/hooks/useHookFormPersist/hookFormPersistSlice';
@@ -202,6 +203,7 @@ const persistedStateReducer = combineReducers({
   chooseFarmFlowReducer,
   mapFilterSettingReducer,
   mapCacheReducer,
+  mapSensorReducer,
   appSettingReducer,
 });
 


### PR DESCRIPTION
Ticket [LF-2533](https://lite-farm.atlassian.net/browse/LF-2533)

7 last days sensor readings of a farm will be populated into the redux store when the farm map is opened.

To Test:
1. Create some dummy sensor reading data (you can manually create them into the db)
2. On `packages/webapp/src/containers/Map/index.jsx` you can console log `mapSensorReadings` from line 333 to see the data when the farm map is opened.