### PR TITLE
Lf 2842 reformat date display based on regional preference

### DIFF
--- a/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
@@ -129,7 +129,7 @@ class OtherExpense extends Component {
         let amount = parseFloat(e.value);
         subTotal += amount;
         detailedHistory.push({
-          date: moment(e.expense_date).toDate().toLocaleDateString(),
+          date: moment(e.expense_date),
           type: this.getExpenseType(e.expense_type_id),
           amount: this.state.currencySymbol + amount.toFixed(2).toString(),
           expense_date: e.expense_date,
@@ -178,6 +178,7 @@ class OtherExpense extends Component {
       {
         id: 'date',
         Header: this.props.t('SALE.LABOUR.TABLE.DATE'),
+        Cell: (d) => <span>{d.value.toDate().toLocaleDateString()}</span>,
         accessor: (d) => d.date,
         minWidth: 70,
         Footer: <div>{this.props.t('SALE.SUMMARY.SUBTOTAL')}</div>,

--- a/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
@@ -129,7 +129,7 @@ class OtherExpense extends Component {
         let amount = parseFloat(e.value);
         subTotal += amount;
         detailedHistory.push({
-          date: moment(e.expense_date),
+          date: moment(e.expense_date).toDate().toLocaleDateString(),
           type: this.getExpenseType(e.expense_type_id),
           amount: this.state.currencySymbol + amount.toFixed(2).toString(),
           expense_date: e.expense_date,
@@ -178,8 +178,8 @@ class OtherExpense extends Component {
       {
         id: 'date',
         Header: this.props.t('SALE.LABOUR.TABLE.DATE'),
-        Cell: (d) => <span>{moment(d.value).format('YYYY-MM-DD')}</span>,
-        accessor: (d) => moment(d.date),
+        //Cell: (d) => <span>{moment(d.value).format('YYYY-MM-DD')}</span>,
+        accessor: (d) => d.date,
         minWidth: 70,
         Footer: <div>{this.props.t('SALE.SUMMARY.SUBTOTAL')}</div>,
       },

--- a/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/OtherExpense/index.jsx
@@ -178,7 +178,6 @@ class OtherExpense extends Component {
       {
         id: 'date',
         Header: this.props.t('SALE.LABOUR.TABLE.DATE'),
-        //Cell: (d) => <span>{moment(d.value).format('YYYY-MM-DD')}</span>,
         accessor: (d) => d.date,
         minWidth: 70,
         Footer: <div>{this.props.t('SALE.SUMMARY.SUBTOTAL')}</div>,


### PR DESCRIPTION
**Description**

Reformat date to display in correct format as per user's browser localization.

Jira link: https://lite-farm.atlassian.net/browse/LF-2842


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**How Has This Been Tested?**

**Steps to recreate:**

1.  Log in to your farm
2. Navigate to finances
3. Filter for a date range with expenses
4. Click “Other expenses”

**Desired:**

- Date is displayed in correct format for user browser localization

**Observed:**
- Displays in yyyy-mm-dd

Follow [this](https://www.aleksandrhovhannisyan.com/blog/changing-locale-in-chrome-with-dev-tools/) guide to change locale in chrome for testing.

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added the GNU General Public License to all new files