### PR TITLE
Lf 2919 inconsistent behaviour between depth and volume water usage calculator

### DIFF
--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -199,9 +199,7 @@ const WaterUseDepthCalculator = ({
 
   useEffect(() => {
     if (percentage_location_irrigated) {
-      const irrigatedArea = roundToTwoDecimal(
-        locationSize * (percentage_location_irrigated ? percentage_location_irrigated / 100 : 1),
-      );
+      const irrigatedArea = roundToTwoDecimal(locationSize * (percentage_location_irrigated / 100));
       setValue(IRRIGATED_AREA, irrigatedArea);
     } else {
       setValue(IRRIGATED_AREA, '');

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -57,32 +57,32 @@ const WaterUseVolumeCalculator = ({
   const estimated_water_usage_unit = getValues('irrigation_task.estimated_water_usage_unit');
 
   useEffect(() => {
-    if (estimated_duration || estimated_flow_rate) {
-      const estimated_flow_rate_value = estimated_flow_rate ? estimated_flow_rate : 1;
-      const estimated_duration_value = estimated_duration ? estimated_duration : 1;
+    if (estimated_duration && estimated_flow_rate) {
       setTotalWaterUsage(() => {
         if (
           ['l/h', 'gal/h'].includes(estimated_flow_rate_unit?.value) &&
           estimated_duration_unit?.label === 'h'
         )
-          return roundToTwoDecimal(estimated_flow_rate_value * estimated_duration_value);
+          return roundToTwoDecimal(estimated_flow_rate * estimated_duration);
         if (
           ['l/min', 'gal/min'].includes(estimated_flow_rate_unit?.value) &&
           estimated_duration_unit?.label === 'm'
         )
-          return roundToTwoDecimal(estimated_flow_rate_value * estimated_duration_value);
+          return roundToTwoDecimal(estimated_flow_rate * estimated_duration);
         if (
           ['l/h', 'gal/h'].includes(estimated_flow_rate_unit?.value) &&
           estimated_duration_unit?.label === 'm'
         )
-          return roundToTwoDecimal(estimated_flow_rate_value * (estimated_duration_value / 60));
+          return roundToTwoDecimal(estimated_flow_rate * (estimated_duration / 60));
         if (
           ['l/min', 'gal/min'].includes(estimated_flow_rate_unit?.value) &&
           estimated_duration_unit?.label === 'h'
         )
-          return roundToTwoDecimal(estimated_flow_rate_value * (estimated_duration_value * 60));
+          return roundToTwoDecimal(estimated_flow_rate * (estimated_duration * 60));
         return totalWaterUsage;
       });
+    } else {
+      setTotalWaterUsage('');
     }
   }, [estimated_duration, estimated_flow_rate]);
 
@@ -198,7 +198,7 @@ const WaterUseDepthCalculator = ({
   }, [location]);
 
   useEffect(() => {
-    if (typeof percentage_location_irrigated === 'number') {
+    if (percentage_location_irrigated) {
       const irrigatedArea = roundToTwoDecimal(
         locationSize * (percentage_location_irrigated ? percentage_location_irrigated / 100 : 1),
       );
@@ -230,6 +230,8 @@ const WaterUseDepthCalculator = ({
           (application_depth ? convert(application_depth).from('mm').to('m') : 1); // to convert application depth from mm to m
         return roundToTwoDecimal(convert(Volume_in_m_cubed).from('m3').to('l')); // to convert from m3 to litres
       });
+    } else {
+      setTotalWaterUsage('');
     }
   }, [application_depth, percentage_location_irrigated, irrigated_area]);
 
@@ -338,7 +340,7 @@ const WaterUseModal = ({
   totalVolumeWaterUsage,
   setTotalVolumeWaterUsage,
   totalDepthWaterUsage,
-  setTotalDepthWaterUSage,
+  setTotalDepthWaterUsage,
   formState,
   locationDefaults,
 }) => {
@@ -357,7 +359,7 @@ const WaterUseModal = ({
       <WaterUseDepthCalculator
         system={system}
         totalWaterUsage={totalDepthWaterUsage}
-        setTotalWaterUsage={setTotalDepthWaterUSage}
+        setTotalWaterUsage={setTotalDepthWaterUsage}
         formState={formState}
         locationDefaults={locationDefaults}
       />
@@ -372,7 +374,7 @@ export default function WaterUsageCalculatorModal({
   totalVolumeWaterUsage,
   setTotalVolumeWaterUsage,
   totalDepthWaterUsage,
-  setTotalDepthWaterUSage,
+  setTotalDepthWaterUsage,
   formState,
   locationDefaults,
 }) {
@@ -411,7 +413,7 @@ export default function WaterUsageCalculatorModal({
         totalVolumeWaterUsage={totalVolumeWaterUsage}
         setTotalVolumeWaterUsage={setTotalVolumeWaterUsage}
         totalDepthWaterUsage={totalDepthWaterUsage}
-        setTotalDepthWaterUSage={setTotalDepthWaterUSage}
+        setTotalDepthWaterUsage={setTotalDepthWaterUsage}
         formState={formState}
         locationDefaults={locationDefaults}
       />

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -63,7 +63,7 @@ export default function PureIrrigationTask({
     if (locationDefaults?.irrigation_task_type) return locationDefaults?.irrigation_task_type;
   });
   const [totalVolumeWaterUsage, setTotalVolumeWaterUsage] = useState();
-  const [totalDepthWaterUsage, setTotalDepthWaterUSage] = useState();
+  const [totalDepthWaterUsage, setTotalDepthWaterUsage] = useState();
   const [estimatedWaterUsageComputed, setEstimatedWaterUsageComputed] = useState(false);
 
   const dispatch = useDispatch();
@@ -174,7 +174,7 @@ export default function PureIrrigationTask({
           ...getValues().irrigation_task,
         },
       });
-      setTotalDepthWaterUSage('');
+      setTotalDepthWaterUsage('');
     }
   }, [showWaterUseCalculatorModal]);
 
@@ -308,7 +308,7 @@ export default function PureIrrigationTask({
           totalVolumeWaterUsage={totalVolumeWaterUsage}
           setTotalVolumeWaterUsage={setTotalVolumeWaterUsage}
           totalDepthWaterUsage={totalDepthWaterUsage}
-          setTotalDepthWaterUSage={setTotalDepthWaterUSage}
+          setTotalDepthWaterUsage={setTotalDepthWaterUsage}
           formState={stateController}
           locationDefaults={locationDefaults}
         />


### PR DESCRIPTION
**Description**

This changes the Water use calculator removes a few unnecessary ternary operators that were setting default values to '1' . This was allowing calculations without the necessary values to compute. 

It also fixes a minor spelling mistake.

Jira link: [LF2919](https://lite-farm.atlassian.net/browse/LF-2919?atlOrigin=eyJpIjoiNWZkYjE3MDNhZDI4NGNlYjg5NDY0MGMwZTQ4ZGJhNDYiLCJwIjoiaiJ9)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain): MANUAL visual test

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added the GNU General Public License shown below to all new files

