### PR TITLE
Legends activation and deactivation on Line Chart

### DIFF
--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './styles.module.scss';
 import {
   LineChart,
@@ -9,11 +9,12 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Surface,
+  Symbols,
 } from 'recharts';
 import { Label, Semibold } from '../Typography';
 import PropTypes from 'prop-types';
 import AxisLabel from './AxisLabel';
-import { NO_DATA } from '../../containers/SensorReadings/constants';
 
 const PureSensorReadingsLineChart = ({
   title,
@@ -25,12 +26,68 @@ const PureSensorReadingsLineChart = ({
   yAxisLabel,
   chartData,
 }) => {
-  const [selectedLine, setSelectedLine] = useState(null);
+  const [disabledLegends, setDisabledLegends] = useState({});
+  const [activeLegends, setActiveLegends] = useState({});
+  const [isActive, setIsActive] = useState(false);
+  const [legendsList, setLegendsList] = useState(() =>
+    yAxisDataKeys.reduce((acc, cv, idx) => {
+      acc[cv] = {
+        id: cv,
+        value: cv,
+        type: 'square',
+        color: lineColors[idx % lineColors.length],
+      };
+      return acc;
+    }, {}),
+  );
 
-  const selectLine = (event) => {
-    if (event.dataKey.includes(NO_DATA)) return;
-    let sl = selectedLine === event.dataKey ? null : event.dataKey.trim();
-    setSelectedLine(sl);
+  useEffect(() => {
+    const activeLegends = Object.keys(legendsList).reduce((acc, cv) => {
+      if (!Object.keys(disabledLegends).includes(cv)) {
+        acc[cv] = legendsList[cv];
+      }
+      return acc;
+    }, {});
+    setActiveLegends(activeLegends);
+  }, [disabledLegends, legendsList, isActive]);
+
+  const handleLabelClick = (entry) => {
+    setDisabledLegends((dis) => {
+      if (dis.hasOwnProperty(entry.value)) delete dis[entry.value];
+      else dis[entry.value] = entry;
+      return dis;
+    });
+    setIsActive((isA) => !isA);
+  };
+
+  const renderCusomizedLegend = ({ payload }) => {
+    return (
+      <div className={styles.legendWrapper}>
+        {Object.values(payload).map((entry, idx) => {
+          const { value = '', color = '' } = entry;
+          const active = Object.keys(disabledLegends).includes(value);
+          const style = {
+            color: active ? '#AAA' : '#000',
+            display: 'flex',
+            alignItems: 'center',
+          };
+          return (
+            <div
+              style={style}
+              key={idx}
+              onClick={() => handleLabelClick(entry)}
+              className={styles.legendContainer}
+            >
+              <Surface style={{ marginTop: '2px' }} width={10} height={10}>
+                <Symbols cx={5} cy={5} type="circle" size={50} fill={color} />
+                {active && <Symbols cx={5} cy={5} type="circle" size={25} fill={'#FFF'} />}
+              </Surface>
+              <span style={{ marginLeft: '4px' }}>{value}</span>
+            </div>
+          );
+        })}
+      </div>
+    );
   };
 
   return (
@@ -69,19 +126,19 @@ const PureSensorReadingsLineChart = ({
               verticalAlign="top"
               align="center"
               wrapperStyle={{ top: 10, left: 50 }}
-              onClick={selectLine}
+              payload={Object.values(legendsList)}
+              content={renderCusomizedLegend}
             />
           )}
           {yAxisDataKeys.length &&
-            yAxisDataKeys.map((attribute, idx) => (
+            Object.values(activeLegends).map((attribute, idx) => (
               <Line
                 key={idx}
                 strokeWidth={2}
-                dataKey={
-                  selectedLine === null || selectedLine === attribute ? attribute : `${attribute} `
-                }
-                stroke={lineColors[idx % lineColors.length]}
+                dataKey={attribute.value}
+                stroke={attribute.color}
                 activeDot={{ r: 6 }}
+                isAnimationActive={false}
               />
             ))}
         </LineChart>

--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -44,7 +44,7 @@ const PureSensorReadingsLineChart = ({
     }
   }, [yAxisDataKeys]);
 
-  const handleLabelClick = (entry) => {
+  const handleLegendClick = (entry) => {
     setLegendsList((legends) => {
       const activeCount = Object.values(legends).filter((l) => l.isActive).length;
       const isActive = legends[entry.value].isActive;
@@ -69,7 +69,7 @@ const PureSensorReadingsLineChart = ({
             <div
               style={style}
               key={idx}
-              onClick={() => handleLabelClick(entry)}
+              onClick={() => handleLegendClick(entry)}
               className={styles.legendContainer}
             >
               <Surface style={{ marginTop: '2px' }} width={10} height={10}>

--- a/packages/webapp/src/components/SensorReadingsLineChart/styles.module.scss
+++ b/packages/webapp/src/components/SensorReadingsLineChart/styles.module.scss
@@ -19,3 +19,14 @@
   margin-left: 12px;
   margin-top: 8px;
 }
+
+.legendWrapper{
+  display: flex;
+  margin-right: 32px;
+  justify-content: center;
+}
+
+.legendContainer{
+  margin-right: 10px;
+  cursor: pointer;
+}

--- a/packages/webapp/src/containers/SensorReadings/index.jsx
+++ b/packages/webapp/src/containers/SensorReadings/index.jsx
@@ -7,6 +7,7 @@ import PageTitle from '../../components/PageTitle/v2';
 import RouterTab from '../../components/RouterTab';
 import { bulkSensorsReadingsSliceSelector } from '../bulkSensorReadingsSlice';
 import { weatherSelector } from '../WeatherBoard/weatherSlice';
+import { sensorsSelector } from '../sensorSlice';
 import utils from '../WeatherBoard/utils';
 import { TEMPERATURE } from './constants';
 
@@ -14,18 +15,17 @@ function SensorReadings({ history, match }) {
   const { t } = useTranslation();
 
   const { location_id = '' } = match?.params;
-  const {
-    selectedSensorName = '',
-    latestMinTemperature = '',
-    latestMaxTemperature = '',
-  } = useSelector(bulkSensorsReadingsSliceSelector);
+  const sensorInfo = useSelector(sensorsSelector(location_id));
+  const { latestMinTemperature = '', latestMaxTemperature = '' } = useSelector(
+    bulkSensorsReadingsSliceSelector,
+  );
   const { measurement } = useSelector(weatherSelector);
   const { tempUnit } = utils.getUnits(measurement);
 
   return (
     <div style={{ padding: '24px 16px', height: '100%' }}>
       <PageTitle
-        title={selectedSensorName}
+        title={sensorInfo.name}
         onGoBack={() => history.push('/map')}
         style={{ marginBottom: '24px' }}
       />


### PR DESCRIPTION
To test, 

1. go to http://localhost:3000/sensor/<location_id>/readings.
2. make sure to have sensor readings in the pg-litefarm local database.
3. check if you can see legends with a dot.
4. click on the legend and see if the graph shows or hides the line.

 
<img width="400" alt="Screen Shot 2022-07-20 at 11 35 40 AM" src="https://user-images.githubusercontent.com/20675885/180057004-99baed77-4c02-47a6-8a4d-54e50e7157d8.png">

Also, try adding some location ids as follows:

File Location: packages/webapp/src/containers/SensorReadings/index.jsx

<img width="1110" alt="Screen Shot 2022-07-20 at 11 21 33 AM" src="https://user-images.githubusercontent.com/20675885/180057111-d87bba5a-8727-4c61-b70c-7db33e36d74d.png">

You'll be able to see this after adding multiple location id:

<img width="1060" alt="Screen Shot 2022-07-20 at 11 40 08 AM" src="https://user-images.githubusercontent.com/20675885/180058203-0863bf24-7559-451e-9050-449e801faa3d.png">

After clicking on legends:

<img width="1020" alt="Screen Shot 2022-07-20 at 11 44 39 AM" src="https://user-images.githubusercontent.com/20675885/180059692-6f15f89c-035a-421e-9ca7-47833848686b.png">

Repeat the above steps to test activate/inactivate lines on the legends click.

For more information, please check 
https://lite-farm.atlassian.net/browse/LF-2502





