### PR TITLE
Fixed 400 error when updating sensor

### DIFF
--- a/packages/api/db/migration/20220613141913_create_sensors_tables.js
+++ b/packages/api/db/migration/20220613141913_create_sensors_tables.js
@@ -12,7 +12,6 @@ exports.up = function (knex) {
       table.string('external_id').notNullable();
       table.uuid('location_id').references('location_id').inTable('location').notNullable();
       table.float('depth');
-      table.enu('depth_unit', ['cm', 'm', 'in', 'ft']).defaultTo('cm');
       table.float('elevation');
     }),
 

--- a/packages/api/db/migration/20220715214935_sensor_as_standard_location.js
+++ b/packages/api/db/migration/20220715214935_sensor_as_standard_location.js
@@ -17,6 +17,7 @@ exports.up = async function (knex) {
       .notNullable();
     table.string('external_id').notNullable();
     table.float('depth');
+    table.enu('depth_unit', ['cm', 'm', 'in', 'ft']).defaultTo('cm');
     table.float('elevation');
     table.string('model');
   });


### PR DESCRIPTION
To test:

Drop database and recreate with new updated sensor migrations

Upload a sensor 
Update the sensor values
Ensure the sensor successfully updates and doesn't throw a 400 (bad request) error