### PR TITLE
Lf 2656 not entering a date on document upload archives the document

### DIFF
--- a/packages/webapp/src/components/Documents/Add/index.jsx
+++ b/packages/webapp/src/components/Documents/Add/index.jsx
@@ -89,8 +89,8 @@ function PureDocumentDetailView({
       }
       return undefined;
     };
-    let validUntil = !!data.valid_until ? data.valid_until : null;
-    data.type = !!data.type ? data.type.value : data.type;
+    let validUntil = data.valid_until ? data.valid_until : null;
+    data.type = data.type ? data.type.value : data.type;
     validUntil = data.no_expiration ? null : validUntil;
     submit({
       ...data,

--- a/packages/webapp/src/components/Documents/Add/index.jsx
+++ b/packages/webapp/src/components/Documents/Add/index.jsx
@@ -92,12 +92,14 @@ function PureDocumentDetailView({
     let validUntil = data.valid_until ? data.valid_until : null;
     data.type = data.type ? data.type.value : data.type;
     validUntil = data.no_expiration ? null : validUntil;
+    const noExpiration = !data?.valid_until ? true : data.no_expiration;
     submit({
       ...data,
       thumbnail_url: getDocumentThumbnailUrl(uploadedFiles),
       files: uploadedFiles.map((file, i) => ({
         ...file,
       })),
+      no_expiration: noExpiration,
       valid_until: validUntil,
     });
   };


### PR DESCRIPTION
<h2>Description</h2>
Set "This file does not expire" to true if user does not provided an "Valid until" date in add document page.

Jira link: [LF-2656](https://lite-farm.atlassian.net/browse/LF-2656)

<h2>Type of change</h2>

- [x] Bug fix (non-breaking change which fixes an issue)

<h2>How has this been tested?</h2>

1. Go to documents page and click in "+Add a new document" link.
2. In put a name, but don't add a "Valid until" date nor select "This file does not expire".
3. Click in "Save" button.

[LF-2656]: https://lite-farm.atlassian.net/browse/LF-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ