### PR TITLE
Fixed map update for sensors

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -258,7 +258,7 @@ const sensorController = {
 
         const successSensors = sensorLocations.reduce((prev, curr, idx) => {
           if (curr.status === 'fulfilled') {
-            prev.push(registeredSensors[idx].external_id);
+            prev.push(curr.value);
           } else {
             errorSensors.push({
               row: data.findIndex((elem) => elem === registeredSensors[idx]) + 2,
@@ -270,12 +270,12 @@ const sensorController = {
           return prev;
         }, []);
 
-        if (successSensors.length < esids.length) {
+        if (successSensors.length < data.length) {
           return sendResponse(
             () => {
               return res.status(400).send({
                 error_type: 'unable_to_claim_all_sensors',
-                success: successSensors,
+                success: successSensors, // We need the full sensor objects to update the redux store
                 errorSensors,
               });
             },
@@ -288,7 +288,7 @@ const sensorController = {
                   error_download: {
                     errors: errorSensors,
                     file_name: 'sensor-upload-outcomes.txt',
-                    success: successSensors,
+                    success: successSensors.map((s) => s.sensor?.external_id), // Notification download needs an array of only ESIDs
                     error_type: 'claim',
                   },
                 },
@@ -300,7 +300,7 @@ const sensorController = {
             () => {
               return res
                 .status(200)
-                .send({ message: 'Successfully uploaded!', sensors: sensorLocations });
+                .send({ message: 'Successfully uploaded!', sensors: successSensors });
             },
             async () => {
               return await sendSensorNotification(

--- a/packages/api/src/models/locationModel.js
+++ b/packages/api/src/models/locationModel.js
@@ -230,7 +230,7 @@ class Location extends baseModel {
 
   static async getSensorLocation(farm_id, partner_id, external_id, trx) {
     return Location.query(trx)
-      .withGraphJoined('sensor')
+      .withGraphJoined('[figure.point, sensor]')
       .where('location.farm_id', farm_id)
       .andWhere('sensor.partner_id', partner_id)
       .andWhere('sensor.external_id', external_id)

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -80,6 +80,9 @@ export default function Map({ history }) {
   const system = useSelector(measurementSelector);
   const overlayData = useSelector(hookFormPersistSelector);
   const bulkSensorsUploadResponse = useSelector(bulkSensorsUploadSliceSelector);
+  const [gMap, setGMap] = useState(null);
+  const [gMaps, setGMaps] = useState(null);
+  const [gMapBounds, setGMapBounds] = useState(null);
 
   const lineTypesWithWidth = [locationEnum.buffer_zone, locationEnum.watercourse];
   const { t } = useTranslation();
@@ -301,7 +304,7 @@ export default function Map({ history }) {
 
     // Drawing locations on map
     let mapBounds = new maps.LatLngBounds();
-    drawAssets(map, maps, mapBounds);
+    const bounds = drawAssets(map, maps, mapBounds);
 
     if (history.location.state?.isStepBack) {
       reconstructOverlay();
@@ -314,6 +317,9 @@ export default function Map({ history }) {
         map.setCenter(location);
       }
     }
+    setGMap(map);
+    setGMaps(maps);
+    setGMapBounds(bounds);
   };
 
   const handleClickAdd = () => {
@@ -384,9 +390,12 @@ export default function Map({ history }) {
     setShowSuccessHeader(false);
     if (bulkSensorsUploadResponse?.isBulkUploadSuccessful) {
       dispatch(bulkSensorsUploadReInit());
-      history.go(0);
     }
   };
+
+  useEffect(() => {
+    gMap && gMaps && gMapBounds && drawAssets(gMap, gMaps, gMapBounds);
+  }, [bulkSensorsUploadResponse?.success?.length]);
 
   const handleDownload = () => {
     html2canvas(mapWrapperRef.current, { useCORS: true }).then((canvas) => {

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -69,6 +69,7 @@ import {
 } from '../../containers/bulkSensorUploadSlice';
 import LocationSelectionModal from './LocationSelectionModal';
 import { useMaxZoom } from './useMaxZoom';
+import { sensorSelector } from '../sensorSlice';
 
 export default function Map({ history }) {
   const windowInnerHeight = useWindowInnerHeight();
@@ -80,6 +81,7 @@ export default function Map({ history }) {
   const system = useSelector(measurementSelector);
   const overlayData = useSelector(hookFormPersistSelector);
   const bulkSensorsUploadResponse = useSelector(bulkSensorsUploadSliceSelector);
+  const sensors = useSelector(sensorSelector);
   const [gMap, setGMap] = useState(null);
   const [gMaps, setGMaps] = useState(null);
   const [gMapBounds, setGMapBounds] = useState(null);
@@ -394,8 +396,11 @@ export default function Map({ history }) {
   };
 
   useEffect(() => {
-    gMap && gMaps && gMapBounds && drawAssets(gMap, gMaps, gMapBounds);
-  }, [bulkSensorsUploadResponse?.success?.length]);
+    if (gMap && gMaps && gMapBounds) {
+      const newBounds = drawAssets(gMap, gMaps, gMapBounds);
+      setGMapBounds(newBounds);
+    }
+  }, [sensors]);
 
   const handleDownload = () => {
     html2canvas(mapWrapperRef.current, { useCORS: true }).then((canvas) => {

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -41,6 +41,7 @@ import {
   onLoadingSensorReadingStart,
   onLoadingSensorReadingFail,
 } from './mapSensorSlice';
+import { postManySensorsSuccess } from '../sensorSlice';
 
 const sendMapToEmailUrl = (farm_id) => `${url}/export/map/farm/${farm_id}`;
 const showedSpotlightUrl = () => `${url}/showed_spotlight`;
@@ -128,6 +129,7 @@ export function* bulkUploadSensorsInfoFileSaga({ payload: { file } }) {
     switch (fileUploadResponse.status) {
       case 200: {
         yield put(bulkSensorsUploadSuccess());
+        yield put(postManySensorsSuccess(fileUploadResponse.data.sensors));
         yield put(
           setSuccessMessage([
             i18n.t('FARM_MAP.MAP_FILTER.SENSOR'),
@@ -153,10 +155,18 @@ export function* bulkUploadSensorsInfoFileSaga({ payload: { file } }) {
         switch (errorType) {
           case bulkSenorUploadErrorTypeEnum?.unable_to_claim_all_sensors: {
             const { success, errorSensors } = error?.response?.data ?? {
-              success: {},
-              errorSensors: {},
+              success: [],
+              errorSensors: [],
             };
-            yield put(bulkSensorsUploadFailure({ success, errorSensors }));
+            if (success.length > 0) {
+              yield put(postManySensorsSuccess(success));
+            }
+            yield put(
+              bulkSensorsUploadFailure({
+                success: success.map((s) => s?.sensor?.external_id),
+                errorSensors,
+              }),
+            );
             break;
           }
           case bulkSenorUploadErrorTypeEnum?.validation_failure:

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -129,7 +129,7 @@ export function* bulkUploadSensorsInfoFileSaga({ payload: { file } }) {
     switch (fileUploadResponse.status) {
       case 200: {
         yield put(bulkSensorsUploadSuccess());
-        yield put(postManySensorsSuccess(fileUploadResponse.data.sensors));
+        yield put(postManySensorsSuccess(fileUploadResponse?.data?.sensors));
         yield put(
           setSuccessMessage([
             i18n.t('FARM_MAP.MAP_FILTER.SENSOR'),

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -222,6 +222,8 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
       });
       setFarmLocationMarker(locationMarker);
       mapBounds.extend(grid_points);
+    } else if (farmLocationMarker) {
+      farmLocationMarker?.setMap(null);
     }
 
     assetsWithLocations.forEach((idx) => {

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -228,15 +228,16 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
       const locationType = assets[idx].type !== undefined ? assets[idx].type : idx;
       assets[idx].type === undefined
         ? assets[locationType].forEach((location) => {
-            newState[locationType]?.push(
-              assetFunctionMap(locationType)(
-                map,
-                maps,
-                mapBounds,
-                location,
-                filterSettings?.[locationType],
-              ),
-            );
+            !newState[locationType].find((l) => l.location_id === location.location_id) &&
+              newState[locationType]?.push(
+                assetFunctionMap(locationType)(
+                  map,
+                  maps,
+                  mapBounds,
+                  location,
+                  filterSettings?.[locationType],
+                ),
+              );
           })
         : newState[locationType]?.push(
             assetFunctionMap(locationType)(
@@ -259,6 +260,7 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
     createMarkerClusters(maps, map, pointsArray);
     // TODO: only fitBounds if there is at least one location in the farm
     hasLocation && map.fitBounds(mapBounds);
+    return mapBounds;
   };
 
   // Draw an area


### PR DESCRIPTION
This PR makes the map update to show newly updated sensors on both a full success and a partial success. It also resolves  a small bug described in the comments on https://lite-farm.atlassian.net/browse/LF-2645 

To test:
1. Upload a file with one ESID which is claimed on another farm and one which is free - you should get one sensor added to your map, and a valid error message.
2. Unclaim the ESID which is claimed on another farm and upload the file again - you should be able to see both sensors on the farm map now