### PR TITLE
LF-2626 - fix: email not appearing correctly on create account

### DIFF
--- a/packages/webapp/src/containers/CustomSignUp/index.jsx
+++ b/packages/webapp/src/containers/CustomSignUp/index.jsx
@@ -66,6 +66,7 @@ function CustomSignUp() {
   const { t, i18n, ready } = useTranslation(['translation', 'common'], { useSuspense: false });
 
   const customSignUpErrorKey = useSelector(customSignUpErrorKeySelector);
+  const [submittedEmail, setSubmittedEmail] = useState('');
 
   const forgotPassword = () => {
     dispatch(sendResetPasswordEmail(email));
@@ -96,8 +97,6 @@ function CustomSignUp() {
     if (!customSignUpErrorKey) return;
     const message = t(customSignUpErrorKey);
 
-    console.log(errors);
-
     setError(EMAIL, {
       type: 'manual',
       message,
@@ -112,6 +111,7 @@ function CustomSignUp() {
 
   const onSubmit = (data) => {
     const { email } = data;
+    setSubmittedEmail(email);
     dispatch(customSignUp({ email: email?.toLowerCase() }));
   };
 
@@ -162,7 +162,7 @@ function CustomSignUp() {
           <PureCreateUserAccount
             onSignUp={onSignUp}
             onGoBack={createUserAccountOnGoBack}
-            email={email}
+            email={submittedEmail}
           />
         </Hidden>
       </Suspense>


### PR DESCRIPTION
Ticket: [LF-2626](https://lite-farm.atlassian.net/browse/LF-2626)

Unfortunately this issue happens intermittently so it is hard to test. My hunch is that this issue had to do with the component not re-rendering on email change since it wasn't state. And I am no longer able to replicate the issue after making it state.

To test: 
- Start the flow to create a new account
- Go back and forth between entering your email and creating the account 
- Try this while using the Slow 3G option in the network tab
- Complete create account flow to see if that still works  