### PR TITLE
Other reason not showing up on read only task view

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1578,6 +1578,7 @@
         "WEATHER": "Weather"
       },
       "REASON_FOR_ABANDONMENT": "Reason for abandoning",
+      "EXPLANATION": "Explanation",
       "TITLE": "Abandon task",
       "WHAT_HAPPENED": "What happened?",
       "WHEN": "When was the task abandoned?"

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1513,6 +1513,7 @@
         "WEATHER": "Clima"
       },
       "REASON_FOR_ABANDONMENT": "Razón para abandonar",
+      "EXPLANATION": "MISSING",
       "TITLE": "Abandonar tarea",
       "WHAT_HAPPENED": "¿Qué sucedió?",
       "WHEN": "¿Cuándo se abandonó la tarea?"

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1514,6 +1514,7 @@
         "WEATHER": "Météo"
       },
       "REASON_FOR_ABANDONMENT": "Raison de l'abandon",
+      "EXPLANATION": "MISSING",
       "TITLE": "Abandonner la tâche",
       "WHAT_HAPPENED": "Que s'est-il passé\u00a0?",
       "WHEN": "Quand la tâche a-t-elle été abandonnée ?"

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1514,6 +1514,7 @@
         "WEATHER": "Clima"
       },
       "REASON_FOR_ABANDONMENT": "Razão de abandono",
+      "EXPLANATION": "MISSING",
       "TITLE": "Abandonar tarefa",
       "WHAT_HAPPENED": "O que aconteceu?",
       "WHEN": "Quando a tarefa foi abandonada?"

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -120,6 +120,7 @@ export default function PureTaskReadOnly({
 
   const isCompleted = !!task.complete_date;
   const isAbandoned = !!task.abandon_date;
+  const isOtherReason = task.abandonment_reason === 'OTHER';
   const isCurrent = !isCompleted && !isAbandoned;
   const taskStatus = getTaskStatus(task);
 
@@ -315,6 +316,14 @@ export default function PureTaskReadOnly({
               value: task.abandonment_reason,
             }}
           />
+          {isOtherReason && (
+            <InputAutoSize
+              style={{ marginTop: '40px', marginBottom: '40px' }}
+              label={t('TASK.ABANDON.EXPLANATION')}
+              value={task.other_abandonment_reason}
+              disabled
+            />
+          )}
 
           {task.duration > 0 && (
             <TimeSlider


### PR DESCRIPTION
Create a task and abandon the task and set the reason for task abandoning to other and fill in the explanation. 
You should be able to click on the task read only card and be able to see the reason set to "other" and explanation there as well