### PR TITLE
A different fix for missing units

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -78,6 +78,7 @@ const getOnKeyDown = (measure) => {
 };
 
 const DEFAULT_REACT_SELECT_WIDTH = 61;
+const DEFAULT_SELECT_ARROW_ICON_WIDTH = 20;
 
 const getReactSelectWidth = (measure) => {
   if (measure === 'time') return 93;
@@ -110,6 +111,7 @@ const useReactSelectStyles = (disabled, { reactSelectWidth = DEFAULT_REACT_SELEC
         width: `${reactSelectWidth - 19}px`,
         display: 'flex',
         justifyContent: 'center',
+        background: state.isDisabled ? 'var(--inputDisabled)' : 'inherit',
       }),
       singleValue: (provided, state) => ({
         fontSize: '16px',
@@ -371,16 +373,15 @@ const Unit = ({
           className={clsx(
             styles.pseudoInputContainer,
             showError && styles.inputError,
-            disabled && styles.disableBackground,
           )}
         >
           <div
             className={clsx(
               styles.verticleDivider,
               showError && styles.inputError,
-              isSelectDisabled && styles.none,
+              disabled && styles.none
             )}
-            style={{ width: `${reactSelectWidth}px` }}
+            style={{ width: `${isSelectDisabled ? reactSelectWidth - DEFAULT_SELECT_ARROW_ICON_WIDTH : reactSelectWidth}px` }}
           />
         </div>
       </div>

--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -29,7 +29,6 @@
   font-family: 'Open Sans', 'SansSerif', serif;
   background: transparent;
   min-width: 0;
-  z-index: 1;
 }
 
 .input[type='number'] {
@@ -122,7 +121,6 @@
 }
 
 .verticleDivider {
-  width: 61px;
   border-left: 1px solid var(--grey400);
 }
 

--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -12,7 +12,6 @@
   right: 0;
   line-height: 40px;
   cursor: pointer;
-  z-index: 2;
   width: 37px;
   display: flex;
   justify-content: center;
@@ -114,7 +113,6 @@
   height: 100%;
   position: absolute;
   width: 100%;
-  z-index: 0;
   display: flex;
   justify-content: flex-end;
   pointer-events: none;
@@ -134,11 +132,6 @@
 
 .none {
   display: none;
-}
-
-.disableBackground {
-  z-index: -1;
-  background-color: var(--inputDisabled);
 }
 
 .noBorderRadius {


### PR DESCRIPTION
@kikemarquez8 

What this solves:
- input container blocking the units multi-select
![image](https://user-images.githubusercontent.com/30075973/203179950-af3d564f-f95d-42a9-a050-3ea360043920.png)
- mismatch between pseudo-container sizes and combined input and units size.
![image](https://user-images.githubusercontent.com/30075973/203180412-50bfab32-72a7-4e17-bc54-54a102c81a2a.png)
![image](https://user-images.githubusercontent.com/30075973/203180501-89a9d7a9-88c3-4087-ba49-478856ca54c7.png)
- future z-index problems

My changes:

1. UNIT line 81, 384 and CSS line 125 - This deals with the the 'pseudoInputContainer' not sizing properly to acommodate the lack of multi-select arrow

2. UNIT line 114, and CSS line 141-145 - This puts the decision to background color off of the 'pseudoInputContainer' which is higher in the z-index causing the cover up back onto the calue container

3. UNIT line 382 - Disables the vertical divider for all disabled units not just where units' options.length <=1.

4. Removes z-index's and extra CSS - line32 of CSS causing overlap onto dropdown- Basically I recently learned of this principle of: "z-index causes problems and should be avoided in most situations" - [Blog post about the general problem](https://www.codegram.com/blog/stop-ab-using-z-index/)
