### PR TITLE
Fixed validation of non-csv files

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -577,6 +577,16 @@ const parseCsvString = (csvString, mapping, delimiter = ',') => {
   const regex = new RegExp(`(?!\\B"[^"]*)${delimiter}(?![^"]*"\\B)`);
   const rows = csvString.split(/\r\n|\r|\n/).filter((elem) => elem !== '');
   const headers = rows[0].split(regex);
+  const requiredHeaders = Object.keys(mapping).filter((m) => mapping[m].required);
+  const headerErrors = [];
+  requiredHeaders.forEach((header) => {
+    if (!headers.includes(header)) {
+      headerErrors.push({ row: 1, column: header, translation_key: sensorErrors.MISSING_COLUMNS });
+    }
+  });
+  if (headerErrors.length > 0) {
+    return { data: [], errors: headerErrors };
+  }
   const allowedHeaders = Object.keys(mapping);
   const dataRows = rows.slice(1);
   const { data, errors } = dataRows.reduce(

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -575,6 +575,9 @@ const sensorController = {
 const parseCsvString = (csvString, mapping, delimiter = ',') => {
   // regex checks for delimiters that are not contained within quotation marks
   const regex = new RegExp(`(?!\\B"[^"]*)${delimiter}(?![^"]*"\\B)`);
+  if (csvString.length === 0 || !/\r\b|\r|\n/.test(csvString)) {
+    return { data: [] };
+  }
   const rows = csvString.split(/\r\n|\r|\n/).filter((elem) => elem !== '');
   const headers = rows[0].split(regex);
   const requiredHeaders = Object.keys(mapping).filter((m) => mapping[m].required);


### PR DESCRIPTION
There is a bug reported by Mwaya where the validation did not work properly if a non-csv file was passed in (e.g. a text file). 

To test:
1. Comment out line 176 in `sensorController.js`
2. Upload a text file to the endpoint using Postman or Insomnia or another http client
3. The API should return a 400 response if it is not a valid csv file that matches the spec