### PR TITLE
 LF-2973-confirm-page-still-showing-after-saving-a-point-or-a-line

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/LineDetails/FenceDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/LineDetails/FenceDetailForm/saga.js
@@ -36,7 +36,7 @@ export function* postFenceLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.FENCE'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    history.push('/map');
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/LineDetails/WatercourseDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/LineDetails/WatercourseDetailForm/saga.js
@@ -39,7 +39,7 @@ export function* postWatercourseLocationSaga({ payload: data }) {
       ]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    history.push('/map');
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/GateDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/GateDetailForm/saga.js
@@ -36,7 +36,7 @@ export function* postGateLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.GATE'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    history.push('/map');
   } catch (e) {
     history.push(
       {

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/WaterValveDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/WaterValveDetailForm/saga.js
@@ -36,7 +36,7 @@ export function* postWaterValveLocationSaga({ payload: data }) {
       setSuccessMessage([i18n.t('FARM_MAP.MAP_FILTER.WV'), i18n.t('message:MAP.SUCCESS_POST')]),
     );
     yield put(canShowSuccessHeader(true));
-    history.back();
+    history.push('/map');
   } catch (e) {
     history.push(
       {


### PR DESCRIPTION
**Description**

On completion of drawing line elements: fence and watercourse and point details: gate and valve  -- modals would remain on screen after completion of the drawing form.

By switching the history.back() to history.push('/map') the correct behaviour is observed. history.back should be used for 'back-like' actions.

Jira link: [LF-2973](https://lite-farm.atlassian.net/browse/LF-2973?atlOrigin=eyJpIjoiNTA2NTcxMjllNjBjNDgzYThhODhkMTNlNTc4MjllY2UiLCJwIjoiaiJ9)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain): 
- On integration the behaviour to be fixed is: 
  - draw one of the elements mentioned in the description on a map. 
  - Confirm the drawing, 
  - press the go back to map button
  - then proceed again with confirm button 
  - Then complete the form
  - Confirm modal remains (does not remain on this branch)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-2973]: https://lite-farm.atlassian.net/browse/LF-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ