### PR TITLE
Lf 2930 form element checkbox does not have the option for a tooltip

### DIFF
--- a/packages/webapp/src/components/Form/Checkbox/checkbox.module.scss
+++ b/packages/webapp/src/components/Form/Checkbox/checkbox.module.scss
@@ -14,9 +14,7 @@
 }
 
 .smallLabel {
-  transform: translate(25px, 1px);
   font-size: 14px;
-  line-height: 16px;
 }
 
 /* Hide the browser's default Checkbox */

--- a/packages/webapp/src/components/Form/Checkbox/index.jsx
+++ b/packages/webapp/src/components/Form/Checkbox/index.jsx
@@ -15,7 +15,7 @@ const Checkbox = ({
   hookFormRegister,
   errors,
   sm,
-  tooltipContent = '',
+  tooltipContent = null,
   ...props
 }) => {
   const name = hookFormRegister?.name ?? props?.name;
@@ -42,7 +42,7 @@ const Checkbox = ({
       <Main
         className={clsx(styles.label, sm && styles.smallLabel)}
         style={classes.label}
-        tooltipContent={tooltipContent ?? undefined}
+        tooltipContent={tooltipContent}
       >
         {label}
       </Main>

--- a/packages/webapp/src/components/Form/Checkbox/index.jsx
+++ b/packages/webapp/src/components/Form/Checkbox/index.jsx
@@ -15,6 +15,7 @@ const Checkbox = ({
   hookFormRegister,
   errors,
   sm,
+  tooltipContent = '',
   ...props
 }) => {
   const name = hookFormRegister?.name ?? props?.name;
@@ -38,7 +39,11 @@ const Checkbox = ({
         {...props}
         disabled={disabled}
       />
-      <Main className={clsx(styles.label, sm && styles.smallLabel)} style={classes.label}>
+      <Main
+        className={clsx(styles.label, sm && styles.smallLabel)}
+        style={classes.label}
+        tooltipContent={tooltipContent ?? undefined}
+      >
         {label}
       </Main>
       <span className={clsx(styles.checkmark)} style={classes.checkbox} />


### PR DESCRIPTION
[Jira Ticket LF-2930](https://lite-farm.atlassian.net/browse/LF-2930)

**Description**
Adding tooltipContent functionality to Checkbox Form element

**What was done**
Pushed the tooltipContent attribute through Checkbox and into the existing Main component in /Typography.
Removed excess styling causing alignment issues when adding a tooltip.
Another component being used by checkbox: `<Main />`. It uses a toolTipContent as a bool so the 'undefined' was necessary to prevent always being rendered. Used `<PurePlantingDate />` as similar use of Main's tooltip.

**How it was tested**
1. Added _tooltipContent="your tooltip content here"_ to one Checkbox on a form and compared to one without tooltip. (Irrigation task is a good candidate for this).
2. Made sure alignment is good in multiple existing views that use `<Checkbox />` and `<Checkbox sm />` and also those same views with a tooltip.