### PR TITLE
Farm worker no longer sees add item to map spotlight

### DIFF
--- a/packages/webapp/src/components/Map/Footer/index.jsx
+++ b/packages/webapp/src/components/Map/Footer/index.jsx
@@ -53,13 +53,17 @@ export default function PureMapFooter({
       open={showSpotlight}
       onFinish={resetSpotlight}
       steps={[
-        {
-          selector: '#mapFirstStep',
-          title: t('FARM_MAP.SPOTLIGHT.ADD_TITLE'),
-          contents: [t('FARM_MAP.SPOTLIGHT.HERE_YOU_CAN')],
-          list: [t('FARM_MAP.SPOTLIGHT.ADD')],
-          position: 'center',
-        },
+        ...(isAdmin
+          ? [
+              {
+                selector: '#mapFirstStep',
+                title: t('FARM_MAP.SPOTLIGHT.ADD_TITLE'),
+                contents: [t('FARM_MAP.SPOTLIGHT.HERE_YOU_CAN')],
+                list: [t('FARM_MAP.SPOTLIGHT.ADD')],
+                position: 'center',
+              },
+            ]
+          : []),
         {
           selector: '#mapSecondStep',
           title: t('FARM_MAP.SPOTLIGHT.FILTER_TITLE'),


### PR DESCRIPTION
To test:
1. Invite a new farm worker with an email
2. Log into Litefarm with the email you used to invite the farm worker
3. Navigate to the farm map. You should only see the "filter map" and "export map" spotlights. You should not see the "add to map" spotlight