### PR TITLE
Lf 2931 unable to create a crop management plan for a plant that can be grown as a cover crop

### DIFF
--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -18,6 +18,7 @@ import CropManagementPlanModel from '../models/cropManagementPlanModel.js';
 import ManagementTasksModel from '../models/managementTasksModel.js';
 import TaskModel from '../models/taskModel.js';
 import TaskTypeModel from '../models/taskTypeModel.js';
+import FieldWorkTypeModel from '../models/fieldWorkTypeModel.js';
 import TransplantTaskModel from '../models/transplantTaskModel.js';
 import PlantTaskModel from '../models/plantTaskModel.js';
 import { raw } from 'objection';
@@ -145,11 +146,15 @@ const managementPlanController = {
                 task_translation_key: 'FIELD_WORK_TASK',
               })
               .first();
+            const fieldWorkType = await FieldWorkTypeModel.query(trx)
+              .select('field_work_type_id')
+              .where({ field_work_type_translation_key: 'TERMINATION' })
+              .first();
             const fieldWorkTask = await TaskModel.query(trx)
               .context(req.user)
               .upsertGraph(
                 getTask(due_date, fieldWorkTaskType.task_type_id, {
-                  field_work_task: { type: 'TERMINATION' },
+                  field_work_task: fieldWorkType,
                   ...taskManagementPlansAndLocations,
                 }),
                 {

--- a/packages/api/tests/managementPlan.test.js
+++ b/packages/api/tests/managementPlan.test.js
@@ -900,146 +900,146 @@ describe('ManagementPlan Tests', () => {
       };
     }
 
-    // async function expectPlantingMethodPosted(res, final_planting_method, initial_planting_method) {
-    //   expect(res.status).toBe(400);
-    //   const { management_plan_id } = res.body.management_plan;
-    //   const {
-    //     already_in_ground,
-    //     for_cover,
-    //     needs_transplant,
-    //   } = res.body.management_plan.crop_management_plan;
-    //   if (!already_in_ground) {
-    //     const { planting_management_plan_id } = await knex('planting_management_plan')
-    //       .where({
-    //         management_plan_id: res.body.management_plan.management_plan_id,
-    //         planting_task_type: 'PLANT_TASK',
-    //       })
-    //       .first();
-    //     const plantingMethod = await knex(final_planting_method)
-    //       .where({ planting_management_plan_id })
-    //       .first();
-    //     expect(plantingMethod).toBeDefined();
+    async function expectPlantingMethodPosted(res, final_planting_method, initial_planting_method) {
+      expect(res.status).toBe(201);
+      const { management_plan_id } = res.body.management_plan;
+      const {
+        already_in_ground,
+        for_cover,
+        needs_transplant,
+      } = res.body.management_plan.crop_management_plan;
+      if (!already_in_ground) {
+        const { planting_management_plan_id } = await knex('planting_management_plan')
+          .where({
+            management_plan_id: res.body.management_plan.management_plan_id,
+            planting_task_type: 'PLANT_TASK',
+          })
+          .first();
+        const plantingMethod = await knex(final_planting_method)
+          .where({ planting_management_plan_id })
+          .first();
+        expect(plantingMethod).toBeDefined();
 
-    //     const plant_task = await knex('plant_task').where({ planting_management_plan_id }).first();
-    //     expect(plant_task).toBeDefined();
-    //   }
-    //   if (initial_planting_method) {
-    //     const { planting_management_plan_id } = await knex('planting_management_plan')
-    //       .where({
-    //         management_plan_id: res.body.management_plan.management_plan_id,
-    //         planting_task_type: 'TRANSPLANT_TASK',
-    //       })
-    //       .first();
-    //     const plantingMethod = await knex(initial_planting_method)
-    //       .where({ planting_management_plan_id })
-    //       .first();
-    //     expect(plantingMethod).toBeDefined();
+        const plant_task = await knex('plant_task').where({ planting_management_plan_id }).first();
+        expect(plant_task).toBeDefined();
+      }
+      if (initial_planting_method) {
+        const { planting_management_plan_id } = await knex('planting_management_plan')
+          .where({
+            management_plan_id: res.body.management_plan.management_plan_id,
+            planting_task_type: 'TRANSPLANT_TASK',
+          })
+          .first();
+        const plantingMethod = await knex(initial_planting_method)
+          .where({ planting_management_plan_id })
+          .first();
+        expect(plantingMethod).toBeDefined();
 
-    //     const transplant_task = await knex('transplant_task')
-    //       .where({ planting_management_plan_id })
-    //       .first();
-    //     expect(transplant_task).toBeDefined();
-    //   }
+        const transplant_task = await knex('transplant_task')
+          .where({ planting_management_plan_id })
+          .first();
+        expect(transplant_task).toBeDefined();
+      }
 
-    //   const { planting_management_plan_id } = await knex('planting_management_plan')
-    //     .where({
-    //       management_plan_id: res.body.management_plan.management_plan_id,
-    //       planting_task_type: needs_transplant ? 'TRANSPLANT_TASK' : 'PLANT_TASK',
-    //     })
-    //     .first();
-    //   if (for_cover) {
-    //     const fieldWorkTask = await knex('management_tasks')
-    //       .join('field_work_task', 'field_work_task.task_id', 'management_tasks.task_id')
-    //       .where({ planting_management_plan_id })
-    //       .first();
-    //     expect(fieldWorkTask).toBeDefined();
-    //   } else {
-    //     const harvestTask = await knex('management_tasks')
-    //       .join('harvest_task', 'harvest_task.task_id', 'management_tasks.task_id')
-    //       .where({ planting_management_plan_id })
-    //       .first();
-    //     expect(harvestTask).toBeDefined();
-    //   }
-    // }
+      const { planting_management_plan_id } = await knex('planting_management_plan')
+        .where({
+          management_plan_id: res.body.management_plan.management_plan_id,
+          planting_task_type: needs_transplant ? 'TRANSPLANT_TASK' : 'PLANT_TASK',
+        })
+        .first();
+      if (for_cover) {
+        const fieldWorkTask = await knex('management_tasks')
+          .join('field_work_task', 'field_work_task.task_id', 'management_tasks.task_id')
+          .where({ planting_management_plan_id })
+          .first();
+        expect(fieldWorkTask).toBeDefined();
+      } else {
+        const harvestTask = await knex('management_tasks')
+          .join('harvest_task', 'harvest_task.task_id', 'management_tasks.task_id')
+          .where({ planting_management_plan_id })
+          .first();
+        expect(harvestTask).toBeDefined();
+      }
+    }
 
-    // test('should create a broadcast management plan with required data', async (done) => {
-    //   postManagementPlanRequest(getBody('broadcast_method'), userFarm, async (err, res) => {
-    //     await expectPlantingMethodPosted(res, 'broadcast_method');
-    //     done();
-    //   });
-    // });
+    test('should create a broadcast management plan with required data', async (done) => {
+      postManagementPlanRequest(getBody('broadcast_method'), userFarm, async (err, res) => {
+        await expectPlantingMethodPosted(res, 'broadcast_method');
+        done();
+      });
+    });
 
-    // test('should create a broadcast management plan with 100% planted', async (done) => {
-    //   const broadcastData = getBody('broadcast_method');
-    //   const { total_area } = await knex('location')
-    //     .join('figure', 'figure.location_id', 'location.location_id')
-    //     .join('area', 'figure.figure_id', 'area.figure_id')
-    //     .where('location.location_id', field.location_id)
-    //     .first();
-    //   broadcastData.crop_management_plan.planting_management_plans[0].broadcast_method.percentage_planted = 100;
-    //   broadcastData.crop_management_plan.planting_management_plans[0].broadcast_method.area_used = total_area;
-    //   postManagementPlanRequest(broadcastData, userFarm, async (err, res) => {
-    //     await expectPlantingMethodPosted(res, 'broadcast_method');
-    //     done();
-    //   });
-    // });
+    test('should create a broadcast management plan with 100% planted', async (done) => {
+      const broadcastData = getBody('broadcast_method');
+      const { total_area } = await knex('location')
+        .join('figure', 'figure.location_id', 'location.location_id')
+        .join('area', 'figure.figure_id', 'area.figure_id')
+        .where('location.location_id', field.location_id)
+        .first();
+      broadcastData.crop_management_plan.planting_management_plans[0].broadcast_method.percentage_planted = 100;
+      broadcastData.crop_management_plan.planting_management_plans[0].broadcast_method.area_used = total_area;
+      postManagementPlanRequest(broadcastData, userFarm, async (err, res) => {
+        await expectPlantingMethodPosted(res, 'broadcast_method');
+        done();
+      });
+    });
 
-    // test('should create a broadcast management plan with transplant', async (done) => {
-    //   postManagementPlanRequest(
-    //     getBody('broadcast_method', 'container_method'),
-    //     userFarm,
-    //     async (err, res) => {
-    //       await expectPlantingMethodPosted(res, 'broadcast_method', 'container_method');
-    //       done();
-    //     },
-    //   );
-    // });
+    test('should create a broadcast management plan with transplant', async (done) => {
+      postManagementPlanRequest(
+        getBody('broadcast_method', 'container_method'),
+        userFarm,
+        async (err, res) => {
+          await expectPlantingMethodPosted(res, 'broadcast_method', 'container_method');
+          done();
+        },
+      );
+    });
 
-    // test('should create a container management plan with required data', async (done) => {
-    //   postManagementPlanRequest(getBody('container_method'), userFarm, async (err, res) => {
-    //     await expectPlantingMethodPosted(res, 'container_method');
-    //     done();
-    //   });
-    // });
+    test('should create a container management plan with required data', async (done) => {
+      postManagementPlanRequest(getBody('container_method'), userFarm, async (err, res) => {
+        await expectPlantingMethodPosted(res, 'container_method');
+        done();
+      });
+    });
 
-    // test('should create a container management plan with transplant', async (done) => {
-    //   postManagementPlanRequest(
-    //     getBody('container_method', 'container_method'),
-    //     userFarm,
-    //     async (err, res) => {
-    //       await expectPlantingMethodPosted(res, 'container_method', 'container_method');
-    //       done();
-    //     },
-    //   );
-    // });
+    test('should create a container management plan with transplant', async (done) => {
+      postManagementPlanRequest(
+        getBody('container_method', 'container_method'),
+        userFarm,
+        async (err, res) => {
+          await expectPlantingMethodPosted(res, 'container_method', 'container_method');
+          done();
+        },
+      );
+    });
 
-    // test('should create a rows management plan', async (done) => {
-    //   postManagementPlanRequest(getBody('row_method'), userFarm, async (err, res) => {
-    //     await expectPlantingMethodPosted(res, 'row_method');
-    //     done();
-    //   });
-    // });
+    test('should create a rows management plan', async (done) => {
+      postManagementPlanRequest(getBody('row_method'), userFarm, async (err, res) => {
+        await expectPlantingMethodPosted(res, 'row_method');
+        done();
+      });
+    });
 
     // //TODO: post management plan middle ware that checks there are maximum 1 plant_task and 1 transplant_task
-    // xtest('should not allow multiple types of plantation', async (done) => {
-    //   const managementPlantWith4plantingManagementPlan = getBody(
-    //     'broadcast_method',
-    //     'container_method',
-    //   );
-    //   managementPlantWith4plantingManagementPlan.crop_management_plan.planting_management_plans = [
-    //     ...managementPlantWith4plantingManagementPlan.crop_management_plan
-    //       .planting_management_plans,
-    //     ...managementPlantWith4plantingManagementPlan.crop_management_plan
-    //       .planting_management_plans,
-    //   ];
-    //   postManagementPlanRequest(
-    //     managementPlantWith4plantingManagementPlan,
-    //     userFarm,
-    //     async (err, res) => {
-    //       expect(res.status).toBe(400);
-    //       done();
-    //     },
-    //   );
-    // });
+    xtest('should not allow multiple types of plantation', async (done) => {
+      const managementPlantWith4plantingManagementPlan = getBody(
+        'broadcast_method',
+        'container_method',
+      );
+      managementPlantWith4plantingManagementPlan.crop_management_plan.planting_management_plans = [
+        ...managementPlantWith4plantingManagementPlan.crop_management_plan
+          .planting_management_plans,
+        ...managementPlantWith4plantingManagementPlan.crop_management_plan
+          .planting_management_plans,
+      ];
+      postManagementPlanRequest(
+        managementPlantWith4plantingManagementPlan,
+        userFarm,
+        async (err, res) => {
+          expect(res.status).toBe(400);
+          done();
+        },
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the bug where a crop management plan could not be created using a cover crop. Previous to this fix, when adding a crop plan and selecting "Is this being grown as a cover crop or for harvest?" > "As a cover crop", plan creation (saving) failed, returning a 400 status and validation error.

Jira link: https://lite-farm.atlassian.net/browse/LF-2931

The issue:
- Creating a new crop management plan with a cover crop also generates a new field work task for its termination. The code controlling this was attempting to set a non-existent property 'type' on the field work task
- This part of the codebase was currently uncovered by the API testing suite

The solution:
- An additional query was introduced to retrieve the field_work_type_id from the field work type table, and this was used when creating the field work task
- The test cases covering this part of the codebase were un-commented, and the status code expectation was fixed


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

With a local instance of the pg-litefarm database:
- Using the frontend and following the workflow in the [Jira ticket](https://lite-farm.atlassian.net/browse/LF-2931)
- Using an API testing tool (Postman) on the `management_plan/` endpoint

With test script + local instance of test_farm database:
- Passes the re-introduced test block "POST management plan" in `api/tests/managementPlant.test.js`

**Test Configuration**:

-   Firmware version: N/A
-   Hardware: N/A
-   Toolchain: N/A
-   SDK: N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak