### PR TITLE
Lf 2952 user is able to complete creating field work task flow without selecting field work

### DIFF
--- a/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
+++ b/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
@@ -67,7 +67,7 @@ const PureFieldWorkTask = ({
       <Controller
         control={control}
         name={FIELD_WORK_TYPE}
-        rules={{ required: true }}
+        rules={{ validate: (option) => !!option.value }}
         render={({ field: { onChange, value } }) => (
           <ReactSelect
             data-cy="fieldWorkTask-typeSelect"


### PR DESCRIPTION
**Description**

User is able to complete creating field work task flow without selecting field work. The button should be disabled if "type of field work" is not selected.

Jira link: https://lite-farm.atlassian.net/browse/LF-2952

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

**Steps to reproduce:**

1. go to `/task`
2. select 'field work task' and continue with the flow
3. On final screen, user should not be able to continue without selecting “type of field work”.

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
