### PR TITLE
Retiring a non-integrated sensor no longer fails

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -553,7 +553,6 @@ const sensorController = {
     const trx = await transaction.start(Model.knex());
     try {
       const { external_id, location_id, farm_id, partner_id, brand_name } = req.body.sensorInfo;
-      console.log(req.body.sensorInfo);
       const user_id = req.user.user_id;
       const { access_token } = await IntegratingPartnersModel.getAccessAndRefreshTokens(
         'Ensemble Scientific',


### PR DESCRIPTION
To test:
1. Upload a non-integrated sensor. A non-integrated sensor is one without a brand name or external id
2. After that sensor is successfully uploaded, go to that sensors details view by clicking on its icon in the map
3. Retire that sensor
4. You should see a success message snackbar. As an extra check, you can check to see if that sensor is deleted in the location table in your db.