### PR TITLE
Increase memory allocation for vite build #2

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "CYPRESS_COVERAGE=TRUE vite --host",
-    "build": "NODE_OPTIONS=--max_old_space_size=4096 tsc && vite build",
+    "build": "NODE_OPTIONS=--max_old_space_size=32768 tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint src",
     "i18n": "npx i18next 'src/**/*.{js,jsx,ts,tsx}' -c 'src/locales/i18next-parser.config.js'",


### PR DESCRIPTION
**Description**

This allocates even more memory to node for the vite build script - 32GB

Please see https://github.com/LiteFarmOrg/LiteFarm/pull/2495, which still produced a JavaScript heap memory error (with 4GB of memory allocated).


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

This will be tested by running deploy upon merge.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
