### PR TITLE
Add types to the TextWithExternalLink component to fix implicit any

### DIFF
--- a/packages/webapp/src/components/Typography/index.tsx
+++ b/packages/webapp/src/components/Typography/index.tsx
@@ -208,13 +208,17 @@ export const Text = ({ children = 'Text', className = '', style, ...props }: Typ
   );
 };
 
+type TextWithExternalLinkProps = TypographyProps & {
+  link: string;
+};
+
 export const TextWithExternalLink = ({
   children = 'SubText',
   className = '',
   style,
   link,
   ...props
-}) => {
+}: TextWithExternalLinkProps) => {
   const { t } = useTranslation(['translation', 'common', 'crop']);
 
   return (


### PR DESCRIPTION
**Description**

We recently removed `"noImplicitAny": false` from our tsconfig.json in
- https://github.com/LiteFarmOrg/LiteFarm/pull/2460

This PR fixes two instances of implicit any in the Typography component file, which was causing tsc errors on the deployment of:
- https://github.com/LiteFarmOrg/LiteFarm/pull/2471

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Other (please explain)

Ran `pnpm run build` (which calls `tsc`) locally.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
