### PR TITLE
removed external id from the required fields of frontend validation b…

### DIFF
--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { bulkSensorsUploadSliceSelector } from '../../../../containers/bulkSensorUploadSlice';
 import { createSensorErrorDownload } from '../../../../util/sensor';
 
-const SENSOR_EXTERNAL_ID = 'External_ID';
 const SENSOR_NAME = 'Name';
 const SENSOR_LATITUDE = 'Latitude';
 const SENSOR_LONGITUDE = 'Longitude';
@@ -16,13 +15,7 @@ const TEMPERATURE = 'temperature';
 
 const requiredReadingTypes = [SOIL_WATER_CONTENT, SOIL_WATER_POTENTIAL, TEMPERATURE];
 
-const requiredFields = [
-  SENSOR_EXTERNAL_ID,
-  SENSOR_NAME,
-  SENSOR_LATITUDE,
-  SENSOR_LONGITUDE,
-  SENSOR_READING_TYPES,
-];
+const requiredFields = [SENSOR_NAME, SENSOR_LATITUDE, SENSOR_LONGITUDE, SENSOR_READING_TYPES];
 
 export function useValidateBulkSensorData(onUpload, t) {
   const bulkSensorsUploadResponse = useSelector(bulkSensorsUploadSliceSelector);
@@ -33,12 +26,6 @@ export function useValidateBulkSensorData(onUpload, t) {
   const fileInputRef = useRef(null);
 
   const validationFields = [
-    {
-      errorMessage: t('FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.EXTERNAL_ID'),
-      /* eslint-disable no-useless-escape */
-      mask: /^[a-zA-Z0-9 \.\-\/!@#$%^&*)(]{1,20}$/,
-      columnName: SENSOR_EXTERNAL_ID,
-    },
     {
       errorMessage: t('FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.SENSOR_NAME'),
       /* eslint-disable no-useless-escape */


### PR DESCRIPTION
To test,

1. upload a CSV file with and without External_id. 
2. If the CSV file doesn’t give any errors related to External_id validation, this means that  External_id is now optional.

For more details:
https://lite-farm.atlassian.net/browse/LF-2458

<img width="619" alt="Screen Shot 2022-06-28 at 12 04 43 PM" src="https://user-images.githubusercontent.com/20675885/176262822-0ce24721-d155-4cfa-a14a-77c85b88f613.png">

