### PR TITLE
Fixed error where bulk upload crashes

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -352,36 +352,33 @@ const sensorController = {
 const parseCsvString = (csvString, mapping, delimiter = ',') => {
   // regex checks for delimiters that are not contained within quotation marks
   const regex = new RegExp(`(?!\\B"[^"]*)${delimiter}(?![^"]*"\\B)`);
-  const headers = csvString.substring(0, csvString.indexOf('\n')).split(regex);
+  const rows = csvString.split(/\r\n|\r|\n/).filter((elem) => elem !== '');
+  const headers = rows[0].split(regex);
   const allowedHeaders = Object.keys(mapping);
-  const { data, errors } = csvString
-    .substring(csvString.indexOf('\n') + 1)
-    .split('\n')
-    .reduce(
-      (previous, row, rowIndex) => {
-        const values = row.split(regex);
-        const parsedRow = headers.reduce((previousObj, current, index) => {
-          if (allowedHeaders.includes(current)) {
-            const val = mapping[current].parseFunction(
-              values[index].replace(/^(["'])(.*)\1$/, '$2'),
-            ); // removes any surrounding quotation marks
-            if (mapping[current].validator(val)) {
-              previousObj[mapping[current].key] = val;
-            } else {
-              previous.errors.push({
-                row: rowIndex + 2,
-                column: current,
-                translation_key: mapping[current].errorTranslationKey,
-              });
-            }
+  const dataRows = rows.slice(1);
+  const { data, errors } = dataRows.reduce(
+    (previous, row, rowIndex) => {
+      const values = row.split(regex);
+      const parsedRow = headers.reduce((previousObj, current, index) => {
+        if (allowedHeaders.includes(current)) {
+          const val = mapping[current].parseFunction(values[index].replace(/^(["'])(.*)\1$/, '$2')); // removes any surrounding quotation marks
+          if (mapping[current].validator(val)) {
+            previousObj[mapping[current].key] = val;
+          } else {
+            previous.errors.push({
+              row: rowIndex + 2,
+              column: current,
+              translation_key: mapping[current].errorTranslationKey,
+            });
           }
-          return previousObj;
-        }, {});
-        previous.data.push(parsedRow);
-        return previous;
-      },
-      { data: [], errors: [] },
-    );
+        }
+        return previousObj;
+      }, {});
+      previous.data.push(parsedRow);
+      return previous;
+    },
+    { data: [], errors: [] },
+  );
   return { data, errors };
 };
 


### PR DESCRIPTION
This PR addresses the bulk upload failure that was occurring for one of the csv files we uploaded during last sprint review. The issue seems to have been to do with the delimiters we were splitting the file on not always being handled, as well as a trailing delimiter leading to an empty string in the array of rows.

To test: 
1. Comment out line 132 in `sensorController.js`
2. Upload [unclaimedSensorsForReview-2.csv](https://github.com/LiteFarmOrg/LiteFarm/files/9040393/unclaimedSensorsForReview-2.csv)
 