### PR TITLE
Fix font-Size warning in deploy script build log

### DIFF
--- a/packages/webapp/src/components/AddCropVariety/styles.module.scss
+++ b/packages/webapp/src/components/AddCropVariety/styles.module.scss
@@ -21,7 +21,7 @@
 .scientificNameLabel{
   vertical-align: top;
   font-style: italic;
-  font-Size: 16px;
+  font-size: 16px;
   height: 18px;
 }
 


### PR DESCRIPTION
This was throwing a warning on build. Just a typo.

**Description**

The following warning was present on build in the deploy script. this fixes the typo.

<img width="839" alt="Screenshot 2023-04-04 at 7 21 20 PM" src="https://user-images.githubusercontent.com/30075973/229943973-13c30ea3-ab84-41ed-9b9a-0a7baea9ad98.png">

Github actions job logs (may be gone if you are visiting from the future): https://github.com/LiteFarmOrg/LiteFarm/actions/runs/4612997486/jobs/8154522605

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
