### PR TITLE
LF-2735: fixed the cluster number that was not getting displayed on farm map export click

### DIFF
--- a/packages/webapp/src/components/Map/MarkerCluster/index.jsx
+++ b/packages/webapp/src/components/Map/MarkerCluster/index.jsx
@@ -42,6 +42,7 @@ const CreateMarkerCluster = (
           icon: {
             url: `data:image/svg+xml;base64,${svg}`,
           },
+          zIndex: 10,
         });
         eventListeners.forEach((e) => {
           m.addListener(e.event, e.callbackFunction(m));


### PR DESCRIPTION
To Test,

1. go to the farm map.
2. click on the export icon i.e last option in the bottom navigation bar.
3. click on the download map button 

check if you can find numbers on the clustered sensors plotted in the farm map

Before 
<img width="408" alt="123Screen Shot 2022-09-07 at 2 06 16 PM" src="https://user-images.githubusercontent.com/20675885/189769973-8dcebb10-b500-47ef-a1dc-68fd3db2e266.png">

After
<img width="408" alt="123Screen Shot 2022-09-07 at 2 06 16 PM" src="https://user-images.githubusercontent.com/20675885/189769991-e49d7805-3e1f-43db-a9be-f6f8b4778445.png">


For more details, please check: 
https://lite-farm.atlassian.net/browse/LF-2735
