### PR TITLE
LF-2618 Entering in an abandon/completion future date for a plan, doesn't change status

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -976,6 +976,7 @@
       "COMPLETE_PLAN": "Complete plan",
       "DATE_OF_CHANGE": "Date of status change",
       "NOTES_CHAR_LIMIT": "Notes must be less than 10,000 characters",
+      "FUTURE_DATE_INVALID": "May not be in the future",
       "RATING": "Rate this crop plan",
       "REASON": {
         "CROP_FAILURE": "Crop failure",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -979,6 +979,7 @@
       "COMPLETE_PLAN": "Completar plan",
       "DATE_OF_CHANGE": "Fecha de cambio de estado",
       "NOTES_CHAR_LIMIT": "Las notas deben tener menos de 10,000 caracteres",
+      "FUTURE_DATE_INVALID": "MISSING",
       "RATING": "Califica este plan de cultivo",
       "REASON": {
         "CROP_FAILURE": "Falla del cultivo",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -980,6 +980,7 @@
       "COMPLETE_PLAN": "Plan complet",
       "DATE_OF_CHANGE": "Date de changement de statut",
       "NOTES_CHAR_LIMIT": "Les notes doivent comporter moins de 10 000 caractères",
+      "FUTURE_DATE_INVALID": "MISSING",
       "RATING": "Évaluez ce plan de gestion",
       "REASON": {
         "CROP_FAILURE": "Échec de la récolte",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -979,6 +979,7 @@
       "COMPLETE_PLAN": "Plano completo",
       "DATE_OF_CHANGE": "Data de alteração da situação",
       "NOTES_CHAR_LIMIT": "As observações não podem exceder 10.000 caractéres",
+      "FUTURE_DATE_INVALID": "MISSING",
       "RATING": "Avaliar este plano de cultivo",
       "REASON": {
         "CROP_FAILURE": "Quebra de safra",

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -61,14 +61,13 @@ export function PureCompleteManagementPlan({
   const CREATED_ABANDON_REASON = 'created_abandon_reason';
 
   const [showAbandonModal, setShowAbandonModal] = useState(false);
-  const [invalidDate, setInvalidDate] = useState(false);
 
   const disabled = !isValid;
 
   return (
     <Form
       buttonGroup={
-        <Button disabled={disabled || invalidDate} fullLength>
+        <Button disabled={disabled} fullLength>
           {isAbandonPage ? t('common:MARK_ABANDON') : t('common:MARK_COMPLETE')}
         </Button>
       }
@@ -85,25 +84,19 @@ export function PureCompleteManagementPlan({
           ? t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_PLAN')
           : t('MANAGEMENT_PLAN.COMPLETE_PLAN.COMPLETE_PLAN')}
       </Title>
-      <div style={{ marginBottom: '40px' }}>
-        <Input
-          label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
-          hookFormRegister={register(DATE, {
-            required: true,
-            validate: isNotInFuture,
-          })}
-          errors={errors[DATE] ? isNotInFuture() : null}
-          type={'date'}
-          max={getDateInputFormat()}
-          min={start_date}
-          required
-        />
-        {invalidDate && (
-          <p style={{ marginTop: '4px', color: 'var(--error)' }}>
-            {t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID')}
-          </p>
-        )}
-      </div>
+      <Input
+        style={{ marginBottom: '40px' }}
+        label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
+        hookFormRegister={register(DATE, {
+          required: true,
+          validate: isNotInFuture,
+        })}
+        errors={errors[DATE] ? isNotInFuture() : null}
+        type={'date'}
+        max={getDateInputFormat()}
+        min={start_date}
+        required
+      />
       {isAbandonPage && (
         <>
           <Controller

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -1,6 +1,6 @@
 import Form from '../../Form';
 import CropHeader from '../CropHeader';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import Button from '../../Form/Button';
 import { useTranslation } from 'react-i18next';

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -66,7 +66,9 @@ export function PureCompleteManagementPlan({
 
   useEffect(() => {
     watch((value) => {
-      setInvalidDate(new Date(value?.abandon_date) > new Date());
+      setInvalidDate(
+        new Date(value?.abandon_date) > new Date() || new Date(value?.complete_date) > new Date(),
+      );
     });
   }, [invalidDate]);
 

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -1,6 +1,6 @@
 import Form from '../../Form';
 import CropHeader from '../CropHeader';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import Button from '../../Form/Button';
 import { useTranslation } from 'react-i18next';
@@ -60,12 +60,20 @@ export function PureCompleteManagementPlan({
   const CREATED_ABANDON_REASON = 'created_abandon_reason';
 
   const [showAbandonModal, setShowAbandonModal] = useState(false);
+  const [invalidDate, setInvalidDate] = useState(false);
 
   const disabled = !isValid;
+
+  useEffect(() => {
+    watch((value) => {
+      setInvalidDate(new Date(value?.abandon_date) > new Date());
+    });
+  }, [invalidDate]);
+
   return (
     <Form
       buttonGroup={
-        <Button disabled={disabled} fullLength>
+        <Button disabled={disabled || invalidDate} fullLength>
           {isAbandonPage ? t('common:MARK_ABANDON') : t('common:MARK_COMPLETE')}
         </Button>
       }
@@ -82,15 +90,21 @@ export function PureCompleteManagementPlan({
           ? t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_PLAN')
           : t('MANAGEMENT_PLAN.COMPLETE_PLAN.COMPLETE_PLAN')}
       </Title>
-      <Input
-        style={{ marginBottom: '40px' }}
-        label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
-        hookFormRegister={register(DATE)}
-        type={'date'}
-        max={getDateInputFormat()}
-        min={start_date}
-        required
-      />
+      <div style={{ marginBottom: '40px' }}>
+        <Input
+          label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
+          hookFormRegister={register(DATE)}
+          type={'date'}
+          max={getDateInputFormat()}
+          min={start_date}
+          required
+        />
+        {invalidDate && (
+          <p style={{ marginTop: '4px', color: 'var(--error)' }}>
+            {t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID')}
+          </p>
+        )}
+      </div>
       {isAbandonPage && (
         <>
           <Controller

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -12,6 +12,7 @@ import Input from '../../Form/Input';
 import { getDateInputFormat } from '../../../util/moment';
 import AbandonManagementPlanModal from '../../Modals/AbandonManagementPlanModal';
 import i18n from '../../../locales/i18n';
+import { isNotInFuture } from '../../Form/Input/utils';
 
 export const SOMETHING_ELSE = 'Something Else';
 export const defaultAbandonManagementPlanReasonOptions = [
@@ -64,14 +65,6 @@ export function PureCompleteManagementPlan({
 
   const disabled = !isValid;
 
-  useEffect(() => {
-    watch((value) => {
-      setInvalidDate(
-        new Date(value?.abandon_date) > new Date() || new Date(value?.complete_date) > new Date(),
-      );
-    });
-  }, [invalidDate]);
-
   return (
     <Form
       buttonGroup={
@@ -95,7 +88,11 @@ export function PureCompleteManagementPlan({
       <div style={{ marginBottom: '40px' }}>
         <Input
           label={t('MANAGEMENT_PLAN.COMPLETE_PLAN.DATE_OF_CHANGE')}
-          hookFormRegister={register(DATE)}
+          hookFormRegister={register(DATE, {
+            required: true,
+            validate: isNotInFuture,
+          })}
+          errors={errors[DATE] ? isNotInFuture() : null}
           type={'date'}
           max={getDateInputFormat()}
           min={start_date}

--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -12,7 +12,6 @@ import { ReactComponent as Leaf } from '../../../assets/images/signUp/leaf.svg';
 import Infoi from '../../Tooltip/Infoi';
 import { get } from 'react-hook-form';
 import i18n from '../../../locales/i18n';
-import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 
 const Input = ({
   disabled = false,

--- a/packages/webapp/src/components/Form/Input/utils.js
+++ b/packages/webapp/src/components/Form/Input/utils.js
@@ -1,0 +1,7 @@
+import i18n from '../../../locales/i18n';
+
+export const isNotInFuture = (data) => {
+  return new Date(data) <= new Date()
+    ? true
+    : i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID');
+};

--- a/packages/webapp/src/components/Task/AbandonTask/index.jsx
+++ b/packages/webapp/src/components/Task/AbandonTask/index.jsx
@@ -52,9 +52,7 @@ const PureAbandonTask = ({
   const happiness = watch(HAPPINESS);
 
   const disabled = !isValid || (hasAssignee && !happiness && !prefer_not_to_say);
-  // const isNotInFuture = (data) => {
-  //   return new Date(data) <= new Date() ? true : t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID');
-  // }
+
   // TODO: bring the options up to the smart component (eventually will be an api call + selector)
   const abandonmentReasonOptions = [
     { label: t('TASK.ABANDON.REASON.CROP_FAILURE'), value: 'CROP_FAILURE' },

--- a/packages/webapp/src/components/Task/AbandonTask/index.jsx
+++ b/packages/webapp/src/components/Task/AbandonTask/index.jsx
@@ -13,6 +13,7 @@ import TimeSlider from '../../Form/Slider/TimeSlider';
 import Checkbox from '../../Form/Checkbox';
 import Rating from '../../Rating';
 import { getDateInputFormat } from '../../../util/moment';
+import { isNotInFuture } from '../../Form/Input/utils';
 
 const PureAbandonTask = ({
   onSubmit,
@@ -51,7 +52,9 @@ const PureAbandonTask = ({
   const happiness = watch(HAPPINESS);
 
   const disabled = !isValid || (hasAssignee && !happiness && !prefer_not_to_say);
-
+  // const isNotInFuture = (data) => {
+  //   return new Date(data) <= new Date() ? true : t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID');
+  // }
   // TODO: bring the options up to the smart component (eventually will be an api call + selector)
   const abandonmentReasonOptions = [
     { label: t('TASK.ABANDON.REASON.CROP_FAILURE'), value: 'CROP_FAILURE' },
@@ -79,7 +82,11 @@ const PureAbandonTask = ({
 
       <Input
         label={t('TASK.ABANDON.DATE')}
-        hookFormRegister={register(ABANDON_DATE, { required: true })}
+        hookFormRegister={register(ABANDON_DATE, {
+          required: true,
+          validate: isNotInFuture,
+        })}
+        errors={errors[ABANDON_DATE] ? isNotInFuture() : null}
         style={{ marginBottom: '24px' }}
         type={'date'}
         max={getDateInputFormat()}

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -13,6 +13,7 @@ import styles from './styles.module.scss';
 import { getObjectInnerValues } from '../../../util';
 import Input from '../../Form/Input';
 import { getDateInputFormat } from '../../../util/moment';
+import { isNotInFuture } from '../../Form/Input/utils';
 
 export default function PureTaskComplete({
   onSave,
@@ -100,7 +101,11 @@ export default function PureTaskComplete({
 
       <Input
         label={t('TASK.COMPLETE.DATE')}
-        hookFormRegister={register(COMPLETE_DATE, { required: true })}
+        hookFormRegister={register(COMPLETE_DATE, {
+          required: true,
+          validate: isNotInFuture,
+        })}
+        errors={errors[COMPLETE_DATE] ? isNotInFuture() : null}
         style={{ marginBottom: '24px' }}
         type={'date'}
         max={getDateInputFormat()}


### PR DESCRIPTION
Ticket [LF-2618](https://lite-farm.atlassian.net/browse/LF-2618)

To Test:
1. Go to an existing crop plan (or create one if not).
2. Go through the abandon crop plan flow.
3. Change the "Date of status change" to a future date by clicking the input form and manually typing in a future date (calendar selection is already disabled for future dates).
4. There should be an in-line error message and "Abandon" button should be disabled.