### PR TITLE
LF-3077 Mismatch between read-only and modify to complete task views

### DIFF
--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -106,6 +106,7 @@ export default function PureIrrigationTask({
   const MEASUREMENT_TYPE = 'irrigation_task.measuring_type';
   const ESTIMATED_WATER_USAGE = 'irrigation_task.estimated_water_usage';
   const ESTIMATED_WATER_USAGE_UNIT = 'irrigation_task.estimated_water_usage_unit';
+  const IS_MODIFIED_ON_COMPLETION = 'irrigation_task.is_modified_on_completion';
 
   const estimated_water_usage = watch(ESTIMATED_WATER_USAGE);
   const estimated_water_usage_unit = watch(ESTIMATED_WATER_USAGE_UNIT);
@@ -115,10 +116,12 @@ export default function PureIrrigationTask({
   // If the task is being modified on completion then set the "set default" flags to false in the form
   // this is to avoid overwriting default setting set by another task during that task's creation
   // the "set default" checkbox is only a visual reference for users to see this irrigation type was set as default during its creation
+  // UPDATE: this logic is now handled in redux saga before the api call is made
   useEffect(() => {
     if (isModified) {
-      setValue(DEFAULT_IRRIGATION_TASK_LOCATION, false);
-      setValue(DEFAULT_IRRIGATION_MEASUREMENT, false);
+      setValue(IS_MODIFIED_ON_COMPLETION, true);
+    } else {
+      setValue(IS_MODIFIED_ON_COMPLETION, false);
     }
   }, [isModified]);
 

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -616,6 +616,12 @@ const getCompleteIrrigationTaskBody = (task_translation_key) => (data) => {
         ? data.taskData[taskType]?.irrigation_task_type_other
         : data.taskData[taskType]?.irrigation_type_name;
       data.taskData[taskType].location_id = data.location_id;
+      if (data.taskData[taskType]?.is_modified_on_completion) {
+        if (data.taskData[taskType]?.default_irrigation_task_type_location)
+          data.taskData[taskType].default_irrigation_task_type_location = false;
+        if (data.taskData[taskType]?.default_irrigation_task_type_measurement)
+          data.taskData[taskType].default_irrigation_task_type_measurement = false;
+      }
       data.taskData.location_defaults = [
         {
           location_id: data.location_id,
@@ -643,6 +649,7 @@ const getCompleteIrrigationTaskBody = (task_translation_key) => (data) => {
           'location_size_unit',
           'irrigation_type',
           'irrigation_type_translation_key',
+          'is_modified_on_completion',
         ].includes(element) && delete data.taskData[taskType][element];
       }
     }


### PR DESCRIPTION
**Description**

A follow-up on https://github.com/LiteFarmOrg/LiteFarm/commit/603e8f7faa0d008835f630df3a09e75f5911e866. According to the commit, the checkbox values should be set to false when sending the data through the API call. What this commit did is change the form value from the form component packages/webapp/src/components/Task/PureIrrigationTask/index.jsx, which cause the visual mismatch and confusion for the user. What I did here is change those values only when it is sending the data through the API, so it maintains the functionality and resolves the visual issue.

Jira link: https://lite-farm.atlassian.net/browse/LF-3077

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

I populated my local database with beta server backup and tested it on my local. The visual components show up correctly, and the API call is verified to send the correct data.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
