### PR TITLE
Handling of reading_type undefined value in the PurePreviewPopup 

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1520,7 +1520,7 @@
     },
     "READINGS_PREVIEW": {
       "TEMPERATURE": "Current soil temp",
-      "SOIL_WATER_POTENTIAL": "Current soil watter potential"
+      "SOIL_WATER_POTENTIAL": "Current soil water potential"
     },
     "SENSOR_READING_CHART_SPOTLIGHT": {
       "TITLE": "Temperature sensor readings chart",

--- a/packages/webapp/src/components/Map/PreviewPopup/index.jsx
+++ b/packages/webapp/src/components/Map/PreviewPopup/index.jsx
@@ -55,7 +55,7 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
   const classes = useStyles();
   const { t } = useTranslation();
   const { units } = useSelector(userFarmSelector);
-  const { reading_types } = useSelector(sensorReadingTypesByLocationSelector(location.id));
+  const { reading_types = [] } = useSelector(sensorReadingTypesByLocationSelector(location.id));
 
   const loadReadingView = () => {
     history.push(`/${location.type}/${location.id}/readings`);
@@ -88,13 +88,13 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
    * Add other reading types in the "includes" clause when other compact components are developed.
    * This will allow the PreviewPopup component to only render if a sensor has reading data matching its reading type.
    */
-  if (reading_types.includes(TEMPERATURE) || reading_types.includes(SOIL_WATER_POTENTIAL)) {
+  if (reading_types?.includes(TEMPERATURE) || reading_types?.includes(SOIL_WATER_POTENTIAL)) {
     return (
       <div className={classes.container}>
         <div className={classes.tooltip} style={styleOverride}>
           <div className={classes.arrow} />
           <div className={classes.body}>
-            {reading_types.includes(TEMPERATURE) && (
+            {reading_types?.includes(TEMPERATURE) && (
               <CompactPreview
                 title={t('SENSOR.READINGS_PREVIEW.TEMPERATURE')}
                 value={
@@ -106,7 +106,7 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
                 loadReadingView={loadReadingView}
               />
             )}
-            {reading_types.includes(SOIL_WATER_POTENTIAL) && (
+            {reading_types?.includes(SOIL_WATER_POTENTIAL) && (
               <CompactPreview
                 title={t('SENSOR.READINGS_PREVIEW.SOIL_WATER_POTENTIAL')}
                 value={


### PR DESCRIPTION
To test,

1. add some sensors to the farm
2. long click on the sensor to see the pop-up that shows the latest readings of sensors.


<img width="1440" alt="Screen Shot 2022-12-06 at 4 06 11 PM" src="https://user-images.githubusercontent.com/20675885/206052885-33952c35-b094-4e17-b6cd-fde785a298e9.png">

