### PR TITLE
Displaying actual value of soil water potential 

### DIFF
--- a/packages/webapp/src/components/Map/PreviewPopup/index.jsx
+++ b/packages/webapp/src/components/Map/PreviewPopup/index.jsx
@@ -128,7 +128,7 @@ export default function PurePreviewPopup({ location, history, sensorReadings, st
                 title={t('SENSOR.READINGS_PREVIEW.SOIL_WATER_POTENTIAL')}
                 value={
                   soilWaterPotentialData?.length
-                    ? -getSoilWaterPotentialValue(
+                    ? getSoilWaterPotentialValue(
                         latestSoilWaterPotentialData?.value,
                         units?.measurement,
                       )


### PR DESCRIPTION
To Test,

1. Add a sensor to the farm 
2. make sure to have the latest sensor readings 
3. long click sensor in the farm map 
4. check the soil water potential reading is a positive value.