### PR TITLE
fix: text for body and title of sensor upload fail notification

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1162,8 +1162,8 @@
       "TITLE": "Sensor upload completed"
     },
     "SENSOR_BULK_UPLOAD_FAIL": {
-      "BODY": "Your sensor upload has failed. Click “Take me there” to view the details.",
-      "TITLE": "Sensor upload failed"
+      "BODY": "Your sensor upload has some errors. Click “Take me there” to view the details.",
+      "TITLE": "Sensor upload errors"
     }
   },
   "OUTRO": {


### PR DESCRIPTION
Ticket: [LF-2527](https://lite-farm.atlassian.net/browse/LF-2527)

Quick changes to the notification title and text. 