### PR TITLE
Changed default error behaviour to be more consistent with other errors, translated error files

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -476,6 +476,13 @@
         "ALREADY_OCCUPIED": "Sensor \"{{ sensorId }}\" already registered to another organization, please contact Ensemble support at support@esci.io to troubleshoot.",
         "DOES_NOT_EXIST": "Sensor \"{{ sensorId }}\" does not exist in the Ensemble database. Please ensure that you have spelled the External_ID properly for this entry, and that the sensor is an Ensemble sensor.",
         "INTERNAL_ERROR": "Sensor \"{{ sensorId }}\" failed to upload successfully, please reach out to LiteFarm support at support@litefarm.org to troubleshoot."
+      },
+      "DOWNLOAD_FILE": {
+        "ROW": "[Row: {{ row }}][Column: {{ column }}] {{- errorMessage }} {{ value }}\n",
+        "PARTIAL_SUCCESS_TOP_TEXT": "The following sensors in your file uploaded successfully or already exist on your farm:\n\n",
+        "PARTIAL_SUCCESS_BOTTOM_TEXT": "They should now be visible on your farm map. These sensors will be ignored in future uploads\n\n",
+        "SOME_ERRORS": "Unfortunately, there were some errors with your upload:\n\n",
+        "DEFAULT": "Something went wrong. Please contact support@litefarm.org for assistance."
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -475,6 +475,13 @@
         "ALREADY_OCCUPIED": "MISSING",
         "DOES_NOT_EXIST": "MISSING",
         "INTERNAL_ERROR": "MISSING"
+      },
+      "DOWNLOAD_FILE": {
+        "ROW": "MISSING",
+        "PARTIAL_SUCCESS_TOP_TEXT": "MISSING",
+        "PARTIAL_SUCCESS_BOTTOM_TEXT": "MISSING",
+        "SOME_ERRORS": "MISSING",
+        "DEFAULT": "MISSING"
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -476,6 +476,13 @@
         "ALREADY_OCCUPIED": "MISSING",
         "DOES_NOT_EXIST": "MISSING",
         "INTERNAL_ERROR": "MISSING"
+      },
+      "DOWNLOAD_FILE": {
+        "ROW": "MISSING",
+        "PARTIAL_SUCCESS_TOP_TEXT": "MISSING",
+        "PARTIAL_SUCCESS_BOTTOM_TEXT": "MISSING",
+        "SOME_ERRORS": "MISSING",
+        "DEFAULT": "MISSING"
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -475,6 +475,13 @@
         "ALREADY_OCCUPIED": "MISSING",
         "DOES_NOT_EXIST": "MISSING",
         "INTERNAL_ERROR": "MISSING"
+      },
+      "DOWNLOAD_FILE": {
+        "ROW": "MISSING",
+        "PARTIAL_SUCCESS_TOP_TEXT": "MISSING",
+        "PARTIAL_SUCCESS_BOTTOM_TEXT": "MISSING",
+        "SOME_ERRORS": "MISSING",
+        "DEFAULT": "MISSING"
       }
     },
     "BULK_UPLOAD_TRANSITION": {

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -143,6 +143,12 @@ export function useValidateBulkSensorData(onUpload, t) {
     setTranslatedUploadErrors(translatedErrors);
   }, [bulkSensorsUploadResponse?.errorSensors]);
 
+  useEffect(() => {
+    if (bulkSensorsUploadResponse?.defaultFailure) {
+      setErrorCount(1);
+    }
+  }, [bulkSensorsUploadResponse?.defaultFailure]);
+
   const validateExcel = (rows) => {
     let errors = [];
     for (let i = 0; i < rows.length; i++) {
@@ -251,13 +257,16 @@ export function useValidateBulkSensorData(onUpload, t) {
       const inputFile = fileInputRef.current.files[0];
       if (inputFile) {
         const downloadFileName = `${inputFile.name.replace(/.csv/, '')}_errors.txt`;
-        createSensorErrorDownload(downloadFileName, sheetErrors[0].errors, true);
+        createSensorErrorDownload(downloadFileName, sheetErrors[0].errors, 'validation', t);
       }
+    } else if (bulkSensorsUploadResponse?.defaultFailure) {
+      createSensorErrorDownload('sensor-upload-outcomes.txt', null, 'generic', t);
     } else {
       createSensorErrorDownload(
         'sensor-upload-outcomes.txt',
         translatedUploadErrors,
-        false,
+        'claim',
+        t,
         bulkSensorsUploadResponse?.success,
       );
     }

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -170,8 +170,7 @@ export function* bulkUploadSensorsInfoFileSaga({ payload: { file } }) {
       }
       case 500:
       default: {
-        yield put(bulkSensorsUploadFailure());
-        yield put(enqueueErrorSnackbar(i18n.t('message:BULK_UPLOAD.ERROR.UPLOAD')));
+        yield put(bulkSensorsUploadFailure({ defaultFailure: true }));
         console.log(error);
         break;
       }

--- a/packages/webapp/src/containers/bulkSensorUploadSlice.js
+++ b/packages/webapp/src/containers/bulkSensorUploadSlice.js
@@ -7,6 +7,7 @@ const initialState = {
   success: [],
   errorSensors: [],
   showTransitionModal: false,
+  defaultFailure: false,
 };
 
 const bulkSensorsUploadSlice = createSlice({
@@ -21,6 +22,7 @@ const bulkSensorsUploadSlice = createSlice({
         success: [],
         errorSensors: [],
         showTransitionModal: false,
+        defaultFailure: false,
       });
     },
     bulkSensorsUploadLoading: (state, action) => {
@@ -33,6 +35,8 @@ const bulkSensorsUploadSlice = createSlice({
         state.loading = false;
         state.isBulkUploadSuccessful = true;
         state.validationErrors = [];
+        state.errorSensors = [];
+        state.defaultFailure = false;
         Object.assign(state, payload);
       }
     },
@@ -42,6 +46,7 @@ const bulkSensorsUploadSlice = createSlice({
       state.success = payload?.success ?? [];
       state.errorSensors = payload?.errorSensors ?? [];
       state.validationErrors = [];
+      state.defaultFailure = payload?.defaultFailure ?? false;
     },
     bulkSensorsUploadValidationFailure: (state, { payload }) => {
       state.loading = false;

--- a/packages/webapp/src/util/sensor.js
+++ b/packages/webapp/src/util/sensor.js
@@ -14,10 +14,11 @@
  */
 
 /**
- * The util function is used to generate validation errors related the the sensors.
+ * The util function is used to generate validation errors related to the sensors.
  * @param {Object} errors
  * @param {Function} t
  * should contain row, column, errorMessage and value.
+ * Outputs '[Row: {row}][Column: {column}] {Error message} {Optional value}'
  */
 export const generateErrorFormatForSensors = (errors, t) =>
   errors.reduce((acc, e) => {
@@ -27,9 +28,6 @@ export const generateErrorFormatForSensors = (errors, t) =>
       errorMessage: e?.errorMessage ?? '',
       value: e?.value ?? '',
     });
-    // acc += `[Row: ${e?.row ?? ''}][Column: ${e?.column ?? ''}] ${e?.errorMessage ?? ''} ${
-    //   e?.value ?? ''
-    // }\n`;
     return acc;
   }, '');
 

--- a/packages/webapp/src/util/sensor.js
+++ b/packages/webapp/src/util/sensor.js
@@ -16,13 +16,20 @@
 /**
  * The util function is used to generate validation errors related the the sensors.
  * @param {Object} errors
+ * @param {Function} t
  * should contain row, column, errorMessage and value.
  */
-export const generateErrorFormatForSensors = (errors) =>
+export const generateErrorFormatForSensors = (errors, t) =>
   errors.reduce((acc, e) => {
-    acc += `[Row: ${e?.row ?? ''}][Column: ${e?.column ?? ''}] ${e?.errorMessage ?? ''} ${
-      e?.value ?? ''
-    }\n`;
+    acc += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.ROW', {
+      row: e?.row ?? '',
+      column: e?.column ?? '',
+      errorMessage: e?.errorMessage ?? '',
+      value: e?.value ?? '',
+    });
+    // acc += `[Row: ${e?.row ?? ''}][Column: ${e?.column ?? ''}] ${e?.errorMessage ?? ''} ${
+    //   e?.value ?? ''
+    // }\n`;
     return acc;
   }, '');
 
@@ -30,23 +37,22 @@ export const generateErrorFormatForSensors = (errors) =>
  * Generates the error string related to partial successes claiming sensors from ensemble.
  * @param {Array<Object>} errors
  * @param {Array<String>} success
+ * @param {Function} t
  * @return {string}
  */
-export const generateClaimSensorErrorFile = (errors, success) => {
+export const generateClaimSensorErrorFile = (errors, success, t) => {
   let errorText = '';
   if (success.length > 0) {
-    errorText +=
-      'The following sensors in your file uploaded successfully or already exist on your farm:\n\n';
+    errorText += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.PARTIAL_SUCCESS_TOP_TEXT');
     errorText += success.reduce((acc, e, i) => {
       const ending = i === success.length - 1 ? '\n\n' : ', ';
       acc += e + ending;
       return acc;
     }, '');
-    errorText +=
-      'They should now be visible on your farm map. These sensors will be ignored in future uploads.\n\n';
+    errorText += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.PARTIAL_SUCCESS_BOTTOM_TEXT');
   }
-  errorText += 'Unfortunately, there were some errors with your upload:\n\n';
-  errorText += generateErrorFormatForSensors(errors);
+  errorText += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.SOME_ERRORS');
+  errorText += generateErrorFormatForSensors(errors, t);
   return errorText;
 };
 
@@ -54,20 +60,26 @@ export const generateClaimSensorErrorFile = (errors, success) => {
  * Creates and downloads the file for sensors upload errors.
  * @param {String} downloadFileName
  * @param {Array<Object>} errors
- * @param {Boolean} isValidationError
+ * @param {("validation"|"claim"|"generic")} errorType
  * @param {Array<String>} success
+ * @param {Function} t
  */
-export const createSensorErrorDownload = (
-  downloadFileName,
-  errors,
-  isValidationError,
-  success = [],
-) => {
-  console.table(errors);
+export const createSensorErrorDownload = (downloadFileName, errors, errorType, t, success = []) => {
   const element = document.createElement('a');
-  const formattedError = isValidationError
-    ? generateErrorFormatForSensors(errors)
-    : generateClaimSensorErrorFile(errors, success);
+  let formattedError;
+  switch (errorType) {
+    case 'validation':
+      formattedError = generateErrorFormatForSensors(errors, t);
+      break;
+    case 'claim':
+      formattedError = generateClaimSensorErrorFile(errors, success, t);
+      break;
+    case 'generic':
+      formattedError = t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.DEFAULT');
+      break;
+    default:
+      formattedError = t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.DEFAULT');
+  }
   const file = new Blob([formattedError], {
     type: 'text/plain',
   });


### PR DESCRIPTION
This resolves https://lite-farm.atlassian.net/browse/LF-2645 and also translates all the error downloads

To test:
1. Without setting up an ngrok tunnel or commenting out the code to register a webhook with ensemble, upload sensors
2. You should get an error file instead of a snackbar
3. Set up an ngrok tunnel or comment out the code to register a webhook with ensemble
4. Upload sensors
5. See if the error download is translated (should be full of "MISSING" in other languages)
