### PR TITLE
Made retired sensors show up when re uploaded

### DIFF
--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -74,6 +74,7 @@ class Sensor extends Model {
       if (existingSensor) {
         if (existingSensor.deleted) {
           await LocationModel.unDeleteLocation(user_id, existingSensor.location_id, trx);
+          existingSensor.deleted = false;
         }
         await trx.commit();
         return existingSensor;


### PR DESCRIPTION
This PR resolves the issues reported by Mwaya on https://lite-farm.atlassian.net/browse/LF-2672 

To test:
1. Retire a sensors on a farm
2. Re upload that same sensor
3. The sensor should show up on your map without you needing to refresh