### PR TITLE
update the status code to 200 as per the ensemble's api requirements for add readings

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -401,7 +401,7 @@ const sensorController = {
 
   async addReading(req, res) {
     if (!Object.keys(req.body).length) {
-      return res.status(400).send('No sensor readings posted');
+      return res.status(200).send('No sensor readings posted');
     }
     const trx = await transaction.start(Model.knex());
     try {
@@ -446,7 +446,7 @@ const sensorController = {
       }
     } catch (error) {
       await trx.rollback();
-      return res.status(400).json({
+      return res.status(200).json({
         error,
       });
     }


### PR DESCRIPTION
The add readings status code is been passed by the ensemble API in the registration response of sensors. This was causing us the issue to register sensors. 

The ensemble calls the webhook API to confirm if it working or not with the empty data object. 

Previously, I was sending 400 status code when the req.body was {}. After discussing this with Morten, it's now changed to 200.

the add readings API's response is revived by the ensemble.

