### PR TITLE
LF-2622 : Fix the language search issue in the crop plan page

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
@@ -60,7 +60,7 @@ const PureTaskCrops = ({
 
   const filterManagementPlansByCropVarietyName = (mp) =>
     mp.crop_variety_name.toLowerCase().includes(filter?.toLowerCase()) ||
-    mp.crop_common_name.toLowerCase().includes(filter?.toLowerCase());
+    mp.crop_specie.toLowerCase().includes(filter?.toLowerCase());
   const managementPlansFilteredByInput = useMemo(() => {
     if (!filter) {
       return managementPlansByLocationIds;


### PR DESCRIPTION
To Test,

1. go to the crop plan page.
2. check the crop by its language-specific variety name.
3. check if the English version of variety is not getting filtered in the list.

For more details, Please check: 
https://lite-farm.atlassian.net/browse/LF-2622

