### PR TITLE
LF-2571: drag points pop-up should only appear for accepted polygon

### DIFF
--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -98,8 +98,6 @@ export default function Map({ history }) {
   const { t } = useTranslation();
   const showHeader = useSelector(setShowSuccessHeaderSelector);
   const [showSuccessHeader, setShowSuccessHeader] = useState(false);
-  const [showZeroAreaWarning, setZeroAreaWarning] = useState(false);
-  const [showZeroLengthWarning, setShowZeroLengthWarning] = useState(false);
   const successMessage = useSelector(setSuccessMessageSelector);
 
   const [showingConfirmButtons, setShowingConfirmButtons] = useState(
@@ -161,6 +159,8 @@ export default function Map({ history }) {
       setLineWidth,
       setShowAdjustAreaSpotlightModal,
       setShowAdjustLineSpotlightModal,
+      setZeroAreaWarning,
+      setShowZeroLengthWarning,
     },
   ] = useDrawingManager();
 
@@ -257,8 +257,10 @@ export default function Map({ history }) {
 
     maps.event.addListener(drawingManagerInit, 'polygoncomplete', function (polygon) {
       const polygonAreaCheck = (path) => {
-        if (Math.round(maps.geometry.spherical.computeArea(path)) === 0) setZeroAreaWarning(true);
-        else setZeroAreaWarning(false);
+        if (Math.round(maps.geometry.spherical.computeArea(path)) === 0) {
+          setZeroAreaWarning(true);
+          setShowAdjustAreaSpotlightModal(false);
+        } else setZeroAreaWarning(false);
       };
       const path = polygon.getPath();
       polygonAreaCheck(path);
@@ -273,6 +275,7 @@ export default function Map({ history }) {
       const polylineLengthCheck = (path) => {
         if (Math.round(maps.geometry.spherical.computeLength(path)) === 0) {
           setShowZeroLengthWarning(true);
+          setShowAdjustLineSpotlightModal(false);
         } else {
           setShowZeroLengthWarning(false);
         }
@@ -452,7 +455,13 @@ export default function Map({ history }) {
     dispatch(setMapAddDrawerShow(farm_id));
   };
 
-  const { showAdjustAreaSpotlightModal, showAdjustLineSpotlightModal } = drawingState;
+  const {
+    showAdjustAreaSpotlightModal,
+    showAdjustLineSpotlightModal,
+    showZeroAreaWarning,
+    showZeroLengthWarning,
+  } = drawingState;
+
   return (
     <>
       {!showMapFilter && !showAddDrawer && !drawingState.type && !showSuccessHeader && (

--- a/packages/webapp/src/containers/Map/useDrawingManager.js
+++ b/packages/webapp/src/containers/Map/useDrawingManager.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { areaStyles, icons, lineStyles } from './mapStyles';
 import { isArea, isLine, isPoint, locationEnum, polygonPath } from './constants';
 import { useSelector } from 'react-redux';
@@ -25,6 +25,8 @@ export default function useDrawingManager() {
   const [onBackPressed, setOnBackPressed] = useState(false);
   const [onSteppedBack, setOnSteppedBack] = useState(false);
 
+  const [showZeroAreaWarning, setZeroAreaWarning] = useState(false);
+  const [showZeroLengthWarning, setShowZeroLengthWarning] = useState(false);
   const [showAdjustAreaSpotlightModal, setShowAdjustAreaSpotlightModal] = useState(false);
   const [showAdjustLineSpotlightModal, setShowAdjustLineSpotlightModal] = useState(false);
 
@@ -109,17 +111,17 @@ export default function useDrawingManager() {
     setOnSteppedBack(false);
   }, [onSteppedBack, map, maps, overlayData]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (drawingToCheck) {
-      if (isArea(drawLocationType) && !showedSpotlight.adjust_area)
+      if (isArea(drawLocationType) && !showedSpotlight.adjust_area && !showZeroAreaWarning)
         setShowAdjustAreaSpotlightModal(true);
-      if (isLine(drawLocationType) && !showedSpotlight.adjust_line)
+      if (isLine(drawLocationType) && !showedSpotlight.adjust_line && !showZeroLengthWarning)
         setShowAdjustLineSpotlightModal(true);
     } else {
       setShowAdjustAreaSpotlightModal(false);
       setShowAdjustLineSpotlightModal(false);
     }
-  }, [drawingToCheck]);
+  }, [drawingToCheck, showZeroAreaWarning, showZeroLengthWarning]);
 
   const initDrawingState = (map, maps, drawingManagerInit, drawingModes) => {
     setMap(map);
@@ -224,6 +226,8 @@ export default function useDrawingManager() {
     drawingToCheck,
     showAdjustAreaSpotlightModal,
     showAdjustLineSpotlightModal,
+    showZeroLengthWarning,
+    showZeroAreaWarning,
   };
 
   const drawingFunctions = {
@@ -238,6 +242,8 @@ export default function useDrawingManager() {
     setLineWidth,
     setShowAdjustAreaSpotlightModal,
     setShowAdjustLineSpotlightModal,
+    setZeroAreaWarning,
+    setShowZeroLengthWarning,
   };
 
   return [drawingState, drawingFunctions];


### PR DESCRIPTION
Ticket: [LF-2571](https://lite-farm.atlassian.net/browse/LF-2571)

To test:
- Create a new account
- Go to farm map
- Start process to create a new area
- Stop double click on initial point to stop drawing
- You should get zero area warning modal and no adjust area modal
- Same for new line