### PR TITLE
Bugfix/save button disabled

### DIFF
--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -1,8 +1,23 @@
+/*
+ *  Copyright 2019-2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 import Input, { getInputErrors } from '../../Form/Input';
 import { Controller, useForm } from 'react-hook-form';
 import ReactSelect from '../../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Button from '../../Form/Button';
 import PropTypes from 'prop-types';
 import Form from '../../Form';

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -2,7 +2,7 @@ import Input, { getInputErrors } from '../../Form/Input';
 import { Controller, useForm } from 'react-hook-form';
 import ReactSelect from '../../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Button from '../../Form/Button';
 import PropTypes from 'prop-types';
 import Form from '../../Form';
@@ -35,7 +35,10 @@ export default function PureEditUser({
     value: role_id,
     label: dropDownMap[role_id],
   }));
-  const roleOption = { value: userFarm.role_id, label: dropDownMap[userFarm.role_id] };
+  const roleOption =
+    userFarm.role_id !== 4
+      ? { value: userFarm.role_id, label: dropDownMap[userFarm.role_id] }
+      : { value: 3, label: dropDownMap[3] };
 
   const {
     register,
@@ -62,14 +65,17 @@ export default function PureEditUser({
   const email = watch(EMAIL);
   const role = watch(ROLE);
   const wage = watch(WAGE);
-  const disabled =
-    !isValid ||
-    (shouldInvitePseudoUser && (!email || !role?.label)) ||
-    (!shouldInvitePseudoUser &&
-      !isPseudoUser &&
-      Number(role?.value) === userFarm.role_id &&
-      (wage || 0) === Number(userFarm.wage?.amount)) ||
-    (!shouldInvitePseudoUser && isPseudoUser && (wage || 0) === Number(userFarm.wage?.amount));
+  const disabled = useMemo(
+    () =>
+      !isValid ||
+      (shouldInvitePseudoUser && (!email || !role?.label)) ||
+      (!shouldInvitePseudoUser &&
+        !isPseudoUser &&
+        Number(role?.value) === userFarm.role_id &&
+        (wage || 0) === Number(userFarm.wage?.amount)) ||
+      (!shouldInvitePseudoUser && isPseudoUser && (wage || 0) === Number(userFarm.wage?.amount)),
+    [isValid, shouldInvitePseudoUser, email, role, userFarm.wage?.amount, wage],
+  );
 
   return (
     <Form

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -1,18 +1,3 @@
-/*
- *  Copyright 2019-2022 LiteFarm.org
- *  This file is part of LiteFarm.
- *
- *  LiteFarm is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  LiteFarm is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
- */
-
 import Input, { getInputErrors } from '../../Form/Input';
 import { Controller, useForm } from 'react-hook-form';
 import ReactSelect from '../../Form/ReactSelect';
@@ -89,12 +74,20 @@ export default function PureEditUser({
         Number(role?.value) === userFarm.role_id &&
         (wage || 0) === Number(userFarm.wage?.amount)) ||
       (!shouldInvitePseudoUser && isPseudoUser && (wage || 0) === Number(userFarm.wage?.amount)),
-    [isValid, shouldInvitePseudoUser, email, role, userFarm.wage?.amount, wage],
+    [
+      isValid,
+      shouldInvitePseudoUser,
+      email,
+      role,
+      userFarm.wage?.amount,
+      wage,
+      Object.keys(errors).length,
+    ],
   );
 
   return (
     <Form
-      onSubmit={handleSubmit(shouldInvitePseudoUser ? onInvite : onUpdate)}
+      onSubmit={handleSubmit(shouldInvitePseudoUser ? onInvite : onUpdate, (e) => console.log(e))}
       buttonGroup={
         <>
           {userFarm.status === 'Inactive' ? (
@@ -145,9 +138,16 @@ export default function PureEditUser({
             message: t('INVITE_USER.INVALID_EMAIL_ERROR'),
           },
           validate: {
-            existing: (value) =>
-              (value && !userFarmEmails.includes(value)) ||
-              t('INVITE_USER.ALREADY_EXISTING_EMAIL_ERROR'),
+            existing: (value) => {
+              if (!shouldInvitePseudoUser) {
+                return true;
+              } else {
+                return (
+                  (value && !userFarmEmails.includes(value)) ||
+                  t('INVITE_USER.ALREADY_EXISTING_EMAIL_ERROR')
+                );
+              }
+            },
           },
         })}
         errors={getInputErrors(errors, EMAIL)}


### PR DESCRIPTION
This PR fixes a bug where the submit button remained disabled after the email was corrected on the upgrade pseudo user flow.

To test:
1. Try to upgrade a pseudo user to a full user using an email already existing on that user farm
2. This should not work
3. Try switching the email to a new email
4. You should now be able to save the users info