### PR TITLE
LF-2712 improve error message format for reading types

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -658,7 +658,6 @@ const parseCsvString = (csvString, mapping, delimiter = ',') => {
       const parsedRow = headers.reduce((previousObj, current, index) => {
         if (allowedHeaders.includes(current)) {
           const val = mapping[current].parseFunction(values[index].replace(/^(["'])(.*)\1$/, '$2')); // removes any surrounding quotation marks
-          console.log(val, mapping[current].validator(val));
           if (mapping[current].validator(val)) {
             previousObj[mapping[current].key] = val;
           } else {

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -70,6 +70,7 @@ const sensorController = {
       const { access_token } = await IntegratingPartnersModel.getAccessAndRefreshTokens(
         'Ensemble Scientific',
       );
+      const invalidReadingTypes = [];
       const { data, errors } = parseCsvString(req.file.buffer.toString(), {
         Name: {
           key: 'name',
@@ -113,6 +114,7 @@ const sensorController = {
             ];
             val.forEach((readingType) => {
               if (!allowedReadingTypes.includes(readingType)) {
+                invalidReadingTypes.push(readingType);
                 return false;
               }
             });
@@ -120,6 +122,7 @@ const sensorController = {
           },
           required: true,
           errorTranslationKey: sensorErrors.SENSOR_READING_TYPES,
+          variables: { invalidReadingTypes },
         },
         Depth: {
           key: 'depth',

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -482,7 +482,7 @@
         "SENSOR_NAME": "Invalid sensor name, must be between 1 and 100 characters.",
         "SENSOR_LATITUDE": "Invalid latitude value, must be between -90 and 90. and fewer than 10 decimals.",
         "SENSOR_LONGITUDE": "Invalid longitude value, must be between -180 and 180. and fewer than 10 decimals.",
-        "SENSOR_READING_TYPES": "Invalid reading type detected, valid values include: soil_water_content, soil_water_potential, temperature.",
+        "SENSOR_READING_TYPES": "Invalid reading type detected: {{ invalidReadingTypes }}. Valid values include: soil_water_content, soil_water_potential, temperature.",
         "SENSOR_DEPTH": "Invalid depth value, must be between 0 and 1000.",
         "SENSOR_BRAND": "Invalid brand name, must be between 1 and 100 characters.",
         "SENSOR_MODEL": "Invalid model name, must be between 1 and 100 characters.",

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -95,8 +95,9 @@ export function useValidateBulkSensorData(onUpload, t) {
         return {
           row: rowNumber,
           column: columnName,
-          errorMessage: t('FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.SENSOR_READING_TYPES'),
-          value: invalidReadingTypes.join(','),
+          errorMessage: t('FARM_MAP.BULK_UPLOAD_SENSORS.VALIDATION.SENSOR_READING_TYPES', {
+            invalidReadingTypes: invalidReadingTypes.join(', '),
+          }),
         };
       },
     },


### PR DESCRIPTION
Ticket [LF-2712](https://lite-farm.atlassian.net/browse/LF-2712)

To Test:
1. Create a "add sensors to litefarm" CSV file with invalid reading types.
2. Upload the file and download the error message.
3. The error message format should be changed to as described by the ticket.