### PR TITLE
Addition of soft delete condition to get location_id for sensor readings 

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -408,13 +408,11 @@ const sensorController = {
       const infoBody = [];
       for (const sensor of Object.keys(req.body)) {
         const sensorData = req.body[sensor].data;
-        let corresponding_sensor = await SensorModel.query()
-          .select('location_id')
-          .where('external_id', sensor)
-          .where('partner_id', req.params.partner_id);
-
+        let { rows: corresponding_sensor = [] } = await SensorModel.getLocationIdForSensorReadings(
+          sensor,
+          req.params.partner_id,
+        );
         if (!corresponding_sensor.length) return res.status(400).send('sensor id not found');
-
         corresponding_sensor = corresponding_sensor[0];
         for (const sensorInfo of sensorData) {
           const parameter_number = sensorInfo.parameter_category.toLowerCase().replaceAll(' ', '_');

--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -236,6 +236,17 @@ class Sensor extends Model {
       console.log(error);
     }
   }
+
+  static async getLocationIdForSensorReadings(external_id, partner_id) {
+    return Model.knex().raw(
+      `
+        SELECT loc.location_id FROM sensor AS s
+        JOIN location AS loc ON loc.location_id = s.location_id 
+        WHERE external_id = ? and partner_id = ? AND deleted = ?;
+      `,
+      [external_id, partner_id, false],
+    );
+  }
 }
 
 export default Sensor;


### PR DESCRIPTION
To Test:

1. add sensors to your farm or go to the farm having sensors.
2. call the following API from your postman: 

POST URL: <base_url>/sensor/reading/partner/1/farm/<farm_id>
headers: authorization: <farm_id>sensor_secret

 check the soft delete condition so that we get the correct location_id for the recently added sensor to a new farm.  

For more details: 
1. Please connect with me on call to see if it's working.
2. https://lite-farm.atlassian.net/browse/LF-2454

Adding Screenshot for better understanding:

<img width="801" alt="Screen Shot 2022-11-25 at 11 13 15 AM" src="https://user-images.githubusercontent.com/20675885/204043647-9eb6b5c8-1642-4342-bc17-c7ad749b4b4f.png">

