### PR TITLE
Correct default units for sensor depth

### DIFF
--- a/packages/webapp/src/components/LocationDetailLayout/PointDetails/Sensor/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/PointDetails/Sensor/index.jsx
@@ -159,7 +159,7 @@ export default function PureSensorDetail({ history, isAdmin, system, sensorInfo 
 
       <Unit
         register={register}
-        defaultValue={depth}
+        value={depth}
         displayUnitName={DEPTH_UNIT}
         label={t('SENSOR.DETAIL.DEPTH')}
         hookFormSetValue={setValue}


### PR DESCRIPTION
To test:
1. Navigate to the details page of a sensor
2. If you are using the imperial system, the depth field should be using inches. If you are using metric, the depth field should be using cm