### PR TITLE
Lf 2525 handle asynchronous add sensor outcome

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -28,8 +28,6 @@ const {
 
 const sensorErrors = require('../util/sensorErrors');
 
-// TODO: make function which returns a sendReturn() function that depending on the timer status sends the appropriate response
-
 const sensorController = {
   async addSensors(req, res) {
     let hasTimedOut = false;
@@ -120,7 +118,7 @@ const sensorController = {
               user_id,
               farm_id,
               SensorNotificationTypes.SENSOR_BULK_UPLOAD_FAIL,
-              { error_download: { errors, file_name: 'sensor-upload-outcomes.txt' } }, //TODO: update to have proper file name
+              { error_download: { errors, file_name: 'sensor-upload-outcomes.txt' } },
             )
           : res
               .status(400)

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -38,9 +38,9 @@ const sensorController = {
           'Processing your upload is taking longer than expected. We will send you a notification when this finished processing.',
       });
     }, 5000);
+    const { farm_id } = req.headers;
+    const { user_id } = req.user;
     try {
-      const { farm_id } = req.headers;
-      const { user_id } = req.user;
       const { access_token } = await IntegratingPartnersModel.getAccessAndRefreshTokens(
         'Ensemble Scientific',
       );
@@ -213,8 +213,6 @@ const sensorController = {
       }
     } catch (e) {
       console.log(e);
-      const { user_id } = req.user;
-      const { farm_id } = req.headers;
       return hasTimedOut
         ? await sendSensorNotification(
             user_id,

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -197,7 +197,8 @@ const sensorController = {
               )
             : res.status(400).send({
                 error_type: 'unable_to_claim_all_sensors',
-                registeredSensors,
+                success,
+                errorSensors,
               }) && clearTimeout(timer);
         } else {
           return hasTimedOut

--- a/packages/api/src/util/sensorErrors.js
+++ b/packages/api/src/util/sensorErrors.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 module.exports = {
   FILE_ROW_LIMIT_EXCEEDED: 'FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.FILE_ROW_LIMIT_EXCEEDED',
   MISSING_COLUMNS: 'FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.MISSING_COLUMNS',
@@ -10,4 +25,6 @@ module.exports = {
   SENSOR_BRAND: 'FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.SENSOR_BRAND',
   SENSOR_MODEL: 'FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.SENSOR_MODEL',
   SENSOR_HARDWARE_VERSION: 'FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.SENSOR_HARDWARE_VERSION',
+  SENSOR_ALREADY_OCCUPIED: 'FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_CLAIM_ERROR.ALREADY_OCCUPIED',
+  SENSOR_DOES_NOT_EXIST: 'FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_CLAIM_ERROR.DOES_NOT_EXIST',
 };

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -468,6 +468,10 @@
         "SENSOR_BRAND": "Invalid brand name, must be between 1 and 100 characters.",
         "SENSOR_MODEL": "Invalid model name, must be between 1 and 100 characters.",
         "SENSOR_HARDWARE_VERSION": "Invalid hardware version name, must be between 1 and 100 characters."
+      },
+      "SENSOR_CLAIM_ERROR": {
+        "ALREADY_OCCUPIED": "Sensor \"{{ sensorId }}\" already registered to another organization, please contact Ensemble support at support@esci.io to troubleshoot.",
+        "DOES_NOT_EXIST": "Sensor \"{{ sensorId }}\" does not exist in the Ensemble database. Please ensure that you have spelled the External_ID properly for this entry, and that the sensor is an Ensemble sensor."
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -467,6 +467,10 @@
         "SENSOR_BRAND": "MISSING",
         "SENSOR_MODEL": "MISSING",
         "SENSOR_HARDWARE_VERSION": "MISSING"
+      },
+      "SENSOR_CLAIM_ERROR": {
+        "ALREADY_OCCUPIED": "MISSING",
+        "DOES_NOT_EXIST": "MISSING"
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -468,6 +468,10 @@
         "SENSOR_BRAND": "MISSING",
         "SENSOR_MODEL": "MISSING",
         "SENSOR_HARDWARE_VERSION": "MISSING"
+      },
+      "SENSOR_CLAIM_ERROR": {
+        "ALREADY_OCCUPIED": "MISSING",
+        "DOES_NOT_EXIST": "MISSING"
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -467,6 +467,10 @@
         "SENSOR_BRAND": "MISSING",
         "SENSOR_MODEL": "MISSING",
         "SENSOR_HARDWARE_VERSION": "MISSING"
+      },
+      "SENSOR_CLAIM_ERROR": {
+        "ALREADY_OCCUPIED": "MISSING",
+        "DOES_NOT_EXIST": "MISSING"
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 import { useEffect, useRef, useState } from 'react';
 import * as XLSX from 'xlsx';
 import { useSelector } from 'react-redux';
@@ -217,7 +232,7 @@ export function useValidateBulkSensorData(onUpload, t) {
     const inputfFile = fileInputRef.current.files[0];
     if (inputfFile) {
       const downloadFileName = `${inputfFile.name.replace(/.csv/, '')}_errors.txt`;
-      createSensorErrorDownload(downloadFileName, sheetErrors[0].errors);
+      createSensorErrorDownload(downloadFileName, sheetErrors[0].errors, true);
     }
   };
 

--- a/packages/webapp/src/components/Notifications/index.jsx
+++ b/packages/webapp/src/components/Notifications/index.jsx
@@ -51,9 +51,18 @@ function PureNotificationReadOnly({ onGoBack, notification, relatedNotifications
       notification.context.notification_type === SENSOR_BULK_UPLOAD_FAIL
     ) {
       const translatedErrors = notification.ref.error_download.errors.map((e) => {
-        return { row: e.row, column: e.column, errorMessage: t(e.translation_key) };
+        return {
+          row: e.row,
+          column: e.column,
+          errorMessage: e.variables ? t(e.translation_key, e.variables) : t(e.translation_key),
+        };
       });
-      createSensorErrorDownload(notification.ref.error_download.file_name, translatedErrors);
+      createSensorErrorDownload(
+        notification.ref.error_download.file_name,
+        translatedErrors,
+        notification.ref.error_download.is_validation_error,
+        notification.ref.error_download.success ?? [],
+      );
     } else {
       route = '/';
     }

--- a/packages/webapp/src/util/sensor.js
+++ b/packages/webapp/src/util/sensor.js
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * The util function is used to generate validation errors related the the sensors.
  * @param {Object} errors
@@ -11,9 +26,47 @@ export const generateErrorFormatForSensors = (errors) =>
     return acc;
   }, '');
 
-export const createSensorErrorDownload = (downloadFileName, errors) => {
+/**
+ * Generates the error string related to partial successes claiming sensors from ensemble.
+ * @param {Array<Object>} errors
+ * @param {Array<String>} success
+ * @return {string}
+ */
+export const generateClaimSensorErrorFile = (errors, success) => {
+  let errorText = '';
+  if (success.length > 0) {
+    errorText +=
+      'The following sensors in your file uploaded successfully or already exist on your farm:\n\n';
+    errorText += success.reduce((acc, e, i) => {
+      const ending = i === success.length - 1 ? '\n\n' : ', ';
+      acc += e + ending;
+      return acc;
+    }, '');
+    errorText +=
+      'They should now be visible on your farm map. These sensors will be ignored in future uploads.\n\n';
+  }
+  errorText += 'Unfortunately, there were some errors with your upload:\n\n';
+  errorText += generateErrorFormatForSensors(errors);
+  return errorText;
+};
+
+/**
+ * Creates and downloads the file for sensors upload errors.
+ * @param {String} downloadFileName
+ * @param {Array<Object>} errors
+ * @param {Boolean} isValidationError
+ * @param {Array<String>} success
+ */
+export const createSensorErrorDownload = (
+  downloadFileName,
+  errors,
+  isValidationError,
+  success = [],
+) => {
   const element = document.createElement('a');
-  const formattedError = generateErrorFormatForSensors(errors);
+  const formattedError = isValidationError
+    ? generateErrorFormatForSensors(errors)
+    : generateClaimSensorErrorFile(errors, success);
   const file = new Blob([formattedError], {
     type: 'text/plain',
   });


### PR DESCRIPTION
This PR handles the sync/async outcomes based off how long the flow is taking.

To test:
1. In `sensorController.js` on line 42, set the timeout to something small, like `50`
2. Comment out line 134 in `sensorController.js` as the webhook won't register properly until we are on beta/avocado
3. Try uploading a test csv file - you should see an error snackbar appear, this is because the 202 response code is not currently handled on the frontend in this branch - that is being handled in #2099 
4. Go to the notification that has been generated, it should have a "take me there" button which either a) downloads a text file if there were errors, or b) takes you to the map if it was successful

A useful testing file is: 
[testBulkUpload.csv](https://github.com/LiteFarmOrg/LiteFarm/files/9002688/testBulkUpload.csv)
