### PR TITLE
LF-2253 when revoking a users access ensure at least one fo fm or eo retains access to the farm

### DIFF
--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -391,8 +391,10 @@ const userFarmController = {
 
         // check if access is revoked or restored: update email info based on this
         if (currentStatus === 'Active' || currentStatus === 'Invited') {
-          if (admins.length <= 1 && admins[0].user_id === user_id) {
-            return res.status(400).send("You cannot revoke the last admin's access on this farm");
+          if (admins.length <= 1 && admins[0].user_id === user_id && currentStatus === 'Active') {
+            return res
+              .status(400)
+              .send("You cannot revoke the last active admin's access on this farm");
           }
           template_path = emails.ACCESS_REVOKE;
         } else if (currentStatus === 'Inactive') {

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -387,8 +387,13 @@ const userFarmController = {
           return;
         }
 
+        const managers = await userFarmModel.getFarmManagementByFarmId(farm_id);
+
         // check if access is revoked or restored: update email info based on this
         if (currentStatus === 'Active' || currentStatus === 'Invited') {
+          if (managers.length <= 1) {
+            return res.status(400).send("You cannot revoke the last manager's access on this farm");
+          }
           template_path = emails.ACCESS_REVOKE;
         } else if (currentStatus === 'Inactive') {
           template_path = emails.ACCESS_RESTORE;

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -387,12 +387,12 @@ const userFarmController = {
           return;
         }
 
-        const managers = await userFarmModel.getFarmManagementByFarmId(farm_id);
+        const admins = await userFarmModel.getFarmManagementByFarmId(farm_id);
 
         // check if access is revoked or restored: update email info based on this
         if (currentStatus === 'Active' || currentStatus === 'Invited') {
-          if (managers.length <= 1) {
-            return res.status(400).send("You cannot revoke the last manager's access on this farm");
+          if (admins.length <= 1) {
+            return res.status(400).send("You cannot revoke the last admin's access on this farm");
           }
           template_path = emails.ACCESS_REVOKE;
         } else if (currentStatus === 'Inactive') {

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -391,7 +391,7 @@ const userFarmController = {
 
         // check if access is revoked or restored: update email info based on this
         if (currentStatus === 'Active' || currentStatus === 'Invited') {
-          if (admins.length <= 1) {
+          if (admins.length <= 1 && admins[0].user_id === user_id) {
             return res.status(400).send("You cannot revoke the last admin's access on this farm");
           }
           template_path = emails.ACCESS_REVOKE;

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1262,6 +1262,8 @@
       "PAY": "Pay",
       "RESTORE_ACCESS": "Restore User Access",
       "REVOKE_ACCESS": "Revoke User Access",
+      "INVALID_REVOKE_ACCESS": "Cannot revoke access",
+      "LAST_ADMIN_ERROR": "We’re unable to revoke access to this user because they are the last manager at this farm. If you would like to delete your farm, create a ticket by clicking <1>here</1> instead.",
       "ROLE": "Role",
       "ROLE_CHANGE_ALERT": "Role change will take full effect upon next login. Workers cannot set themselves to Admins.",
       "SEARCH": "Search",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1265,6 +1265,8 @@
       "PAY": "Pago",
       "RESTORE_ACCESS": "Restaurar acceso de usuario",
       "REVOKE_ACCESS": "Revocar acceso de usuario",
+      "INVALID_REVOKE_ACCESS": "MISSING",
+      "LAST_ADMIN_ERROR": "MISSING",
       "ROLE": "Rol",
       "ROLE_CHANGE_ALERT": "Cambio de rol se reflejará completamente en la siguiente sesión. Trabajadores no pueden configurarse como Administradores.",
       "SEARCH": "Buscar",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1266,6 +1266,8 @@
       "PAY": "Payer",
       "RESTORE_ACCESS": "Restaurer l'accès utilisateur",
       "REVOKE_ACCESS": "Révoquer l'accès utilisateur",
+      "INVALID_REVOKE_ACCESS": "MISSING",
+      "LAST_ADMIN_ERROR": "MISSING",
       "ROLE": "Rôle",
       "ROLE_CHANGE_ALERT": "Le changement de rôle prendra pleinement effet lors de la prochaine connexion. Les travailleurs ne peuvent pas se définir comme administrateurs.",
       "SEARCH": "Chercher",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1266,6 +1266,8 @@
       "PAY": "Salário",
       "RESTORE_ACCESS": "Restaurar o acesso do usuário",
       "REVOKE_ACCESS": "Revogar o acesso do usuário",
+      "INVALID_REVOKE_ACCESS": "MISSING",
+      "LAST_ADMIN_ERROR": "MISSING",
       "ROLE": "Papel",
       "ROLE_CHANGE_ALERT": "A mudança de papel terá efeito no próximo login. Os trabalhadores não podem se definir como administradores.",
       "SEARCH": "Pesquisar",

--- a/packages/webapp/src/components/Modals/InvalidRevokeUserAccessModal/index.jsx
+++ b/packages/webapp/src/components/Modals/InvalidRevokeUserAccessModal/index.jsx
@@ -1,23 +1,21 @@
 import React from 'react';
 import ModalComponent from '../ModalComponent/v2';
-import { useTranslation } from 'react-i18next';
-import Button from '../../Form/Button';
+import { Trans, useTranslation } from 'react-i18next';
+import styles from '../../../../src/components/Typography/typography.module.scss';
 
 export default function InvalidRevokeUserAccessModal({ dismissModal }) {
   const { t } = useTranslation();
   return (
     <ModalComponent
       title={t(`PROFILE.PEOPLE.INVALID_REVOKE_ACCESS`)}
-      contents={[t('PROFILE.PEOPLE.LAST_ADMIN_ERROR')]}
       dismissModal={dismissModal}
-      buttonGroup={
-        <>
-          <Button onClick={dismissModal} color={'secondary'} sm>
-            {t('common:NO')}
-          </Button>
-        </>
-      }
       warning
-    />
+    >
+      <div className={styles.info}>
+        <Trans i18nKey="PROFILE.PEOPLE.LAST_ADMIN_ERROR">
+          text <a href="/help">link</a> text
+        </Trans>
+      </div>
+    </ModalComponent>
   );
 }

--- a/packages/webapp/src/components/Modals/InvalidRevokeUserAccessModal/index.jsx
+++ b/packages/webapp/src/components/Modals/InvalidRevokeUserAccessModal/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ModalComponent from '../ModalComponent/v2';
+import { useTranslation } from 'react-i18next';
+import Button from '../../Form/Button';
+
+export default function InvalidRevokeUserAccessModal({ dismissModal }) {
+  const { t } = useTranslation();
+  return (
+    <ModalComponent
+      title={t(`PROFILE.PEOPLE.REVOKE_ACCESS`)}
+      contents={[t('PROFILE.PEOPLE.DO_YOU_WANT_TO_REMOVE'), t('PROFILE.PEOPLE.THIS_WILL_REMOVE')]}
+      dismissModal={dismissModal}
+      buttonGroup={
+        <>
+          <Button onClick={dismissModal} color={'secondary'} sm>
+            {t('common:NO')}
+          </Button>
+        </>
+      }
+      warning
+    />
+  );
+}

--- a/packages/webapp/src/components/Modals/InvalidRevokeUserAccessModal/index.jsx
+++ b/packages/webapp/src/components/Modals/InvalidRevokeUserAccessModal/index.jsx
@@ -7,8 +7,8 @@ export default function InvalidRevokeUserAccessModal({ dismissModal }) {
   const { t } = useTranslation();
   return (
     <ModalComponent
-      title={t(`PROFILE.PEOPLE.REVOKE_ACCESS`)}
-      contents={[t('PROFILE.PEOPLE.DO_YOU_WANT_TO_REMOVE'), t('PROFILE.PEOPLE.THIS_WILL_REMOVE')]}
+      title={t(`PROFILE.PEOPLE.INVALID_REVOKE_ACCESS`)}
+      contents={[t('PROFILE.PEOPLE.LAST_ADMIN_ERROR')]}
       dismissModal={dismissModal}
       buttonGroup={
         <>

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -76,6 +76,8 @@ export default function PureEditUser({
   };
 
   const isUserLastAdmin = () => {
+    if (userFarm.status === 'Invited') return false;
+
     let adminCount = 0;
     userFarms.forEach((user) => {
       if (adminRoles.includes(user.role_id) && user.status === 'Active') adminCount++;

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -8,7 +8,10 @@ import PropTypes from 'prop-types';
 import Form from '../../Form';
 import PageTitle from '../../PageTitle/v2';
 import RevokeUserAccessModal from '../../Modals/RevokeUserAccessModal';
+import InvalidRevokeUserAccessModal from '../../Modals/InvalidRevokeUserAccessModal';
 import Checkbox from '../../Form/Checkbox';
+import { useSelector } from 'react-redux';
+import { userFarmsByFarmSelector } from '../../../containers/userFarmSlice';
 
 export default function PureEditUser({
   userFarm,
@@ -35,6 +38,8 @@ export default function PureEditUser({
     3: t('role:WORKER'),
     5: t('role:EXTENSION_OFFICER'),
   };
+  const userFarms = useSelector(userFarmsByFarmSelector);
+  const adminRoles = [1, 2, 5];
 
   const genderOptions = [
     { value: 'MALE', label: t('gender:MALE') },
@@ -70,6 +75,15 @@ export default function PureEditUser({
     }
   };
 
+  const isUserLastManager = () => {
+    let adminCount = 0;
+    userFarms.forEach((user) => {
+      if (adminRoles.includes(user.role_id)) adminCount++;
+    });
+
+    return adminCount === 1 && adminRoles.includes(userFarm.role_id);
+  };
+
   const {
     register,
     handleSubmit,
@@ -85,6 +99,7 @@ export default function PureEditUser({
   });
 
   const [showRevokeUserAccessModal, setShowRevokeUserAccessModal] = useState();
+  const [showInvalidRevokeUserAccessModal, setShowInvalidRevokeUserAccessModal] = useState(false);
   const [shouldInvitePseudoUser, setShouldInvitePseudoUser] = useState(false);
   const onInviteUserCheckboxClick = () => {
     setValue(EMAIL, shouldInvitePseudoUser ? userFarm.email : '');
@@ -134,7 +149,9 @@ export default function PureEditUser({
             <Button
               type={'button'}
               onClick={() => {
-                setShowRevokeUserAccessModal(true);
+                isUserLastManager()
+                  ? setShowInvalidRevokeUserAccessModal(true)
+                  : setShowRevokeUserAccessModal(true);
               }}
               fullLength
               color={'secondary'}
@@ -298,6 +315,13 @@ export default function PureEditUser({
             setShowRevokeUserAccessModal(false);
           }}
           onRevoke={onRevoke}
+        />
+      )}
+      {showInvalidRevokeUserAccessModal && (
+        <InvalidRevokeUserAccessModal
+          dismissModal={() => {
+            setShowInvalidRevokeUserAccessModal(false);
+          }}
         />
       )}
     </Form>

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -75,7 +75,7 @@ export default function PureEditUser({
     }
   };
 
-  const isUserLastManager = () => {
+  const isUserLastAdmin = () => {
     let adminCount = 0;
     userFarms.forEach((user) => {
       if (adminRoles.includes(user.role_id)) adminCount++;
@@ -149,7 +149,7 @@ export default function PureEditUser({
             <Button
               type={'button'}
               onClick={() => {
-                isUserLastManager()
+                isUserLastAdmin()
                   ? setShowInvalidRevokeUserAccessModal(true)
                   : setShowRevokeUserAccessModal(true);
               }}

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -78,7 +78,7 @@ export default function PureEditUser({
   const isUserLastAdmin = () => {
     let adminCount = 0;
     userFarms.forEach((user) => {
-      if (adminRoles.includes(user.role_id)) adminCount++;
+      if (adminRoles.includes(user.role_id) && user.status === 'Active') adminCount++;
     });
 
     return adminCount === 1 && adminRoles.includes(userFarm.role_id);


### PR DESCRIPTION
Ticket [LF-2253](https://lite-farm.atlassian.net/browse/LF-2253)

To Test:
1. Create a farm with one admin account (try one admin and no workers, try one inactive admin and one active admin, try two active admins, etc.).
2. Go edit the last admin's profile.
3. Click "Revoke User Access".
4. "Cannot revoke access" modal should pop up instead of "Revoke User Access" modal.
5. If you click "here" in the modal, it should redirect you to Request Help page.