### PR TITLE
Addition of the deleted column to the field_work_type table

### DIFF
--- a/packages/api/db/migration/20221207172217_alter_field_work_type_table.js
+++ b/packages/api/db/migration/20221207172217_alter_field_work_type_table.js
@@ -1,0 +1,11 @@
+export const up = async function (knex) {
+  await knex.schema.alterTable('field_work_type', (t) => {
+    t.boolean('deleted').defaultTo(false);
+  });
+};
+
+export const down = async function (knex) {
+  await knex.schema.alterTable('field_work_type', (t) => {
+    t.dropColumn('deleted');
+  });
+};


### PR DESCRIPTION
Based on the following comment: 


<img width="612" alt="Screen Shot 2022-12-07 at 10 04 30 AM" src="https://user-images.githubusercontent.com/20675885/206261226-aed3fac4-b69e-40e6-b585-b313376210c8.png">


Here is the new migration change I have made.

To Test,

1. run the latest migration 
2. go to the field_work_type table and check deleted column is present with the default value as false.