### PR TITLE
LF-2592: hyphenate long crop names on crop catalogue

### DIFF
--- a/packages/webapp/src/components/CropTile/styles.module.scss
+++ b/packages/webapp/src/components/CropTile/styles.module.scss
@@ -63,6 +63,10 @@
   font-weight: 600;
   font-size: 12px;
   line-height: 16px;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
+  overflow-wrap: break-word;
 }
 
 .infoBody {


### PR DESCRIPTION
Ticket: [LF-2592](https://lite-farm.atlassian.net/browse/LF-2592)

To test: 
- Go to the crop catalogue
- Add a crop with a long name
- See that the crop name breaks and hyphenates on the crop tile