### PR TITLE
User is returned to map after creating buffer zone

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/LineDetails/BufferZoneDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/LineDetails/BufferZoneDetailForm/saga.js
@@ -36,7 +36,7 @@ export function* postBufferZoneLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.BZ'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    history.push('/map');
   } catch (e) {
     history.push(
       {


### PR DESCRIPTION
To test:
1. Begin creating a buffer zone
2. Enter a very large value for the width, enough that it start shifting.
3. Click confirm, then enter random information in all fields of the form. The form doesn't let you continue when the width value is too big so adjust for that
4. Click the '<' button, click confirm again, then proceed to saving the buffer zone while entering all the info

You should be returned to the map with your new buffer zone