### PR TITLE
LF-2976 (Feat) Allow sending LiteFarm emails from personal accounts in development environment

### DIFF
--- a/packages/api/.env.default
+++ b/packages/api/.env.default
@@ -30,11 +30,21 @@ GOOGLE_API_KEY=?
 OPEN_WEATHER_APP_ID=?
 
 # Create your own Google API key at https://developers.google.com/identity/oauth2/web/guides/get-google-api-clientid
-GMAIL_API_CLIENT_ID=?
-GMAIL_API_CLIENT_SECRET=?
-GMAIL_ACCESS_TOKEN=?
-GMAIL_REFRESH_TOKEN=?
 GOOGLE_OAUTH_CLIENT_ID=?
+
+# For sending automatic LiteFarm emails on certain events (e.g. joining a farm)
+# To send from system@litefarm.org you will need the corresponding beta/production values for the Client ID, Secret, and Refresh Token
+LITEFARM_SERVICE_EMAIL=
+GMAIL_API_CLIENT_ID=
+GMAIL_API_CLIENT_SECRET=
+GMAIL_REFRESH_TOKEN=
+# Generate a refresh token using the OAuth Playground as described here: https://dev.to/chandrapantachhetri/sending-emails-securely-using-node-js-nodemailer-smtp-gmail-and-oauth2-g3a
+
+
+# (Optional; for easier setup only) Follow the directions here: https://support.google.com/mail/answer/185833 to create an app password for sending emails via your own personal gmail account
+# Omit or leave blank to defer to OAuth2 above
+DEV_GMAIL=
+DEV_GMAIL_APP_PASSWORD=
 
 # ???
 CONTACT_FORM_EMAIL=?

--- a/packages/api/src/templates/sendEmailTemplate.js
+++ b/packages/api/src/templates/sendEmailTemplate.js
@@ -46,6 +46,26 @@ function homeUrl(defaultUrl = 'http://localhost:3000') {
   return homeUrl;
 }
 
+function gmailAuth() {
+  const environment = process.env.NODE_ENV || 'development';
+  if (environment === 'development' && process.env.DEV_GMAIL) {
+    return {
+      user: process.env.DEV_GMAIL,
+      pass: process.env.DEV_GMAIL_APP_PASSWORD,
+    };
+  }
+  return {
+    type: 'OAuth2',
+    clientId: credentials.LiteFarm_Service_Gmail.client_id,
+    clientSecret: credentials.LiteFarm_Service_Gmail.client_secret,
+    user:
+      environment === 'development'
+        ? credentials.LiteFarm_Service_Gmail.user || 'system@litefarm.org'
+        : 'system@litefarm.org',
+    refreshToken: credentials.LiteFarm_Service_Gmail.refresh_token,
+  };
+}
+
 const emailTransporter = new EmailTemplates({
   views: {
     root: path.join(dir, 'emails'),
@@ -63,13 +83,7 @@ const emailTransporter = new EmailTemplates({
     port: 465,
     secure: true,
     service: 'gmail',
-    auth: {
-      type: 'OAuth2',
-      clientId: credentials.LiteFarm_Service_Gmail.client_id,
-      clientSecret: credentials.LiteFarm_Service_Gmail.client_secret,
-      user: 'system@litefarm.org',
-      refreshToken: credentials.LiteFarm_Service_Gmail.refresh_token,
-    },
+    auth: gmailAuth(),
   },
 });
 


### PR DESCRIPTION
Currently, LiteFarm emails (sent when, e.g., joining a farm or inviting users) are only sent from system@litefarm.org and require the Beta/Production gmail API keys and refresh token to work.

This PR adds the option of sending, in the development environment only, emails from another account with either 1) the correct OAuth2 credentials or 2) an app password set up through Google. Instructions for generating those credentials were added to `.env.default` along with more precise instructions about what the beta/production keys are for. To set up OAuth2, the currently unused `LITEFARM_SERVICE_EMAIL` environment variable was re-introduced.

This change is entirely opt-in; emails should continue to work as before whether the developer's `.env` file contains the official beta/production keys or not. That is, if the developer possessed the keys and was previously getting development emails sent for localhost actions via system@litefarm.org, they will continue to receive them. Contributors not using the LiteFarm gmail API keys will not start getting emails unless they set up their own account credentials following the `.env.default` instructions.

There are no beta or production changes; this only concerns development.

Jira link: https://lite-farm.atlassian.net/browse/LF-2976

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

In my local environment:
- Tested using both OAuth2 and App Password `.env` variables using my personal Gmail account. Emails are then sent upon localhost actions with my own gmail as the sender
- Tested with the beta keys in `.env` and with no opt-in variables; emails are successfully sent from system@litefarm.org

**Checklist:**

- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files