### PR TITLE
LF-2933: After selecting a recently uploaded sensor I get a white screen

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/EditSensor.jsx
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/EditSensor.jsx
@@ -78,7 +78,6 @@ export default function UpdateSensor({ history, match }) {
       data.farm_id = sensorInfo.farm_id;
       data.location_id = sensorInfo.location_id;
     });
-    console.log(sensorData);
     dispatch(patchSensor(getProcessedFormData(sensorData)));
   };
 

--- a/packages/webapp/src/containers/Map/saga.js
+++ b/packages/webapp/src/containers/Map/saga.js
@@ -135,6 +135,7 @@ export function* bulkUploadSensorsInfoFileSaga({ payload: { file } }) {
       case 200: {
         yield put(bulkSensorsUploadSuccess());
         yield put(postManySensorsSuccess(fileUploadResponse?.data?.sensors));
+        yield put(getAllSensorReadingTypes());
         yield put(
           setSuccessMessage([
             i18n.t('FARM_MAP.MAP_FILTER.SENSOR'),

--- a/packages/webapp/src/containers/SensorReadings/index.jsx
+++ b/packages/webapp/src/containers/SensorReadings/index.jsx
@@ -98,6 +98,10 @@ function SensorReadings({ history, match }) {
             ?.sort()
             ?.reverse()
             ?.map((type, index) => {
+              if (!sensorVisualizationPropList[type]) {
+                return null;
+              }
+
               const {
                 title,
                 subTitle,


### PR DESCRIPTION
## Description

There are two bugs for creating a sensor:
- after a sensor is created, the app crashes by clicking the sensor icon on the map
- the app crashes when a sensor is created with the reading type "soil_water_content"

What is done:
- after creating a sensor, update `sensorReadingTypes`(`getAllSensorReadingTypes()`) state in redux
- enable `sensorReadings` component to handle the sensorReadingType `soil_water_content`

Jira link: https://lite-farm.atlassian.net/browse/LF-2933

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. go to `/map`, click "+" button and create a sensor. 
2. click the sensor icon on the map.
3. you should see graph/empty box for the reading type(s) of the sensor you just created.

1. create a sensor with the reading type `soil_water_content`, and do 2-3.

If reading types of the sensor are soil_water_content, soil_water_potential and temperature, the view looks like this:
![Screenshot 2023-01-31 at 8 45 35 AM](https://user-images.githubusercontent.com/33141219/216459170-54192be3-c99f-4cf2-bb13-3d1817c769b9.png)
