### PR TITLE
LF-2642 crop plan based pop up for adding a location

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1105,6 +1105,11 @@
     "WHERE_TRANSPLANT_LOCATION": "Where will you transplant to?",
     "WILD_CROP": "Are you harvesting a wild crop?"
   },
+  "LOCATION_CREATION": {
+    "TITLE": "No locations found!",
+    "CROP_PLAN_BODY": "You’ll need a Field, Garden, Greenhouse, or Buffer Zone before you can finish this crop plan. Do you want to create one now?",
+    "CREATE_BUTTON": "Create Location"
+  },
   "MY_FARM": {
     "CERTIFICATIONS": "Certifications",
     "FARM_INFO": "Farm info",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1108,6 +1108,11 @@
     "WHERE_TRANSPLANT_LOCATION": "¿A dónde va a trasplantar?",
     "WILD_CROP": "¿Estás cosechando un cultivo silvestre?"
   },
+  "LOCATION_CREATION": {
+    "TITLE": "MISSING",
+    "CROP_PLAN_BODY": "MISSING",
+    "CREATE_BUTTON": "MISSING"
+  },
   "MY_FARM": {
     "CERTIFICATIONS": "Certificaciones",
     "FARM_INFO": "Información de la finca",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1109,6 +1109,11 @@
     "WHERE_TRANSPLANT_LOCATION": "Où allez-vous transplanter?",
     "WILD_CROP": "Récoltez-vous une culture sauvage\u00a0?"
   },
+  "LOCATION_CREATION": {
+    "TITLE": "MISSING",
+    "CROP_PLAN_BODY": "MISSING",
+    "CREATE_BUTTON": "MISSING"
+  },
   "MY_FARM": {
     "CERTIFICATIONS": "Certifications",
     "FARM_INFO": "Informations sur la ferme",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1109,6 +1109,11 @@
     "WHERE_TRANSPLANT_LOCATION": "Onde você fará o transplante?",
     "WILD_CROP": "Você está colhendo uma planta silvestre?"
   },
+  "LOCATION_CREATION": {
+    "TITLE": "MISSING",
+    "CROP_PLAN_BODY": "MISSING",
+    "CREATE_BUTTON": "MISSING"
+  },
   "MY_FARM": {
     "CERTIFICATIONS": "Certificações",
     "FARM_INFO": "Informação da fazenda",

--- a/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
@@ -102,6 +102,8 @@ export default function PurePlantingLocation({
     setCreateCropLocation(false);
   };
 
+  const onCreateCropLocation = () => {};
+
   const handlePinMode = () => {
     setPinToggle((pinToggle) => !pinToggle);
   };
@@ -189,7 +191,14 @@ export default function PurePlantingLocation({
           />
         )}
         {createCropLocation && (
-          <LocationCreationModal dismissModal={dismissLocationCreationModal} />
+          <LocationCreationModal
+            title={'No locations found! (need translation)'}
+            body={
+              'You’ll need a Field, Garden, Greenhouse, or Buffer Zone before you can finish this crop plan. Do you want to create one now?'
+            }
+            dismissModal={dismissLocationCreationModal}
+            locationCreation={onCreateCropLocation}
+          />
         )}
       </Layout>
     </>

--- a/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
@@ -192,10 +192,8 @@ export default function PurePlantingLocation({
         )}
         {createCropLocation && (
           <LocationCreationModal
-            title={'No locations found! (need translation)'}
-            body={
-              'You’ll need a Field, Garden, Greenhouse, or Buffer Zone before you can finish this crop plan. Do you want to create one now?'
-            }
+            title={t('LOCATION_CREATION.TITLE')}
+            body={t('LOCATION_CREATION.CROP_PLAN_BODY')}
             dismissModal={dismissLocationCreationModal}
             locationCreation={onCreateCropLocation}
           />

--- a/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
@@ -12,6 +12,7 @@ import Checkbox from '../../Form/Checkbox';
 import { useForm } from 'react-hook-form';
 import { cloneObject } from '../../../util';
 import { getPlantingLocationPaths } from '../getAddManagementPlanPath';
+import LocationCreationModal from '../../LocationCreationModal';
 
 export default function PurePlantingLocation({
   persistedFormData,
@@ -94,6 +95,12 @@ export default function PurePlantingLocation({
   useEffect(() => {
     setPinToggle(!!pinCoordinate && showPinButton);
   }, [showPinButton]);
+
+  const [createCropLocation, setCreateCropLocation] = useState(!cropLocations.length);
+
+  const dismissLocationCreationModal = () => {
+    setCreateCropLocation(false);
+  };
 
   const handlePinMode = () => {
     setPinToggle((pinToggle) => !pinToggle);
@@ -180,6 +187,9 @@ export default function PurePlantingLocation({
             checked={!!defaultInitialLocationId}
             onChange={defaultLocationCheckboxOnChange}
           />
+        )}
+        {createCropLocation && (
+          <LocationCreationModal dismissModal={dismissLocationCreationModal} />
         )}
       </Layout>
     </>

--- a/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
@@ -13,6 +13,9 @@ import { useForm } from 'react-hook-form';
 import { cloneObject } from '../../../util';
 import { getPlantingLocationPaths } from '../getAddManagementPlanPath';
 import LocationCreationModal from '../../LocationCreationModal';
+import { useDispatch, useSelector } from 'react-redux';
+import { setMapFilterSetting } from '../../../containers/Map/mapFilterSettingSlice';
+import { userFarmSelector } from '../../../containers/userFarmSlice';
 
 export default function PurePlantingLocation({
   persistedFormData,
@@ -25,11 +28,13 @@ export default function PurePlantingLocation({
   farmCenterCoordinate,
 }) {
   const { t } = useTranslation(['translation', 'common', 'crop']);
+  const dispatch = useDispatch();
   const { getValues, watch, setValue } = useForm({
     defaultValues: cloneObject(persistedFormData),
     shouldUnregister: false,
   });
   const { historyCancel } = useHookFormPersist(getValues);
+  const { farm_id } = useSelector(userFarmSelector);
 
   const {
     crop_management_plan: { needs_transplant, is_seed, is_wild, already_in_ground },
@@ -102,7 +107,13 @@ export default function PurePlantingLocation({
     setCreateCropLocation(false);
   };
 
-  const onCreateCropLocation = () => {};
+  const onCreateCropLocation = () => {
+    const payload = {};
+    payload.farm_id = farm_id;
+    payload.addDrawer = true;
+    dispatch(setMapFilterSetting(payload));
+    history.push('/map');
+  };
 
   const handlePinMode = () => {
     setPinToggle((pinToggle) => !pinToggle);

--- a/packages/webapp/src/components/LocationCreationModal/index.jsx
+++ b/packages/webapp/src/components/LocationCreationModal/index.jsx
@@ -36,7 +36,7 @@ export default function LocationCreationModal({ title, body, dismissModal, locat
             {t('common:BACK')}
           </Button>
           <Button onClick={locationCreation} sm>
-            Create location
+            {t('LOCATION_CREATION.CREATE_BUTTON')}
           </Button>
         </div>
       </div>

--- a/packages/webapp/src/components/LocationCreationModal/index.jsx
+++ b/packages/webapp/src/components/LocationCreationModal/index.jsx
@@ -1,32 +1,52 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from '../Modals';
 import styles from './styles.module.scss';
 import Button from '../Form/Button';
 import PropTypes from 'prop-types';
+import { Info, Semibold } from '../Typography';
 
-export default function LocationCreationModal({
-  title,
-  uploadPlaceholder,
-  dismissModal,
-  onUpload,
-  disabled,
-}) {
+export default function LocationCreationModal({ title, body, dismissModal, locationCreation }) {
   const { t } = useTranslation();
 
   return (
     <Modal dismissModal={dismissModal}>
-      <div className={styles.container}></div>
+      <div className={styles.container}>
+        <div className={styles.modalHeaderWrapper}>
+          <Semibold className={styles.title}>{title}</Semibold>
+        </div>
+        <Info className={styles.body}>{body}</Info>
+        <div className={styles.buttonContainer}>
+          <Button onClick={dismissModal} sm>
+            {t('common:BACK')}
+          </Button>
+          <Button onClick={locationCreation} sm>
+            Create location
+          </Button>
+        </div>
+      </div>
     </Modal>
   );
 }
 
 LocationCreationModal.prototype = {
   title: PropTypes.string,
-  uploadInstructionMessage: PropTypes.string,
-  uploadPlaceholder: PropTypes.string,
+  body: PropTypes.string,
   dismissModal: PropTypes.func,
-  disabled: PropTypes.bool,
-  onUpload: PropTypes.func,
-  onTemplateDownloadClick: PropTypes.func,
+  locationCreation: PropTypes.func,
 };

--- a/packages/webapp/src/components/LocationCreationModal/index.jsx
+++ b/packages/webapp/src/components/LocationCreationModal/index.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Modal } from '../Modals';
+import styles from './styles.module.scss';
+import Button from '../Form/Button';
+import PropTypes from 'prop-types';
+
+export default function LocationCreationModal({
+  title,
+  uploadPlaceholder,
+  dismissModal,
+  onUpload,
+  disabled,
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal dismissModal={dismissModal}>
+      <div className={styles.container}></div>
+    </Modal>
+  );
+}
+
+LocationCreationModal.prototype = {
+  title: PropTypes.string,
+  uploadInstructionMessage: PropTypes.string,
+  uploadPlaceholder: PropTypes.string,
+  dismissModal: PropTypes.func,
+  disabled: PropTypes.bool,
+  onUpload: PropTypes.func,
+  onTemplateDownloadClick: PropTypes.func,
+};

--- a/packages/webapp/src/components/LocationCreationModal/styles.module.scss
+++ b/packages/webapp/src/components/LocationCreationModal/styles.module.scss
@@ -46,10 +46,3 @@
   margin-bottom: 16px;
   align-items: center;
 }
-
-.errorMessage{
-  text-decoration: underline;
-  font-size: 12px;
-  color: var(--red700); 
-  cursor: pointer;
-}

--- a/packages/webapp/src/components/LocationCreationModal/styles.module.scss
+++ b/packages/webapp/src/components/LocationCreationModal/styles.module.scss
@@ -28,84 +28,23 @@
   color: var(--teal700);
   line-height: 24px;
   margin-bottom: 4px;
-  margin-left: 12px;
 }
 
-.buttonUpload{
-  margin-top: 20px;
-}
-
-.uploadSelectInput{
-  border: 1px solid var(--grey400);
-  box-sizing: border-box;
-  border-radius: 4px;
-  height: 48px;
-  padding-left: 8px;
-  font-size: 16px;
-  line-height: 24px;
-  color: var(--fontColor);
-  background-color: transparent;
-  background-position: calc(100% - 36px) 50%;
-  font-family: Open Sans,SansSerif,serif; 
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-
-.invalidateUploadSelectInput{
-  border: 1px solid var(--red700); 
-  box-sizing: border-box;
-  border-radius: 4px;
-  height: 48px;
-  padding-left: 8px;
-  font-size: 16px;
-  line-height: 24px;
-  color: var(--fontColor);
-  background-color: transparent;
-  background-position: calc(100% - 36px) 50%;
-  font-family: Open Sans,SansSerif,serif; 
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-
-.uploadPlaceholder{
-  margin-top: 24px;  
-  margin-bottom: 4px;
+.body {
+  color: var(grey600);
+  margin-bottom: 20px;
 }
 
 .buttonContainer {
-  background: none;
-  border: 0;
-  color: var(--buttonPrimary);
-  cursor: pointer;
-  max-height: 32px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .modalHeaderWrapper {
   display: flex;
   margin-bottom: 16px;
   align-items: center;
-}
-
-.fileNameLabel{
-  margin-bottom: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.uploadIconContainer{
-  font-size: 20px;
-  color: var(--grey600); 
-  margin-right: 8px;
-  min-width: 20px;
-}
-
-.csvErrorMessageWrapper{
-  font-size: 12px;
-  color: var(--red700); 
-  margin-top: 8px;
 }
 
 .errorMessage{

--- a/packages/webapp/src/components/LocationCreationModal/styles.module.scss
+++ b/packages/webapp/src/components/LocationCreationModal/styles.module.scss
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+.container {
+  display: flex;
+  flex-direction: column;
+  max-width: 350px;
+  width: 90vw;
+  background: #fafafd;
+  border-radius: 7.05466px;
+  position: relative;
+  padding: 24px;
+}
+
+.title {
+  color: var(--teal700);
+  line-height: 24px;
+  margin-bottom: 4px;
+  margin-left: 12px;
+}
+
+.buttonUpload{
+  margin-top: 20px;
+}
+
+.uploadSelectInput{
+  border: 1px solid var(--grey400);
+  box-sizing: border-box;
+  border-radius: 4px;
+  height: 48px;
+  padding-left: 8px;
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--fontColor);
+  background-color: transparent;
+  background-position: calc(100% - 36px) 50%;
+  font-family: Open Sans,SansSerif,serif; 
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.invalidateUploadSelectInput{
+  border: 1px solid var(--red700); 
+  box-sizing: border-box;
+  border-radius: 4px;
+  height: 48px;
+  padding-left: 8px;
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--fontColor);
+  background-color: transparent;
+  background-position: calc(100% - 36px) 50%;
+  font-family: Open Sans,SansSerif,serif; 
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.uploadPlaceholder{
+  margin-top: 24px;  
+  margin-bottom: 4px;
+}
+
+.buttonContainer {
+  background: none;
+  border: 0;
+  color: var(--buttonPrimary);
+  cursor: pointer;
+  max-height: 32px;
+}
+
+.modalHeaderWrapper {
+  display: flex;
+  margin-bottom: 16px;
+  align-items: center;
+}
+
+.fileNameLabel{
+  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.uploadIconContainer{
+  font-size: 20px;
+  color: var(--grey600); 
+  margin-right: 8px;
+  min-width: 20px;
+}
+
+.csvErrorMessageWrapper{
+  font-size: 12px;
+  color: var(--red700); 
+  margin-top: 8px;
+}
+
+.errorMessage{
+  text-decoration: underline;
+  font-size: 12px;
+  color: var(--red700); 
+  cursor: pointer;
+}

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -281,6 +281,7 @@ export default function Map({ history }) {
       setShowingConfirmButtons(true);
       finishDrawing(drawing, maps, map);
       this.setDrawingMode();
+      dispatch(setMapFilterSetting({ farm_id, addDrawer: false }));
     });
     initDrawingState(map, maps, drawingManagerInit, {
       POLYGON: maps.drawing.OverlayType.POLYGON,

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -163,8 +163,9 @@ export default function Map({ history }) {
     if (showHeader) setShowSuccessHeader(true);
   }, [showHeader]);
 
+  const showAddDrawer = filterSettings.addDrawer;
+
   const [showMapFilter, setShowMapFilter] = useState(false);
-  const [showAddDrawer, setShowAddDrawer] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showDrawAreaSpotlightModal, setShowDrawAreaSpotlightModal] = useState(false);
   const [showDrawLineSpotlightModal, setShowDrawLineSpotlightModal] = useState(false);
@@ -326,18 +327,18 @@ export default function Map({ history }) {
   const handleClickAdd = () => {
     setShowExportModal(false);
     setShowMapFilter(false);
-    setShowAddDrawer(!showAddDrawer);
+    dispatch(setMapFilterSetting({ farm_id, addDrawer: !showAddDrawer }));
   };
 
   const handleClickExport = () => {
     setShowExportModal(!showExportModal);
     setShowMapFilter(false);
-    setShowAddDrawer(false);
+    dispatch(setMapFilterSetting({ farm_id, addDrawer: false }));
   };
 
   const handleClickFilter = () => {
     setShowExportModal(false);
-    setShowAddDrawer(false);
+    dispatch(setMapFilterSetting({ farm_id, addDrawer: false }));
     setShowMapFilter(!showMapFilter);
   };
 
@@ -368,7 +369,7 @@ export default function Map({ history }) {
     } else if (isLine(locationType) && !showedSpotlight.draw_line) {
       setShowDrawLineSpotlightModal(true);
     } else if (locationType === locationEnum.sensor) {
-      setShowAddDrawer(!showAddDrawer);
+      dispatch(setMapFilterSetting({ farm_id, addDrawer: !showAddDrawer }));
       setShowBulkSensorUploadModal(true);
       dispatch(resetBulkUploadSensorsInfoFile());
       return;
@@ -437,7 +438,7 @@ export default function Map({ history }) {
 
   const dismissBulkSensorsUploadModal = () => {
     setShowBulkSensorUploadModal(false);
-    setShowAddDrawer(true);
+    dispatch(setMapFilterSetting({ farm_id, addDrawer: true }));
   };
 
   const { showAdjustAreaSpotlightModal, showAdjustLineSpotlightModal } = drawingState;
@@ -524,7 +525,9 @@ export default function Map({ history }) {
             showModal={showExportModal}
             setShowMapFilter={setShowMapFilter}
             showMapFilter={showMapFilter}
-            setShowAddDrawer={setShowAddDrawer}
+            setShowAddDrawer={(showAddDrawer) => {
+              dispatch(setMapFilterSetting({ farm_id, addDrawer: showAddDrawer }));
+            }}
             showAddDrawer={showAddDrawer}
             handleClickFilter={handleClickFilter}
             filterSettings={filterSettings}

--- a/packages/webapp/src/containers/Map/mapFilterSettingSlice.js
+++ b/packages/webapp/src/containers/Map/mapFilterSettingSlice.js
@@ -21,6 +21,7 @@ const initialState = {
   map_background: true,
   label: true,
   sensor: true,
+  addDrawer: false,
 };
 
 const mapFilterSettingAdapter = createEntityAdapter({


### PR DESCRIPTION
Ticket [LF-2642](https://lite-farm.atlassian.net/browse/LF-2642)

To Test:
1. Create a new farm without adding any locations on the map.
2. Create a new crop plan.
3. When entering select location page, there should be a popup.
4. Clicking "go back" will return the user to crop plan creation flow.
5. Clicking "create location" will redirect the user to the farm map with "+" tab expanded.