### PR TITLE
LF-2623 tasks not showing up

### DIFF
--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -41,6 +41,7 @@ import { DATE_RANGE, SEARCHABLE_MULTI_SELECT } from '../../../components/Filter/
 import { tasksSelector } from '../../taskSlice';
 import { locationsSelector } from '../../locationSlice';
 import { getSupportedTaskTypesSet } from '../../../components/Task/getSupportedTaskTypesSet';
+import { getAllUserFarmsByFarmId } from '../../Profile/People/saga';
 
 const TasksFilterPage = ({ onGoBack }) => {
   const { t } = useTranslation(['translation', 'filter', 'task']);
@@ -49,7 +50,7 @@ const TasksFilterPage = ({ onGoBack }) => {
   const dispatch = useDispatch();
   const locations = useSelector(locationsSelector);
   const activeUsers = useSelector(userFarmsByFarmSelector).filter(
-    (user) => user.status != 'Inactive',
+    (user) => user.status !== 'Inactive',
   );
   const defaultTaskTypes = useSelector(defaultTaskTypesSelector);
   const customTaskTypes = useSelector(userCreatedTaskTypesSelector);
@@ -89,7 +90,7 @@ const TasksFilterPage = ({ onGoBack }) => {
     }
     assignees['unassigned'] = t('TASK.UNASSIGNED');
     return { taskTypes, assignees };
-  }, [tasks.length]);
+  }, [tasks.length, activeUsers]);
 
   const cropVarietyEntities = useMemo(() => {
     return tasks.reduce((cropVarietyEntities, { managementPlans }) => {

--- a/packages/webapp/src/containers/filterSlice.js
+++ b/packages/webapp/src/containers/filterSlice.js
@@ -212,7 +212,6 @@ export const documentsFilterSelector = createSelector(
   (filterReducer) => filterReducer.documents,
 );
 export const tasksFilterSelector = createSelector([filterReducerSelector], (filterReducer) => {
-  console.log(filterReducer);
   return filterReducer.tasks;
 });
 export const cropCatalogueFilterDateSelector = createSelector(

--- a/packages/webapp/src/containers/filterSlice.js
+++ b/packages/webapp/src/containers/filterSlice.js
@@ -143,6 +143,7 @@ const filterSliceReducer = createSlice({
       state.tasks = {
         ...state.tasks,
         ASSIGNEE: {
+          unassigned: { active: false, label: t('TASK.UNASSIGNED') },
           ...activeUsers.reduce((prev, curr) => {
             prev[curr.user_id] = {
               active: false,

--- a/packages/webapp/src/containers/filterSlice.js
+++ b/packages/webapp/src/containers/filterSlice.js
@@ -139,6 +139,41 @@ const filterSliceReducer = createSlice({
         label: `${first_name} ${last_name}`,
       };
     },
+    updateTasksFilterObjects: (state, { payload: { activeUsers, taskTypes, locations, t } }) => {
+      state.tasks = {
+        ...state.tasks,
+        ASSIGNEE: {
+          ...activeUsers.reduce((prev, curr) => {
+            prev[curr.user_id] = {
+              active: false,
+              label: `${curr.first_name} ${curr.last_name}`,
+            };
+            return prev;
+          }, {}),
+          ...state.tasks.ASSIGNEE,
+        },
+        TYPE: {
+          ...taskTypes.reduce((prev, curr) => {
+            prev[curr.task_type_id] = {
+              active: false,
+              label: t(`task:${curr.task_translation_key}`),
+            };
+            return prev;
+          }, {}),
+          ...state.tasks.TYPE,
+        },
+        LOCATION: {
+          ...locations.reduce((prev, curr) => {
+            prev[curr.location_id] = {
+              active: false,
+              label: curr.name,
+            };
+            return prev;
+          }, {}),
+          ...state.tasks.LOCATION,
+        },
+      };
+    },
   },
 });
 
@@ -157,6 +192,7 @@ export const {
   setTasksFilter,
   setTasksFilterUnassignedDueThisWeek,
   setTasksFilterDueToday,
+  updateTasksFilterObjects,
 } = filterSliceReducer.actions;
 export default filterSliceReducer.reducer;
 
@@ -175,10 +211,10 @@ export const documentsFilterSelector = createSelector(
   [filterReducerSelector],
   (filterReducer) => filterReducer.documents,
 );
-export const tasksFilterSelector = createSelector(
-  [filterReducerSelector],
-  (filterReducer) => filterReducer.tasks,
-);
+export const tasksFilterSelector = createSelector([filterReducerSelector], (filterReducer) => {
+  console.log(filterReducer);
+  return filterReducer.tasks;
+});
 export const cropCatalogueFilterDateSelector = createSelector(
   [cropCatalogueFilterSelector],
   (cropCatalogueFilter) => cropCatalogueFilter.date || getDateInputFormat(new Date()),


### PR DESCRIPTION
This PR fixes a class of bugs that were occurring on the tasks page (documented here: https://lite-farm.atlassian.net/browse/LF-2623). Whenever a user created or updated a task that referenced a resource (assignee, task type, location) that was created after the filter on the task page was initialized, the task would disappear. 

To test:
1. Go to the tasks tab
2. Create a new user
3. Go back to the tasks tab and assign a task to the new user
4. The task should still be there
5. Create a new task type
6. Create a task of the new task type
7. That task should show up
8. Create a new location
9. Create a new task with that location set as its location
10. That task should show up

