### PR TITLE
fix: spanish reading types issue

### DIFF
--- a/packages/shared/validation/sensorCSV.js
+++ b/packages/shared/validation/sensorCSV.js
@@ -84,7 +84,7 @@ const readingTypeTranslations = {
   },
   es: {
     soil_water_content: 'contenido_de_agua_en_el_suelo',
-    soil_water_potential: 'contenido_de_agua_en_el_suelo',
+    soil_water_potential: 'potencial_hídrico_del_suelo',
     temperature: 'temperatura',
   },
   fr: {


### PR DESCRIPTION
To test:
- Change user preference to spanish
- With a tool like Postman or Insomnia, upload a valid sensor csv with the reading type "potencial_hídrico_del_suelo"
- This should succeed