### PR TITLE
Added error handling of soil water potential unit in the preview tab

### DIFF
--- a/packages/webapp/src/components/Map/PreviewPopup/index.jsx
+++ b/packages/webapp/src/components/Map/PreviewPopup/index.jsx
@@ -98,11 +98,11 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
               <CompactPreview
                 title={t('SENSOR.READINGS_PREVIEW.TEMPERATURE')}
                 value={
-                  temperatureData.length
-                    ? getTemperatureValue(latestTemperatureData.value, units.measurement)
+                  temperatureData?.length
+                    ? getTemperatureValue(latestTemperatureData?.value, units?.measurement)
                     : null
                 }
-                unit={temperatureData.length ? getTemperatureUnit(units.measurement) : null}
+                unit={temperatureData?.length ? getTemperatureUnit(units?.measurement) : null}
                 loadReadingView={loadReadingView}
               />
             )}
@@ -110,9 +110,11 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
               <CompactPreview
                 title={t('SENSOR.READINGS_PREVIEW.SOIL_WATER_POTENTIAL')}
                 value={
-                  temperatureData.length ? -latestSoilWaterPotentialData.value.toFixed(2) : null
+                  soilWaterPotentialData?.length
+                    ? -latestSoilWaterPotentialData?.value?.toFixed(2)
+                    : null
                 }
-                unit={latestSoilWaterPotentialData.unit}
+                unit={soilWaterPotentialData?.length ? latestSoilWaterPotentialData?.unit : null}
                 loadReadingView={loadReadingView}
               />
             )}


### PR DESCRIPTION
To Test,


1. Add a sensor to the farm
2. on the farm map page, long click on the sensor point.
3. check if the error is handled 

Before: 

<img width="1436" alt="Screen Shot 2022-12-05 at 1 55 06 PM" src="https://user-images.githubusercontent.com/20675885/205750661-a2a49f7f-364e-49b8-bbba-3e3798dfe58c.png">

After: 

<img width="1440" alt="Screen Shot 2022-12-05 at 1 55 19 PM" src="https://user-images.githubusercontent.com/20675885/205750730-bf72f7f7-c21c-4f35-b27f-6518f2590788.png">



