### PR TITLE
fix: change longpress to 0.5 seconds

### DIFF
--- a/packages/webapp/src/containers/Map/constants.js
+++ b/packages/webapp/src/containers/Map/constants.js
@@ -5,7 +5,7 @@ export const DEFAULT_CENTER = {
 export const DEFAULT_ZOOM = 15;
 export const GMAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 export const ENVIRONMENT = import.meta.env.NODE_ENV;
-export const longPress = 800;
+export const longPress = 500;
 
 export const getAreaLocationTypes = () => [
   locationEnum.barn,


### PR DESCRIPTION
David wanted the long press to be shorter than what it currently is (0.8 seconds).

To Test:
1. Have sensors on the farm map.
2. Long press a sensor and the preview should pop up after holding the mouse down for 0.5 seconds.