### PR TITLE
LF-3057: Irrigation task is created without irrigation_type_id when select is untouched

### DIFF
--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -159,6 +159,7 @@ export default function PureIrrigationTask({
           (options) => options.irrigation_type_id === locationDefaults?.irrigation_type_id,
         ),
       );
+      setValue(IRRIGATION_TYPE_ID, locationDefaults.irrigation_type_id);
     }
     if (locationDefaults?.default_measuring_type) {
       setValue(MEASUREMENT_TYPE, locationDefaults?.default_measuring_type);


### PR DESCRIPTION
**Description**

This PR is to fix the issue that an irrigation task is created without `irrigation_type_id`.
The issue is seen when an irrigation task is created without the user's action of "selecting an irrigation type".
I added  `setValue` to set default irrigation task id so that `irrigation_type_id` is included in the API's payload when the user creates an irrigation task without "selecting" a type.

Jira link: https://lite-farm.atlassian.net/browse/LF-3057

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)
(you need to have a default irrigation type)
1. go to `/tasks`
2. click “+ Create a task”
3. click “Irrigation”
4. input a date
5. select a location
6. click “Continue” without touching “Type of Irrigation” select
7. “Save”
8. Check the payload of `POST: /task/irrigation_task` API. `irrigation_type_id` should be included. 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
