### PR TITLE
Hotfix: sensor reading type route failing

### DIFF
--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -45,7 +45,7 @@ router.get('/reading/farm/:farm_id', SensorController.getReadingsByFarmId);
 router.post('/reading/invalidate', SensorController.invalidateReadings);
 router.post('/unclaim', SensorController.retireSensor);
 router.get('/:location_id/reading_type', SensorController.getSensorReadingTypes);
-router.get('/:farm_id/reading_type', SensorController.getAllSensorReadingTypes);
+router.get('/farm/:farm_id/reading_type', SensorController.getAllSensorReadingTypes);
 router.get('/partner/:partner_id/brand_name', SensorController.getBrandName);
 router.post('/reading/visualization', SensorController.getAllSensorReadingsByLocationIds);
 module.exports = router;

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -219,7 +219,7 @@ export function* getAllSensorReadingTypesSaga() {
   const header = getHeader(user_id, farm_id);
   try {
     yield put(onLoadingSensorReadingTypesStart());
-    const result = yield call(axios.get, `${sensorUrl}/${farm_id}/reading_type`, header);
+    const result = yield call(axios.get, `${sensorUrl}/farm/${farm_id}/reading_type`, header);
     if (result.status === 200) {
       yield put(getSensorReadingTypesSuccess(result.data));
     } else {


### PR DESCRIPTION
This PR fixes the issue where `sensor/:farm_id/reading_type` endpoint was not returning anything.