### PR TITLE
Fix : on modal outside click the user is not taken to the next step

### DIFF
--- a/packages/webapp/src/components/Modals/OrganicStatusMismatchModal/index.jsx
+++ b/packages/webapp/src/components/Modals/OrganicStatusMismatchModal/index.jsx
@@ -18,7 +18,7 @@ const OrganicStatusMismatchModal = ({ modalContent, dismissModal }) => {
     <ModalComponent
       title={modalContent?.title ?? ''}
       contents={[modalContent?.subTitle ?? '']}
-      dismissModal={() => dismissModal(0)}
+      dismissModal={() => dismissModal(buttonStatusEnum.GO_BACK)}
       buttonGroup={
         <>
           <Button


### PR DESCRIPTION
To Test:

1. Click outside of the modal and check if the user can able to move to the next step or not.
2. If the modal is dismissed and the user stays on the very same page, this means the bug is fixed.