### PR TITLE
LF-2581: Fixed text label overflow issue of units component

### DIFF
--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -76,7 +76,6 @@
 .labelContainer {
   display: flex;
   justify-content: space-between;
-  height: 20px;
   position: relative;
 }
 


### PR DESCRIPTION
To Test,


1. go to http://localhost:3000/crop/<management_plan_id>/add_management_plan/row_method.
2. check if the UI is fixed for the text-overflow label above the unit's component input field.

Before: 

<img width="396" alt="Screen Shot 2022-09-06 at 2 55 16 PM" src="https://user-images.githubusercontent.com/20675885/188748097-6f6a92cc-1757-4fc0-9e45-d4351fdb1aea.png">


After: 

<img width="443" alt="Screen Shot 2022-09-06 at 2 50 47 PM" src="https://user-images.githubusercontent.com/20675885/188748121-12bd5c6e-a67e-43a0-bf82-5febd933db9f.png">



 