### PR TITLE
LF-2480 home page background displays the wrong season

### DIFF
--- a/packages/webapp/src/containers/Home/utils/season.js
+++ b/packages/webapp/src/containers/Home/utils/season.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { DO_CDN_URL } from '../../../util/constants';
 
 const autumn = `${DO_CDN_URL}/home/fall.webp`;
@@ -8,19 +7,20 @@ const summer = `${DO_CDN_URL}/home/summer.webp`;
 
 export const getSeason = (lat) => {
   const isNorth = lat > 0;
-  const now = moment();
-  const year = now.get('year');
-  const autumnStartDate = moment(`${year}-9-1`);
-  const springStartDate = moment(`${year}-3-1`);
-  const summerStartDate = moment(`${year}-6-1`);
-  const winterStartDate = moment(`${year}-12-1`);
-  if (now.isBefore(springStartDate)) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const autumnStartDate = new Date(year, 9, 1);
+  const springStartDate = new Date(year, 3, 1);
+  const summerStartDate = new Date(year, 6, 1);
+  const winterStartDate = new Date(year, 12, 1);
+
+  if (now < springStartDate) {
     return isNorth ? winter : summer;
-  } else if (now.isBefore(summerStartDate)) {
+  } else if (now < summerStartDate) {
     return isNorth ? spring : autumn;
-  } else if (now.isBefore(autumnStartDate)) {
+  } else if (now < autumnStartDate) {
     return isNorth ? summer : winter;
-  } else if (now.isBefore(winterStartDate)) {
+  } else if (now < winterStartDate) {
     return isNorth ? autumn : spring;
   } else return isNorth ? winter : summer;
 };

--- a/packages/webapp/src/containers/Home/utils/season.js
+++ b/packages/webapp/src/containers/Home/utils/season.js
@@ -9,10 +9,10 @@ export const getSeason = (lat) => {
   const isNorth = lat > 0;
   const now = new Date();
   const year = now.getFullYear();
-  const autumnStartDate = new Date(year, 9, 1);
-  const springStartDate = new Date(year, 3, 1);
-  const summerStartDate = new Date(year, 6, 1);
-  const winterStartDate = new Date(year, 12, 1);
+  const autumnStartDate = new Date(year, 8, 1);
+  const springStartDate = new Date(year, 2, 1);
+  const summerStartDate = new Date(year, 5, 1);
+  const winterStartDate = new Date(year, 11, 1);
 
   if (now < springStartDate) {
     return isNorth ? winter : summer;


### PR DESCRIPTION
Ticket: [LF-2480)](https://lite-farm.atlassian.net/browse/LF-2480)

Switched from using moment js to javascript date object to fix season image issue. (Note, the month value in the javascript date object is from 0-11. So June is 5 not 6 as we would expect).

To test:
- create a farm in the northern hemisphere (ex. Canada) and farm is the southern hemisphere (ex. Australia)
- Make sure the image being shown in the north is summer (since it is currently June 28).
- Make sure the image being shown in the south is winter 