### PR TITLE
LF-2864 - refactor TaskLocation to handle deselect

### DIFF
--- a/packages/webapp/src/components/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/components/Task/TaskLocations/index.jsx
@@ -55,8 +55,14 @@ export default function PureTaskLocations({
   );
 
   const onSelectLocation = (location_id) => {
-    if(!isMulti && getValues('show_wild_crop')){
-      setValue(SHOW_WILD_CROP, false);
+    if(!isMulti){
+      if(getValues('show_wild_crop')){
+        setValue(SHOW_WILD_CROP, false);
+      }
+      if (selectedLocations[0]?.location_id === location_id) {
+        setValue(LOCATIONS, []);
+        return;
+      } 
     }
     setValue(
       LOCATIONS,


### PR DESCRIPTION
**Description:**
Fix for [LF-2864](https://lite-farm.atlassian.net/jira/software/c/projects/LF/issues/LF-2864?filter=myopenissues) handle deselect of location on click of selected location.

**To Test**
Add a new task [one of: Transplant task or Irrigation task]. When you reach the location selection part of task creation you should be able to deselect a location by clicking on that same selected location.

**Code details**
OnSelectLocation now checks if the selected location is already the first in the array. Now nested under an isMulti check.