### PR TITLE
Various sensor fixes

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -478,7 +478,7 @@
       "VALIDATION": {
         "FILE_ROW_LIMIT_EXCEEDED": "File row limit exceeded. The max number of sensors that can be uploaded from a file is 100.",
         "MISSING_COLUMNS": "Columns are required/missing.",
-        "EXTERNAL_ID": "Invalid external id, must be between 1 and 20 characters.",
+        "EXTERNAL_ID": "Invalid external id, must be between 1 and 40 characters.",
         "SENSOR_NAME": "Invalid sensor name, must be between 1 and 100 characters.",
         "SENSOR_LATITUDE": "Invalid latitude value, must be between -90 and 90. and fewer than 10 decimals.",
         "SENSOR_LONGITUDE": "Invalid longitude value, must be between -180 and 180. and fewer than 10 decimals.",

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -112,20 +112,23 @@ export function useValidateBulkSensorData(onUpload, t) {
   // errors on the modal frontend.
   useEffect(() => {
     let validationErrorsResponseList = bulkSensorsUploadResponse?.validationErrors || [];
+    // console.table(validationErrorsResponseList)
     if (validationErrorsResponseList.length) {
       const sheetErrorResponse = {
         sheetName: 'API_ERROR_SHEET',
         errors: [],
       };
       sheetErrorResponse.errors = validationErrorsResponseList.reduce((acc, validationError) => {
+        console.log(validationError);
         acc.push({
-          column: validationError?.errorColumn ?? '',
-          errorMessage: '',
-          row: validationError?.line ?? '',
-          value: '',
+          column: validationError?.column ?? '',
+          errorMessage: t(validationError?.translation_key) ?? '',
+          row: validationError?.row ?? '',
+          value: validationError?.errorMessage ?? '',
         });
         return acc;
       }, []);
+      setErrorCount(sheetErrorResponse?.errors?.length);
       setSheetErrors([sheetErrorResponse]);
     }
   }, [bulkSensorsUploadResponse?.validationErrors]);

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -112,14 +112,12 @@ export function useValidateBulkSensorData(onUpload, t) {
   // errors on the modal frontend.
   useEffect(() => {
     let validationErrorsResponseList = bulkSensorsUploadResponse?.validationErrors || [];
-    // console.table(validationErrorsResponseList)
     if (validationErrorsResponseList.length) {
       const sheetErrorResponse = {
         sheetName: 'API_ERROR_SHEET',
         errors: [],
       };
       sheetErrorResponse.errors = validationErrorsResponseList.reduce((acc, validationError) => {
-        console.log(validationError);
         acc.push({
           column: validationError?.column ?? '',
           errorMessage: t(validationError?.translation_key) ?? '',


### PR DESCRIPTION
This PR resolves https://lite-farm.atlassian.net/browse/LF-2667, https://lite-farm.atlassian.net/browse/LF-2713, https://lite-farm.atlassian.net/browse/LF-2678, and https://lite-farm.atlassian.net/browse/LF-2725

To test:
1. Either use ngrok or comment out line 209 in `sensorController.js`
2. Take a valid sensor upload file
3. Duplicate one of the sensors (it should have the same brand and external_id as another sensor in the file)
4. Add an empty row after the existing rows (this works better in a raw text editor than in excel) - you can also put the empty rows between existing rows, but the frontend validation doesn't always allow this.
5. Upload this file - this should succeed! Only the first of the two duplicate sensors should be created on the farm, and it shouldn't complain about validation for the empty row (in the response from the backend - this PR doesn't change how it works on the frontend).
6. Look at a newly created sensor - it's depth should be the value from the upload file in cm.
7. Modify a sensor in the csv to have an External_Id longer than 40 characters and upload the file. You should get a validation error response from the API.