### PR TITLE
Added undelete functionality

### DIFF
--- a/packages/api/src/models/locationModel.js
+++ b/packages/api/src/models/locationModel.js
@@ -236,6 +236,13 @@ class Location extends baseModel {
       .andWhere('sensor.external_id', external_id)
       .first();
   }
+
+  static async unDeleteLocation(user_id, location_id, trx) {
+    return Location.query(trx)
+      .context({ user_id })
+      .where({ location_id })
+      .patch({ deleted: false });
+  }
 }
 
 module.exports = Location;

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -76,6 +76,9 @@ class Sensor extends Model {
         trx,
       );
       if (existingSensor) {
+        if (existingSensor.deleted) {
+          await LocationModel.unDeleteLocation(user_id, existingSensor.location_id, trx);
+        }
         await trx.commit();
         return existingSensor;
       }


### PR DESCRIPTION
This PR fixes issues with sensors not being undeleted on subsequent uploads (see comments on https://lite-farm.atlassian.net/browse/LF-2646)

To test:
1. Set deleted = true on a sensor's location
2. Re-upload that sensor
3. The sensor should now have deleted = false on its location