### PR TITLE
Fixed differences in sensor pages UI

### DIFF
--- a/packages/webapp/src/components/LocationDetailLayout/PointDetails/Sensor/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/PointDetails/Sensor/index.jsx
@@ -83,14 +83,14 @@ export default function PureSensorDetail({ history, isAdmin, system, sensorInfo 
   }
 
   return (
-    <div style={{ padding: '24px 16px 24px 16px' }}>
+    <div style={{ padding: '24px 16px 24px 24px' }}>
       <PageTitle
         title={name}
         onGoBack={() => history.push('/map')}
         style={{ marginBottom: '24px' }}
       />
       <RouterTab
-        classes={{ container: { margin: '24px 0 24px 0' } }}
+        classes={{ container: { margin: '30px 8px 26px 0px' } }}
         history={history}
         tabs={[
           {

--- a/packages/webapp/src/containers/SensorReadings/index.jsx
+++ b/packages/webapp/src/containers/SensorReadings/index.jsx
@@ -23,14 +23,14 @@ function SensorReadings({ history, match }) {
   const { tempUnit } = utils.getUnits(measurement);
 
   return (
-    <div style={{ padding: '24px 16px', height: '100%' }}>
+    <div style={{ padding: '24px 16px 24px 24px', height: '100%' }}>
       <PageTitle
         title={sensorInfo.name}
         onGoBack={() => history.push('/map')}
         style={{ marginBottom: '24px' }}
       />
       <RouterTab
-        classes={{ container: { margin: '24px 0' } }}
+        classes={{ container: { margin: '30px 8px 26px 0px' } }}
         history={history}
         tabs={[
           {


### PR DESCRIPTION
To Test:

Upload a sensor

Go on the sensor details page and flip through the readings details and task tabs and make sure the router tabs' padding are all the same