### PR TITLE
LF-2776 New completion date component for task completion flow

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1667,7 +1667,7 @@
       "WHICH_DATE": "Which date?",
       "DATE_ORIGINAL": "The original due date",
       "DATE_TODAY": "Today",
-      "DATE_ANOTHER": "Another",
+      "DATE_ANOTHER": "Another date",
       "INFO": "Abandoning this task will change its' status to abandoned and remove it from all users ‘To do’ and ‘Unassigned’ lists.",
       "NOTES": "Task abandonment notes",
       "NOTES_CHAR_LIMIT": "Notes must be less than 10,000 characters",

--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -203,6 +203,7 @@ Input.propTypes = {
   }),
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
   hasLeaf: PropTypes.bool,
   max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/webapp/src/components/Form/Radio/index.jsx
+++ b/packages/webapp/src/components/Form/Radio/index.jsx
@@ -3,6 +3,7 @@ import styles from './radio.module.scss';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import Infoi from '../../Tooltip/Infoi';
+import Pill from '../../Pill';
 
 const Radio = ({
   label = 'label',
@@ -18,6 +19,9 @@ const Radio = ({
   ...props
 }) => {
   const name = hookFormRegister?.name ?? props?.name;
+  const pill = props?.pill;
+  const checked = props?.checked;
+
   return (
     <label
       className={clsx(styles.container, disabled && styles.disabled)}
@@ -40,6 +44,7 @@ const Radio = ({
       />
       <p className={clsx(styles.label)} style={classes.label}>
         {label}
+        {pill && <Pill body={pill} spaceBefore={!!label} active={checked}></Pill>}
       </p>
       {toolTipContent && <Infoi content={toolTipContent} />}
 

--- a/packages/webapp/src/components/Form/RadioGroup/index.jsx
+++ b/packages/webapp/src/components/Form/RadioGroup/index.jsx
@@ -128,6 +128,7 @@ RadioGroup.propTypes = {
     PropTypes.shape({
       style: PropTypes.object,
       label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+      pill: PropTypes.string,
       defaultChecked: PropTypes.bool,
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.number]),
     }),

--- a/packages/webapp/src/components/Pill/index.jsx
+++ b/packages/webapp/src/components/Pill/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './styles.module.scss';
+import clsx from 'clsx';
+
+const Pill = ({
+  body,
+  active,
+  spaceBefore,
+}) => {
+  return (
+    <span className={clsx(
+      styles.pill, 
+      active ? styles.active : styles.inactive,
+      spaceBefore && styles.spaceBefore
+    )}>
+      { body }
+    </span>
+  );
+};
+
+Pill.propTypes = {
+  body: PropTypes.string,
+  active: PropTypes.bool,
+  spaceBefore: PropTypes.bool,
+};
+
+export default Pill;

--- a/packages/webapp/src/components/Pill/styles.module.scss
+++ b/packages/webapp/src/components/Pill/styles.module.scss
@@ -1,0 +1,25 @@
+.pill {
+  border-radius: 32px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.active {
+  border: 1px solid var(--teal700);
+  background-color: var(--teal600);
+  color: white;
+}
+
+.inactive {
+  border: 1px solid var(--grey400);
+  background-color: var(--grey200);
+  color: var(--grey500);
+}
+
+.spaceBefore {
+  margin-left: 6px;
+}


### PR DESCRIPTION
**Description**

Jira link: https://lite-farm.atlassian.net/browse/LF-2776

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [x] Other (please explain)

1. Create a task and select it
2. Mark as Completed and step forward to the new Completed Date
3. See Jira for how new completed date component should work

**OBS**

I had to add some additional fixes for edge cases.

1. `Due date >= Today`: Disable "Due date" and use "Today" as default date choice as the completion date cannot be in future and if `Due date == Today` there isn't any point to have both active.
2. When completing an irrigation task that targets a wild crop. There is no location available so completion logic fails. Separate fix PR here: https://github.com/LiteFarmOrg/LiteFarm/pull/2535

Also see this [discussion](https://github.com/LiteFarmOrg/LiteFarm/pull/2525#issuecomment-1493881136) about the structure of the Pill components

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- Wasn't needed as the only one I updated already had MISSING values present
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
- This isn't present in any of the files I'm working in. Should I still add it to eg: `Pill/index.jsx`?

