### PR TITLE
Added extra case in handling the ensemble sensor claim response

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -234,6 +234,14 @@ const sensorController = {
                 translation_key: sensorErrors.SENSOR_ALREADY_OCCUPIED,
                 variables: { sensorId: curr.external_id },
               });
+            } else {
+              // we know that it is an ESID but for some reason it was not returned in the expected format from the API
+              prev.errorSensors.push({
+                row: idx + 2,
+                column: 'External_ID',
+                translation_key: sensorErrors.INTERNAL_ERROR,
+                variables: { sensorId: curr.external_id },
+              });
             }
             return prev;
           },


### PR DESCRIPTION
This PR just adds a little bit of extra safety into our sensor upload flow, and sends a generic error message if the ensemble API returns data that is not in the expected format for some/all of the sensors.