### PR TITLE
Sensor details only makes necessary callouts

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/index.jsx
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/index.jsx
@@ -32,7 +32,7 @@ export default function SensorDetail({ history, user, match }) {
   useEffect(() => {
     dispatch(getSensorReadingTypes({ location_id, sensor_id }));
     dispatch(getSensorBrand({ location_id, partner_id }));
-  });
+  }, []);
 
   return (
     <PureSensorDetail history={history} isAdmin={isAdmin} system={system} sensorInfo={sensorInfo} />


### PR DESCRIPTION
To test:
1. Open the 'Network' tab in your browsers developer tools.
2. Navigate to a sensor's details view. In the network tab,  ensure the necessary callouts are being made once and not redundantly

