### PR TITLE
LF-2938: [fix] Set 'override_hourly_wage' to true when setting wage_at_moment 

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -175,7 +175,7 @@ const taskController = {
       const result = await TaskModel.query()
         .context(req.user)
         .findById(task_id)
-        .patch({ wage_at_moment });
+        .patch({ wage_at_moment, override_hourly_wage: true });
       return result ? res.sendStatus(200) : res.status(404).send('Task not found');
     } catch (error) {
       console.log(error);

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -2367,6 +2367,7 @@ describe('Task tests', () => {
           expect(res.status).toBe(200);
           const updated_task = await getTask(task_id);
           expect(updated_task.wage_at_moment).toBe(wage_at_moment);
+          expect(updated_task.override_hourly_wage).toBe(true);
           done();
         });
         return;


### PR DESCRIPTION
**Description**

@MwayaB spotted that `override_hourly_wage` needs to be updated to `true` when `wage_at_moment` is set.
Thank you Mwaya!!!


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

On the UI, when assigning a task and override a wage for the task, `override_hourly_wage` in the task table is updated to `true`.

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
