### PR TITLE
Lf 2704 abandon status filter for crop management plans on crop catalogue not working

### DIFF
--- a/packages/webapp/public/locales/en/common.json
+++ b/packages/webapp/public/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "ABANDON": "Abandon",
+  "ABANDONED": "Abandoned",
   "ACTIVE": "Active",
   "ADD": "Add",
   "ALL": "All",

--- a/packages/webapp/public/locales/es/common.json
+++ b/packages/webapp/public/locales/es/common.json
@@ -1,5 +1,6 @@
 {
   "ABANDON": "Abandonar",
+  "ABANDONED": "MISSING",
   "ACTIVE": "Activo",
   "ADD": "Agregar",
   "ALL": "Todo",

--- a/packages/webapp/public/locales/fr/common.json
+++ b/packages/webapp/public/locales/fr/common.json
@@ -1,5 +1,6 @@
 {
   "ABANDON": "Abandonner",
+  "ABANDONED": "MISSING",
   "ACTIVE": "Actif",
   "ADD": "Ajouter",
   "ALL": "Tout",

--- a/packages/webapp/public/locales/pt/common.json
+++ b/packages/webapp/public/locales/pt/common.json
@@ -1,5 +1,6 @@
 {
   "ABANDON": "Abandonar",
+  "ABANDONED": "MISSING",
   "ACTIVE": "Ativo",
   "ADD": "Adicionar",
   "ALL": "Tudo",

--- a/packages/webapp/src/components/CropCatalogue/CropStatusInfoBox/index.jsx
+++ b/packages/webapp/src/components/CropCatalogue/CropStatusInfoBox/index.jsx
@@ -65,6 +65,10 @@ export default function CropStatusInfoBox({
             {t('common:ACTIVE')}
           </div>
           <div className={classes.cropCountContainer}>
+            <Square color={'abandoned'}>{status.abandoned}</Square>
+            {t('common:ABANDONED')}
+          </div>
+          <div className={classes.cropCountContainer}>
             <Square color={'planned'}>{status.planned}</Square>
             {t('common:PLANNED')}
           </div>
@@ -88,6 +92,7 @@ CropStatusInfoBox.propTypes = {
 
   status: PropTypes.exact({
     active: PropTypes.number,
+    abandoned: PropTypes.number,
     planned: PropTypes.number,
     past: PropTypes.number,
     noPlans: PropTypes.number,

--- a/packages/webapp/src/components/CropTile/index.jsx
+++ b/packages/webapp/src/components/CropTile/index.jsx
@@ -21,8 +21,9 @@ export default function PureCropTile({
   children,
   isSelected,
   status,
+  view,
 }) {
-  const { active = 0, planned = 0, past = 0, noPlans = 0 } = cropCount;
+  const { active = 0, abandoned=0, planned = 0, past = 0, noPlans = 0 } = cropCount;
   const { t } = useTranslation();
   return (
     <div
@@ -71,14 +72,40 @@ export default function PureCropTile({
         </div>
       )}
 
-      {noPlans !== 0 && (
-        <div className={styles.needsPlanContainer}>
-          <Square color={'needsPlan'} isCropTile style={{ borderBottomRightRadius: '4px' }}>
-            {noPlans}
-          </Square>
-        </div>
+      {view === 'CropVariety' && (
+        <>
+          {noPlans !== 0 && (
+          <div className={styles.planStateContainer}>
+            <Square color={'needsPlan'} isCropTile style={{ borderBottomRightRadius: '4px' }}>
+              {noPlans}
+            </Square>
+          </div>
+          )}
+          {abandoned !== 0 && (
+          <div className={styles.planStateContainer}>
+            <Square color={'abandoned'} isCropTile style={{ borderBottomRightRadius: '4px' }}>
+              {abandoned}
+            </Square>
+          </div>
+          )}
+        </>
       )}
 
+      {view === 'CropCatalogue' && (
+        <>
+          {noPlans + abandoned !== 0 && (
+            <div className={styles.planStateContainer}>
+              <Square color={'abandoned'} isCropTile>
+                {abandoned}
+              </Square>
+              <Square color={'needsPlan'} isCropTile style={{ borderBottomRightRadius: '4px' }}>
+                {noPlans}
+              </Square>
+            </div>
+          )}
+        </>
+      )}
+    
       <div className={styles.info}>
         <div className={styles.infoMain}>{title}</div>
         {children}
@@ -103,4 +130,5 @@ PureCropTile.prototype = {
   isPastVariety: PropTypes.bool,
   isCropTemplate: PropTypes.bool,
   status: PropTypes.oneOf(['active', 'planned', 'completed', 'abandoned']),
+  view: PropTypes.oneOf(['CropCatalogue', 'CropVariety']),
 };

--- a/packages/webapp/src/components/CropTile/styles.module.scss
+++ b/packages/webapp/src/components/CropTile/styles.module.scss
@@ -96,7 +96,7 @@
   flex-direction: column;
 }
 
-.needsPlanContainer {
+.planStateContainer {
   display: flex;
   left: 0;
   position: absolute;

--- a/packages/webapp/src/components/Square/index.jsx
+++ b/packages/webapp/src/components/Square/index.jsx
@@ -23,6 +23,9 @@ const useStyles = makeStyles({
   active: {
     backgroundColor: colors.brightGreen700,
   },
+  abandoned: {
+    backgroundColor: colors.grey900,
+  },
   planned: {
     backgroundColor: colors.brown700,
   },
@@ -62,6 +65,7 @@ export default function Square({ color = 'active', children, isCropTile, ...prop
 Square.propTypes = {
   color: PropTypes.oneOf([
     'active',
+    'abandoned',
     'planned',
     'past',
     'needsPlan',

--- a/packages/webapp/src/containers/CropCatalogue/index.jsx
+++ b/packages/webapp/src/containers/CropCatalogue/index.jsx
@@ -135,6 +135,7 @@ export default function CropCatalogue({ history }) {
                     cropCount={{
                       noPlans: noPlansCount,
                     }}
+                    view='CropCatalogue'
                   />
                 );
               })}
@@ -142,6 +143,7 @@ export default function CropCatalogue({ history }) {
                 const {
                   crop_translation_key,
                   active,
+                  abandoned,
                   planned,
                   past,
                   imageKey,
@@ -155,6 +157,7 @@ export default function CropCatalogue({ history }) {
                     key={crop_translation_key}
                     cropCount={{
                       active: active.length,
+                      abandoned: abandoned.length,
                       planned: planned.length,
                       past: past.length,
                       noPlans: cropCatalog?.noPlans?.length,
@@ -165,6 +168,7 @@ export default function CropCatalogue({ history }) {
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => history.push(`/crop_varieties/crop/${cropCatalog.crop_id}`)}
+                    view='CropCatalogue'
                   />
                 );
               })}
@@ -200,6 +204,7 @@ export default function CropCatalogue({ history }) {
                         onClick={() => {
                           onAddCropVariety(crop.crop_id);
                         }}
+                        view='CropCatalogue'
                       />
                     );
                   })}

--- a/packages/webapp/src/containers/CropCatalogue/index.jsx
+++ b/packages/webapp/src/containers/CropCatalogue/index.jsx
@@ -40,7 +40,7 @@ export default function CropCatalogue({ history }) {
 
   const [filterString, setFilterString] = useState('');
   const filterStringOnChange = (e) => setFilterString(e.target.value);
-  const { active, planned, past, noPlans, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
+  const { active, abandoned, planned, past, noPlans, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
     useCropCatalogue(filterString);
   const crops = useStringFilteredCrops(
     useSortByCropTranslation(useSelector(cropsSelector)),
@@ -114,7 +114,7 @@ export default function CropCatalogue({ history }) {
           <>
             <PageBreak style={{ paddingBottom: '16px' }} label={t('CROP_CATALOGUE.ON_YOUR_FARM')} />
             <CropStatusInfoBox
-              status={{ active, past, planned, noPlans }}
+              status={{ active, abandoned, past, planned, noPlans }}
               style={{ marginBottom: '16px' }}
               date={date}
               setDate={setDate}

--- a/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
+++ b/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
@@ -191,7 +191,7 @@ export default function useCropCatalogue(filterString) {
     }));
   }, [filteredCropVarietiesWithoutManagementPlan, sortedCropCatalogue]);
 
-  // this method is used to calculate the sum of active, planned, past, noPlans of all
+  // this method is used to calculate the sum of active, abandoned, planned, past, noPlans of all
   // crop varieties for a particular crop.
   // calculates the active, abandoned, planned, past, noPlans for CropStatusInfoBox component.
   const cropCataloguesStatus = useMemo(() => {

--- a/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
+++ b/packages/webapp/src/containers/CropCatalogue/useCropCatalogue.js
@@ -1,5 +1,6 @@
 import {
   getCurrentManagementPlans,
+  getAbandonedManagementPlans,
   getExpiredManagementPlans,
   getPlannedManagementPlans,
 } from '../managementPlanSlice';
@@ -9,6 +10,7 @@ import { useMemo } from 'react';
 import useStringFilteredCrops from './useStringFilteredCrops';
 import {
   ACTIVE,
+  ABANDONED,
   COMPLETE,
   LOCATION,
   PLANNED,
@@ -80,6 +82,7 @@ export default function useCropCatalogue(filterString) {
     const time = new Date(cropCatalogFilterDate).getTime();
     const managementPlansByStatus = {
       active: getCurrentManagementPlans(managementPlansFilteredBySuppliers, time),
+      abandoned: getAbandonedManagementPlans(managementPlansFilteredBySuppliers, time),
       planned: getPlannedManagementPlans(managementPlansFilteredBySuppliers, time),
       past: getExpiredManagementPlans(managementPlansFilteredBySuppliers, time),
     };
@@ -89,6 +92,7 @@ export default function useCropCatalogue(filterString) {
         if (!managementPlansByCropId.hasOwnProperty(managementPlan.crop_id)) {
           managementPlansByCropId[managementPlan.crop_id] = {
             active: [],
+            abandoned: [],
             planned: [],
             past: [],
             crop_common_name: managementPlan.crop_common_name,
@@ -134,6 +138,7 @@ export default function useCropCatalogue(filterString) {
     const newCropCatalogue = cropCatalogue.map((catalogue) => ({
       ...catalogue,
       active: statusFilter[ACTIVE].active ? catalogue.active : [],
+      abandoned: statusFilter[ABANDONED].active ? catalogue.abandoned : [],
       planned: statusFilter[PLANNED].active ? catalogue.planned : [],
       past: statusFilter[COMPLETE].active ? catalogue.past : [],
       noPlans: statusFilter[NEEDS_PLAN].active ? catalogue.noPlans : [],
@@ -141,6 +146,7 @@ export default function useCropCatalogue(filterString) {
     return newCropCatalogue.filter(
       (catalog) =>
         catalog.active.length ||
+        catalog.abandoned.length ||
         catalog.past.length ||
         catalog.planned.length ||
         catalog.noPlans.length,
@@ -187,9 +193,9 @@ export default function useCropCatalogue(filterString) {
 
   // this method is used to calculate the sum of active, planned, past, noPlans of all
   // crop varieties for a particular crop.
-  // calculates the active, planned, past, noPlans for CropStatusInfoBox component.
+  // calculates the active, abandoned, planned, past, noPlans for CropStatusInfoBox component.
   const cropCataloguesStatus = useMemo(() => {
-    const cropCataloguesStatus = { active: 0, planned: 0, past: 0, noPlans: 0 };
+    const cropCataloguesStatus = { active: 0, abandoned: 0, planned: 0, past: 0, noPlans: 0 };
     for (const managementPlansByStatus of cropCatalogueFilteredByStatus) {
       for (const status in cropCataloguesStatus) {
         cropCataloguesStatus[status] += managementPlansByStatus[status].length;
@@ -203,6 +209,7 @@ export default function useCropCatalogue(filterString) {
       ...cropCataloguesStatus,
       sum:
         cropCataloguesStatus.active +
+        cropCataloguesStatus.abandoned +
         cropCataloguesStatus.planned +
         cropCataloguesStatus.past +
         cropCataloguesStatus.noPlans,

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -43,7 +43,7 @@ export default function CropVarieties({ history, match, location }) {
     dispatch(resetAndUnLockFormData());
   }, []);
 
-  const { active, planned, past, noPlans, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
+  const { active, abandoned, planned, past, noPlans, sum, cropCatalogue, filteredCropsWithoutManagementPlan } =
     useCropVarietyCatalogue(filterString, crop_id);
 
   const {
@@ -110,7 +110,7 @@ export default function CropVarieties({ history, match, location }) {
           <>
             <PageBreak style={{ paddingBottom: '16px' }} label={t('CROP_CATALOGUE.ON_YOUR_FARM')} />
             <CropStatusInfoBox
-              status={{ active, past, planned, noPlans }}
+              status={{ active, abandoned, past, planned, noPlans }}
               style={{ marginBottom: '16px' }}
               date={date}
               setDate={setDate}
@@ -145,6 +145,7 @@ export default function CropVarieties({ history, match, location }) {
                 const {
                   crop_translation_key,
                   active,
+                  abandoned,
                   planned,
                   past,
                   imageKey,
@@ -162,6 +163,7 @@ export default function CropVarieties({ history, match, location }) {
                     key={crop_variety_id}
                     cropCount={{
                       active: active.length,
+                      abandoned: abandoned.length,
                       planned: planned.length,
                       past: past.length,
                       noPlans: noPlans.length,

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -138,6 +138,7 @@ export default function CropVarieties({ history, match, location }) {
                     cropCount={{
                       noPlans: noPlansCount,
                     }}
+                    view='CropVariety'
                   />
                 );
               })}
@@ -174,6 +175,7 @@ export default function CropVarieties({ history, match, location }) {
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => goToVarietyManagement(crop_variety_id)}
+                    view='CropVariety'
                   />
                 );
               })}

--- a/packages/webapp/src/containers/managementPlanSlice.js
+++ b/packages/webapp/src/containers/managementPlanSlice.js
@@ -204,6 +204,21 @@ export const getCurrentManagementPlans = (managementPlans, time) => {
   return managementPlans.filter((managementPlan) => isCurrentManagementPlan(managementPlan, time));
 };
 
+
+// 
+
+export const isAbandonedManagementPlan = (managementPlan, time) => {
+  return (
+    managementPlan.abandon_date
+  );
+};
+
+export const getAbandonedManagementPlans = (managementPlans, time) => {
+  return managementPlans.filter((managementPlan) => isAbandonedManagementPlan(managementPlan, time));
+};
+
+//
+
 export const plannedManagementPlansSelector = createSelector(
   [managementPlansSelector, lastActiveDatetimeSelector],
   (managementPlans, lastActiveDatetime) => {
@@ -278,6 +293,14 @@ export const currentManagementPlanByCropIdSelector = (crop_id) =>
     (managementPlans, cropCatalogFilterDate) =>
       getCurrentManagementPlans(managementPlans, new Date(cropCatalogFilterDate).getTime()),
   );
+//
+export const abandonedManagementPlanByCropIdSelector = (crop_id) =>
+  createSelector(
+    [managementPlanByCropIdSelector(crop_id), cropCatalogueFilterDateSelector],
+    (managementPlans, cropCatalogFilterDate) =>
+      getAbandonedManagementPlans(managementPlans, new Date(cropCatalogFilterDate).getTime()),
+  );
+//
 export const plannedManagementPlanByCropIdSelector = (crop_id) =>
   createSelector(
     [managementPlanByCropIdSelector(crop_id), cropCatalogueFilterDateSelector],
@@ -307,6 +330,12 @@ export const currentCropVarietiesByCropIdSelector = (crop_id) =>
   createSelector([currentManagementPlanByCropIdSelector(crop_id)], (managementPlans) =>
     getUniqueEntities(managementPlans, 'crop_variety_id'),
   );
+//
+export const abandonedCropVarietiesByCropIdSelector = (crop_id) =>
+  createSelector([abandonedManagementPlanByCropIdSelector(crop_id)], (managementPlans) =>
+    getUniqueEntities(managementPlans, 'crop_variety_id'),
+  );
+//
 export const plannedCropVarietiesByCropIdSelector = (crop_id) =>
   createSelector([plannedManagementPlanByCropIdSelector(crop_id)], (managementPlans) =>
     getUniqueEntities(managementPlans, 'crop_variety_id'),
@@ -329,7 +358,15 @@ export const currentManagementPlanByCropVarietyIdSelector = (crop_variety_id) =>
     (managementPlans, lastActiveDate) =>
       getCurrentManagementPlans(managementPlans, new Date(lastActiveDate).getTime()),
   );
-export const plannedManagementPlanByCropVarietyIdSelector = (crop_variety_id) =>
+//
+export const abandonedManagementPlanByCropVarietyIdSelector = (crop_variety_id) =>
+  createSelector(
+    [managementPlansByCropVarietyIdSelector(crop_variety_id), lastActiveDatetimeSelector],
+    (managementPlans, lastActiveDate) =>
+      getAbandonedManagementPlans(managementPlans, new Date(lastActiveDate).getTime()),
+  );
+//
+  export const plannedManagementPlanByCropVarietyIdSelector = (crop_variety_id) =>
   createSelector(
     [managementPlansByCropVarietyIdSelector(crop_variety_id), lastActiveDatetimeSelector],
     (managementPlans, lastActiveDate) =>

--- a/packages/webapp/src/containers/managementPlanSlice.js
+++ b/packages/webapp/src/containers/managementPlanSlice.js
@@ -163,6 +163,16 @@ export const abandonedManagementPlansSelector = createSelector(
   },
 );
 
+export const isAbandonedManagementPlan = (managementPlan, time) => {
+  return (
+    managementPlan.abandon_date
+  );
+};
+
+export const getAbandonedManagementPlans = (managementPlans, time) => {
+  return managementPlans.filter((managementPlan) => isAbandonedManagementPlan(managementPlan, time));
+};
+
 /**
  *
  * @param {Object} managementPlan
@@ -203,21 +213,6 @@ export const isCurrentManagementPlan = (managementPlan, time) => {
 export const getCurrentManagementPlans = (managementPlans, time) => {
   return managementPlans.filter((managementPlan) => isCurrentManagementPlan(managementPlan, time));
 };
-
-
-// 
-
-export const isAbandonedManagementPlan = (managementPlan, time) => {
-  return (
-    managementPlan.abandon_date
-  );
-};
-
-export const getAbandonedManagementPlans = (managementPlans, time) => {
-  return managementPlans.filter((managementPlan) => isAbandonedManagementPlan(managementPlan, time));
-};
-
-//
 
 export const plannedManagementPlansSelector = createSelector(
   [managementPlansSelector, lastActiveDatetimeSelector],
@@ -293,14 +288,14 @@ export const currentManagementPlanByCropIdSelector = (crop_id) =>
     (managementPlans, cropCatalogFilterDate) =>
       getCurrentManagementPlans(managementPlans, new Date(cropCatalogFilterDate).getTime()),
   );
-//
+
 export const abandonedManagementPlanByCropIdSelector = (crop_id) =>
   createSelector(
     [managementPlanByCropIdSelector(crop_id), cropCatalogueFilterDateSelector],
     (managementPlans, cropCatalogFilterDate) =>
       getAbandonedManagementPlans(managementPlans, new Date(cropCatalogFilterDate).getTime()),
   );
-//
+
 export const plannedManagementPlanByCropIdSelector = (crop_id) =>
   createSelector(
     [managementPlanByCropIdSelector(crop_id), cropCatalogueFilterDateSelector],
@@ -330,12 +325,12 @@ export const currentCropVarietiesByCropIdSelector = (crop_id) =>
   createSelector([currentManagementPlanByCropIdSelector(crop_id)], (managementPlans) =>
     getUniqueEntities(managementPlans, 'crop_variety_id'),
   );
-//
+
 export const abandonedCropVarietiesByCropIdSelector = (crop_id) =>
   createSelector([abandonedManagementPlanByCropIdSelector(crop_id)], (managementPlans) =>
     getUniqueEntities(managementPlans, 'crop_variety_id'),
   );
-//
+
 export const plannedCropVarietiesByCropIdSelector = (crop_id) =>
   createSelector([plannedManagementPlanByCropIdSelector(crop_id)], (managementPlans) =>
     getUniqueEntities(managementPlans, 'crop_variety_id'),


### PR DESCRIPTION
Seems to be working now but I will have a few questions since I am new to the stack here.

a. Would it be possible to get someone familiar with `useCropCatalogue.js`,` useCropVarietyCatalogue.js`, and `managementPlanSlice.js` to really scrutinize this PR? I mostly just duplicated existing code for the other filters and while I tried to understand the slicer I am really not confident here. I will added some line by line PR comments where I am particularly unsure.

b. I chose Grey900 for the color for the abandoned sum color any objections?

c. I added a sum square to the photos, grouped with needs plan when convenient. Any objections?

d. This PR brought up more issues: 
1. Filter sums are deceiving in crop catalogue: https://lite-farm.atlassian.net/browse/LF-2782
2. Crop card for catalogue and variety is getting clogged with filter sums: https://lite-farm.atlassian.net/browse/LF-2783
3. Filter options do not line up 1:1 with Crop Status Info Box: https://lite-farm.atlassian.net/browse/LF-2784
4. Slices may contain repetitive code: https://lite-farm.atlassian.net/browse/LF-2785