### PR TITLE
Lf 2595 received two requests for help when modifying the preferred contact method for email

### DIFF
--- a/packages/api/src/controllers/supportTicketController.js
+++ b/packages/api/src/controllers/supportTicketController.js
@@ -39,46 +39,44 @@ const supportTicketController = {
   //   };
   // },
 
-  addSupportTicket() {
-    return async (req, res) => {
-      try {
-        const data = JSON.parse(req.body.data);
-        data.attachments = [];
-        const user_id = req.user.user_id;
-        const user = await userModel.query().findById(user_id);
-        const result = await supportTicketModel
-          .query()
-          .context({ user_id })
-          .insert(data)
-          .returning('*');
-        const replacements = {
-          first_name: user.first_name,
-          support_type: result.support_type,
-          message: result.message,
-          contact_method: capitalize(result.contact_method),
-          contact: result[result.contact_method],
-          locale: user.language_preference,
-        };
-        const email = data.contact_method === 'email' && data.email;
-        if (email && email !== user.email) {
-          await sendEmail(emails.HELP_REQUEST_EMAIL, replacements, email, {
-            sender: 'system@litefarm.org',
-            attachments: [req.file],
-          });
-        } else {
-          await sendEmail(emails.HELP_REQUEST_EMAIL, replacements, user.email, {
-            sender: 'system@litefarm.org',
-            attachments: [req.file],
-          });
-        }
-        res.status(201).send(result);
-      } catch (error) {
-        console.log(error);
-        res.status(400).json({
-          error,
+  async addSupportTicket(req, res) {
+    try {
+      const data = JSON.parse(req.body.data);
+      data.attachments = [];
+      const user_id = req.user.user_id;
+      const user = await userModel.query().findById(user_id);
+      const result = await supportTicketModel
+        .query()
+        .context({ user_id })
+        .insert(data)
+        .returning('*');
+      const replacements = {
+        first_name: user.first_name,
+        support_type: result.support_type,
+        message: result.message,
+        contact_method: capitalize(result.contact_method),
+        contact: result[result.contact_method],
+        locale: user.language_preference,
+      };
+      const email = data.contact_method === 'email' && data.email;
+      if (email && email !== user.email) {
+        await sendEmail(emails.HELP_REQUEST_EMAIL, replacements, email, {
+          sender: 'system@litefarm.org',
+          attachments: [req.file],
+        });
+      } else {
+        await sendEmail(emails.HELP_REQUEST_EMAIL, replacements, user.email, {
+          sender: 'system@litefarm.org',
+          attachments: [req.file],
         });
       }
-    };
+      res.status(201).send(result);
+    } catch (error) {
+      console.log(error);
+      res.status(400).json({
+        error,
+      });
+    }
   },
 
   // Disabled

--- a/packages/api/src/controllers/supportTicketController.js
+++ b/packages/api/src/controllers/supportTicketController.js
@@ -20,24 +20,24 @@ const { emails, sendEmail } = require('../templates/sendEmailTemplate');
 
 const supportTicketController = {
   // Disabled
-  getSupportTicketsByFarmId() {
-    return async (req, res) => {
-      try {
-        const farm_id = req.params.farm_id;
-        const result = await supportTicketModel.query().whereNotDeleted().where({ farm_id });
-        if (!result) {
-          res.sendStatus(404);
-        } else {
-          res.status(200).send(result);
-        }
-      } catch (error) {
-        //handle more exceptions
-        res.status(400).json({
-          error,
-        });
-      }
-    };
-  },
+  // getSupportTicketsByFarmId() {
+  //   return async (req, res) => {
+  //     try {
+  //       const farm_id = req.params.farm_id;
+  //       const result = await supportTicketModel.query().whereNotDeleted().where({ farm_id });
+  //       if (!result) {
+  //         res.sendStatus(404);
+  //       } else {
+  //         res.status(200).send(result);
+  //       }
+  //     } catch (error) {
+  //       //handle more exceptions
+  //       res.status(400).json({
+  //         error,
+  //       });
+  //     }
+  //   };
+  // },
 
   addSupportTicket() {
     return async (req, res) => {
@@ -82,25 +82,25 @@ const supportTicketController = {
   },
 
   // Disabled
-  patchStatus() {
-    return async (req, res) => {
-      const support_ticket_id = req.params.support_ticket_id;
-      try {
-        const user_id = req.user.user_id;
-        const status = req.body.status;
-        await supportTicketModel
-          .query()
-          .context({ user_id })
-          .findById(support_ticket_id)
-          .patch({ status });
-        res.sendStatus(200);
-      } catch (error) {
-        res.status(400).json({
-          error,
-        });
-      }
-    };
-  },
+  // patchStatus() {
+  //   return async (req, res) => {
+  //     const support_ticket_id = req.params.support_ticket_id;
+  //     try {
+  //       const user_id = req.user.user_id;
+  //       const status = req.body.status;
+  //       await supportTicketModel
+  //         .query()
+  //         .context({ user_id })
+  //         .findById(support_ticket_id)
+  //         .patch({ status });
+  //       res.sendStatus(200);
+  //     } catch (error) {
+  //       res.status(400).json({
+  //         error,
+  //       });
+  //     }
+  //   };
+  // },
 };
 
 const capitalize = (string) => {

--- a/packages/api/src/routes/supportTicketRoute.js
+++ b/packages/api/src/routes/supportTicketRoute.js
@@ -18,7 +18,6 @@ const router = express.Router();
 const supportTicketController = require('../controllers/supportTicketController');
 const multerDiskUpload = require('../util/fileUpload');
 
-router.post('/', multerDiskUpload, supportTicketController.addSupportTicket());
-
+router.post('/', multerDiskUpload, supportTicketController.addSupportTicket);
 
 module.exports = router;


### PR DESCRIPTION
This PR makes it so that if you put down a separate email than your account email when requested support, you only get a single email.

To test:
1. Click on the profile icon in the top right corner
2. Click on "Help"
3. Try sending a help request with the default email for your account - make sure you get this email!
4. Try sending a help request with a different email than the one associated with your account - make sure you get this email!