### PR TITLE
LF-2850(2): Add copyright link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+_Please delete options that are not relevant._
+
 **Description**
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
@@ -5,8 +7,6 @@ Please include a summary of the change and which issue is fixed. Please also inc
 Jira link:
 
 **Type of change**
-
-Please delete options that are not relevant.
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Jira link: 
+Jira link:
 
 **Type of change**
 
@@ -27,19 +27,4 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] The precommit and linting ran successfully
 - [ ] I have added or updated language tags for text that's part of the UI
 - [ ] I have added "MISSING" for all new language tags to languages I don't speak
-- [ ] I have added the GNU General Public License shown below to all new files
-
-/*
-*  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
-*  This file (file_name.file_format) is part of LiteFarm.
-*
-*  LiteFarm is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 3 of the License, or
-*  (at your option) any later version.
-*
-*  LiteFarm is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
-*/
+- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-_Please delete options that are not relevant._
-
 **Description**
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
@@ -24,6 +22,10 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 **Checklist:**
 
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
 - [ ] The precommit and linting ran successfully
 - [ ] I have added or updated language tags for text that's part of the UI
 - [ ] I have added "MISSING" for all new language tags to languages I don't speak


### PR DESCRIPTION
## Description
- add the copyright link in Confluence page
- move "Please delete options that are not relevant." up to the top