### PR TITLE
Lf 2575 : Fix: user selected date should be maintained for field garden and greenhouse when transitioning is unselected

### DIFF
--- a/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Field/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Field/index.jsx
@@ -90,9 +90,7 @@ export function FieldDetailsChildren({ isViewLocationPage }) {
   const { t } = useTranslation();
   const { control, watch, register } = useFormContext();
   const fieldTypeSelection = watch(fieldEnum.organic_status);
-  const [defaultTransitionalDate, setDefaultTransitionalDate] = useState(
-    watch(fieldEnum.transition_date),
-  );
+  const [transitionalDate, setTransitionalDate] = useState(watch(fieldEnum.transition_date));
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -131,8 +129,8 @@ export function FieldDetailsChildren({ isViewLocationPage }) {
             label={t('FARM_MAP.FIELD.DATE')}
             hookFormRegister={register(fieldEnum.transition_date, { required: true })}
             disabled={isViewLocationPage}
-            onChange={(e) => setDefaultTransitionalDate(e.target.value)}
-            value={defaultTransitionalDate}
+            onChange={(e) => setTransitionalDate(e.target.value)}
+            value={transitionalDate}
           />
         )}
       </div>

--- a/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Field/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Field/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AreaDetails from '../AreaDetails';
 import { useForm, useFormContext } from 'react-hook-form';
@@ -90,6 +90,9 @@ export function FieldDetailsChildren({ isViewLocationPage }) {
   const { t } = useTranslation();
   const { control, watch, register } = useFormContext();
   const fieldTypeSelection = watch(fieldEnum.organic_status);
+  const [defaultTransitionalDate, setDefaultTransitionalDate] = useState(
+    watch(fieldEnum.transition_date),
+  );
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -128,6 +131,8 @@ export function FieldDetailsChildren({ isViewLocationPage }) {
             label={t('FARM_MAP.FIELD.DATE')}
             hookFormRegister={register(fieldEnum.transition_date, { required: true })}
             disabled={isViewLocationPage}
+            onChange={(e) => setDefaultTransitionalDate(e.target.value)}
+            value={defaultTransitionalDate}
           />
         )}
       </div>

--- a/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Garden/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Garden/index.jsx
@@ -85,9 +85,7 @@ export function GardenDetailsChildren({ isViewLocationPage }) {
     formState: { errors },
   } = useFormContext();
   const gardenTypeSelection = watch(gardenEnum.organic_status);
-  const [defaultTransitionalDate, setDefaultTransitionalDate] = useState(
-    watch(gardenEnum.transition_date),
-  );
+  const [transitionalDate, setTransitionalDate] = useState(watch(gardenEnum.transition_date));
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -132,8 +130,8 @@ export function GardenDetailsChildren({ isViewLocationPage }) {
             style={{ paddingTop: '16px', paddingBottom: '20px' }}
             disabled={isViewLocationPage}
             errors={getInputErrors(errors, gardenEnum.transition_date)}
-            onChange={(e) => setDefaultTransitionalDate(e.target.value)}
-            value={defaultTransitionalDate}
+            onChange={(e) => setTransitionalDate(e.target.value)}
+            value={transitionalDate}
           />
         )}
       </div>

--- a/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Garden/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Garden/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
 import Leaf from '../../../../assets/images/farmMapFilter/Leaf.svg';
@@ -85,6 +85,9 @@ export function GardenDetailsChildren({ isViewLocationPage }) {
     formState: { errors },
   } = useFormContext();
   const gardenTypeSelection = watch(gardenEnum.organic_status);
+  const [defaultTransitionalDate, setDefaultTransitionalDate] = useState(
+    watch(gardenEnum.transition_date),
+  );
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -129,6 +132,8 @@ export function GardenDetailsChildren({ isViewLocationPage }) {
             style={{ paddingTop: '16px', paddingBottom: '20px' }}
             disabled={isViewLocationPage}
             errors={getInputErrors(errors, gardenEnum.transition_date)}
+            onChange={(e) => setDefaultTransitionalDate(e.target.value)}
+            value={defaultTransitionalDate}
           />
         )}
       </div>

--- a/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Greenhouse/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Greenhouse/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AreaDetails from '../AreaDetails';
 import { useForm, useFormContext } from 'react-hook-form';
@@ -92,6 +92,9 @@ export function GreenhouseDetailsChildren({ isViewLocationPage }) {
   const { t } = useTranslation();
   const { register, watch, control } = useFormContext();
   const greenhouseTypeSelection = watch(greenhouseEnum.organic_status);
+  const [defaultTransitionalDate, setDefaultTransitionalDate] = useState(
+    watch(greenhouseEnum.transition_date),
+  );
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -129,6 +132,8 @@ export function GreenhouseDetailsChildren({ isViewLocationPage }) {
             hookFormRegister={register(greenhouseEnum.transition_date, { required: true })}
             style={{ paddingTop: '16px', paddingBottom: '20px' }}
             disabled={isViewLocationPage}
+            onChange={(e) => setDefaultTransitionalDate(e.target.value)}
+            value={defaultTransitionalDate}
           />
         )}
       </div>

--- a/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Greenhouse/index.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/AreaDetails/Greenhouse/index.jsx
@@ -92,9 +92,7 @@ export function GreenhouseDetailsChildren({ isViewLocationPage }) {
   const { t } = useTranslation();
   const { register, watch, control } = useFormContext();
   const greenhouseTypeSelection = watch(greenhouseEnum.organic_status);
-  const [defaultTransitionalDate, setDefaultTransitionalDate] = useState(
-    watch(greenhouseEnum.transition_date),
-  );
+  const [transitionalDate, setTransitionalDate] = useState(watch(greenhouseEnum.transition_date));
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -132,8 +130,8 @@ export function GreenhouseDetailsChildren({ isViewLocationPage }) {
             hookFormRegister={register(greenhouseEnum.transition_date, { required: true })}
             style={{ paddingTop: '16px', paddingBottom: '20px' }}
             disabled={isViewLocationPage}
-            onChange={(e) => setDefaultTransitionalDate(e.target.value)}
-            value={defaultTransitionalDate}
+            onChange={(e) => setTransitionalDate(e.target.value)}
+            value={transitionalDate}
           />
         )}
       </div>


### PR DESCRIPTION
To Test:

1. Be on an organic certification-pursuing farm
2. Select a field, garden, or greenhouse from the map. Select edit.
3. Select “Transitioning” from the “What type of field is this?” list
4. Select a transition date different from the preselected date
5. Select one of the other options, either “None organic” or “Organic”
6. Switch back to “Transitioning”

Expected result:
The previously selected date is maintained

Actual result:
The current date is preselected again.

For more details: 
https://lite-farm.atlassian.net/browse/LF-2575