### PR TITLE
LF-2923 Helptext next to crop group on the crop type creation page is unselectable on mobile

### DIFF
--- a/packages/webapp/src/components/Form/ReactSelect/index.jsx
+++ b/packages/webapp/src/components/Form/ReactSelect/index.jsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { colors } from '../../../assets/theme';
 import Infoi from '../../Tooltip/Infoi';
 import { BsX } from 'react-icons/bs';
+import scss from './reactSelect.module.scss';
 
 export const styles = {
   option: (provided, state) => ({
@@ -161,36 +162,25 @@ const ReactSelect = React.forwardRef(function ReactSelect(
   if (!createPromptText) createPromptText = t('common:CREATE');
 
   return (
-    <div data-cy="react-select" style={style}>
+    <div data-cy="react-select" className={scss.container} style={style}>
       {(label || toolTipContent || icon) && (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            minHeight: '20px',
-            position: 'relative',
-          }}
-        >
-          <Label style={{ position: 'absolute', bottom: 0 }}>
+        <div className={scss.labelContainer}>
+          <Label className={scss.labelText}>
             {label}
             {optional && (
-              <Label sm className={styles.sm} style={{ marginLeft: '4px' }}>
+              <Label sm className={scss.sm}>
                 {t('common:OPTIONAL')}
               </Label>
             )}
           </Label>
           {toolTipContent && (
-            <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+            <div className={scss.tooltipIconContainer}>
               <Infoi content={toolTipContent} autoOpen={autoOpen} />
             </div>
           )}
-          {icon && (
-            <span style={{ marginRight: 'auto', marginLeft: '8px' }} className={styles.icon}>
-              {icon}
-            </span>
-          )}
+          {icon && <span className={scss.icon}>{icon}</span>}
         </div>
-      )}{' '}
+      )}
       {creatable && (
         <CreatableSelect
           customStyles

--- a/packages/webapp/src/components/Form/ReactSelect/index.jsx
+++ b/packages/webapp/src/components/Form/ReactSelect/index.jsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { colors } from '../../../assets/theme';
 import Infoi from '../../Tooltip/Infoi';
 import { BsX } from 'react-icons/bs';
+import { ReactComponent as Leaf } from '../../../assets/images/farmMapFilter/Leaf.svg';
 import scss from './reactSelect.module.scss';
 
 export const styles = {
@@ -144,6 +145,7 @@ const ReactSelect = React.forwardRef(function ReactSelect(
     placeholder,
     createPromptText,
     options,
+    hasLeaf,
     toolTipContent,
     icon,
     style,
@@ -172,6 +174,7 @@ const ReactSelect = React.forwardRef(function ReactSelect(
                 {t('common:OPTIONAL')}
               </Label>
             )}
+            {hasLeaf && <Leaf className={scss.leaf} />}
           </Label>
           {toolTipContent && (
             <div className={scss.tooltipIconContainer}>

--- a/packages/webapp/src/components/Form/ReactSelect/index.jsx
+++ b/packages/webapp/src/components/Form/ReactSelect/index.jsx
@@ -167,10 +167,11 @@ const ReactSelect = React.forwardRef(function ReactSelect(
           style={{
             display: 'flex',
             justifyContent: 'space-between',
-            height: '20px',
+            minHeight: '20px',
+            position: 'relative',
           }}
         >
-          <Label>
+          <Label style={{ position: 'absolute', bottom: 0 }}>
             {label}
             {optional && (
               <Label sm className={styles.sm} style={{ marginLeft: '4px' }}>
@@ -179,7 +180,7 @@ const ReactSelect = React.forwardRef(function ReactSelect(
             )}
           </Label>
           {toolTipContent && (
-            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
               <Infoi content={toolTipContent} autoOpen={autoOpen} />
             </div>
           )}

--- a/packages/webapp/src/components/Form/ReactSelect/reactSelect.module.scss
+++ b/packages/webapp/src/components/Form/ReactSelect/reactSelect.module.scss
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+.sm {
+  margin-left: 8px;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  overflow: visible;
+  position: relative;
+  min-width: 0;
+}
+
+.labelContainer {
+  display: flex;
+  justify-content: space-between;
+  min-height: 20px;
+  position: relative;
+}
+
+.labelText {
+  position: absolute;
+  bottom: 0;
+}
+
+.leaf {
+  transform: translate(4px, 3px);
+  margin-left: 4px;
+}
+
+.tooltipIconContainer {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.icon {
+  position: absolute;
+  right: 0;
+  color: var(--iconDefault);
+}
+
+.icon > * {
+  cursor: pointer;
+}

--- a/packages/webapp/src/components/Task/AddProduct/index.jsx
+++ b/packages/webapp/src/components/Task/AddProduct/index.jsx
@@ -101,7 +101,7 @@ const AddProduct = ({
         value={productValue}
         style={{ marginBottom: '40px' }}
         creatable
-        icon={<Leaf />}
+        hasLeaf={true}
         isDisabled={disabled}
       />
       <input name={NAME} style={{ display: 'none' }} {...register(NAME, { required: true })} />

--- a/packages/webapp/src/components/Tooltip/Infoi/index.tsx
+++ b/packages/webapp/src/components/Tooltip/Infoi/index.tsx
@@ -2,12 +2,17 @@ import { AiOutlineInfoCircle } from 'react-icons/ai';
 import OverlayTooltip, { OverlayTooltipProps } from '../';
 import React from 'react';
 
-export default function Infoi({ content, placement = 'bottom', style, ...props }: OverlayTooltipProps) {
+export default function Infoi({
+  content,
+  placement = 'bottom',
+  style,
+  ...props
+}: OverlayTooltipProps) {
   return (
     <OverlayTooltip
       placement={placement}
       content={content}
-      icon={<AiOutlineInfoCircle style={style} />}
+      icon={<AiOutlineInfoCircle style={{ fontSize: '18px', ...style }} />}
       {...props}
     />
   );


### PR DESCRIPTION
**Description**

This PR makes the styling of the label region of the React Select component consistent with the Input component's. The discrepancy in label container height and tooltip container width is probably why the tooltip on React Select is difficult to tap (see Jira ticket). For the very minor changes to CSS involved, please see commit [cb2d57b](https://github.com/LiteFarmOrg/LiteFarm/commit/cb2d57b91a08e8d6d956fd5a443017906f017b52).

This PR also introduces an scss module for the React Select component to maintain consistency with Input, provide readable class names for debugging, and avoid using inline styles for static styling. This module is imported as `scss` because React Select [uses the styles namespace](https://react-select.com/styles#the-styles-prop).

Finally, the Infoi (information icon) component's font size has been fixed to 18px to maintain consistency across views. Although we had previously discussed editing the SVG itself, it is part of the 'react-icons/ai' package and only occurs in our app via the Infoi component.

Jira link: https://lite-farm.atlassian.net/browse/LF-2923

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view

This has been tested manually on both desktop and on a mobile device using Chrome for Android.

The React Select with tooltip occurs in seven views (see Jira ticket). The best view to test with is the Invite User view, which contains both a React Select with tooltip (Gender) and an Input with tooltip (Birth Year).

The React Select with Leaf occurs within Add Tasks > Add Product. For instance: Add A Task > Soil Amendment > (Date and Location) > Product.

**Checklist:**
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files