### PR TITLE
LF-2674: Changing the contents of a sensor upload file but not the name requires restarting the upload flow

### DIFF
--- a/packages/webapp/src/components/Modals/BulkSensorUploadModal/FileUploader.jsx
+++ b/packages/webapp/src/components/Modals/BulkSensorUploadModal/FileUploader.jsx
@@ -16,7 +16,13 @@ export default function FileUploader({
   uploadErrorMessage,
   errorTypeCode,
 }) {
-  const handleClick = (event) => fileInputRef.current.click();
+  const handleClick = (event) => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = null;
+    }
+    fileInputRef.current.click();
+  };
+
   const handleChange = (event) => handleSelectedFile(event);
   return (
     <>


### PR DESCRIPTION
Ticket: [LF-2674](https://lite-farm.atlassian.net/browse/LF-2674)

To test: 
- Upload an invalid sensor upload file named “test.csv”
- View validation errors
- Click the upload symbol
- Upload a valid sensor upload file named “test.csv”
- Validation for the file should be run again