### PR TITLE
Fixed regex and validation of empty case

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -103,7 +103,7 @@ const sensorController = {
           key: 'reading_types',
           parseFunction: (val) => val.replaceAll(' ', '').split(','),
           validator: (val) => {
-            if (!val.length) {
+            if (!val.length || (val.length === 1 && val[0] === '')) {
               return false;
             }
             const allowedReadingTypes = [
@@ -632,7 +632,9 @@ const sensorController = {
 
 const parseCsvString = (csvString, mapping, delimiter = ',') => {
   // regex checks for delimiters that are not contained within quotation marks
-  const regex = new RegExp(`(?!\\B"[^"]*)${delimiter}(?![^"]*"\\B)`);
+  const regex = new RegExp(
+    `(?:${delimiter}|\\n|^)("(?:(?:"")*[^"]*)*"|[^"${delimiter}\\n]*|(?:\\n|$))`,
+  );
   if (csvString.length === 0 || !/\r\b|\r|\n/.test(csvString)) {
     return { data: [] };
   }


### PR DESCRIPTION
To test:
1. Upload a csv file where the `Reading_types` column is empty for a sensor through your favourite http client to `http://localhost:5001/sensor/`. You will need to set the Bearer token to be the one used by your currently authenticated user, and also set the farm_id header appropriately for this to work. The upload is a POST request with a multipart form data field where the key for the csv file is `sensors`
2. You should get a validation error