### PR TITLE
Removed date check for update task

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -25,14 +25,14 @@ const User = require('../models/userModel');
 
 const { typesOfTask } = require('./../middleware/validation/task');
 const adminRoles = [1, 2, 5];
-const isDateInPast = (date) => {
-  const today = new Date();
-  const newDate = new Date(date);
-  if (newDate.setUTCHours(0, 0, 0, 0) < today.setUTCHours(0, 0, 0, 0)) {
-    return true;
-  }
-  return false;
-};
+// const isDateInPast = (date) => {
+//   const today = new Date();
+//   const newDate = new Date(date);
+//   if (newDate.setUTCHours(0, 0, 0, 0) < today.setUTCHours(0, 0, 0, 0)) {
+//     return true;
+//   }
+//   return false;
+// };
 
 const taskController = {
   async assignTask(req, res) {
@@ -130,10 +130,10 @@ const taskController = {
       const { due_date } = req.body;
 
       //Ensure the task due date is not in the past
-      const isPast = await isDateInPast(due_date);
-      if (isPast) {
-        return res.status(400).send('Task due date must be today or in the future');
-      }
+      // const isPast = await isDateInPast(due_date);
+      // if (isPast) {
+      //   return res.status(400).send('Task due date must be today or in the future');
+      // }
 
       //Ensure only adminRoles can modify task due date
       if (!adminRoles.includes(req.role)) {

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -2185,7 +2185,7 @@ describe('Task tests', () => {
       });
     });
 
-    test('Farm owner must not be able to patch task due date to a date in the past', async (done) => {
+    test('Farm owner should be able to patch task due date to a date in the past', async (done) => {
       const past = faker.date.past();
       const due_date = past.toISOString().split('T')[0];
       const patchTaskDateBody = { due_date };
@@ -2198,7 +2198,7 @@ describe('Task tests', () => {
       });
 
       patchTaskDateRequest({ user_id, farm_id }, patchTaskDateBody, task_id, async (err, res) => {
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(200);
         done();
       });
     });
@@ -2242,7 +2242,7 @@ describe('Task tests', () => {
       });
     });
 
-    test('EO must not be able to patch task due date to a date in the past', async (done) => {
+    test('EO should be able to patch task due date to a date in the past', async (done) => {
       const past = faker.date.past();
       const due_date = past.toISOString().split('T')[0];
       const patchTaskDateBody = { due_date };
@@ -2255,7 +2255,7 @@ describe('Task tests', () => {
       });
 
       patchTaskDateRequest({ user_id, farm_id }, patchTaskDateBody, task_id, async (err, res) => {
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(200);
         done();
       });
     });
@@ -2299,7 +2299,7 @@ describe('Task tests', () => {
       });
     });
 
-    test('Managers must not be able to patch task due date to a date in the past', async (done) => {
+    test('Managers should be able to patch task due date to a date in the past', async (done) => {
       const past = faker.date.past();
       const due_date = past.toISOString().split('T')[0];
       const patchTaskDateBody = { due_date };
@@ -2312,7 +2312,7 @@ describe('Task tests', () => {
       });
 
       patchTaskDateRequest({ user_id, farm_id }, patchTaskDateBody, task_id, async (err, res) => {
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(200);
         done();
       });
     });


### PR DESCRIPTION
This PR removes the check for dates in the past @smattingly per the discussion here: https://lite-farm.atlassian.net/browse/LF-2634