### PR TITLE
Fixed UI to refleect that the current user can't change their own role

### DIFF
--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -18,6 +18,7 @@ export default function PureEditUser({
   onActivate,
   onRevoke,
   onInvite,
+  isCurrentUser,
 }) {
   const { t } = useTranslation();
   const ROLE = 'role_id';
@@ -171,6 +172,7 @@ export default function PureEditUser({
           render={({ field }) => (
             <ReactSelect
               {...field}
+              isDisabled={!isAdmin || isCurrentUser}
               label={t('INVITE_USER.ROLE')}
               options={roleOptions}
               style={{ marginBottom: '24px' }}
@@ -178,6 +180,7 @@ export default function PureEditUser({
             />
           )}
           rules={{ required: true }}
+          disabled={!isAdmin || isCurrentUser}
         />
       )}
       {isPseudoUser && shouldInvitePseudoUser && (

--- a/packages/webapp/src/containers/Profile/EditUser.jsx
+++ b/packages/webapp/src/containers/Profile/EditUser.jsx
@@ -2,14 +2,19 @@ import PureEditUser from '../../components/Profile/EditUser';
 import { useDispatch, useSelector } from 'react-redux';
 import { isAdminSelector, userFarmEntitiesSelector, userFarmSelector } from '../userFarmSlice';
 import { deactivateUser, invitePseudoUser, reactivateUser, updateUserFarm } from './People/saga';
+import { useMemo } from 'react';
 
 export default function EditUser({ history, match }) {
-  const { farm_id } = useSelector(userFarmSelector);
+  const { farm_id, user_id: currentUserId } = useSelector(userFarmSelector);
   const isAdmin = useSelector(isAdminSelector);
   const dispatch = useDispatch();
   const userFarmsEntities = useSelector(userFarmEntitiesSelector);
   const { user_id } = match.params;
   const userFarm = userFarmsEntities[farm_id]?.[user_id];
+
+  const isCurrentUser = useMemo(() => {
+    return user_id === currentUserId;
+  }, [user_id, currentUserId]);
 
   const getReqBody = (data) => {
     const role_id = parseInt(data.role_id.value);
@@ -45,6 +50,7 @@ export default function EditUser({ history, match }) {
       onRevoke={onRevoke}
       history={history}
       onInvite={onInvite}
+      isCurrentUser={isCurrentUser}
     />
   );
 }


### PR DESCRIPTION
This PR addresses the comments left on https://lite-farm.atlassian.net/browse/LF-2554

To test:
1. Log into a farm as an admin user
2. Go to people -> your current user
3. The dropdown to change your role should be disabled
4. Go to people -> some other user
5. The dropdown to change their role should be enabled