### PR TITLE
Re-introduce iOS map downloads

### DIFF
--- a/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
+++ b/packages/webapp/src/components/Modals/ExportMapModal/index.jsx
@@ -48,15 +48,11 @@ export function PureExportMapModal({
   return (
     <div className={styles.container}>
       <Title>{t('FARM_MAP.EXPORT_MODAL.TITLE')}</Title>
-      {!isiOS() && (
-        <>
-          <Main>{t('FARM_MAP.EXPORT_MODAL.BODY')}</Main>
-          <Button color="secondary" className={styles.button} onClick={onClickDownload}>
-            <DownloadIcon className={styles.downloadSvg} />
-            <div>{t('FARM_MAP.EXPORT_MODAL.DOWNLOAD')}</div>
-          </Button>
-        </>
-      )}
+      <Main>{t('FARM_MAP.EXPORT_MODAL.BODY')}</Main>
+      <Button color="secondary" className={styles.button} onClick={onClickDownload}>
+        <DownloadIcon className={styles.downloadSvg} />
+        <div>{t('FARM_MAP.EXPORT_MODAL.DOWNLOAD')}</div>
+      </Button>
       <Button
         color="secondary"
         disabled={isEmailing}


### PR DESCRIPTION
To Test,

1. Open the app on the IOS device.
2. go to farm maps and click on farm map download.
3. check if the map gets downloaded on the IOS device.

For more details, Please check: 
https://lite-farm.atlassian.net/browse/LF-2624
