### PR TITLE
fix: map spotlight crashes the map

### DIFF
--- a/packages/webapp/src/components/Map/Footer/index.jsx
+++ b/packages/webapp/src/components/Map/Footer/index.jsx
@@ -121,7 +121,7 @@ export default function PureMapFooter({
       <MapDrawer
         key={'add'}
         setShowMapDrawer={setShowAddDrawer}
-        showMapDrawer={showAddDrawer}
+        showMapDrawer={!showSpotlight && showAddDrawer}
         drawerDefaultHeight={window.innerHeight - 156}
         headerTitle={t('FARM_MAP.MAP_FILTER.ADD_TITLE')}
         onMenuItemClick={onAddMenuClick}


### PR DESCRIPTION
Upon creating a new account, going to the map (either directly or indirectly from location creation popup) crashes the map.

To Test:
1. Create a new account.
2. Go to tasks and try creating a new task.
3. When a location creation popup comes up, click "create location".
4. You will see the map spotlight. Once you go through the rest of the spotlight, you will see the map with "+" tab expanded.

Try steps 1 - 4 for crop plans (creating a crop plan will prompt you to create a crop location first).