### PR TITLE
LF-2614: api crashes when user ignores invite and continues with google

### DIFF
--- a/packages/api/src/controllers/loginController.js
+++ b/packages/api/src/controllers/loginController.js
@@ -118,6 +118,9 @@ const loginController = {
         }
         const isPasswordNeeded = !ssoUser && passwordUser;
         const id_token = isPasswordNeeded ? '' : await createToken('access', { user_id });
+        if (user?.status_id === 2) {
+          await sendMissingInvitations(user);
+        }
         return res.status(201).send({
           id_token,
           user: {
@@ -133,6 +136,7 @@ const loginController = {
               : `${first_name} ${last_name}`,
           },
           isSignUp: isUserNew,
+          isInvited: user?.status_id === 2,
         });
       } catch (err) {
         return res.status(400).json({

--- a/packages/webapp/src/containers/CustomSignUp/constants.js
+++ b/packages/webapp/src/containers/CustomSignUp/constants.js
@@ -1,8 +1,9 @@
 export const CUSTOM_SIGN_UP = 'PureCustomSignUp';
 export const ENTER_PASSWORD_PAGE = 'PureEnterPasswordPage';
 export const CREATE_USER_ACCOUNT = 'PureCreateUserAccount';
+
 export const inlineErrors = {
-  sso: 'sso',
-  expired: 'expired',
-  invited: 'invited',
+  sso: 'SIGNUP.SSO_ERROR',
+  expired: 'SIGNUP.EXPIRED_ERROR',
+  invited: 'SIGNUP.INVITED_ERROR',
 };

--- a/packages/webapp/src/containers/CustomSignUp/index.jsx
+++ b/packages/webapp/src/containers/CustomSignUp/index.jsx
@@ -1,6 +1,6 @@
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState, useLayoutEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PureCustomSignUp from '../../components/CustomSignUp';
 import {
   customCreateUser,
@@ -20,6 +20,7 @@ import {
 } from './constants';
 import { isChrome } from '../../util';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
+import { customSignUpErrorKeySelector, setCustomSignUpErrorKey } from '../customSignUpSlice';
 
 const ResetPassword = React.lazy(() => import('../ResetPassword'));
 const PureEnterPasswordPage = React.lazy(() => import('../../components/Signup/EnterPasswordPage'));
@@ -47,7 +48,6 @@ function CustomSignUp() {
     watch,
     setValue,
     setError,
-
     formState: { errors },
   } = useForm({
     mode: 'onTouched',
@@ -64,6 +64,8 @@ function CustomSignUp() {
   const showPureCreateUserAccount = componentToShow === CREATE_USER_ACCOUNT;
   const showPureCustomSignUp = !showPureCreateUserAccount && !showPureEnterPasswordPage;
   const { t, i18n, ready } = useTranslation(['translation', 'common'], { useSuspense: false });
+
+  const customSignUpErrorKey = useSelector(customSignUpErrorKeySelector);
 
   const forgotPassword = () => {
     dispatch(sendResetPasswordEmail(email));
@@ -86,27 +88,31 @@ function CustomSignUp() {
     }
   }, [componentToShow]);
 
-  const showSSOErrorAndRedirect = (error) => {
-    //OC: Dynamically setting the error is not an option because of the need to reflect the key on the translation file
-    const allMessages = {
-      sso: t('SIGNUP.SSO_ERROR'),
-      expired: t('SIGNUP.EXPIRED_ERROR'),
-      invited: t('SIGNUP.INVITED_ERROR'),
-    };
-    const message = allMessages[error];
+  useLayoutEffect(() => {
+    dispatch(setCustomSignUpErrorKey({ key: null }));
+  }, []);
+
+  useEffect(() => {
+    if (!customSignUpErrorKey) return;
+    const message = t(customSignUpErrorKey);
+
+    console.log(errors);
+
     setError(EMAIL, {
       type: 'manual',
       message,
     });
-    if (error === inlineErrors.sso) {
+
+    if (customSignUpErrorKey === inlineErrors.sso) {
       // TODO: Create custom google login button pass in React google login along with ref
       const googleLoginButton = document.getElementsByClassName('google-login-button')[0];
       googleLoginButton.click();
     }
-  };
+  }, [customSignUpErrorKey, errors]);
+
   const onSubmit = (data) => {
     const { email } = data;
-    dispatch(customSignUp({ email: email?.toLowerCase(), showSSOError: showSSOErrorAndRedirect }));
+    dispatch(customSignUp({ email: email?.toLowerCase() }));
   };
 
   const onSignUp = (user) => {
@@ -174,6 +180,7 @@ function CustomSignUp() {
               label: t('SIGNUP.ENTER_EMAIL'),
               hookFormRegister: emailRegister,
               errors: errors[EMAIL] && (errors[EMAIL].message || t('SIGNUP.EMAIL_INVALID')),
+              onChange: () => dispatch(setCustomSignUpErrorKey({ key: null })),
             },
           ]}
         />

--- a/packages/webapp/src/containers/CustomSignUp/saga.js
+++ b/packages/webapp/src/containers/CustomSignUp/saga.js
@@ -24,6 +24,7 @@ import { getFirstNameLastName } from '../../util';
 import { axios } from '../saga';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
+import { setCustomSignUpErrorKey } from '../customSignUpSlice';
 
 const loginUrl = (email) => `${url}/login/user/${email}`;
 const loginWithPasswordUrl = () => `${url}/login`;
@@ -32,7 +33,7 @@ const resetPasswordUrl = () => `${url}/password_reset/send_email`;
 
 export const customSignUp = createAction(`customSignUpSaga`);
 
-export function* customSignUpSaga({ payload: { email, showSSOError } }) {
+export function* customSignUpSaga({ payload: { email } }) {
   try {
     const result = yield call(axios.get, loginUrl(email));
     if (result.data.exists && !result.data.sso) {
@@ -50,9 +51,9 @@ export function* customSignUpSaga({ payload: { email, showSSOError } }) {
         },
       );
     } else if (result.data.invited) {
-      showSSOError(inlineErrors.invited);
+      yield put(setCustomSignUpErrorKey({ key: inlineErrors.invited }));
     } else if (result.data.expired) {
-      showSSOError(inlineErrors.expired);
+      yield put(setCustomSignUpErrorKey({ key: inlineErrors.expired }));
     } else if (!result.data.exists && !result.data.sso) {
       history.push(
         {
@@ -64,7 +65,7 @@ export function* customSignUpSaga({ payload: { email, showSSOError } }) {
         },
       );
     } else if (result.data.sso) {
-      showSSOError(inlineErrors.sso);
+      yield put(setCustomSignUpErrorKey({ key: inlineErrors.sso }));
     }
   } catch (e) {
     console.log(e);

--- a/packages/webapp/src/containers/GoogleLoginButton/saga.js
+++ b/packages/webapp/src/containers/GoogleLoginButton/saga.js
@@ -8,6 +8,8 @@ import { axios } from '../saga';
 import { ENTER_PASSWORD_PAGE } from '../CustomSignUp/constants';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
+import { setCustomSignUpErrorKey } from '../customSignUpSlice';
+import { inlineErrors } from '../CustomSignUp/constants';
 
 const loginUrl = () => `${url}/google`;
 
@@ -28,10 +30,12 @@ export function* loginWithGoogleSaga({ payload: google_id_token }) {
       { language_preference: getLanguageFromLocalStorage() },
       header,
     );
-    const { id_token, user, isSignUp } = result.data;
+    const { id_token, user, isSignUp, isInvited } = result.data;
     localStorage.setItem('id_token', id_token);
     localStorage.setItem('litefarm_lang', user.language_preference);
-    if (id_token === '') {
+    if (isInvited) {
+      yield put(setCustomSignUpErrorKey({ key: inlineErrors.invited }));
+    } else if (id_token === '') {
       history.push(
         {
           pathname: '/',

--- a/packages/webapp/src/containers/customSignUpSlice.js
+++ b/packages/webapp/src/containers/customSignUpSlice.js
@@ -1,0 +1,22 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  customSignUpErrorKey: null,
+};
+
+const customSignUpSlice = createSlice({
+  name: 'customSignUpReducer',
+  initialState,
+  reducers: {
+    setCustomSignUpErrorKey: (state, { payload: { key } }) => {
+      state.customSignUpErrorKey = key;
+    },
+  },
+});
+
+export const { setCustomSignUpErrorKey } = customSignUpSlice.actions;
+
+export const customSignUpErrorKeySelector = (state) =>
+  state.tempStateReducer[customSignUpSlice.name]?.customSignUpErrorKey;
+
+export default customSignUpSlice.reducer;

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -78,6 +78,8 @@ import certificationReducer from '../containers/OrganicCertifierSurvey/certifica
 import certifierReducer from '../containers/OrganicCertifierSurvey/certifierSlice';
 import snackbarReducer from '../containers/Snackbar/snackbarSlice';
 import appSettingReducer from '../containers/appSettingSlice';
+import customSignUpReducer from '../containers/customSignUpSlice';
+
 import { ActionTypes } from './actionTypes';
 // all the initial state for the forms
 const initialFarmState = {
@@ -215,6 +217,7 @@ const tempStateReducer = combineReducers({
   hookFormPersistReducer,
   filterReducer,
   snackbarReducer,
+  customSignUpReducer,
 });
 
 // combine all reducers here and pass it to application


### PR DESCRIPTION
Ticket: [LF-2614](https://lite-farm.atlassian.net/browse/LF-2614)

To test:
- Invite a user whose email is @gmail.com or backed by Google, such as a litefarm org user 
- Logout, or use a different browser to …
- Visit the app homepage. Click “Continue with Google”. Log in using the invited user’s email.
- You should see the inline error: `We've updated our infrastructure and you'll need to check your inbox for a farm invitation to proceed.`