### PR TITLE
LF-2528 compact temperature component type bug fix

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -50,7 +50,7 @@ const sensorController = {
     const { farm_id } = req.params;
     try {
       const allSensorReadingTypesResponse = await SensorModel.getAllSensorReadingTypes(farm_id);
-      const allReadingTypes = allSensorReadingTypesResponse.rows.reduce((obj, item) => {
+      const allReadingTypesObject = allSensorReadingTypesResponse.rows.reduce((obj, item) => {
         if (item.location_id in obj) {
           obj[item.location_id].push(item.readable_value);
         } else {
@@ -58,6 +58,11 @@ const sensorController = {
         }
         return obj;
       }, {});
+      const allReadingTypes = Object.keys(allReadingTypesObject).map(key => {
+        return {
+          location_id: key, reading_types: allReadingTypesObject[key],
+        }
+      });
       res.status(200).send(allReadingTypes);
     } catch (error) {
       res.status(404).send('No sensors found');

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -46,6 +46,23 @@ const sensorController = {
       res.status(404).send('Sensor not found');
     }
   },
+  async getAllSensorReadingTypes(req, res) {
+    const { farm_id } = req.params;
+    try {
+      const allSensorReadingTypesResponse = await SensorModel.getAllSensorReadingTypes(farm_id);
+      const allReadingTypes = allSensorReadingTypesResponse.rows.reduce((obj, item) => {
+        if (item.location_id in obj) {
+          obj[item.location_id].push(item.readable_value);
+        } else {
+          obj[item.location_id] = [item.readable_value];
+        }
+        return obj;
+      }, {});
+      res.status(200).send(allReadingTypes);
+    } catch (error) {
+      res.status(404).send('No sensors found');
+    }
+  },
   async getBrandName(req, res) {
     try {
       const { partner_id } = req.params;

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -165,6 +165,18 @@ class Sensor extends Model {
     );
   }
 
+  static async getAllSensorReadingTypes(farm_id) {
+    return Model.knex().raw(
+      `
+        SELECT prt.readable_value, l.location_id FROM location as l
+        JOIN sensor_reading_type as srt ON srt.location_id = l.location_id 
+        JOIN partner_reading_type as prt ON srt.partner_reading_type_id = prt.partner_reading_type_id 
+        WHERE l.farm_id = ?;
+      `,
+      farm_id,
+    );
+  }
+
   static async patchSensorReadingTypes(location_id, readingTypes) {
     try {
       for (const readingTypeKey in readingTypes) {

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -45,6 +45,7 @@ router.get('/reading/farm/:farm_id', SensorController.getReadingsByFarmId);
 router.post('/reading/invalidate', SensorController.invalidateReadings);
 router.post('/unclaim', SensorController.retireSensor);
 router.get('/:location_id/reading_type', SensorController.getSensorReadingTypes);
+router.get('/:farm_id/reading_types', SensorController.getAllSensorReadingTypes);
 router.get('/partner/:partner_id/brand_name', SensorController.getBrandName);
 router.post('/reading/visualization', SensorController.getAllSensorReadingsByLocationIds);
 module.exports = router;

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -45,7 +45,7 @@ router.get('/reading/farm/:farm_id', SensorController.getReadingsByFarmId);
 router.post('/reading/invalidate', SensorController.invalidateReadings);
 router.post('/unclaim', SensorController.retireSensor);
 router.get('/:location_id/reading_type', SensorController.getSensorReadingTypes);
-router.get('/:farm_id/reading_types', SensorController.getAllSensorReadingTypes);
+router.get('/:farm_id/reading_type', SensorController.getAllSensorReadingTypes);
 router.get('/partner/:partner_id/brand_name', SensorController.getBrandName);
 router.post('/reading/visualization', SensorController.getAllSensorReadingsByLocationIds);
 module.exports = router;

--- a/packages/webapp/src/components/Map/PreviewPopup/index.jsx
+++ b/packages/webapp/src/components/Map/PreviewPopup/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from '@material-ui/core/styles';
@@ -7,9 +7,8 @@ import CompactPreview from './CompactPreview';
 import { TEMPERATURE } from '../../../containers/SensorReadings/constants';
 import { getTemperatureUnit, getTemperatureValue } from './utils';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
-import { useSelector, useDispatch } from 'react-redux';
-import { sensorsSelector } from '../../../containers/sensorSlice';
-import { getSensorReadingTypes } from '../../../containers/LocationDetails/PointDetails/SensorDetail/saga';
+import { useSelector } from 'react-redux';
+import { sensorReadingTypesByLocationSelector } from '../../../containers/sensorReadingTypesSlice';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -50,15 +49,10 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function PurePreviewPopup({ location, history, sensorReadings, styleOverride }) {
-  const dispatch = useDispatch();
   const classes = useStyles();
   const { t } = useTranslation();
   const { units } = useSelector(userFarmSelector);
-  const { sensor_reading_types } = useSelector(sensorsSelector(location.id));
-
-  useEffect(() => {
-    dispatch(getSensorReadingTypes({ location_id: location.id }));
-  }, []);
+  const { reading_types } = useSelector(sensorReadingTypesByLocationSelector(location.id));
 
   const loadReadingView = () => {
     history.push(`/${location.type}/${location.id}/readings`);
@@ -83,7 +77,7 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
    * Add other reading types in the "includes" clause when other compact components are developed.
    * This will allow the PreviewPopup component to only render if a sensor has reading data matching its reading type.
    */
-  if (sensor_reading_types.includes(TEMPERATURE)) {
+  if (reading_types.includes(TEMPERATURE)) {
     return (
       <div className={classes.container}>
         <div className={classes.tooltip} style={styleOverride}>

--- a/packages/webapp/src/components/Map/PreviewPopup/index.jsx
+++ b/packages/webapp/src/components/Map/PreviewPopup/index.jsx
@@ -8,7 +8,10 @@ import { TEMPERATURE } from '../../../containers/SensorReadings/constants';
 import { getTemperatureUnit, getTemperatureValue } from './utils';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import { useSelector } from 'react-redux';
-import { sensorReadingTypesByLocationSelector } from '../../../containers/sensorReadingTypesSlice';
+import {
+  sensorReadingTypesByLocationSelector,
+  sensorReadingTypesSelector,
+} from '../../../containers/sensorReadingTypesSlice';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -83,16 +86,18 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
         <div className={classes.tooltip} style={styleOverride}>
           <div className={classes.arrow} />
           <div className={classes.body}>
-            <CompactPreview
-              title={t('SENSOR.READINGS_PREVIEW.TEMPERATURE')}
-              value={
-                temperatureData.length
-                  ? getTemperatureValue(latestTemperatureData.value, units.measurement)
-                  : null
-              }
-              unit={temperatureData.length ? getTemperatureUnit(units.measurement) : null}
-              loadReadingView={loadReadingView}
-            />
+            {reading_types.includes(TEMPERATURE) && (
+              <CompactPreview
+                title={t('SENSOR.READINGS_PREVIEW.TEMPERATURE')}
+                value={
+                  temperatureData.length
+                    ? getTemperatureValue(latestTemperatureData.value, units.measurement)
+                    : null
+                }
+                unit={temperatureData.length ? getTemperatureUnit(units.measurement) : null}
+                loadReadingView={loadReadingView}
+              />
+            )}
             {/*other compact views*/}
           </div>
         </div>

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -20,6 +20,7 @@ import {
   setSpotlightToShown,
   bulkUploadSensorsInfoFile,
   getSensorReadings,
+  getAllSensorReadingTypes,
   resetBulkUploadSensorsInfoFile,
   resetShowTransitionModalState,
 } from './saga';
@@ -358,6 +359,7 @@ export default function Map({ history }) {
 
   useEffect(() => {
     dispatch(getSensorReadings());
+    dispatch(getAllSensorReadingTypes());
   }, []);
 
   const handleAddMenuClick = (locationType) => {

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -219,7 +219,7 @@ export function* getAllSensorReadingTypesSaga() {
   const header = getHeader(user_id, farm_id);
   try {
     yield put(onLoadingSensorReadingTypesStart());
-    const result = yield call(axios.get, `${sensorUrl}/${farm_id}/reading_types`, header);
+    const result = yield call(axios.get, `${sensorUrl}/${farm_id}/reading_type`, header);
     if (result.status === 200) {
       yield put(getSensorReadingTypesSuccess(result.data));
     } else {

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -42,6 +42,11 @@ import {
   onLoadingSensorReadingFail,
 } from './mapSensorSlice';
 import { postManySensorsSuccess } from '../sensorSlice';
+import {
+  getSensorReadingTypesSuccess,
+  onLoadingSensorReadingTypesFail,
+  onLoadingSensorReadingTypesStart,
+} from '../sensorReadingTypesSlice';
 
 const sendMapToEmailUrl = (farm_id) => `${url}/export/map/farm/${farm_id}`;
 const showedSpotlightUrl = () => `${url}/showed_spotlight`;
@@ -207,11 +212,31 @@ export function* getSensorReadingsSaga() {
   }
 }
 
+export const getAllSensorReadingTypes = createAction('getAllSensorReadingTypesSaga');
+
+export function* getAllSensorReadingTypesSaga() {
+  const { user_id, farm_id } = yield select(userFarmSelector);
+  const header = getHeader(user_id, farm_id);
+  try {
+    yield put(onLoadingSensorReadingTypesStart());
+    const result = yield call(axios.get, `${sensorUrl}/${farm_id}/reading_types`, header);
+    if (result.status === 200) {
+      yield put(getSensorReadingTypesSuccess(result.data));
+    } else {
+      yield put(onLoadingSensorReadingTypesFail(result.error));
+    }
+  } catch (e) {
+    yield put(onLoadingSensorReadingTypesFail(e));
+    console.error(e);
+  }
+}
+
 export default function* supportSaga() {
   yield takeLeading(sendMapToEmail.type, sendMapToEmailSaga);
   yield takeLeading(setSpotlightToShown.type, setSpotlightToShownSaga);
   yield takeLeading(bulkUploadSensorsInfoFile.type, bulkUploadSensorsInfoFileSaga);
   yield takeLeading(getSensorReadings.type, getSensorReadingsSaga);
+  yield takeLeading(getAllSensorReadingTypes.type, getAllSensorReadingTypesSaga);
   yield takeLeading(resetBulkUploadSensorsInfoFile.type, resetBulkUploadSensorsInfoFileSaga);
   yield takeLeading(resetShowTransitionModalState.type, resetShowTransitionModalStateSaga);
 }

--- a/packages/webapp/src/containers/sensorReadingTypesSlice.js
+++ b/packages/webapp/src/containers/sensorReadingTypesSlice.js
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import { createSelector } from 'reselect';
+
+const addManySensorReadingTypes = (state, { payload: sensorReadingsTypes }) => {
+  sensorReadingTypesAdapter.upsertMany(state, sensorReadingsTypes);
+};
+
+const sensorReadingTypesAdapter = createEntityAdapter({
+  selectId: (sensorReadingType) => sensorReadingType.location_id,
+});
+
+const sensorReadingTypesSlice = createSlice({
+  name: 'sensorReadingTypesReducer',
+  initialState: sensorReadingTypesAdapter.getInitialState({
+    loading: false,
+    loaded: false,
+    error: undefined,
+  }),
+  reducers: {
+    onLoadingSensorReadingTypesStart: (state) => {
+      state.loading = true;
+    },
+    onLoadingSensorReadingTypesFail: (state, { payload: error }) => {
+      state.loading = false;
+      state.error = error;
+      state.loaded = true;
+    },
+    getSensorReadingTypesSuccess: (state, { payload: sensorReadingsTypes }) => {
+      addManySensorReadingTypes(state, { payload: sensorReadingsTypes });
+      state.loading = false;
+      state.loaded = true;
+      state.error = null;
+    },
+  },
+});
+
+export const {
+  onLoadingSensorReadingTypesStart,
+  onLoadingSensorReadingTypesFail,
+  getSensorReadingTypesSuccess,
+} = sensorReadingTypesSlice.actions;
+export default sensorReadingTypesSlice.reducer;
+
+export const sensorReadingTypesReducerSelector = (state) =>
+  state.persistedStateReducer[sensorReadingTypesSlice.name];
+
+const sensorReadingTypesSelectors = sensorReadingTypesAdapter.getSelectors(
+  (state) => state.persistedStateReducer[sensorReadingTypesSlice.name],
+);
+
+export const sensorReadingTypesSelector = createSelector(
+  [sensorReadingTypesSelectors.selectEntities],
+  (sensorReadingTypesEntities) => {
+    return sensorReadingTypesEntities;
+  },
+);
+
+export const sensorReadingTypesByLocationSelector = (locationId) => {
+  return createSelector(
+    [sensorReadingTypesSelectors.selectEntities],
+    (sensorReadingTypesEntities) => {
+      return sensorReadingTypesEntities[locationId];
+    },
+  );
+};

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -62,6 +62,7 @@ import mapLocationReducer from '../containers/mapSlice';
 import mapFilterSettingReducer from '../containers/Map/mapFilterSettingSlice';
 import mapCacheReducer from '../containers/Map/mapCacheSlice';
 import mapSensorReducer from '../containers/Map/mapSensorSlice';
+import sensorReadingTypesReducer from '../containers/sensorReadingTypesSlice';
 import showedSpotlightReducer from '../containers/showedSpotlightSlice';
 import bulkSensorsUploadReducer from '../containers/bulkSensorUploadSlice';
 import bulkSensorsReadingsReducer from '../containers/bulkSensorReadingsSlice';
@@ -210,6 +211,7 @@ const persistedStateReducer = combineReducers({
   mapFilterSettingReducer,
   mapCacheReducer,
   mapSensorReducer,
+  sensorReadingTypesReducer,
   appSettingReducer,
 });
 


### PR DESCRIPTION
Read the latest comment by Mwaya from [LF-2528](https://lite-farm.atlassian.net/browse/LF-2528)

The issue was that sensor reading preview popup was being rendered for all sensors regardless of their reading types. If a sensor's reading type is "soil water content", the preview popup should not render compact temperature view. Currently, no matter what a sensor's reading types are, compact temperature view is visible.

Currently, reading types are added to the redux store (sensor individually) when a sensor detail's page is rendered. I tried to dispatch that action when a sensor's preview is activated, but that triggers re-rendering of the map component, which messes up the zoom level of the map. So I had to find a way to store reading types of all sensors of that farm when the map is rendered.

To Test:
1. Have multiple sensors on the map. (one sensor needs to have "temperature" as its reading types, other sensors need to exclude "temperature" as their reading types).
2. Long press the temperature sensor on the map. It should popup the preview component with "current soil temp".
3. Long press the other sensors on the map. It should not popup anything since we do not have any other compact reading components (i.e. soil water content, etc.)
4. You can try step 2 & 3 again after editing the sensors' reading types in their details page.