### PR TITLE
Add try/catch

### DIFF
--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- *  This file (farmModel.js) is part of LiteFarm.
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -64,40 +64,46 @@ class Sensor extends Model {
   static async createSensor(sensor, farm_id, user_id) {
     const trx = await transaction.start(Model.knex());
 
-    const readingTypes = await Promise.all(
-      sensor.reading_types.map(async (r) => {
-        return await PartnerReadingTypeModel.getReadingTypeByReadableValue(r);
-      }),
-    );
-
-    const data = {
-      farm_id,
-      figure: {
-        point: { point: { lat: sensor.latitude, lng: sensor.longitude } },
-        type: 'sensor',
-      },
-      name: sensor.name,
-      notes: '',
-      sensor: {
-        farm_id,
-        name: sensor.name,
-        partner_id: 1,
-        depth: sensor.depth,
-        external_id: sensor.external_id,
-        sensor_reading_type: readingTypes.map((readingType) => {
-          return { partner_reading_type_id: readingType.partner_reading_type_id };
+    try {
+      const readingTypes = await Promise.all(
+        sensor.reading_types.map(async (r) => {
+          return await PartnerReadingTypeModel.getReadingTypeByReadableValue(r);
         }),
-      },
-    };
+      );
 
-    const sensorLocationWithGraph = await LocationModel.createLocation(
-      'sensor',
-      { user_id },
-      data,
-      trx,
-    );
-    await trx.commit();
-    return sensorLocationWithGraph;
+      const data = {
+        farm_id,
+        figure: {
+          point: { point: { lat: sensor.latitude, lng: sensor.longitude } },
+          type: 'sensor',
+        },
+        name: sensor.name,
+        notes: '',
+        sensor: {
+          farm_id,
+          name: sensor.name,
+          partner_id: 1,
+          depth: sensor.depth,
+          external_id: sensor.external_id,
+          sensor_reading_type: readingTypes.map((readingType) => {
+            return { partner_reading_type_id: readingType.partner_reading_type_id };
+          }),
+        },
+      };
+
+      const sensorLocationWithGraph = await LocationModel.createLocation(
+        'sensor',
+        { user_id },
+        data,
+        trx,
+      );
+      await trx.commit();
+      return sensorLocationWithGraph;
+    } catch (error) {
+      console.log(error);
+      await trx.rollback();
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
I believe this fixes a crash experienced with beta api. Operations using db transactions should be wrapped with `try`, and `catch` block should rollback transaction. Otherwise knex connection pool becomes exhausted.