### PR TITLE
LF-2730 augment sensor preview

### DIFF
--- a/packages/webapp/src/components/Map/SelectionHandler/index.jsx
+++ b/packages/webapp/src/components/Map/SelectionHandler/index.jsx
@@ -60,7 +60,7 @@ export default function PureSelectionHandler({ locations, history, sensorReading
         setIsSensor(true);
         setSensorIdx(idx);
       }
-    }, 1000);
+    }, 800);
   };
 
   const handleMouseUp = (location) => {
@@ -84,16 +84,6 @@ export default function PureSelectionHandler({ locations, history, sensorReading
       }
     : {};
 
-  const longPressHandlers = isTouchDevice()
-    ? {
-        onTouchStart: handleMouseDown,
-        onTouchEnd: handleMouseUp,
-      }
-    : {
-        onMouseDown: handleMouseDown,
-        onMouseUp: handleMouseUp,
-      };
-
   return locations.map((location, idx) => {
     const { type, asset, name } = { ...location };
     let icon = imgMapping(asset, type);
@@ -101,16 +91,21 @@ export default function PureSelectionHandler({ locations, history, sensorReading
     return (
       <div
         key={idx}
-        onMouseDown={(e) => {
-          e.stopPropagation();
-          handleMouseDown(location, idx);
-        }}
-        onMouseUp={() => handleMouseUp(location)}
-        onTouchStart={(e) => {
-          e.stopPropagation();
-          handleMouseDown(location, idx);
-        }}
-        onTouchEnd={() => handleMouseUp(location)}
+        {...(isTouchDevice()
+          ? {
+              onTouchStart: (e) => {
+                e.stopPropagation();
+                handleMouseDown(location, idx);
+              },
+              onTouchEnd: () => handleMouseUp(location),
+            }
+          : {
+              onMouseDown: (e) => {
+                e.stopPropagation();
+                handleMouseDown(location, idx);
+              },
+              onMouseUp: () => handleMouseUp(location),
+            })}
       >
         <div className={classes.container}>
           <div style={{ float: 'left', paddingTop: '8px', paddingLeft: '20px', ...removeSelect }}>

--- a/packages/webapp/src/containers/Map/LocationSelectionModal/index.jsx
+++ b/packages/webapp/src/containers/Map/LocationSelectionModal/index.jsx
@@ -7,6 +7,7 @@ import { canShowSelectionSelector, mapLocationsSelector } from '../../mapSlice';
 import PurePreviewPopup from '../../../components/Map/PreviewPopup';
 import { SENSOR } from '../../SensorReadings/constants';
 import { mapSensorSelector, sensorReadingsByLocationSelector } from '../mapSensorSlice';
+import { isTouchDevice } from '../../../util/device';
 
 export default function LocationSelectionModal({ history, selectingOnly }) {
   const { dismissSelectionModal } = useSelectionHandler();
@@ -34,7 +35,12 @@ export default function LocationSelectionModal({ history, selectingOnly }) {
     return (
       <>
         {showSelection && (
-          <div className={styles.selectionModal} onMouseDown={dismissSelectionModal}>
+          <div
+            className={styles.selectionModal}
+            {...(isTouchDevice()
+              ? { onTouchStart: dismissSelectionModal }
+              : { onMouseDown: dismissSelectionModal })}
+          >
             <div className={styles.selectionContainer}>
               <PureSelectionHandler
                 locations={locations}

--- a/packages/webapp/src/containers/Map/LocationSelectionModal/index.jsx
+++ b/packages/webapp/src/containers/Map/LocationSelectionModal/index.jsx
@@ -34,7 +34,7 @@ export default function LocationSelectionModal({ history, selectingOnly }) {
     return (
       <>
         {showSelection && (
-          <div className={styles.selectionModal} onClick={dismissSelectionModal}>
+          <div className={styles.selectionModal} onMouseDown={dismissSelectionModal}>
             <div className={styles.selectionContainer}>
               <PureSelectionHandler
                 locations={locations}

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -487,42 +487,37 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
       this.setOptions({ icon: icons[type] });
     });
 
-    let longPressed, longPressTimeout, longPressActive;
+    let longPressed, longPressTimeout;
 
-    maps.event.addListener(marker, 'mousedown', function (event) {
-      longPressActive = true;
+    maps.event.addListener(marker, 'mousedown', function (mapsMouseEvent) {
       longPressed = false;
       longPressTimeout = setTimeout(function () {
-        if (longPressActive === true) {
-          longPressed = true;
+        longPressed = true;
+        if (point.type === 'sensor') {
+          map.panTo(grid_point);
+          const index = assetGeometries.sensor.findIndex(
+            (sensor) => sensor.location_id === point.location_id,
+          );
+          setTimeout(function () {
+            handleSelection(
+              MouseEvent.latLng,
+              { sensor: [assetGeometries.sensor[index]] },
+              maps,
+              true,
+              false,
+              true,
+            );
+          }, 400);
         }
-      }, 200);
+      }, 800);
     });
 
-    maps.event.addListener(marker, 'mouseup', function (event) {
+    maps.event.addListener(marker, 'mouseup', function (mapsMouseEvent) {
       clearTimeout(longPressTimeout);
-      longPressActive = false;
-    });
-
-    // Event listener for point click
-    maps.event.addListener(marker, 'click', function (mapsMouseEvent) {
       const latlng = map.getCenter().toJSON();
-      dispatch(setPosition(latlng));
-      dispatch(setZoomLevel(map.getZoom()));
-      if (point.type === 'sensor' && longPressed) {
-        map.setCenter(grid_point);
-        const index = assetGeometries.sensor.findIndex(
-          (sensor) => sensor.location_id === point.location_id,
-        );
-        handleSelection(
-          MouseEvent.latLng,
-          { sensor: [assetGeometries.sensor[index]] },
-          maps,
-          true,
-          false,
-          true,
-        );
-      } else {
+      if (!longPressed) {
+        dispatch(setPosition(latlng));
+        dispatch(setZoomLevel(map.getZoom()));
         handleSelection(mapsMouseEvent.latLng, assetGeometries, maps, true);
       }
     });


### PR DESCRIPTION
Ticket [LF-2730](https://lite-farm.atlassian.net/browse/LF-2730)

**To Test:**
Case 1:
1. Have at least 2 sensors uploaded to the map (apart from each other so they're not clustered up).
2. Long press a sensor for about 1 second (0.8 seconds to be exact) without lifting the mouse up.
3. The map should pan to the long pressed sensor location (smoother transition than before).
4. Repeat step 2 for the other sensor (same result expected).

Case 2:
1. Now have at least 2 sensors clustered up (update the lat lng to be the same in the details page).
2. Click the cluster to see the list of sensors/other locations.
3. Long press a sensor in the list without lifting the mouse up.
4. The map should show the sensor preview popup.

Mobile:
1. Repeat the above two cases on mobile devices (using ngrok).

*may not work on android but there's a [separate ticket](https://lite-farm.atlassian.net/browse/LF-2722) for that so this PR won't cover android specific long press*