### PR TITLE
Revise docker build by moving memory allocation to build script and swapping container build order

### DIFF
--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -21,6 +21,16 @@ services:
       retries: 5
     volumes:
       - ~/docker/volumes/postgres:/var/lib/postgresql/data
+  frontend:
+    container_name: litefarm-web
+    build:
+      context: ./packages/
+      dockerfile: ./webapp/prod.Dockerfile
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+    ports:
+      - "80:80"
+      - "443:443"
   backend:
     container_name: litefarm-api
     deploy:
@@ -41,13 +51,3 @@ services:
       DEV_DATABASE: ${DEV_DATABASE}
       DEV_DATABASE_USER: ${DEV_DATABASE_USER}
       DEV_DATABASE_PASSWORD: ${DEV_DATABASE_PASSWORD}
-  frontend:
-    container_name: litefarm-web
-    build:
-      context: ./packages/
-      dockerfile: ./webapp/prod.Dockerfile
-    volumes:
-      - /etc/letsencrypt:/etc/letsencrypt
-    ports:
-      - "80:80"
-      - "443:443"

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "CYPRESS_COVERAGE=TRUE vite --host",
-    "build": "tsc && vite build",
+    "build": "tsc && NODE_OPTIONS=--max_old_space_size=3000 vite build",
     "preview": "vite preview",
     "lint": "eslint src",
     "i18n": "npx i18next 'src/**/*.{js,jsx,ts,tsx}' -c 'src/locales/i18next-parser.config.js'",

--- a/packages/webapp/prod.Dockerfile
+++ b/packages/webapp/prod.Dockerfile
@@ -10,8 +10,6 @@ COPY ./webapp/ /usr/src/app/
 
 COPY ./shared/ /usr/src/shared/
 
-ENV NODE_OPTIONS=--max_old_space_size=4096
-
 RUN pnpm run build
 
 FROM nginx:1.15


### PR DESCRIPTION
**Description**

This is a continuation of our troubleshooting of the deployment of the integration branch to beta.litefarm.org.

**Background**

For information on the original build error:
- https://github.com/LiteFarmOrg/LiteFarm/pull/2495

Unsuccessful attempts to address this build error:
- https://github.com/LiteFarmOrg/LiteFarm/pull/2496
- https://github.com/LiteFarmOrg/LiteFarm/pull/2497

This PR successfully addressed the memory error and allowed build to complete:
- https://github.com/LiteFarmOrg/LiteFarm/pull/2500

However, the API of this deployment began crashing shortly after.

**The current PR**
- Moves the memory allocation to the correct place in the build run script (thank you @JimmyRowland)
- Removes memory allocation from the frontend dockerfile
- Swaps the building of the frontend and backend containers in docker-compose.beta.yml

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

I ran Docker locally to test that build completedly successfully. The API issue can only be tested on deployment -- I have never seen the API crash on local Docker.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
