### PR TITLE
Fixed the cross display issue on the unit components

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -319,49 +319,32 @@ const Unit = ({
           )}
         </div>
       )}
-      {showError && (
-        <Cross
-          onClick={onClear}
-          style={{
-            position: 'absolute',
-            right: 0,
-            transform: isSelectDisabled
-              ? 'translate(-1px, 23px)'
-              : unitType.databaseUnit === 'd'
-              ? 'translate(-95px, 23px)' // long date unit component
-              : 'translate(-62px, 23px)',
-            lineHeight: '40px',
-            cursor: 'pointer',
-            zIndex: 2,
-            width: '37px',
-            display: 'flex',
-            justifyContent: 'center',
-            backgroundColor: 'white',
-          }}
-        />
-      )}
+
       <div className={styles.inputContainer}>
-        <input
-          disabled={disabled}
-          className={clsx(styles.input)}
-          style={{ ...classes.input }}
-          aria-invalid={showError ? 'true' : 'false'}
-          type={'number'}
-          value={visibleInputValue}
-          size={1}
-          onKeyDown={getOnKeyDown(measure)}
-          onBlur={
-            mode === 'onBlur'
-              ? (e) => {
-                  inputOnBlur(e);
-                  onBlur && onBlur(e);
-                }
-              : onBlur
-          }
-          onChange={inputOnChange}
-          onWheel={preventNumberScrolling}
-          {...props}
-        />
+        <div className={styles.inputWrapper}>
+          <input
+            disabled={disabled}
+            className={clsx(styles.input)}
+            style={{ ...classes.input }}
+            aria-invalid={showError ? 'true' : 'false'}
+            type={'number'}
+            value={visibleInputValue}
+            size={1}
+            onKeyDown={getOnKeyDown(measure)}
+            onBlur={
+              mode === 'onBlur'
+                ? (e) => {
+                    inputOnBlur(e);
+                    onBlur && onBlur(e);
+                  }
+                : onBlur
+            }
+            onChange={inputOnChange}
+            onWheel={preventNumberScrolling}
+            {...props}
+          />
+          {showError && <Cross onClick={onClear} className={styles.crossWrapper} />}
+        </div>
 
         <Controller
           control={control}

--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -1,4 +1,23 @@
 
+.inputWrapper {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+  position: relative;
+}
+
+.crossWrapper {
+  top: 2px;
+  position: absolute;
+  right: 0;
+  line-height: 40px;
+  cursor: pointer;
+  z-index: 2;
+  width: 37px;
+  display: flex;
+  justify-content: center;
+  background-color: white;
+}
 
 .input {
   flex-grow: 1;


### PR DESCRIPTION
To Test:

go to crop management flow. select row.
you would see the following page, with a UI fix:

Before:
<img width="408" alt="123Screen Shot 2022-09-07 at 2 06 16 PM" src="https://user-images.githubusercontent.com/20675885/188980877-9b50d8cf-3720-406b-888b-9c5c2374fcdc.PNG">

![IMG_0363]()

After: 
<img width="408" alt="Screen Shot 2022-09-07 at 2 06 16 PM" src="https://user-images.githubusercontent.com/20675885/188980996-d1ff3ff4-edd2-45fe-8f23-7b311cf4b3c3.png">

