### PR TITLE
Improve api logging in development

### DIFF
--- a/packages/api/src/common/logger.js
+++ b/packages/api/src/common/logger.js
@@ -1,31 +1,80 @@
 import winston from 'winston';
 import DailyRotateFile from 'winston-daily-rotate-file';
+import moment from 'moment';
+import express from 'express';
+const router = express.Router();
 
-const logger = winston.createLogger({
-  level: 'info',
-  format: winston.format.json(),
-  defaultMeta: { service: 'user-service' },
-  transports: [
-    //
-    // - Write all logs with importance level of `error` or less to `error.log`
-    // - Write all logs with importance level of `info` or less to `combined.log`
-    //
-    new DailyRotateFile({ filename: './logs/error.log', level: 'error' }),
-    new DailyRotateFile({ filename: './logs/combined.log' }),
-    new winston.transports.Console({ level: 'info' }),
-  ],
-});
+let logger
 
-//
-// If we're not in production then log to the `console` with the format:
-// `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
-//
-if (process.env.NODE_ENV !== 'production') {
-  logger.add(
-    new winston.transports.Console({
-      format: winston.format.simple(),
-    }),
-  );
+if (process.env.NODE_ENV != 'development') {
+  // This code should probably be reviewed later on
+  // But keeping non-development logging identical for now
+  logger = winston.createLogger({
+    level: 'info',
+    format: winston.format.json(),
+    defaultMeta: { service: 'user-service' },
+    transports: [
+      // Write all logs with importance level of `error` or less to `error.log`
+      new DailyRotateFile({ filename: './logs/error.log', level: 'error' }),
+      // Write all logs with importance level of `info` or less to `combined.log`
+      new DailyRotateFile({ filename: './logs/combined.log' }),
+      new winston.transports.Console({ level: 'info' })
+    ],
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    logger.add(
+      new winston.transports.Console({
+        format: winston.format.simple(),
+      }),
+    );
+  }
+} else {
+  // DEVELOPMENT LOGGING
+  const levels = {
+    error: 0,
+    warn: 1,
+    info: 2,
+    http: 3,
+    verbose: 4,
+    debug: 5,
+    dev: 6 // replace default "silly" with "dev" for dev logging
+  }
+  const custom_colors = {dev: 'white magentaBG'}
+  winston.addColors(custom_colors)
+  const colorizer = winston.format.colorize(custom_colors);
+
+  const logFormat = winston.format.printf(info => {
+    const prefix = `[${info.level} ${info.timestamp}]`;
+    return `${colorizer.colorize(info.level, prefix)} ${info.message}`;
+  })
+
+  logger = winston.createLogger({
+    levels: levels,
+    level: 'dev', // Include all levels
+    format: winston.format.json(),
+    defaultMeta: { service: 'user-service' },
+    transports: [
+      new winston.transports.Console({
+        format: winston.format.combine(
+          winston.format.timestamp({format: () => (
+            moment().tz(process.env.TZ).format('DD/M HH:mm:ss')
+          )}),
+          logFormat
+        )
+      }),
+    ]
+  });
+
+  // Using alternative syntax just to avoid hits in application wide searches for console . dev
+  // In this way it is easy to find and clean out any debugging logs created during development
+  Object.assign(console, {dev: (...args) => logger.dev.call(logger, ...args)});
+
+  // Add basic route logging
+  router.use((req, res, next) => {
+    logger.debug(`${req.method} ${req.originalUrl}`)
+    next()
+  })
 }
 
 console.log = (...args) => logger.info.call(logger, ...args);
@@ -35,3 +84,4 @@ console.error = (...args) => logger.error.call(logger, ...args);
 console.debug = (...args) => logger.debug.call(logger, ...args);
 
 export default logger;
+export {router as routerLoggingMiddleware}

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -96,7 +96,7 @@ import knex from './util/knex.js';
 Model.knex(knex);
 
 // import logger
-import logger from './common/logger.js';
+import logger, {routerLoggingMiddleware} from './common/logger.js';
 
 // import routes
 import loginRoutes from './routes/loginRoute.js';
@@ -221,6 +221,7 @@ app
     next();
   })
   .use(router)
+  .use(routerLoggingMiddleware)
   .set('json spaces', 2)
   .use('/login', loginRoutes)
   .use('/password_reset', passwordResetRoutes)


### PR DESCRIPTION
## Description
- Improve/fix api development logs using the already included Winston log package.
- Add new `console.dev` that prints heavily highlighted output for dev debugging (see second screenshot below). This is useful also to easily find and clean out debugging log messages before pushing your work - they aren't meant to be committed to the app.
- Timestamp respects `TZ` in `.env`. 
- Also added a simple route logging middleware (blue lines in new log).

This PR intends to target only api development logs for now.

I think the node knex db transaction log is very useful, activated by `DEBUG=knex:query`. Once we merge the docker setup, it will be easy to set the DEBUG  variable directly in `.env`. But for now, you have to integrate it in your own commands, see examples in api `package.json`.

Old api log
![image](https://user-images.githubusercontent.com/9784434/227995559-b0db36eb-c724-4842-ac15-d6a081119a4b.png)

New api log
![image](https://user-images.githubusercontent.com/9784434/228562367-461743e2-24ec-4e0b-8311-d824c9cdcab7.png)



## Testing

1. Add `console.dev('Hello')` at beginning of action `notificationUserController#subscribeToAlerts`
2. Go to http://localhost:3000, refresh
3. See the api logs and the highlighted hello output
4. Check that the code logic doesn't change non-development environments