### PR TITLE
fix: invite user form name length validation

### DIFF
--- a/packages/webapp/src/components/Form/Input/utils.js
+++ b/packages/webapp/src/components/Form/Input/utils.js
@@ -5,3 +5,20 @@ export const isNotInFuture = (data) => {
     ? true
     : i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID');
 };
+
+export const isValidName = (name) => {
+  const nameSplit = name.split(/ (.+)/);
+  const firstName = nameSplit.length > 0 ? nameSplit[0] : '';
+  const lastName = nameSplit.length > 1 ? nameSplit[1] : '';
+  if (firstName.length > 255 && lastName.length > 255) {
+    return (
+      i18n.t('PROFILE.ERROR.FIRST_NAME_LENGTH') + ', ' + i18n.t('PROFILE.ERROR.LAST_NAME_LENGTH')
+    );
+  } else if (lastName.length > 255) {
+    return i18n.t('PROFILE.ERROR.LAST_NAME_LENGTH');
+  } else if (firstName.length > 255) {
+    return i18n.t('PROFILE.ERROR.FIRST_NAME_LENGTH');
+  } else {
+    return true;
+  }
+};

--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -1,6 +1,7 @@
 import Form from '../Form';
 import Button from '../Form/Button';
 import Input, { getInputErrors, integerOnKeyDown, numberOnKeyDown } from '../Form/Input';
+import { isValidName } from '../Form/Input/utils';
 import React, { useEffect } from 'react';
 import { Title } from '../Typography';
 import PropTypes from 'prop-types';
@@ -80,7 +81,7 @@ export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, rol
         data-cy="invite-fullName"
         style={{ marginBottom: '28px' }}
         label={t('INVITE_USER.FULL_NAME')}
-        hookFormRegister={register(NAME, { required: true })}
+        hookFormRegister={register(NAME, { required: true, validate: isValidName })}
         errors={getInputErrors(errors, NAME)}
       />
       <Controller


### PR DESCRIPTION
To test:
- Go to invite a new user to your farm
- Enter a name with a first name and/or last name greater than 255 characters
- You should get an appropriate inline error 