### PR TITLE
Fixed issue with clusters only sometimes working

### DIFF
--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -150,7 +150,7 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
 
     markerClusterRef.current.addMarkers(markers, true);
     maps.event.addListener(markerClusterRef.current, 'click', (cluster) => {
-      if (map.getZoom() >= (maxZoomRef?.current || 20) && cluster.markers.length > 1) {
+      if (map.getZoom() > (maxZoomRef?.current || 20) && cluster.markers.length > 1) {
         const pointAssets = {
           gate: [],
           water_valve: [],


### PR DESCRIPTION
This PR resolves the issues discussed in the comments on https://lite-farm.atlassian.net/browse/LF-2632

To test:
1. Create a new farm, or go to a farm without any other locations on the map.
2. Add two gates that are close together on the map, but not touching at the closest zoom level.
3. Zoom out so that these gates appear as a cluster.
4. Click on the cluster - it should zoom you in and show the two locations, instead of showing a location selector popup and then showing the two locations.