### PR TITLE
Fixed bug where it was impossible to invite a pseudo user

### DIFF
--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -109,7 +109,7 @@ export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, rol
           },
           validate: {
             existing: (value) => {
-              if (role.value === 3) {
+              if (role.value === 3 && !value) {
                 return true;
               } else {
                 return (

--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -109,10 +109,14 @@ export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, rol
           },
           validate: {
             existing: (value) => {
-              return (
-                (value && !userFarmEmails.includes(value.toLowerCase())) ||
-                t('INVITE_USER.ALREADY_EXISTING_EMAIL_ERROR')
-              );
+              if (role.value === 3) {
+                return true;
+              } else {
+                return (
+                  (value && !userFarmEmails.includes(value.toLowerCase())) ||
+                  t('INVITE_USER.ALREADY_EXISTING_EMAIL_ERROR')
+                );
+              }
             },
           },
         })}


### PR DESCRIPTION
This PR resolves the issue described in the comments of https://lite-farm.atlassian.net/browse/LF-2672

To test:
1. Try and invite a pseudo user
2. This should work
3. Try and invite a non pseudo user using an email of an existing user on the farm
4. You should be shown an inline error