### PR TITLE
Upgrade node version to 16.15.0 in webapp dockerfile

### DIFF
--- a/packages/webapp/prod.Dockerfile
+++ b/packages/webapp/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2 as build
+FROM node:16.15.0 as build
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
**Description**

As of version 8.0.0, pnpm no longer supports Node versions under 16.14. This causes an error on deploy as we had been using Node 16.13.2 in our frontend dockerfile.

This PR updates the dockerfile node version to 16.15.0, the same Node version used in our API dockerfile.

For more info, see:
- https://github.com/pnpm/pnpm/issues/6297


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Other (please explain)

Tested on local Docker build.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
