### PR TITLE
LF-2430 : Fixed the UI shift issue

### DIFF
--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -54,7 +54,7 @@
   flex-direction: column;
   overflow: visible;
   position: relative;
-  justify-content: space-between;
+  justify-content: start;
 }
 
 .sm {


### PR DESCRIPTION
To Test:

1. go to crop management flow. select row.
2. you would see the following page, with UI fix:

Before

![image-20220525-201737](https://user-images.githubusercontent.com/20675885/188200650-de8f6a26-6fe0-4adc-8eec-05877334896f.png)


After

<img width="545" alt="Screen Shot 2022-09-02 at 9 37 43 AM" src="https://user-images.githubusercontent.com/20675885/188200290-07c9eb33-7c10-4b69-b788-e4b13c859a24.png">

<img width="466" alt="Screen Shot 2022-09-02 at 9 38 55 AM" src="https://user-images.githubusercontent.com/20675885/188200320-6aac0602-d1ca-42f5-82b0-7004fe5aefce.png">

<img width="462" alt="Screen Shot 2022-09-02 at 9 39 05 AM" src="https://user-images.githubusercontent.com/20675885/188200338-f5a6317e-b222-48ff-b105-68d6e91a4407.png">


