### PR TITLE
fix: sensor reading types for sensors without brand

### DIFF
--- a/packages/api/db/migration/20220812191948_defualt_reading_types.js
+++ b/packages/api/db/migration/20220812191948_defualt_reading_types.js
@@ -1,0 +1,25 @@
+exports.up = function (knex) {
+  return knex('partner_reading_type').insert([
+    {
+      partner_id: 0,
+      readable_value: 'soil_water_content',
+    },
+    {
+      partner_id: 0,
+      readable_value: 'soil_water_potential',
+    },
+    {
+      partner_id: 0,
+      readable_value: 'temperature',
+    },
+  ]);
+};
+
+exports.down = function (knex) {
+  return knex.raw(
+    `
+    DELETE FROM partner_reading_type WHERE partner_id = 0 
+    AND readable_value IN ('soil_water_content', 'soil_water_potential', 'temperature');
+    `,
+  );
+};

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/saga.js
@@ -67,6 +67,7 @@ export function* getSensorReadingTypesSaga({ payload: { location_id } }) {
     const sensor_reading_types = sensor_reading_types_response.data;
     yield put(onSensorReadingTypesSuccess({ location_id, sensor_reading_types }));
   } catch (error) {
+    console.log(error);
     yield put(onLoadingSensorFail());
   }
 }
@@ -83,6 +84,7 @@ export function* getSensorBrandSaga({ payload: { location_id, partner_id } }) {
     const brand_name = brand_name_response.data;
     yield put(onSensorBrandSuccess({ location_id, brand_name }));
   } catch (error) {
+    console.log(error);
     yield put(onLoadingSensorFail());
   }
 }

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/saga.js
@@ -83,7 +83,6 @@ export function* getSensorBrandSaga({ payload: { location_id, partner_id } }) {
     const brand_name = brand_name_response.data;
     yield put(onSensorBrandSuccess({ location_id, brand_name }));
   } catch (error) {
-    console.log(error);
     yield put(onLoadingSensorFail());
   }
 }

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/saga.js
@@ -67,7 +67,6 @@ export function* getSensorReadingTypesSaga({ payload: { location_id } }) {
     const sensor_reading_types = sensor_reading_types_response.data;
     yield put(onSensorReadingTypesSuccess({ location_id, sensor_reading_types }));
   } catch (error) {
-    console.log(error);
     yield put(onLoadingSensorFail());
   }
 }


### PR DESCRIPTION
To test:
- Create a non ESCI sensor if you don't have one already
- Remove and re-add a sensor reading type