### PR TITLE
Lf 2577 shifting issue for watercourse and buffer zone

### DIFF
--- a/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
+++ b/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
@@ -13,6 +13,7 @@ import { line_width } from '../../../util/convert-units/unit';
 import { cloneObject } from '../../../util';
 import { useSelector } from 'react-redux';
 import { measurementSelector } from '../../../containers/userFarmSlice';
+import { useMemo } from 'react';
 
 export default function PureLineBox({
   typeOfLine,
@@ -41,8 +42,8 @@ export default function PureLineBox({
   });
 
   const { t } = useTranslation();
-  const measurmentUnit = useSelector(measurementSelector);
-  const maxValue = measurmentUnit == 'metric' ? 1600 : 5280;
+  const measurementUnit = useSelector(measurementSelector);
+  const maxValue = useMemo(() => (measurementUnit === 'metric' ? 1600 : 5280), [measurementUnit]);
 
   const widthLabel =
     typeOfLine === locationEnum.watercourse

--- a/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
+++ b/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
@@ -11,6 +11,8 @@ import { watercourseEnum } from '../../../containers/constants';
 import Unit from '../../Form/Unit';
 import { line_width } from '../../../util/convert-units/unit';
 import { cloneObject } from '../../../util';
+import { useSelector } from 'react-redux';
+import { measurementSelector } from '../../../containers/userFarmSlice';
 
 export default function PureLineBox({
   typeOfLine,
@@ -39,6 +41,8 @@ export default function PureLineBox({
   });
 
   const { t } = useTranslation();
+  const measurmentUnit = useSelector(measurementSelector);
+  const maxValue = measurmentUnit == 'metric' ? 1600 : 5280;
 
   const widthLabel =
     typeOfLine === locationEnum.watercourse
@@ -58,7 +62,11 @@ export default function PureLineBox({
 
   useEffect(() => {
     trigger();
-    updateWidth((widthValue || 0) + (bufferWidthValue || 0));
+    updateWidth(
+      (widthValue ? (widthValue <= maxValue ? widthValue : maxValue) : 0) +
+        (bufferWidthValue ? (bufferWidthValue <= maxValue ? bufferWidthValue : maxValue) : 0),
+    );
+    // updateWidth((widthValue || 0) + (bufferWidthValue || 0));
   }, [widthValue, bufferWidthValue]);
 
   return (
@@ -92,6 +100,7 @@ export default function PureLineBox({
             control={control}
             required
             mode={'onChange'}
+            max={measurmentUnit == 'metric' ? 1600 : 5280}
           />
         </div>
         {typeOfLine === locationEnum.watercourse && (
@@ -111,6 +120,7 @@ export default function PureLineBox({
               control={control}
               required
               mode={'onChange'}
+              max={measurmentUnit == 'metric' ? 1600 : 5280}
             />
           </div>
         )}

--- a/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
+++ b/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
@@ -99,7 +99,7 @@ export default function PureLineBox({
             control={control}
             required
             mode={'onChange'}
-            max={measurmentUnit == 'metric' ? 1600 : 5280}
+            max={maxValue}
           />
         </div>
         {typeOfLine === locationEnum.watercourse && (
@@ -119,7 +119,7 @@ export default function PureLineBox({
               control={control}
               required
               mode={'onChange'}
-              max={measurmentUnit == 'metric' ? 1600 : 5280}
+              max={maxValue}
             />
           </div>
         )}

--- a/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
+++ b/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
@@ -66,7 +66,6 @@ export default function PureLineBox({
       (widthValue ? (widthValue <= maxValue ? widthValue : maxValue) : 0) +
         (bufferWidthValue ? (bufferWidthValue <= maxValue ? bufferWidthValue : maxValue) : 0),
     );
-    // updateWidth((widthValue || 0) + (bufferWidthValue || 0));
   }, [widthValue, bufferWidthValue]);
 
   return (


### PR DESCRIPTION
To test:
1. Navigate to your farm map
2. Begin the process to add a watercourse
3. Play around with the values in the input fields. If you surpass the maximum acceptable value, you should see a warning. Any values greater than the acceptable max should default to the maximum (not in the input field but visually) and not be accepted.
4. Repeat steps 2-3 for a buffer zone

**NOTE:** If you have any, please make suggestions on how to better deal with the constant defined on line 61 of packages/webapp/src/components/Map/LineMapBoxes/index.jsx.