### PR TITLE
fix water use calculator

### DIFF
--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -172,8 +172,6 @@ export default function PureIrrigationTask({
         ...getValues(),
         irrigation_task: {
           ...getValues().irrigation_task,
-          application_depth: '',
-          percent_of_location_irrigated: '',
         },
       });
       setTotalDepthWaterUSage('');


### PR DESCRIPTION
persist application depth and % of location to be irrigated values for the depth measurement type when user clicks out of the model 