### PR TITLE
singleValue for units should be black not grey

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -114,7 +114,7 @@ const useReactSelectStyles = (disabled, { reactSelectWidth = DEFAULT_REACT_SELEC
       singleValue: (provided, state) => ({
         fontSize: '16px',
         lineHeight: '24px',
-        color: 'var(--grey600)',
+        color: 'var(--fontColor)',
         fontStyle: 'normal',
         fontWeight: 'normal',
         fontFamily: '"Open Sans", "SansSerif", serif',


### PR DESCRIPTION
I returned the font color to the value set in `ReactSelect` referred to as default styles in `Unit`. Seems to work in views mentioned in Jira for: area creation, task creation, and crop plan creation.