### PR TITLE
Lf 2711/add sensor upload in line error when non csv file is attached

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -457,6 +457,8 @@
       "UPLOAD_LINK_MESSAGE": "Download this template",
       "UPLOAD_INSTRUCTION_MESSAGE": "for correct formatting.",
       "UPLOAD_PLACEHOLDER": "Upload CSV file",
+      "INVALID_FILE_TYPE": "Upload file must be a csv,",
+      "DOWNLOAD_TEMPLATE_LINK_MESSAGE": "click here to download the template",
       "UPLOAD_ERROR_MESSAGE": "There were some issues with your upload. ",
       "UPLOAD_ERROR_LINK": "Click here to view them.",
       "EMPTY_FILE_UPLOAD_ERROR_MESSAGE": "No sensors found, please check your upload and try again.",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -457,6 +457,8 @@
       "UPLOAD_INSTRUCTION_MESSAGE": "MISSING - Es - for correct formatting.",
       "UPLOAD_PLACEHOLDER": "MISSING - Es - Upload CSV file",
       "UPLOAD_ERROR_MESSAGE": "MISSING - Es - There were some issues with your upload. ",
+      "INVALID_FILE_TYPE": "MISSING - Es - Upload file must be a csv,",
+      "DOWNLOAD_TEMPLATE_LINK_MESSAGE": "MISSING - Es - click here to download the template",
       "UPLOAD_ERROR_LINK": "MISSING - Es - Click here to view them.",
       "EMPTY_FILE_UPLOAD_ERROR_MESSAGE": "MISSING - Es - No sensors found, please check your upload and try again.",
       "SENSOR_FIELDS": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -458,6 +458,8 @@
       "UPLOAD_INSTRUCTION_MESSAGE": "pour un formatage correct.",
       "UPLOAD_PLACEHOLDER": "Téléverser le fichier CSV",
       "UPLOAD_ERROR_MESSAGE": "Il y avait qulques problèmes avec votre téléchargement. ",
+      "INVALID_FILE_TYPE": "MISSING - Fr - Upload file must be a csv,",
+      "DOWNLOAD_TEMPLATE_LINK_MESSAGE": "MISSING - Fr - click here to download the template",
       "UPLOAD_ERROR_LINK": "Cliquez ici pour les voir.",
       "EMPTY_FILE_UPLOAD_ERROR_MESSAGE": "Aucun capteur trouvé, veuillez vérifier votre téléchargment et essayez à nouveau.",
       "SENSOR_FIELDS": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -457,6 +457,8 @@
       "UPLOAD_INSTRUCTION_MESSAGE": "MISSING - Pt - for correct formatting.",
       "UPLOAD_PLACEHOLDER": "MISSING - Pt - Upload CSV file",
       "UPLOAD_ERROR_MESSAGE": "MISSING - Pt - There were some issues with your upload. ",
+      "INVALID_FILE_TYPE": "MISSING - Pt - Upload file must be a csv,",
+      "DOWNLOAD_TEMPLATE_LINK_MESSAGE": "MISSING - Pt - click here to download the template",
       "UPLOAD_ERROR_LINK": "MISSING - Pt - Click here to view them.",
       "EMPTY_FILE_UPLOAD_ERROR_MESSAGE": "MISSING - Pt - No sensors found, please check your upload and try again.",
       "SENSOR_FIELDS": {

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/constants.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/constants.js
@@ -1,5 +1,6 @@
 export const ErrorTypes = {
   DEFAULT: -1,
-  EMPTY_FILE: 1,
   INVALID_CSV: 0,
+  EMPTY_FILE: 1,
+  INVALID_FILE_TYPE: 2,
 };

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/index.jsx
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/index.jsx
@@ -28,6 +28,7 @@ export default function BulkSensorUploadModal({ dismissModal, onUpload }) {
       uploadPlaceholder={t('FARM_MAP.BULK_UPLOAD_SENSORS.UPLOAD_PLACEHOLDER')}
       uploadErrorMessage={uploadErrorMessage}
       uploadErrorLink={t('FARM_MAP.BULK_UPLOAD_SENSORS.UPLOAD_ERROR_LINK')}
+      invalidFileTypeErrorLink={t('FARM_MAP.BULK_UPLOAD_SENSORS.DOWNLOAD_TEMPLATE_LINK_MESSAGE')}
       dismissModal={dismissModal}
       onUpload={onUploadClicked}
       handleSelectedFile={handleSelectedFile}

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -110,10 +110,13 @@ export function useValidateBulkSensorData(onUpload, t) {
     onUpload(file);
   };
 
+  const getFileExtension = (fileName) => fileName.split('.').pop();
+
   const handleSelectedFile = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
     try {
+      const fileExtension = getFileExtension(file?.name);
       setSelectedFileName(file?.name);
 
       const fileString = await readFile(file);
@@ -131,7 +134,10 @@ export function useValidateBulkSensorData(onUpload, t) {
         });
       }
 
-      if (errors.length !== 0) {
+      if (fileExtension !== 'csv') {
+        setErrorTypeCode(ErrorTypes.INVALID_FILE_TYPE);
+        setUploadErrorMessage(t('FARM_MAP.BULK_UPLOAD_SENSORS.INVALID_FILE_TYPE'));
+      } else if (errors.length !== 0) {
         setErrorTypeCode(ErrorTypes.INVALID_CSV);
         setUploadErrorMessage(t('FARM_MAP.BULK_UPLOAD_SENSORS.UPLOAD_ERROR_MESSAGE'));
       } else if (data.length === 0) {
@@ -147,7 +153,11 @@ export function useValidateBulkSensorData(onUpload, t) {
     }
   };
 
-  const onShowErrorClick = (e) => {
+  const onShowErrorClick = (errorCode) => {
+    if (errorCode === 2) {
+      onTemplateDownloadClick();
+      return;
+    }
     if (sheetErrors.length) {
       const inputFile = fileInputRef.current.files[0];
       if (inputFile) {

--- a/packages/webapp/src/components/Modals/BulkSensorUploadModal/FileUploader.jsx
+++ b/packages/webapp/src/components/Modals/BulkSensorUploadModal/FileUploader.jsx
@@ -15,6 +15,7 @@ export default function FileUploader({
   uploadErrorLink,
   uploadErrorMessage,
   errorTypeCode,
+  invalidFileTypeErrorLink,
 }) {
   const handleClick = (event) => {
     if (fileInputRef.current) {
@@ -45,8 +46,13 @@ export default function FileUploader({
           <label>
             {uploadErrorMessage}{' '}
             {!errorTypeCode && (
-              <span className={styles.errorMessage} onClick={onShowErrorClick}>
+              <span className={styles.errorMessage} onClick={() => onShowErrorClick(errorTypeCode)}>
                 {uploadErrorLink}
+              </span>
+            )}
+            {errorTypeCode === 2 && (
+              <span className={styles.errorMessage} onClick={() => onShowErrorClick(errorTypeCode)}>
+                {invalidFileTypeErrorLink}
               </span>
             )}
           </label>
@@ -65,4 +71,5 @@ FileUploader.prototype = {
   uploadErrorLink: PropTypes.string,
   uploadErrorMessage: PropTypes.string,
   errorTypeCode: PropTypes.number,
+  invalidFileTypeErrorLink: PropTypes.string,
 };

--- a/packages/webapp/src/components/Modals/BulkSensorUploadModal/index.jsx
+++ b/packages/webapp/src/components/Modals/BulkSensorUploadModal/index.jsx
@@ -47,7 +47,7 @@ export default function BulkSensorUploadModal({
           </div>
           <FileUploader
             handleSelectedFile={handleSelectedFile}
-            acceptedFormat="*"
+            acceptedFormat=".csv"
             selectedFileName={selectedFileName}
             fileInputRef={fileInputRef}
             isValid={!errorCount}

--- a/packages/webapp/src/components/Modals/BulkSensorUploadModal/index.jsx
+++ b/packages/webapp/src/components/Modals/BulkSensorUploadModal/index.jsx
@@ -24,6 +24,7 @@ export default function BulkSensorUploadModal({
   uploadErrorMessage,
   uploadErrorLink,
   errorTypeCode,
+  invalidFileTypeErrorLink,
 }) {
   const { t } = useTranslation();
 
@@ -46,7 +47,7 @@ export default function BulkSensorUploadModal({
           </div>
           <FileUploader
             handleSelectedFile={handleSelectedFile}
-            acceptedFormat=".csv"
+            acceptedFormat="*"
             selectedFileName={selectedFileName}
             fileInputRef={fileInputRef}
             isValid={!errorCount}
@@ -54,6 +55,7 @@ export default function BulkSensorUploadModal({
             uploadErrorMessage={uploadErrorMessage}
             uploadErrorLink={uploadErrorLink}
             errorTypeCode={errorTypeCode}
+            invalidFileTypeErrorLink={invalidFileTypeErrorLink}
           />
           <Button
             className={styles.buttonUpload}
@@ -86,4 +88,5 @@ BulkSensorUploadModal.prototype = {
   uploadErrorMessage: PropTypes.string,
   uploadErrorLink: PropTypes.string,
   errorTypeCode: PropTypes.number,
+  invalidFileTypeErrorLink: PropTypes.string,
 };


### PR DESCRIPTION
To Test,

1. Open the app on the android device. 
2. go to the farm maps page.
3. select a non-CSV file and check if the validation error is shown.

For more details:
https://lite-farm.atlassian.net/browse/LF-2711


Adding screenshot:
<img width="555" alt="Screen Shot 2022-08-30 at 1 18 21 PM" src="https://user-images.githubusercontent.com/20675885/187535011-10e4608d-316f-42b6-90bd-d24303c920d7.png">

