### PR TITLE
Fixed invite flow to have inline error when user with same email already exists

### DIFF
--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -9,7 +9,7 @@ import ReactSelect from '../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
 import { getFirstNameLastName } from '../../util';
 
-export default function PureInviteUser({ onInvite, onGoBack, roleOptions = [] }) {
+export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, roleOptions = [] }) {
   const {
     register,
     handleSubmit,
@@ -106,6 +106,14 @@ export default function PureInviteUser({ onInvite, onGoBack, roleOptions = [] })
           pattern: {
             value: /^$|^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/,
             message: t('INVITE_USER.INVALID_EMAIL_ERROR'),
+          },
+          validate: {
+            existing: (value) => {
+              return (
+                (value && !userFarmEmails.includes(value.toLowerCase())) ||
+                t('INVITE_USER.ALREADY_EXISTING_EMAIL_ERROR')
+              );
+            },
           },
         })}
         errors={getInputErrors(errors, EMAIL)}

--- a/packages/webapp/src/containers/InviteUser/index.jsx
+++ b/packages/webapp/src/containers/InviteUser/index.jsx
@@ -5,7 +5,7 @@ import { addPseudoWorker, getRoles, inviteUserToFarm } from './saga';
 import history from '../../history';
 import PureInviteUser from '../../components/InviteUser';
 import { rolesSelector } from '../Profile/People/slice';
-import { loginSelector } from '../userFarmSlice';
+import { loginSelector, userFarmEntitiesSelector } from '../userFarmSlice';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -26,6 +26,10 @@ function InviteUser() {
       pathname: '/people',
     });
   };
+  const userFarmEntities = useSelector(userFarmEntitiesSelector);
+  const userFarmEmails = Object.values(userFarmEntities[farm_id]).map((user) => {
+    return user.email.toLowerCase();
+  });
 
   const onInvite = (userInfo) => {
     const {
@@ -95,7 +99,14 @@ function InviteUser() {
     dispatch(getRoles());
   }, []);
 
-  return <PureInviteUser onGoBack={onGoBack} onInvite={onInvite} roleOptions={roleOptions} />;
+  return (
+    <PureInviteUser
+      onGoBack={onGoBack}
+      onInvite={onInvite}
+      roleOptions={roleOptions}
+      userFarmEmails={userFarmEmails}
+    />
+  );
 }
 
 export default InviteUser;


### PR DESCRIPTION
To test:
1. Create a new user on a farm
2. Try and invite a second user who has the same email as either your current user or another user on the farm
3. There should be an inline error which prevents you from inviting the user until you have provided a valid email