### PR TITLE
Fixed which fields display on a completed crop plan

### DIFF
--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -62,7 +62,6 @@ export default function PureManagementDetail({
     shouldUnregister: false,
     mode: 'onChange',
   });
-  console.log(plan);
 
   const isAbandoned = plan.abandon_date ? true : false;
   const isCompleted = plan.complete_date ? true : false;

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanDetail.jsx
@@ -62,8 +62,10 @@ export default function PureManagementDetail({
     shouldUnregister: false,
     mode: 'onChange',
   });
+  console.log(plan);
 
   const isAbandoned = plan.abandon_date ? true : false;
+  const isCompleted = plan.complete_date ? true : false;
   const DATE_OF_STATUS_CHANGE = isAbandoned ? 'abandon_date' : 'complete_date';
   const ABANDON_REASON = 'abandon_reason';
   const DATE = isAbandoned ? 'ABANDON_DATE' : 'COMPLETE_DATE';
@@ -120,21 +122,25 @@ export default function PureManagementDetail({
         ]}
       />
 
-      <InputAutoSize
-        style={{ marginBottom: '40px' }}
-        label={t(`MANAGEMENT_PLAN.COMPLETE_PLAN.${DATE}`)}
-        hookFormRegister={register(DATE_OF_STATUS_CHANGE)}
-        errors={errors[DATE_OF_STATUS_CHANGE]?.message}
-        disabled
-      />
+      {(isAbandoned || isCompleted) && (
+        <InputAutoSize
+          style={{ marginBottom: '40px' }}
+          label={t(`MANAGEMENT_PLAN.COMPLETE_PLAN.${DATE}`)}
+          hookFormRegister={register(DATE_OF_STATUS_CHANGE)}
+          errors={errors[DATE_OF_STATUS_CHANGE]?.message}
+          disabled
+        />
+      )}
 
-      <Rating
-        className={styles.rating}
-        style={{ marginBottom: '34px' }}
-        label={t('MANAGEMENT_PLAN.RATE_THIS_MANAGEMENT_PLAN')}
-        stars={plan.rating}
-        onRate={() => {}}
-      />
+      {(isAbandoned || isCompleted) && (
+        <Rating
+          className={styles.rating}
+          style={{ marginBottom: '34px' }}
+          label={t('MANAGEMENT_PLAN.RATE_THIS_MANAGEMENT_PLAN')}
+          stars={plan.rating}
+          onRate={() => {}}
+        />
+      )}
 
       {isAbandoned && (
         <InputAutoSize
@@ -148,19 +154,21 @@ export default function PureManagementDetail({
         />
       )}
 
-      <InputAutoSize
-        style={{ marginBottom: '40px' }}
-        label={
-          isAbandoned
-            ? t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_NOTES')
-            : t('MANAGEMENT_PLAN.COMPLETION_NOTES')
-        }
-        hookFormRegister={register(COMPLETE_NOTES, {
-          maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.NOTES_CHAR_LIMIT') },
-        })}
-        errors={errors[COMPLETE_NOTES]?.message}
-        disabled
-      />
+      {(isAbandoned || isCompleted) && (
+        <InputAutoSize
+          style={{ marginBottom: '40px' }}
+          label={
+            isAbandoned
+              ? t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_NOTES')
+              : t('MANAGEMENT_PLAN.COMPLETION_NOTES')
+          }
+          hookFormRegister={register(COMPLETE_NOTES, {
+            maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.NOTES_CHAR_LIMIT') },
+          })}
+          errors={errors[COMPLETE_NOTES]?.message}
+          disabled
+        />
+      )}
 
       <InputAutoSize
         style={{ marginBottom: '40px' }}


### PR DESCRIPTION
This PR resolves https://lite-farm.atlassian.net/browse/LF-2519

To test:
1. Create a crop plan
2. Ensure that the only fields you can see in the "detail" tab are the plan name above the tabs, as well as the Plan notes, and Estimated annual harvest
3. Complete the crop plan. You should now be able to see all the same fields before in the details page, as well as: Completed date, Plan rating, and Completion notes