### PR TITLE
Added the x-axix ticks and x axis labels

### DIFF
--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -97,8 +97,9 @@ const PureSensorReadingsLineChart = ({
   const renderDateOnXAxis = (tickProps) => {
     const { x, y, payload, index } = tickProps;
     const { value, offset } = payload;
-    const displayDate = dateFormat.format(new Date(value));
-    const displayDay = dayFormat.format(new Date(value));
+    const tickDate = new Date(value);
+    const displayDate = dateFormat.format(tickDate);
+    const displayDay = dayFormat.format(tickDate);
 
     if (index % 4 == 2) {
       return (

--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -93,12 +93,18 @@ const PureSensorReadingsLineChart = ({
   const renderDateOnXAxis = (tickProps) => {
     const { x, y, payload, index } = tickProps;
     const { value, offset } = payload;
-    const displayDate = moment(value).format('ddd, MMM DD');
+    const displayDate = moment(value).format('DD');
+    const displayDay = moment(value).format('ddd');
     if (index % 4 == 2) {
       return (
-        <text x={x} y={y - 16} textAnchor="middle">
-          {displayDate}
-        </text>
+        <>
+          <text x={x} y={y - 16} textAnchor="middle">
+            {displayDate}
+          </text>
+          <text x={x} y={y} textAnchor="middle">
+            {displayDay}
+          </text>
+        </>
       );
     }
     if (index % 4 === 0 && index !== 0) {
@@ -127,14 +133,14 @@ const PureSensorReadingsLineChart = ({
       </div>
       <Label className={styles.subTitle}>{subTitle}</Label>
       <Label className={styles.subTitle}>{weatherStationName}</Label>
-      <ResponsiveContainer width="100%" height="50%">
+      <ResponsiveContainer width="100%" height="60%">
         <LineChart
           data={chartData}
           margin={{
             top: 20,
             right: 30,
-            left: 5,
-            bottom: 20,
+            left: 20,
+            bottom: 60,
           }}
         >
           <pattern
@@ -150,14 +156,9 @@ const PureSensorReadingsLineChart = ({
             <rect x="0" y="0" width="100%" height="100%" fill="url(#pattern-stripe)" />
           </mask>
           <CartesianGrid strokeDasharray="1 1" />
+          <XAxis dataKey={xAxisDataKey} tick={false} tickFormatter={dateTickFormatter} />
           <XAxis
-            label={{ value: xAxisLabel, position: 'insideBottom' }}
-            dataKey={xAxisDataKey}
-            tick={false}
-            tickFormatter={dateTickFormatter}
-          />
-          <XAxis
-            label={{ value: xAxisLabel, position: 'insideBottom' }}
+            label={{ value: xAxisLabel, position: 'insideBottom', dy: 45 }}
             dataKey={xAxisDataKey}
             axisLine={false}
             tickLine={false}
@@ -167,13 +168,7 @@ const PureSensorReadingsLineChart = ({
             scale="band"
             xAxisId="quarter"
           />
-          <YAxis
-            label={
-              <AxisLabel axisType="yAxis" x={25} y={165} width={0} height={0}>
-                {yAxisLabel}
-              </AxisLabel>
-            }
-          />
+          <YAxis label={{ value: yAxisLabel, position: 'insideCenter', angle: -90, dx: -20 }} />
           <Tooltip />
           {yAxisDataKeys.length > 1 && (
             <Legend

--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -17,7 +17,7 @@ import { Label, Semibold } from '../Typography';
 import PropTypes from 'prop-types';
 import AxisLabel from './AxisLabel';
 import PredictedRect from './PredictedRect';
-import moment from 'moment';
+import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
 
 const PureSensorReadingsLineChart = ({
   title,
@@ -33,6 +33,10 @@ const PureSensorReadingsLineChart = ({
   predictedXAxisLabel,
 }) => {
   const [legendsList, setLegendsList] = useState({});
+
+  const language = getLanguageFromLocalStorage();
+  const dateFormat = new Intl.DateTimeFormat(language, { day: '2-digit' });
+  const dayFormat = new Intl.DateTimeFormat(language, { weekday: 'short' });
 
   useEffect(() => {
     if (yAxisDataKeys.length) {
@@ -93,8 +97,9 @@ const PureSensorReadingsLineChart = ({
   const renderDateOnXAxis = (tickProps) => {
     const { x, y, payload, index } = tickProps;
     const { value, offset } = payload;
-    const displayDate = moment(value).format('DD');
-    const displayDay = moment(value).format('ddd');
+    const displayDate = dateFormat.format(new Date(value));
+    const displayDay = dayFormat.format(new Date(value));
+
     if (index % 4 == 2) {
       return (
         <>

--- a/packages/webapp/src/components/SensorReadingsLineChart/styles.module.scss
+++ b/packages/webapp/src/components/SensorReadingsLineChart/styles.module.scss
@@ -21,7 +21,17 @@
 .legendWrapper{
   display: flex;
   margin-right: 32px;
-  justify-content: center;
+  justify-content: start;
+  flex-wrap: wrap;
+}
+
+@media (min-width: 500px) {
+  .legendWrapper{
+    display: flex;
+    margin-right: 32px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
 }
 
 .legendContainer{
@@ -44,4 +54,19 @@
   justify-content: space-between;
   align-items: baseline;
   flex-wrap: wrap;
+}
+
+.graphWrapper{
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  overflow-x: scroll;
+  overflow-y: hidden;
+}
+
+.yAxisWrapper {
+  background: white;
+  position: sticky;
+  left: 0;
+  z-index: 3;
 }

--- a/packages/webapp/src/containers/SensorReadings/index.jsx
+++ b/packages/webapp/src/containers/SensorReadings/index.jsx
@@ -22,6 +22,7 @@ function SensorReadings({ history, match }) {
     nearestStationName = '',
     lastUpdatedReadingsTime = '',
     predictedXAxisLabel = '',
+    xAxisLabel = '',
   } = useSelector(bulkSensorsReadingsSliceSelector);
   const measurementUnit = useSelector(measurementSelector);
   const { tempUnit } = utils.getUnits(measurementUnit);
@@ -75,6 +76,7 @@ function SensorReadings({ history, match }) {
           },
         )}
         predictedXAxisLabel={predictedXAxisLabel}
+        xAxisLabel={xAxisLabel}
       />
     </div>
   );

--- a/packages/webapp/src/containers/SensorReadings/saga.js
+++ b/packages/webapp/src/containers/SensorReadings/saga.js
@@ -169,6 +169,14 @@ export function* getSensorsReadingsSaga({ payload }) {
     );
     const lastUpdatedReadingsTime = moment(lastUpdated).startOf('day').fromNow();
 
+    let xAxisLabel = '';
+    if (Object.keys(ambientDataWithSensorsReadings).length) {
+      const startDateObj = new Date(+Object.keys(ambientDataWithSensorsReadings)[0] * 1000);
+      const endDateObj = new Date(+Object.keys(ambientDataWithSensorsReadings).at(-1) * 1000);
+      xAxisLabel = `${moment(startDateObj).format('MMM DD')} - ${moment(endDateObj).format(
+        'MMM DD',
+      )}`;
+    }
     yield put(
       bulkSensorReadingsSuccess({
         sensorReadings: Object.values(ambientDataWithSensorsReadings),
@@ -177,6 +185,7 @@ export function* getSensorsReadingsSaga({ payload }) {
         nearestStationName: stationName,
         lastUpdatedReadingsTime,
         predictedXAxisLabel,
+        xAxisLabel,
       }),
     );
   } catch (error) {

--- a/packages/webapp/src/containers/SensorReadings/saga.js
+++ b/packages/webapp/src/containers/SensorReadings/saga.js
@@ -28,6 +28,7 @@ import { sensorUrl } from '../../apiConfig';
 import { getHeader } from '../../containers/saga';
 import { findCenter } from './utils';
 import { AMBIENT_TEMPERATURE, CURRENT_DATE_TIME } from './constants';
+import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
 
 const sensorReadingsUrl = () => `${sensorUrl}/reading/visualization`;
 
@@ -170,12 +171,18 @@ export function* getSensorsReadingsSaga({ payload }) {
     const lastUpdatedReadingsTime = moment(lastUpdated).startOf('day').fromNow();
 
     let xAxisLabel = '';
-    if (Object.keys(ambientDataWithSensorsReadings).length) {
-      const startDateObj = new Date(+Object.keys(ambientDataWithSensorsReadings)[0] * 1000);
-      const endDateObj = new Date(+Object.keys(ambientDataWithSensorsReadings).at(-1) * 1000);
-      xAxisLabel = `${moment(startDateObj).format('MMM DD')} - ${moment(endDateObj).format(
-        'MMM DD',
-      )}`;
+    const allTimestamps = Object.keys(ambientDataWithSensorsReadings);
+    if (allTimestamps.length) {
+      const startDateObj = new Date(+allTimestamps[0] * 1000);
+      const endDateObj = new Date(+allTimestamps.at(-1) * 1000);
+
+      const language = getLanguageFromLocalStorage();
+      const options = { month: 'short', day: '2-digit' };
+      const dateTimeFormat = new Intl.DateTimeFormat(language, options);
+
+      let startDateXAxisLabel = dateTimeFormat.format(startDateObj);
+      let endDateXAxisLabel = dateTimeFormat.format(endDateObj);
+      xAxisLabel = `${startDateXAxisLabel} - ${endDateXAxisLabel}`;
     }
     yield put(
       bulkSensorReadingsSuccess({

--- a/packages/webapp/src/containers/bulkSensorReadingsSlice.js
+++ b/packages/webapp/src/containers/bulkSensorReadingsSlice.js
@@ -9,6 +9,7 @@ const initialState = {
   nearestStationName: '',
   lastUpdatedReadingsTime: '',
   predictedXAxisLabel: '',
+  xAxisLabel: '',
 };
 
 const bulkSensorsReadingsSlice = createSlice({
@@ -25,6 +26,7 @@ const bulkSensorsReadingsSlice = createSlice({
         nearestStationName: '',
         lastUpdatedReadingsTime: '',
         predictedXAxisLabel: '',
+        xAxisLabel: '',
       });
     },
     bulkSensorReadingsLoading: (state, action) => {
@@ -37,6 +39,7 @@ const bulkSensorsReadingsSlice = createSlice({
         nearestStationName: '',
         lastUpdatedReadingsTime: '',
         predictedXAxisLabel: '',
+        xAxisLabel: '',
       });
     },
     bulkSensorReadingsSuccess: (state, { payload }) => {
@@ -50,6 +53,7 @@ const bulkSensorsReadingsSlice = createSlice({
           nearestStationName: payload?.nearestStationName,
           lastUpdatedReadingsTime: payload?.lastUpdatedReadingsTime,
           predictedXAxisLabel: payload?.predictedXAxisLabel,
+          xAxisLabel: payload?.xAxisLabel,
         });
       }
     },
@@ -60,6 +64,7 @@ const bulkSensorsReadingsSlice = createSlice({
       state.nearestStationName = '';
       state.lastUpdatedReadingsTime = '';
       state.predictedXAxisLabel = '';
+      state.xAxisLabel = '';
       (state.latestMinTemperature = null), (state.latestMaxTemperature = null);
     },
   },


### PR DESCRIPTION
To test: 

1. go to http://localhost:3000/sensor/<location_id>/readings
2. check if you can find the following changes on the x-axis in the line chart:

<img width="1105" alt="Screen Shot 2022-08-15 at 5 41 44 PM" src="https://user-images.githubusercontent.com/20675885/184759524-f3050eb5-b66f-44c5-bcdd-1be68128b2a4.png">


```
CREATE OR REPLACE FUNCTION generate_sensor_readings(
  readingType TEXT,
  unit TEXT,
  valid BOOLEAN,
  startDate DATE,
  endDate DATE,
  tMax REAL,
  tMin REAL 
  ) RETURNS INTEGER AS
$func$
DECLARE 
 currentDate DATE := NOW();
 valueData REAL := 0;
 r RECORD;
 s RECORD;
 intervalDuration TEXT := '1 hour';
 returnedID TEXT := '';
 counter INTEGER := 0;
BEGIN
  EXECUTE $$ TRUNCATE TABLE sensor_reading $$;  
  FOR s IN SELECT * FROM sensor LOOP 
    FOR r IN SELECT * FROM generate_series(
        startDate,endDate, 
        intervalDuration::INTERVAL) AS s(i) LOOP
        
        valueData := ROUND((RANDOM()*(tMax-tMin)+tMin)::NUMERIC, 1);
        EXECUTE $$
        INSERT INTO public.sensor_reading(
        location_id, 
        read_time, 
        created_at, 
        reading_type, 
        value, 
        unit, 
        valid)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING reading_id $$     
        USING s.location_id, r.i ,currentDate, readingType, 
        valueData, unit ,valid
        INTO returnedID;
        counter := counter + 1;
    END LOOP;
  END LOOP;
  RETURN counter;
END
$func$ LANGUAGE plpgsql;
SELECT 
generate_sensor_readings AS g_asd 
FROM generate_sensor_readings(
    'temperature', 
    'C', 
    true, 
    '2022-08-05', 
    '2022-08-20',
    17,
    23.5
);
```
