### PR TITLE
Lf 2955 spike investigate current irrigation task architecture

### DIFF
--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -77,8 +77,7 @@ export default function PureIrrigationTask({
         value: irrigationType.irrigation_type_name,
         label: defaultIrrigationTaskTypes.includes(irrigationType.irrigation_type_name)
           ? t(`ADD_TASK.IRRIGATION_VIEW.TYPE.${irrigationType.irrigation_type_name}`)
-          // is the false case here really needed?
-          : t(irrigationType.irrigation_type_name),
+          : irrigationType.irrigation_type_name,
         default_measuring_type: irrigationType.default_measuring_type,
         irrigation_type_id: irrigationType.irrigation_type_id,
       };

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -17,16 +17,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { irrigationTaskTypesSliceSelector } from '../../../containers/irrigationTaskTypesSlice';
 import { cropLocationsSelector } from '../../../containers/locationSlice';
 
-const defaultIrrigationTaskTypes = [
-  'HAND_WATERING',
-  'CHANNEL',
-  'DRIP',
-  'FLOOD',
-  'PIVOT',
-  'SPRINKLER',
-  'SUB_SURFACE',
-  'OTHER',
-];
 export default function PureIrrigationTask({
   system,
   register,
@@ -44,7 +34,7 @@ export default function PureIrrigationTask({
   createTask = false,
 }) {
   const { t } = useTranslation();
-  const { errors, isValid } = formState;
+  const { errors } = formState;
   const [showWaterUseCalculatorModal, setShowWaterUseCalculatorModal] = useState(false);
   const { irrigationTaskTypes = [] } = useSelector(irrigationTaskTypesSliceSelector);
   const cropLocations = useSelector(cropLocationsSelector);
@@ -69,13 +59,25 @@ export default function PureIrrigationTask({
 
   const dispatch = useDispatch();
 
+  const getDefaultIrrigationTypes = () => {
+    let  defaultIrrigationTaskTypes = [];
+    for (let type of irrigationTaskTypes) {
+      if (type.farm_id === null) {
+        defaultIrrigationTaskTypes.push(type.irrigation_type_name);
+      }
+    }
+    return defaultIrrigationTaskTypes;
+  }
+
   const IrrigationTypeOptions = useMemo(() => {
     let options;
+    let defaultIrrigationTaskTypes = getDefaultIrrigationTypes()
     options = irrigationTaskTypes.map((irrigationType) => {
       return {
         value: irrigationType.irrigation_type_name,
         label: defaultIrrigationTaskTypes.includes(irrigationType.irrigation_type_name)
           ? t(`ADD_TASK.IRRIGATION_VIEW.TYPE.${irrigationType.irrigation_type_name}`)
+          // is the false case here really needed?
           : t(irrigationType.irrigation_type_name),
         default_measuring_type: irrigationType.default_measuring_type,
         irrigation_type_id: irrigationType.irrigation_type_id,
@@ -111,9 +113,9 @@ export default function PureIrrigationTask({
   const irrigation_type = watch(IRRIGATION_TYPE);
   const measurement_type = watch(MEASUREMENT_TYPE);
 
-  // If the task is being modified on completion then set the default flags to false in the form
+  // If the task is being modified on completion then set the "set default" flags to false in the form
   // this is to avoid overwriting default setting set by another task during that task's creation
-  // the 'set default' is only a visual reference for user to see this irrigation type was set as default during its creation
+  // the "set default" checkbox is only a visual reference for users to see this irrigation type was set as default during its creation
   useEffect(() => {
     if (isModified) {
       setValue(DEFAULT_IRRIGATION_TASK_LOCATION, false)

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -38,6 +38,7 @@ export default function PureIrrigationTask({
   formState,
   getFieldState = {},
   disabled = false,
+  isModified = false,
   locations,
   otherTaskType = false,
   createTask = false,
@@ -110,6 +111,16 @@ export default function PureIrrigationTask({
   const irrigation_type = watch(IRRIGATION_TYPE);
   const measurement_type = watch(MEASUREMENT_TYPE);
 
+  // If the task is being modified on completion then set the default flags to false in the form
+  // this is to avoid overwriting default setting set by another task during that task's creation
+  // the 'set default' is only a visual reference for user to see this irrigation type was set as default during its creation
+  useEffect(() => {
+    if (isModified) {
+      setValue(DEFAULT_IRRIGATION_TASK_LOCATION, false)
+      setValue(DEFAULT_IRRIGATION_MEASUREMENT, false)
+    }
+  });
+
   const onDismissWaterUseCalculatorModel = () => setShowWaterUseCalculatorModal(false);
   const handleModalSubmit = () => {
     const isDepthCalculatorValid =
@@ -178,9 +189,6 @@ export default function PureIrrigationTask({
     }
   }, [showWaterUseCalculatorModal]);
 
-  const selectedIrrigationTypeOption = useMemo(() => {
-    return IrrigationTypeOptions.filter((options) => options.value === irrigation_type)[0];
-  }, [irrigation_type, IrrigationTypeOptions]);
 
   return (
     <>
@@ -229,7 +237,7 @@ export default function PureIrrigationTask({
         sm
         style={{ marginTop: '6px', marginBottom: '40px' }}
         hookFormRegister={register(DEFAULT_IRRIGATION_TASK_LOCATION)}
-        disabled={disabled}
+        disabled={disabled || isModified}
       />
       <Label className={styles.label} style={{ marginBottom: '24px', fontSize: '16px' }}>
         {t('ADD_TASK.IRRIGATION_VIEW.HOW_DO_YOU_MEASURE_WATER_USE_FOR_THIS_IRRIGATION_TYPE')}
@@ -262,7 +270,7 @@ export default function PureIrrigationTask({
         label={t('ADD_TASK.IRRIGATION_VIEW.SET_AS_DEFAULT_MEASUREMENT_FOR_THIS_IRRIGATION_TYPE')}
         sm
         hookFormRegister={register(DEFAULT_IRRIGATION_MEASUREMENT)}
-        disabled={disabled}
+        disabled={disabled || isModified}
       />
 
       <Unit
@@ -321,4 +329,5 @@ PureIrrigationTask.propTypes = {
   system: PropTypes.oneOf(['imperial', 'metric']).isRequired,
   disabled: PropTypes.bool,
   locations: PropTypes.array,
+  isModified: PropTypes.bool,
 };

--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -23,7 +23,6 @@ export default function PureCompleteStepOne({
   farm,
   system,
   products,
-
   useHookFormPersist,
 }) {
   const { t } = useTranslation();
@@ -88,6 +87,7 @@ export default function PureCompleteStepOne({
           farm,
           task: selectedTask,
           disabled: !changesRequired,
+          isModified: changesRequired,
         })}
     </Form>
   );


### PR DESCRIPTION
**Description**
This irrigation task PR includes the following:
- In the “Mark complete” flow, when a user select “Yes” to “Did you have to make any changes to this task?” Each of the default checkboxes should be visible but disabled
    -  When a user goes to complete an irrigation task that was created with default checkboxes checked, the task completion page will show which boxes the user checked and the checkboxes are disabled. However, if a user select "Yes" to make changes to this task, the check boxes uncheck themselves and are still disabled. In either cases, they won't set default values again once the task is complete. Default values are only set during creation.

- In the original file, there was a hard coded constant with all the default irrigation types for translation. The updated method in this PR has made it so that it generates a variable from the data provided by the back end server. The back end was not touched in this PR. 

Note:
I noticed this warning when I'm on the Tasks page:
`TypeError: Cannot read properties of undefined (reading 'irrigation_type')
    at getIrrigationTask (irrigationTaskSlice.js:43:1)
    at irrigationTaskSlice.js:57:5
    at Array.map (<anonymous>)
    at upsertManyIrrigationTask (irrigationTaskSlice.js:53:5)
    at createReducer.ts:280:20
    at produce (immerClass.ts:94:14)
    at createReducer.ts:279:18
    at Array.reduce (<anonymous>)
    at reducer (createReducer.ts:246:25)
    at reducer (createSlice.ts:325:14)`
I couldn't resolve this issue but it shouldn't be from changes from this PR, I think it's due to my local setup.


Jira link: [LF-2955](https://lite-farm.atlassian.net/browse/LF-2955?atlOrigin=eyJpIjoiMmRlYzk2NmJmZjlkNDljZjg2MTgzMDJjYzlkNDM0MjEiLCJwIjoiaiJ9)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)
    - tested locally on my machine
    - Create an irrigation task with irrigation type "Channel", make that the default method
    - Create another irrigation task on the same field with irrigation type "Pivot", make it default as well
    - Complete the task with the "Channel" type
    - Try to create another irrigation task on the same field, the irrigation type should be "Pivot" instead of "Channel"
    - You shouldn't be able to set default values during the task completion process
    
**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-2955]: https://lite-farm.atlassian.net/browse/LF-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ