### PR TITLE
LF-2527 - fix: sensor error download issue for sensor fail notification

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -116,13 +116,20 @@ const sensorController = {
       if (!data.length > 0) {
         return await sendResponse(
           () => {
-            return res.status(400).send({ error_type: 'emtpy_file' });
+            return res.status(400).send({ error_type: 'empty_file' });
           },
           async () => {
             return await sendSensorNotification(
               user_id,
               farm_id,
               SensorNotificationTypes.SENSOR_BULK_UPLOAD_FAIL,
+              {
+                error_download: {
+                  errors: [],
+                  file_name: 'sensor-upload-outcomes.txt',
+                  error_type: 'generic',
+                },
+              },
             );
           },
         );
@@ -130,16 +137,20 @@ const sensorController = {
       if (errors.length > 0) {
         return await sendResponse(
           () => {
-            return res
-              .status(400)
-              .send({ error_type: 'validation_failure', errors, is_validation_error: true });
+            return res.status(400).send({ error_type: 'validation_failure', errors });
           },
           async () => {
             return await sendSensorNotification(
               user_id,
               farm_id,
               SensorNotificationTypes.SENSOR_BULK_UPLOAD_FAIL,
-              { error_download: { errors, file_name: 'sensor-upload-outcomes.txt' } },
+              {
+                error_download: {
+                  errors,
+                  file_name: 'sensor-upload-outcomes.txt',
+                  error_type: 'validation',
+                },
+              },
             );
           },
         );
@@ -236,8 +247,8 @@ const sensorController = {
                   error_download: {
                     errors: errorSensors,
                     file_name: 'sensor-upload-outcomes.txt',
-                    is_validation_error: false,
                     success: successSensors,
+                    error_type: 'claim',
                   },
                 },
               );
@@ -271,6 +282,13 @@ const sensorController = {
             user_id,
             farm_id,
             SensorNotificationTypes.SENSOR_BULK_UPLOAD_FAIL,
+            {
+              error_download: {
+                errors: [],
+                file_name: 'sensor-upload-outcomes.txt',
+                error_type: 'generic',
+              },
+            },
           );
         },
       );

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -257,16 +257,15 @@ export function useValidateBulkSensorData(onUpload, t) {
       const inputFile = fileInputRef.current.files[0];
       if (inputFile) {
         const downloadFileName = `${inputFile.name.replace(/.csv/, '')}_errors.txt`;
-        createSensorErrorDownload(downloadFileName, sheetErrors[0].errors, 'validation', t);
+        createSensorErrorDownload(downloadFileName, sheetErrors[0].errors, 'validation');
       }
     } else if (bulkSensorsUploadResponse?.defaultFailure) {
-      createSensorErrorDownload('sensor-upload-outcomes.txt', null, 'generic', t);
+      createSensorErrorDownload('sensor-upload-outcomes.txt', null, 'generic');
     } else {
       createSensorErrorDownload(
         'sensor-upload-outcomes.txt',
         translatedUploadErrors,
         'claim',
-        t,
         bulkSensorsUploadResponse?.success,
       );
     }

--- a/packages/webapp/src/components/Notifications/index.jsx
+++ b/packages/webapp/src/components/Notifications/index.jsx
@@ -60,7 +60,7 @@ function PureNotificationReadOnly({ onGoBack, notification, relatedNotifications
       createSensorErrorDownload(
         notification.ref.error_download.file_name,
         translatedErrors,
-        notification.ref.error_download.is_validation_error,
+        notification.ref.error_download.error_type,
         notification.ref.error_download.success ?? [],
       );
     } else {

--- a/packages/webapp/src/util/sensor.js
+++ b/packages/webapp/src/util/sensor.js
@@ -13,16 +13,17 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import i18n from '../locales/i18n';
+
 /**
  * The util function is used to generate validation errors related to the sensors.
  * @param {Object} errors
- * @param {Function} t
  * should contain row, column, errorMessage and value.
  * Outputs '[Row: {row}][Column: {column}] {Error message} {Optional value}'
  */
-export const generateErrorFormatForSensors = (errors, t) =>
+export const generateErrorFormatForSensors = (errors) =>
   errors.reduce((acc, e) => {
-    acc += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.ROW', {
+    acc += i18n.t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.ROW', {
       row: e?.row ?? '',
       column: e?.column ?? '',
       errorMessage: e?.errorMessage ?? '',
@@ -35,22 +36,21 @@ export const generateErrorFormatForSensors = (errors, t) =>
  * Generates the error string related to partial successes claiming sensors from ensemble.
  * @param {Array<Object>} errors
  * @param {Array<String>} success
- * @param {Function} t
  * @return {string}
  */
-export const generateClaimSensorErrorFile = (errors, success, t) => {
+export const generateClaimSensorErrorFile = (errors, success) => {
   let errorText = '';
   if (success.length > 0) {
-    errorText += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.PARTIAL_SUCCESS_TOP_TEXT');
+    errorText += i18n.t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.PARTIAL_SUCCESS_TOP_TEXT');
     errorText += success.reduce((acc, e, i) => {
       const ending = i === success.length - 1 ? '\n\n' : ', ';
       acc += e + ending;
       return acc;
     }, '');
-    errorText += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.PARTIAL_SUCCESS_BOTTOM_TEXT');
+    errorText += i18n.t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.PARTIAL_SUCCESS_BOTTOM_TEXT');
   }
-  errorText += t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.SOME_ERRORS');
-  errorText += generateErrorFormatForSensors(errors, t);
+  errorText += i18n.t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.SOME_ERRORS');
+  errorText += generateErrorFormatForSensors(errors);
   return errorText;
 };
 
@@ -60,23 +60,22 @@ export const generateClaimSensorErrorFile = (errors, success, t) => {
  * @param {Array<Object>} errors
  * @param {("validation"|"claim"|"generic")} errorType
  * @param {Array<String>} success
- * @param {Function} t
  */
-export const createSensorErrorDownload = (downloadFileName, errors, errorType, t, success = []) => {
+export const createSensorErrorDownload = (downloadFileName, errors, errorType, success = []) => {
   const element = document.createElement('a');
   let formattedError;
   switch (errorType) {
     case 'validation':
-      formattedError = generateErrorFormatForSensors(errors, t);
+      formattedError = generateErrorFormatForSensors(errors);
       break;
     case 'claim':
-      formattedError = generateClaimSensorErrorFile(errors, success, t);
+      formattedError = generateClaimSensorErrorFile(errors, success);
       break;
     case 'generic':
-      formattedError = t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.DEFAULT');
+      formattedError = i18n.t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.DEFAULT');
       break;
     default:
-      formattedError = t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.DEFAULT');
+      formattedError = i18n.t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_FILE.DEFAULT');
   }
   const file = new Blob([formattedError], {
     type: 'text/plain',


### PR DESCRIPTION
Due to recent changes to the `createSensorErrorDownload` function some issues resulted for the sensor fail notification which are dealt with in this PR.

To test:
- Add an item to local storage: `sensorUploadTimer : 10` to trigger the async flow
- Upload sensors to trigger failures and partial successes. See that the error download is working as expected in the notification when clicking "Take Me There"
- Try this in different languages as well