### PR TITLE
fix: overlapping sensor points

### DIFF
--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -152,6 +152,7 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
         const pointAssets = {
           gate: [],
           water_valve: [],
+          sensor: [],
         };
         cluster.markers_.map((point) => {
           pointAssets[point.type].push({


### PR DESCRIPTION
To test:
- Upload sensors where more than one point has the same lat and long
- Click on the cluster (green box with a number inside) with that lat long
- You should see something like this but for sensors:
![points_desired_behaviour](https://user-images.githubusercontent.com/104768598/177641910-ecf7fb51-b26f-45ee-98ad-201a829e65f4.png)

