### PR TITLE
Addition of the partner reading type validation in the add sensor readings API

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -24,6 +24,7 @@ import LocationModel from '../models/locationModel.js';
 import PointModel from '../models/pointModel.js';
 import FigureModel from '../models/figureModel.js';
 import UserModel from '../models/userModel.js';
+import PartnerReadingTypeModel from '../models/PartnerReadingTypeModel.js';
 
 import { transaction, Model } from 'objection';
 
@@ -406,16 +407,26 @@ const sensorController = {
     }
     try {
       const infoBody = [];
+      const partnerId = parseInt(req.params.partner_id) || 1;
+      const {
+        rows: partnerSensorReadingTypes = [],
+      } = await PartnerReadingTypeModel.getPartnerReadingTypeByPartnerId(partnerId);
+      if (!partnerSensorReadingTypes.length)
+        return res.status(400).send('partner not registered with the Litefarm');
       for (const sensor of Object.keys(req.body)) {
         const sensorData = req.body[sensor].data;
         let { rows: corresponding_sensor = [] } = await SensorModel.getLocationIdForSensorReadings(
           sensor,
-          req.params.partner_id,
+          partnerId,
         );
         if (!corresponding_sensor.length) return res.status(400).send('sensor id not found');
         corresponding_sensor = corresponding_sensor[0];
         for (const sensorInfo of sensorData) {
-          const parameter_number = sensorInfo.parameter_category.toLowerCase().replaceAll(' ', '_');
+          const readingType = sensorInfo.parameter_category.toLowerCase().replaceAll(' ', '_');
+          const isPartnerReadingTypePresent = partnerSensorReadingTypes.some(
+            (partnerSensorReadingType) => partnerSensorReadingType.readable_value === readingType,
+          );
+          if (!isPartnerReadingTypePresent) continue;
           const unit = sensorInfo.unit;
 
           if (sensorInfo.values.length < sensorInfo.timestamps.length)
@@ -426,7 +437,7 @@ const sensorController = {
               read_time: sensorInfo.timestamps[k] || '',
               location_id: corresponding_sensor.location_id,
               value: sensorInfo.values[k],
-              reading_type: parameter_number,
+              reading_type: readingType,
               valid: sensorInfo.validated[k] || false,
               unit,
             });

--- a/packages/api/src/models/PartnerReadingTypeModel.js
+++ b/packages/api/src/models/PartnerReadingTypeModel.js
@@ -75,6 +75,16 @@ class PartnerReadingTypeModel extends BaseModel {
   static async getReadingTypeByReadableValue(readableValue) {
     return PartnerReadingTypeModel.query().where('readable_value', readableValue).first();
   }
+
+  static async getPartnerReadingTypeByPartnerId(partner_id) {
+    return Model.knex().raw(
+      `
+        SELECT readable_value FROM public.partner_reading_type
+        WHERE partner_id=?
+      `,
+      [partner_id],
+    );
+  }
 }
 
 export default PartnerReadingTypeModel;

--- a/packages/api/src/models/sensorReadingModel.js
+++ b/packages/api/src/models/sensorReadingModel.js
@@ -33,7 +33,6 @@ class SensorReading extends Model {
       required: [
         'read_time',
         'location_id',
-        'reading_type',
         'value',
         'unit',
         'read_time',


### PR DESCRIPTION
To Test:

1. add sensors to your farm or go to the farm having sensors.
2. call the following API from your postman: 

POST URL: <base_url>/sensor/reading/partner/1/farm/<farm_id>
headers: authorization: <farm_id>sensor_secret

 check the soft delete condition so that we get the correct location_id for the recently added sensor to a new farm.  

For more details: 
1. Please connect with me on call to see if it's working.
2. https://lite-farm.atlassian.net/browse/LF-2454

