### PR TITLE
Prevented api from crashing

### DIFF
--- a/packages/api/src/controllers/loginController.js
+++ b/packages/api/src/controllers/loginController.js
@@ -45,13 +45,9 @@ const loginController = {
 
       try {
         const userData = await userModel.query().select('*').where('email', email).first();
-        const pwData = await passwordModel
-          .query()
-          .select('*')
-          .where('user_id', userData.user_id)
-          .first();
-        const isMatch = await bcrypt.compare(password, pwData.password_hash);
         userID = userData.user_id;
+        const pwData = await passwordModel.query().select('*').where('user_id', userID).first();
+        const isMatch = await bcrypt.compare(password, pwData?.password_hash);
         if (!isMatch) {
           await userLogModel.query().insert({
             user_id: userID,


### PR DESCRIPTION
This PR fixes the API crashes from the login flow, although it doesn't address why users without a password in the password table were able to log in with a password through the UI as I was unable to recreate that.

To test:
1. Create a user with a password
2. Log out and verify that you can log back in with the password
3. Delete the password from the password table
4. Try to log in again - you shouldn't be allowed to login, but the API shouldn't crash anymore