### PR TITLE
Lf 2701 custom crop photo for new crop crop not displaying on crop varieties or crop catalogue page if added via edit

### DIFF
--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -141,7 +141,7 @@ export default function CropVarieties({ history, match, location }) {
                   <PureCropTile
                     key={crop_variety_id}
                     title={crop_variety_name}
-                    src={crop_variety_photo_url}
+                    src={crop_variety_photo_url ?? crop_photo_url}
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => goToVarietyManagement(crop_variety_id)}
@@ -181,7 +181,7 @@ export default function CropVarieties({ history, match, location }) {
                     }}
                     needsPlan={!!noPlansCount}
                     title={crop_variety_name}
-                    src={crop_variety_photo_url}
+                    src={crop_variety_photo_url ?? crop_photo_url}
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => goToVarietyManagement(crop_variety_id)}

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -130,6 +130,7 @@ export default function CropVarieties({ history, match, location }) {
                   crop_translation_key,
                   crop_photo_url,
                   crop_id,
+                  crop_variety_photo_url,
                   crop_variety_name,
                   crop_variety_id,
                   noPlansCount,
@@ -140,7 +141,7 @@ export default function CropVarieties({ history, match, location }) {
                   <PureCropTile
                     key={crop_variety_id}
                     title={crop_variety_name}
-                    src={crop_photo_url}
+                    src={crop_variety_photo_url}
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => goToVarietyManagement(crop_variety_id)}
@@ -163,6 +164,7 @@ export default function CropVarieties({ history, match, location }) {
                   needsPlan,
                   noPlans,
                   noPlansCount,
+                  crop_variety_photo_url,
                   crop_variety_name,
                   crop_variety_id,
                 } = cropCatalog;
@@ -179,7 +181,7 @@ export default function CropVarieties({ history, match, location }) {
                     }}
                     needsPlan={!!noPlansCount}
                     title={crop_variety_name}
-                    src={crop_photo_url}
+                    src={crop_variety_photo_url}
                     alt={imageKey}
                     style={{ width: cardWidth }}
                     onClick={() => goToVarietyManagement(crop_variety_id)}

--- a/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
+++ b/packages/webapp/src/containers/CropVarieties/useCropVarietyCatalogue.js
@@ -95,6 +95,7 @@ export default function useCropVarietyCatalogue(filterString, crop_id) {
             imageKey: managementPlan.crop_translation_key?.toLowerCase(),
             crop_id: managementPlan.crop_id,
             crop_photo_url: managementPlan.crop_photo_url,
+            crop_variety_photo_url: managementPlan.crop_variety_photo_url,
             crop_variety_id: managementPlan.crop_variety_id,
             crop_variety_name: managementPlan.crop_variety_name,
           };


### PR DESCRIPTION
**Description**
Crop variety catalogue should now be using the crop_variety_photo_url instead of any default crop_photo_url.

**Testing**
For UI testing - probably have to wait until it is merged into beta unless your local interacts with AWS.

Backend - The only way I could test this was to enter debugging mode and view that a url is indeed being supplied to the crop_variety_photo_url

[Jira ticket](https://lite-farm.atlassian.net/browse/LF-2701?atlOrigin=eyJpIjoiNGFkZDY1Y2RhNTRmNGI1ZmE2MDVhNTU3N2U1NDZlM2IiLCJwIjoiaiJ9)
