### PR TITLE
fix: crop plan 400 error on setting estimated seeding to mt

### DIFF
--- a/packages/api/db/migration/20220804164229_estimated_seeds_unit_add_tonnes.js
+++ b/packages/api/db/migration/20220804164229_estimated_seeds_unit_add_tonnes.js
@@ -1,0 +1,17 @@
+exports.up = function (knex) {
+  return knex.schema.raw(`
+        ALTER TABLE planting_management_plan
+        DROP CONSTRAINT planting_management_plan_estimated_seeds_unit_check,
+        ADD CONSTRAINT planting_management_plan_estimated_seeds_unit_check
+        CHECK (estimated_seeds_unit = ANY (ARRAY['g'::text, 'kg'::text, 'mt'::text, 'oz'::text, 'lb'::text, 't'::text]));
+    `);
+};
+
+exports.down = function (knex) {
+  return knex.schema.raw(`
+        ALTER TABLE planting_management_plan
+        DROP CONSTRAINT planting_management_plan_estimated_seeds_unit_check,
+        ADD CONSTRAINT planting_management_plan_estimated_seeds_unit_check
+        CHECK (estimated_seeds_unit = ANY (ARRAY['g'::text, 'kg'::text, 'oz'::text, 'lb'::text]));
+    `);
+};

--- a/packages/api/src/models/plantingManagementPlanModel.js
+++ b/packages/api/src/models/plantingManagementPlanModel.js
@@ -15,7 +15,6 @@
 
 const Model = require('objection').Model;
 
-
 class plantingManagementPlanModel extends Model {
   static get tableName() {
     return 'planting_management_plan';
@@ -33,7 +32,10 @@ class plantingManagementPlanModel extends Model {
         planting_management_plan_id: { type: 'string' },
         management_plan_id: { type: 'integer' },
         is_final_planting_management_plan: { type: 'boolean' },
-        planting_task_type: { type: ['string', null], enum: ['TRANSPLANT_TASK', 'PLANT_TASK', null] },
+        planting_task_type: {
+          type: ['string', null],
+          enum: ['TRANSPLANT_TASK', 'PLANT_TASK', null],
+        },
         planting_method: {
           type: ['string', null],
           enum: ['BROADCAST_METHOD', 'CONTAINER_METHOD', 'BED_METHOD', 'ROW_METHOD', null],
@@ -42,7 +44,7 @@ class plantingManagementPlanModel extends Model {
           type: ['boolean', null],
         },
         estimated_seeds: { type: ['number', null] },
-        estimated_seeds_unit: { type: ['string'], enum: ['g', 'kg', 'oz', 'lb'] },
+        estimated_seeds_unit: { type: ['string'], enum: ['g', 'kg', 'mt', 'oz', 'lb', 't'] },
         location_id: { type: ['string', null] },
         pin_coordinate: {
           type: ['object', null],


### PR DESCRIPTION
Ticket (See latest comment):  [LF-2521](https://lite-farm.atlassian.net/browse/LF-2521)

To test:
- Run the latest migrations
- Start the flow to creating a planting crop plan
-  Choose rows as planting method
- Enter an amount for 'Estimated seeding' and change the unit to `mt`
- Complete plan creation flow