### PR TITLE
Fix date range logic

### DIFF
--- a/packages/api/src/controllers/organicCertifierSurveyController.js
+++ b/packages/api/src/controllers/organicCertifierSurveyController.js
@@ -182,9 +182,7 @@ const organicCertifierSurveyController = {
         .query()
         .withGraphJoined('files')
         .where((builder) => {
-          builder
-            .whereBetween('valid_until', [from_date, to_date])
-            .orWhere({ no_expiration: true });
+          builder.where('valid_until', '>=', from_date).orWhere({ no_expiration: true });
         })
         .where({ archived: false })
         .andWhere({ farm_id });


### PR DESCRIPTION
Per [LF-2692](https://lite-farm.atlassian.net/browse/LF-2692) this modifies certification exports to include documents that did not expire before the report’s start date. That is, include the document if `document.valid_until >= report.start_date`.