### PR TITLE
LF-2957-Bulk-sensor-upload-ignores-sensors-beyond-the-first

### DIFF
--- a/packages/shared/validation/sensorCSV.js
+++ b/packages/shared/validation/sensorCSV.js
@@ -185,7 +185,11 @@ const getReadableValuesForReadingTypes = (lang, readingTypes) => {
 };
 
 const generateSensorKey = (sensor) => {
-  return `${sensor.brand ?? ''}:${sensor.external_id ?? ''}`;
+  if (sensor.brand.length !== 0 && sensor.external_id.length !== 0) {
+    return `${sensor.brand}:${sensor.external_id}`;
+  } else {
+    return sensor.name;
+  }
 };
 
 export const parseSensorCsv = (csvString, lang) => {


### PR DESCRIPTION
fix: sensor CSV now checks row uniqueness by brand:external_id if available, else it uses sensor name