### PR TITLE
LF-2990 Ensure private SurveyStack submissions can be read

### DIFF
--- a/packages/api/.env.default
+++ b/packages/api/.env.default
@@ -61,6 +61,10 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=test
 
+# For document export of private SurveyStack responses
+SURVEY_USER=<userId>
+SURVEY_TOKEN=<token>
+
 # The following vars are only needed if working with Ensemble Scientific sensors and actuators
 #ENSEMBLE_USERNAME=?
 #ENSEMBLE_PASSWORD=?

--- a/packages/api/src/jobs/certification/pdf.js
+++ b/packages/api/src/jobs/certification/pdf.js
@@ -3,6 +3,14 @@ import fs from 'fs';
 import rp from 'request-promise';
 const surveyStackURL = 'https://app.surveystack.io/api/';
 
+// Add cookies to the SurveyStack requests
+rp.defaults({ jar: true });
+const cookiejar = rp.jar();
+cookiejar.setCookie(
+  `user=${process.env.SURVEY_USER}; token=${process.env.SURVEY_TOKEN};`,
+  'https://app.surveystack.io',
+);
+
 export default (nextQueue, emailQueue) => async (job) => {
   console.log('STEP 3 > PDF');
   const {

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -2,6 +2,14 @@ import XlsxPopulate from 'xlsx-populate';
 import rp from 'request-promise';
 const surveyStackURL = 'https://app.surveystack.io/api/';
 
+// Add cookies to the SurveyStack requests
+rp.defaults({ jar: true });
+const cookiejar = rp.jar();
+cookiejar.setCookie(
+  `user=${process.env.SURVEY_USER}; token=${process.env.SURVEY_TOKEN};`,
+  'https://app.surveystack.io',
+);
+
 export default async (emailQueue, submission, exportId, organicCertifierSurvey) => {
   if (!submission) {
     emailQueue.add({ fail: true });


### PR DESCRIPTION
**Description**

This PR allows viewing (export) of private survey responses by adding cookies to the SurveyStack data request.

Please see the complete discussion of this feature on Confluence: [Allow LiteFarm to access private SurveyStack data](https://lite-farm.atlassian.net/wiki/spaces/LITEFARM/pages/1271889935/Allow+LiteFarm+to+access+private+SurveyStack+data)

This functionality requires adding two variables to your `.env` file, obtained from inspecting either your cookies or local storage when visiting app.surveystack.io, logged in with an account with access right to the private survey in question. Access rights mean administrator of the group that owns the survey, or administrator in the parent group to a subgroup that owns the survey. 

```
SURVEY_USER=<user ID>
SURVEY_TOKEN=<token>
```

Jira link: https://lite-farm.atlassian.net/browse/LF-2990

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


**How Has This Been Tested?**
- [x] Other (please explain)

That the SurveyStack API returns private question data only when the correct user + token cookies are supplied was verified with:

- An API testing tool (Postman) on these SurveyStack endpoints:

From the Confluence document:
```
https://app.surveystack.io/api/submissions?survey={{survey_id}}&match={"_id":{"$oid":"{{submission_id}}"}}
```

From the existing document export code:
```
https://app.surveystack.io/api/submissions/{{submission_id}}
```

Small aside/note: the top endpoint appears preferable to me (it's much faster to return a response), but to adapt our code to use it would take some refactoring of document export that isn't directly related to auth and is hard to test without local document export; therefore I didn't consider it within the scope of this ticket.

- Setting cookies using `request-promise` (as in this PR's code) and testing that within a backend controller

The survey ID and submission ID can be found using the SurveyStack webapp. They can also be found from the Network tab when submitting the survey via the LiteFarm frontend. To access the survey from the LiteFarm frontend, you must first manually add the survey ID to your certifiers table.

What I have not been able to test is the full document export flow, because I have not gotten document export working from localhost.

**Checklist:**

- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files