### PR TITLE
LF-2478 conversion of pseudo user to use the existing user's language preference

### DIFF
--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -425,13 +425,11 @@ const userFarmController = {
     return async (req, res) => {
       let result;
       const { user_id, farm_id } = req.user;
-      const { language_preference } = req.body;
       if (!/^\d+$/.test(user_id)) {
         const user = await userModel
           .query()
           .findById(user_id)
-          .patch({ language_preference })
-          .returning('*');
+          .select('*');
         const passwordRow = await passwordModel.query().findById(user_id);
         if (!passwordRow || user.status_id === 2) {
           return res.status(404).send('User does not exist');

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -426,10 +426,7 @@ const userFarmController = {
       let result;
       const { user_id, farm_id } = req.user;
       if (!/^\d+$/.test(user_id)) {
-        const user = await userModel
-          .query()
-          .findById(user_id)
-          .select('*');
+        const user = await userModel.query().findById(user_id).select('*');
         const passwordRow = await passwordModel.query().findById(user_id);
         if (!passwordRow || user.status_id === 2) {
           return res.status(404).send('User does not exist');
@@ -596,12 +593,13 @@ const userFarmController = {
       }
       try {
         const { farm_name } = userFarm;
+        const user = await userModel.query().where({ email }).first();
         await emailModel.createTokenSendEmail(
           {
             email,
             gender,
             birth_year,
-            language_preference: language,
+            language_preference: user ? user.language_preference : language,
           },
           userFarm,
           farm_name,

--- a/packages/webapp/src/containers/Callback/saga.js
+++ b/packages/webapp/src/containers/Callback/saga.js
@@ -52,11 +52,10 @@ export const patchUserFarmStatus = createAction('patchUserFarmStatusSaga');
 export function* patchUserFarmStatusSaga({ payload }) {
   const { invite_token, language } = payload;
   try {
-    const language_preference = getLanguageFromLocalStorage();
     const result = yield call(
       axios.patch,
       patchUserFarmStatusUrl(),
-      { language_preference },
+      {},
       {
         headers: {
           Authorization: `Bearer ${invite_token}`,
@@ -66,6 +65,7 @@ export function* patchUserFarmStatusSaga({ payload }) {
     const { user: userFarm, id_token } = result.data;
     localStorage.setItem('id_token', id_token);
     localStorage.setItem('litefarm_lang', userFarm.language_preference);
+    i18n.changeLanguage(userFarm.language_preference);
     purgeState();
     yield put(acceptInvitationSuccess(userFarm));
     yield put(startInvitationFlow(userFarm.farm_id));


### PR DESCRIPTION
This PR addresses the comment to this ticket [LF-2478](https://lite-farm.atlassian.net/browse/LF-2478)

To Test:
1. Create a user account (in a different language than English)
2. Log into a farm that you already have and create a pseudo user
3. Convert that pseudo user to a user with an account but invite the user from step 1 (select English or a language different from step 1 as the language of invitation)
4. The invite email and the app should be in the language of the existing user rather than the language from step 3