### PR TITLE
LF-3054: Fix calculation for total water usage in water usage calculation modal

### DIFF
--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -13,6 +13,7 @@ import {
   location_area,
   roundToTwoDecimal,
   water_valve_flow_rate,
+  getDefaultUnit,
 } from '../../../util/convert-units/unit';
 import Checkbox from '../../Form/Checkbox';
 import { Label } from '../../Typography';
@@ -165,23 +166,18 @@ const WaterUseDepthCalculator = ({
   const application_depth_unit = watch(APPLICATION_DEPTH_UNIT);
 
   useEffect(() => {
-    if (['gal', 'fl-oz'].includes(getValues('irrigation_task').estimated_water_usage_unit?.value)) {
-      const conversion_unit = location.total_area_unit === 'ha' ? 'ft2' : 'ac';
-      setValue(IRRIGATED_AREA_UNIT, getUnitOptionMap()[conversion_unit]);
-    } else {
-      setValue(IRRIGATED_AREA_UNIT, getUnitOptionMap()[location.total_area_unit]);
-    }
-  }, [location]);
-
-  useEffect(() => {
+    let irrigatedArea = null;
     if (percentage_location_irrigated) {
-      const irrigatedArea = roundToTwoDecimal(
+      irrigatedArea = roundToTwoDecimal(
         location.total_area * (percentage_location_irrigated / 100),
       );
-      setValue(IRRIGATED_AREA, irrigatedArea);
-    } else {
-      setValue(IRRIGATED_AREA, '');
     }
+    setValue(IRRIGATED_AREA, irrigatedArea);
+    setValue(
+      IRRIGATED_AREA_UNIT,
+      getUnitOptionMap()[getDefaultUnit(location_area, irrigatedArea, system).displayUnit],
+      { shouldValidate: true },
+    );
   }, [location, percentage_location_irrigated]);
 
   useEffect(() => {

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -90,6 +90,7 @@ const WaterUseVolumeCalculator = ({
         control={control}
         defaultValue={locationDefaults?.estimated_flow_rate || null}
         to={locationDefaults?.estimated_flow_rate_unit || ''}
+        data-testid="volumecalculator-flowrate"
       />
 
       <Checkbox
@@ -113,6 +114,7 @@ const WaterUseVolumeCalculator = ({
         control={control}
         onKeyDown={numberOnKeyDown}
         style={{ paddingBottom: '32px' }}
+        data-testid="volumecalculator-duration"
       />
 
       <TotalWaterUsage totalWaterUsage={totalWaterUsage} system={system} />
@@ -184,6 +186,7 @@ const WaterUseDepthCalculator = ({
         control={control}
         defaultValue={locationDefaults?.application_depth || null}
         to={locationDefaults?.application_depth_unit || ''}
+        data-testid="depthcalculator-depth"
       />
 
       <Checkbox
@@ -232,6 +235,7 @@ const WaterUseDepthCalculator = ({
           control={control}
           defaultValue={location.total_area}
           disabled
+          data-testid="depthcalculator-locationsize"
         />
 
         <Unit
@@ -247,6 +251,7 @@ const WaterUseDepthCalculator = ({
           hookFromWatch={watch}
           control={control}
           disabled={true}
+          data-testid="depthcalculator-irrigatedarea"
         />
       </div>
       <TotalWaterUsage totalWaterUsage={totalWaterUsage} system={system} />

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -17,8 +17,6 @@ import {
 } from '../../../util/convert-units/unit';
 import Checkbox from '../../Form/Checkbox';
 import { Label } from '../../Typography';
-import { useSelector } from 'react-redux';
-import { cropLocationsSelector } from '../../../containers/locationSlice';
 import { convert } from '../../../util/convert-units/convert';
 import modalStyles from './styles.module.scss';
 import Input, { getInputErrors, numberOnKeyDown } from '../../Form/Input';
@@ -135,14 +133,11 @@ const WaterUseDepthCalculator = ({
   totalWaterUsage,
   formState,
   locationDefaults,
+  location,
   errors,
 }) => {
   const { t } = useTranslation();
   const { register, getValues, watch, control, setValue } = formState();
-
-  const location = useSelector(cropLocationsSelector).filter(
-    (location) => location?.location_id === getValues().locations[0]?.location_id,
-  )[0];
 
   const APPLICATION_DEPTH = 'irrigation_task.application_depth';
   const APPLICATION_DEPTH_UNIT = 'irrigation_task.application_depth_unit';
@@ -287,6 +282,7 @@ const WaterUseModal = ({
   setTotalDepthWaterUsage,
   formState,
   locationDefaults,
+  location,
   errors,
 }) => {
   if (measurementType === 'VOLUME')
@@ -307,6 +303,7 @@ const WaterUseModal = ({
         setTotalWaterUsage={setTotalDepthWaterUsage}
         formState={formState}
         locationDefaults={locationDefaults}
+        location={location}
         errors={errors}
       />
     );
@@ -323,6 +320,7 @@ export default function WaterUsageCalculatorModal({
   setTotalDepthWaterUsage,
   formState,
   locationDefaults,
+  location,
   errors,
 }) {
   const { t } = useTranslation();
@@ -363,6 +361,7 @@ export default function WaterUsageCalculatorModal({
         setTotalDepthWaterUsage={setTotalDepthWaterUsage}
         formState={formState}
         locationDefaults={locationDefaults}
+        location={location}
         errors={errors}
       />
     </ModalComponent>

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ModalComponent from '../ModalComponent/v2';
 import { ReactComponent as Calculator } from '../../../assets/images/task/Calculator.svg';
@@ -62,6 +62,19 @@ const WaterUseVolumeCalculator = ({
   const estimated_flow_rate_unit = watch(FLOW_RATE_UNIT);
   const estimated_duration = watch(ESTIMATED_DURATION);
 
+  const flowRateDefaultValues = useMemo(() => {
+    if (getValues(FLOW_RATE)) {
+      return { defaultValue: getValues(FLOW_RATE), to: getValues(FLOW_RATE_UNIT).value };
+    }
+    if (locationDefaults?.estimated_flow_rate) {
+      return {
+        defaultValue: locationDefaults.estimated_flow_rate,
+        to: locationDefaults.estimated_flow_rate_unit,
+      };
+    }
+    return {};
+  }, []);
+
   useEffect(() => {
     if (estimated_duration && estimated_flow_rate && estimated_flow_rate_unit) {
       // flow rate database unit: l/min
@@ -88,8 +101,7 @@ const WaterUseVolumeCalculator = ({
         max={999999.99}
         system={system}
         control={control}
-        defaultValue={locationDefaults?.estimated_flow_rate || null}
-        to={locationDefaults?.estimated_flow_rate_unit || ''}
+        {...flowRateDefaultValues}
         data-testid="volumecalculator-flowrate"
       />
 

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import ModalComponent from '../ModalComponent/v2';
 import { ReactComponent as Calculator } from '../../../assets/images/task/Calculator.svg';
@@ -30,11 +30,6 @@ const totalWaterUsageUnit = {
 
 const TotalWaterUsage = ({ totalWaterUsage, system }) => {
   const { t } = useTranslation();
-
-  if (!system) {
-    return null;
-  }
-
   const value =
     totalWaterUsage &&
     roundToTwoDecimal(convert(totalWaterUsage).from('l').to(totalWaterUsageUnit[system]));
@@ -158,12 +153,10 @@ const WaterUseDepthCalculator = ({
   const LOCATION_SIZE_UNIT = 'irrigation_task.location_size_unit';
   const IRRIGATED_AREA = 'irrigation_task.irrigated_area';
   const IRRIGATED_AREA_UNIT = 'irrigation_task.irrigated_area_unit';
-  const estimated_water_usage_unit = getValues('irrigation_task.estimated_water_usage_unit');
 
   const irrigated_area = watch(IRRIGATED_AREA);
   const application_depth = watch(APPLICATION_DEPTH);
   const percentage_location_irrigated = watch(PERCENTAGE_LOCATION_IRRIGATED);
-  const application_depth_unit = watch(APPLICATION_DEPTH_UNIT);
 
   useEffect(() => {
     let irrigatedArea = null;
@@ -182,26 +175,7 @@ const WaterUseDepthCalculator = ({
 
   useEffect(() => {
     if (irrigated_area && application_depth) {
-      setTotalWaterUsage(() => {
-        if (application_depth_unit.value === 'in') {
-          const Irrigated_area_in_ft2 =
-            getValues(IRRIGATED_AREA_UNIT)?.value === 'ft2'
-              ? roundToTwoDecimal(irrigated_area)
-              : roundToTwoDecimal(convert(irrigated_area).from('ac').to('ft2')); // convert from ac to ft2
-          const volume_in_ft3 =
-            Irrigated_area_in_ft2 *
-            (application_depth ? convert(application_depth).from('in').to('ft') : 1); // convert depth from inc to ft
-          return roundToTwoDecimal(convert(volume_in_ft3).from('ft3').to('gal')); // convert ft3 to gallons
-        }
-        const Irrigated_area_in_m_squared =
-          getValues(IRRIGATED_AREA_UNIT)?.value === 'm2'
-            ? roundToTwoDecimal(irrigated_area)
-            : roundToTwoDecimal(convert(irrigated_area).from('ha').to('m2')); // to convert from ha to m2
-        const Volume_in_m_cubed =
-          Irrigated_area_in_m_squared *
-          (application_depth ? convert(application_depth).from('mm').to('m') : 1); // to convert application depth from mm to m
-        return roundToTwoDecimal(convert(Volume_in_m_cubed).from('m3').to('l')); // to convert from m3 to litres
-      });
+      setTotalWaterUsage(irrigated_area * application_depth);
     } else {
       setTotalWaterUsage('');
     }
@@ -209,7 +183,7 @@ const WaterUseDepthCalculator = ({
 
   useEffect(() => {
     if (
-      !watch(APPLICATION_DEPTH) &&
+      !application_depth &&
       locationDefaults?.application_depth &&
       locationDefaults?.application_depth_unit
     ) {
@@ -300,10 +274,7 @@ const WaterUseDepthCalculator = ({
           disabled={true}
         />
       </div>
-      <TotalWaterUsage
-        totalWaterUsage={totalWaterUsage}
-        estimated_water_usage_unit={estimated_water_usage_unit}
-      />
+      <TotalWaterUsage totalWaterUsage={totalWaterUsage} system={system} />
     </>
   );
 };

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -164,11 +164,15 @@ const WaterUseDepthCalculator = ({
 
   useEffect(() => {
     if (irrigated_area && application_depth) {
-      setTotalWaterUsage(irrigated_area * application_depth);
+      setTotalWaterUsage(
+        convert(irrigated_area * application_depth)
+          .from('m3')
+          .to('l'),
+      );
     } else {
       setTotalWaterUsage('');
     }
-  }, [application_depth, percentage_location_irrigated, irrigated_area]);
+  }, [application_depth, irrigated_area]);
 
   return (
     <>

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -148,6 +148,16 @@ const WaterUseDepthCalculator = ({
   const percentage_location_irrigated = watch(PERCENTAGE_LOCATION_IRRIGATED);
 
   useEffect(() => {
+    if (location.total_area !== getValues(LOCATION_SIZE)) {
+      setValue(LOCATION_SIZE, location.total_area);
+      setValue(
+        LOCATION_SIZE_UNIT,
+        getUnitOptionMap()[getDefaultUnit(location_area, location.total_area, system).displayUnit],
+      );
+    }
+  }, []);
+
+  useEffect(() => {
     let irrigatedArea = null;
     if (percentage_location_irrigated) {
       irrigatedArea = roundToTwoDecimal(
@@ -237,7 +247,6 @@ const WaterUseDepthCalculator = ({
           hookFormGetValue={getValues}
           hookFromWatch={watch}
           control={control}
-          defaultValue={location.total_area}
           disabled
           data-testid="depthcalculator-locationsize"
         />

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -27,13 +27,22 @@ const totalWaterUsageUnit = {
   imperial: 'gal',
 };
 
-const TotalWaterUsage = ({ totalWaterUsage, unit }) => {
+const TotalWaterUsage = ({ totalWaterUsage, system }) => {
   const { t } = useTranslation();
+
+  if (!system) {
+    return null;
+  }
+
+  const value =
+    totalWaterUsage &&
+    roundToTwoDecimal(convert(totalWaterUsage).from('l').to(totalWaterUsageUnit[system]));
+
   return (
     <div className={modalStyles.labelContainer}>
       <Label className={modalStyles.label}>{t('ADD_TASK.IRRIGATION_VIEW.TOTAL_WATER_USAGE')}</Label>
       <Label className={modalStyles.label}>
-        {totalWaterUsage} {unit}
+        {value} {totalWaterUsageUnit[system]}
       </Label>
     </div>
   );
@@ -61,17 +70,11 @@ const WaterUseVolumeCalculator = ({
 
   useEffect(() => {
     if (estimated_duration && estimated_flow_rate && estimated_flow_rate_unit) {
-      setTotalWaterUsage(() => {
-        // flow rate database unit: l/min
-        const durationInMin = convert(estimated_duration)
-          .from(irrigation_task_estimated_duration.databaseUnit)
-          .to('min');
-        return roundToTwoDecimal(
-          convert(estimated_flow_rate * durationInMin)
-            .from('l')
-            .to(totalWaterUsageUnit[system]),
-        );
-      });
+      // flow rate database unit: l/min
+      const durationInMin = convert(estimated_duration)
+        .from(irrigation_task_estimated_duration.databaseUnit)
+        .to('min');
+      setTotalWaterUsage(estimated_flow_rate * durationInMin);
     } else {
       setTotalWaterUsage('');
     }
@@ -126,7 +129,7 @@ const WaterUseVolumeCalculator = ({
         style={{ paddingBottom: '32px' }}
       />
 
-      <TotalWaterUsage totalWaterUsage={totalWaterUsage} unit={totalWaterUsageUnit[system]} />
+      <TotalWaterUsage totalWaterUsage={totalWaterUsage} system={system} />
     </>
   );
 };

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -74,15 +74,6 @@ const WaterUseVolumeCalculator = ({
     }
   }, [estimated_duration, estimated_flow_rate]);
 
-  useEffect(() => {
-    if (!estimated_flow_rate && !!locationDefaults?.estimated_flow_rate) {
-      if (locationDefaults?.estimated_flow_rate) {
-        setValue(FLOW_RATE, locationDefaults?.estimated_flow_rate);
-        setValue(FLOW_RATE_UNIT, getUnitOptionMap()[locationDefaults?.estimated_flow_rate_unit]);
-      }
-    }
-  }, [locationDefaults]);
-
   return (
     <>
       <Unit
@@ -97,6 +88,8 @@ const WaterUseVolumeCalculator = ({
         max={999999.99}
         system={system}
         control={control}
+        defaultValue={locationDefaults?.estimated_flow_rate || null}
+        to={locationDefaults?.estimated_flow_rate_unit || ''}
       />
 
       <Checkbox
@@ -175,20 +168,6 @@ const WaterUseDepthCalculator = ({
     }
   }, [application_depth, percentage_location_irrigated, irrigated_area]);
 
-  useEffect(() => {
-    if (
-      !application_depth &&
-      locationDefaults?.application_depth &&
-      locationDefaults?.application_depth_unit
-    ) {
-      setValue(APPLICATION_DEPTH, locationDefaults?.application_depth);
-      setValue(
-        APPLICATION_DEPTH_UNIT,
-        getUnitOptionMap()[locationDefaults?.application_depth_unit],
-      );
-    }
-  }, [locationDefaults]);
-
   return (
     <>
       <Unit
@@ -203,6 +182,8 @@ const WaterUseDepthCalculator = ({
         max={999.9}
         system={system}
         control={control}
+        defaultValue={locationDefaults?.application_depth || null}
+        to={locationDefaults?.application_depth_unit || ''}
       />
 
       <Checkbox

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -76,7 +76,6 @@ const WaterUseVolumeCalculator = ({
     }
   }, [estimated_duration, estimated_flow_rate]);
 
-  // TODO: when does locationDefaults?.estimated_flow_rate have value?
   useEffect(() => {
     if (!estimated_flow_rate && !!locationDefaults?.estimated_flow_rate) {
       if (locationDefaults?.estimated_flow_rate) {

--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -144,7 +144,6 @@ const WaterUseDepthCalculator = ({
 }) => {
   const { t } = useTranslation();
   const { register, getValues, watch, control, setValue } = formState();
-  const [locationSize, setLocationSize] = useState();
 
   const location = useSelector(cropLocationsSelector).filter(
     (location) => location?.location_id === getValues().locations[0]?.location_id,
@@ -168,23 +167,22 @@ const WaterUseDepthCalculator = ({
   useEffect(() => {
     if (['gal', 'fl-oz'].includes(getValues('irrigation_task').estimated_water_usage_unit?.value)) {
       const conversion_unit = location.total_area_unit === 'ha' ? 'ft2' : 'ac';
-      setValue(LOCATION_SIZE_UNIT, getUnitOptionMap()[conversion_unit]);
       setValue(IRRIGATED_AREA_UNIT, getUnitOptionMap()[conversion_unit]);
     } else {
-      setValue(LOCATION_SIZE_UNIT, getUnitOptionMap()[location.total_area_unit]);
       setValue(IRRIGATED_AREA_UNIT, getUnitOptionMap()[location.total_area_unit]);
     }
-    setLocationSize(location.total_area);
   }, [location]);
 
   useEffect(() => {
     if (percentage_location_irrigated) {
-      const irrigatedArea = roundToTwoDecimal(locationSize * (percentage_location_irrigated / 100));
+      const irrigatedArea = roundToTwoDecimal(
+        location.total_area * (percentage_location_irrigated / 100),
+      );
       setValue(IRRIGATED_AREA, irrigatedArea);
     } else {
       setValue(IRRIGATED_AREA, '');
     }
-  }, [locationSize, percentage_location_irrigated]);
+  }, [location, percentage_location_irrigated]);
 
   useEffect(() => {
     if (irrigated_area && application_depth) {
@@ -287,7 +285,7 @@ const WaterUseDepthCalculator = ({
           hookFormGetValue={getValues}
           hookFromWatch={watch}
           control={control}
-          value={locationSize}
+          defaultValue={location.total_area}
           disabled
         />
 

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -12,7 +12,6 @@ import { getUnitOptionMap } from '../../../util/convert-units/getUnitOptionMap';
 import { waterUsage } from '../../../util/convert-units/unit';
 import PropTypes from 'prop-types';
 import WaterUsageCalculatorModal from '../../Modals/WaterUsageCalculatorModal';
-import { convert } from '../../../util/convert-units/convert';
 import { getIrrigationTaskTypes } from '../../../containers/Task/IrrigationTaskTypes/saga';
 import { useDispatch, useSelector } from 'react-redux';
 import { irrigationTaskTypesSliceSelector } from '../../../containers/irrigationTaskTypesSlice';
@@ -291,13 +290,7 @@ export default function PureIrrigationTask({
         style={{ marginTop: '40px', marginBottom: `${disabled ? 40 : 0}px` }}
         disabled={disabled}
         onKeyDown={numberOnKeyDown}
-        onChangeUnitOption={(e) => {
-          setEstimatedWaterUsageComputed(true);
-          setValue(
-            ESTIMATED_WATER_USAGE,
-            convert(estimated_water_usage).from(estimated_water_usage_unit.value).to(e.value),
-          );
-        }}
+        onChangeUnitOption={() => setEstimatedWaterUsageComputed(true)}
       />
       {!disabled && (
         <>

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -39,10 +39,12 @@ export default function PureIrrigationTask({
   const [showWaterUseCalculatorModal, setShowWaterUseCalculatorModal] = useState(false);
   const { irrigationTaskTypes = [] } = useSelector(irrigationTaskTypesSliceSelector);
   const cropLocations = useSelector(cropLocationsSelector);
-  const location_defaults =
+  const location =
     locations &&
-    cropLocations.filter((cropLocation) => cropLocation.location_id === locations[0].location_id)[0]
-      ?.location_defaults;
+    cropLocations.filter(
+      (cropLocation) => cropLocation.location_id === locations[0].location_id,
+    )[0];
+  const location_defaults = location?.location_defaults;
   const locationDefaults = [location_defaults]?.map((location) => {
     return {
       ...location,
@@ -320,6 +322,7 @@ export default function PureIrrigationTask({
           setTotalDepthWaterUsage={setTotalDepthWaterUsage}
           formState={stateController}
           locationDefaults={locationDefaults}
+          location={location}
           errors={errors}
         />
       )}

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -457,6 +457,7 @@ const getIrrigationTaskBody = (data, endpoint, managementPlanWithCurrentLocation
           'percent_of_location_irrigated_unit',
           'irrigated_area',
           'irrigated_area_unit',
+          'location_size',
           'location_size_unit',
         ].includes(element) && delete data.irrigation_task[element];
       }

--- a/packages/webapp/src/stories/Modal/WaterUsageCalculatorModal.stories.jsx
+++ b/packages/webapp/src/stories/Modal/WaterUsageCalculatorModal.stories.jsx
@@ -95,6 +95,10 @@ const args = {
 export const VolumeMetric = Template.bind({});
 VolumeMetric.args = { ...args, measurementType: 'VOLUME', system: 'metric' };
 VolumeMetric.play = async ({ canvasElement }) => {
+  // Wait for elements to be ready. Without this, these tests will fail when using jest-runner.
+  const flowRateInput = await screen.findByTestId('volumecalculator-flowrate');
+  expect(flowRateInput).toBeInTheDocument();
+
   const flowRateTest = new UnitTest(null, 'volumecalculator-flowrate', water_valve_flow_rate);
   const durationTest = new UnitTest(
     null,

--- a/packages/webapp/src/stories/Modal/WaterUsageCalculatorModal.stories.jsx
+++ b/packages/webapp/src/stories/Modal/WaterUsageCalculatorModal.stories.jsx
@@ -1,0 +1,247 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React, { Suspense, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { screen, userEvent } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+import { convert } from '../../util/convert-units/convert';
+import WaterUsageCalculatorModal from '../../components/Modals/WaterUsageCalculatorModal';
+import { componentDecorators } from '../Pages/config/Decorators';
+import {
+  irrigation_task_estimated_duration,
+  location_area,
+  water_valve_flow_rate,
+  irrigation_depth,
+} from '../../util/convert-units/unit';
+import UnitTest from '../../test-utils/storybook/unit';
+import { roundToTwoDecimal } from '../../util';
+
+const convertM3ToWaterUsageUnit = (value, unit) =>
+  convert(value)
+    .from('m3')
+    .to(unit || 'l');
+
+const totalWaterUsageValueToBeInTheDocument = async (value, system = 'metric') => {
+  const unit = system === 'metric' ? 'l' : 'gal';
+  const name = value ? `${roundToTwoDecimal(value)} ${unit}` : unit;
+  const totalWaterUsage = await screen.findByRole('heading', { name });
+  expect(totalWaterUsage).toBeInTheDocument();
+};
+
+const CalculatorWithHookProps = (props) => {
+  const [totalWaterUsage, setTotalWaterUsage] = useState(null);
+  const {
+    register,
+    setValue,
+    getValues,
+    watch,
+    control,
+    formState: { errors },
+  } = useForm();
+  const formState = () => ({ register, getValues, watch, control, setValue });
+
+  return (
+    <Suspense fallback="loading">
+      <WaterUsageCalculatorModal
+        formState={formState}
+        errors={errors}
+        totalVolumeWaterUsage={totalWaterUsage}
+        setTotalVolumeWaterUsage={setTotalWaterUsage}
+        totalDepthWaterUsage={totalWaterUsage}
+        setTotalDepthWaterUsage={setTotalWaterUsage}
+        {...props}
+      />
+    </Suspense>
+  );
+};
+
+const Template = (args) => <CalculatorWithHookProps {...args} />;
+
+export default {
+  title: 'Components/Modals/WaterUsageCalculatorModal',
+  decorators: componentDecorators,
+  component: CalculatorWithHookProps,
+};
+
+const args = {
+  dismissModal: () => ({}),
+  handleModalSubmit: () => ({}),
+  locationDefaults: {
+    location_id: 'f94503c8-d3dc-11ed-af00-e66db4bef551',
+    estimated_flow_rate: 2,
+    estimated_flow_rate_unit: 'l/h',
+    application_depth: 0.02,
+    application_depth_unit: 'mm',
+    irrigation_type_id: 5,
+  },
+  location: {
+    total_area: 21758,
+    total_area_unit: 'ha',
+  },
+};
+
+export const VolumeMetric = Template.bind({});
+VolumeMetric.args = { ...args, measurementType: 'VOLUME', system: 'metric' };
+VolumeMetric.play = async ({ canvasElement }) => {
+  const flowRateTest = new UnitTest(null, 'volumecalculator-flowrate', water_valve_flow_rate);
+  const durationTest = new UnitTest(
+    null,
+    'volumecalculator-duration',
+    irrigation_task_estimated_duration,
+  );
+  const totalWaterUsageText = screen.getByRole('heading', { name: 'Total Water Usage' });
+
+  await flowRateTest.visibleInputToHaveValue(flowRateTest.convertDBValueToDisplayValue(2, 'l/h'));
+  await flowRateTest.hiddenInputToHaveValue(2);
+  await flowRateTest.selectedUnitToBeInTheDocument('l/h');
+  await totalWaterUsageValueToBeInTheDocument('');
+
+  await durationTest.inputValue('20');
+  await userEvent.click(totalWaterUsageText);
+  await totalWaterUsageValueToBeInTheDocument(40);
+
+  await flowRateTest.selectUnit('l/m');
+  const hiddenFlowRate = flowRateTest.convertDisplayValueToHiddenValue(120, 'l/min');
+  await totalWaterUsageValueToBeInTheDocument(hiddenFlowRate * 20);
+
+  await durationTest.selectUnit('h');
+  await userEvent.click(totalWaterUsageText);
+  await totalWaterUsageValueToBeInTheDocument(hiddenFlowRate * (20 * 60));
+};
+
+export const VolumeImperial = Template.bind({});
+VolumeImperial.args = { ...args, measurementType: 'VOLUME', system: 'imperial' };
+VolumeImperial.play = async ({ canvasElement }) => {
+  const flowRateTest = new UnitTest(null, 'volumecalculator-flowrate', water_valve_flow_rate, true);
+  const durationTest = new UnitTest(
+    null,
+    'volumecalculator-duration',
+    irrigation_task_estimated_duration,
+    true,
+  );
+  const totalWaterUsageText = screen.getByRole('heading', { name: 'Total Water Usage' });
+
+  await flowRateTest.visibleInputToHaveValue(flowRateTest.convertDBValueToDisplayValue(2, 'gal/h'));
+  await flowRateTest.hiddenInputToHaveValue(2);
+  await flowRateTest.selectedUnitToBeInTheDocument('g/h');
+  await totalWaterUsageValueToBeInTheDocument('', 'imperial');
+
+  await flowRateTest.selectUnit('g/m');
+  await flowRateTest.inputValue('0.5');
+  await totalWaterUsageValueToBeInTheDocument('', 'imperial');
+
+  await durationTest.inputValue('1');
+  await userEvent.click(totalWaterUsageText);
+  await totalWaterUsageValueToBeInTheDocument(0.5, 'imperial');
+
+  await durationTest.selectUnit('h');
+  await userEvent.click(totalWaterUsageText);
+  await totalWaterUsageValueToBeInTheDocument(30, 'imperial');
+};
+
+export const DepthMetric = Template.bind({});
+DepthMetric.args = { ...args, measurementType: 'DEPTH', system: 'metric' };
+DepthMetric.play = async ({ canvasElement }) => {
+  const depthTest = new UnitTest(null, 'depthcalculator-depth', irrigation_depth);
+  const locationSizeTest = new UnitTest(null, 'depthcalculator-locationsize', location_area);
+  const irrigatedAreaTest = new UnitTest(null, 'depthcalculator-irrigatedarea', location_area);
+  const totalWaterUsageText = screen.getByRole('heading', { name: 'Total Water Usage' });
+  const percentageLocation = screen.getAllByRole('spinbutton')[1];
+
+  await depthTest.visibleInputToHaveValue(20);
+  await depthTest.hiddenInputToHaveValue(0.02);
+  await depthTest.selectedUnitToBeInTheDocument('mm');
+  await locationSizeTest.visibleInputToHaveValue(2.18);
+  await locationSizeTest.hiddenInputToHaveValue(21758);
+  await locationSizeTest.selectedUnitToBeInTheDocument('ha');
+  await irrigatedAreaTest.selectedUnitToBeInTheDocument(UnitTest.getUnitLabelByValue('m2'));
+  await totalWaterUsageValueToBeInTheDocument('');
+
+  await userEvent.clear(percentageLocation);
+  await userEvent.type(percentageLocation, '30');
+  await userEvent.click(totalWaterUsageText);
+  await irrigatedAreaTest.hiddenInputToHaveValue(21758 * 0.3);
+  await irrigatedAreaTest.visibleInputToHaveValue(
+    irrigatedAreaTest.convertDBValueToDisplayValue(21758 * 0.3, 'ha'),
+  );
+  await irrigatedAreaTest.selectedUnitToBeInTheDocument('ha');
+  await totalWaterUsageValueToBeInTheDocument(convertM3ToWaterUsageUnit(0.02 * (21758 * 0.3)));
+
+  await userEvent.clear(percentageLocation);
+  await userEvent.type(percentageLocation, '4');
+  await userEvent.click(totalWaterUsageText);
+  await irrigatedAreaTest.hiddenInputToHaveValue(21758 * 0.04);
+  await irrigatedAreaTest.visibleInputToHaveValue(
+    irrigatedAreaTest.convertDBValueToDisplayValue(21758 * 0.04, 'm2'),
+  );
+  await irrigatedAreaTest.selectedUnitToBeInTheDocument(UnitTest.getUnitLabelByValue('m2'));
+  await totalWaterUsageValueToBeInTheDocument(convertM3ToWaterUsageUnit(0.02 * (21758 * 0.04)));
+
+  await depthTest.inputValueAndBlur('10');
+  await totalWaterUsageValueToBeInTheDocument(convertM3ToWaterUsageUnit(0.01 * (21758 * 0.04)));
+};
+
+export const DepthImperial = Template.bind({});
+DepthImperial.args = { ...args, measurementType: 'DEPTH', system: 'imperial' };
+DepthImperial.play = async ({ canvasElement }) => {
+  const depthTest = new UnitTest(null, 'depthcalculator-depth', irrigation_depth);
+  const locationSizeTest = new UnitTest(null, 'depthcalculator-locationsize', location_area);
+  const irrigatedAreaTest = new UnitTest(null, 'depthcalculator-irrigatedarea', location_area);
+  const totalWaterUsageText = screen.getByRole('heading', { name: 'Total Water Usage' });
+  const percentageLocation = screen.getAllByRole('spinbutton')[1];
+
+  await depthTest.visibleInputToHaveValue(depthTest.convertDBValueToDisplayValue(0.02, 'in'));
+  await depthTest.selectedUnitToBeInTheDocument('in');
+  await locationSizeTest.visibleInputToHaveValue(
+    locationSizeTest.convertDBValueToDisplayValue(21758, 'ac'),
+  );
+  await locationSizeTest.hiddenInputToHaveValue(21758);
+  await locationSizeTest.selectedUnitToBeInTheDocument('ac');
+  await irrigatedAreaTest.selectedUnitToBeInTheDocument(UnitTest.getUnitLabelByValue('ft2'));
+  await totalWaterUsageValueToBeInTheDocument('', 'imperial');
+
+  await depthTest.inputValueAndBlur('1');
+  await depthTest.hiddenInputToHaveValue(depthTest.convertDisplayValueToHiddenValue(1, 'in'));
+  await totalWaterUsageValueToBeInTheDocument('', 'imperial');
+
+  await userEvent.clear(percentageLocation);
+  await userEvent.type(percentageLocation, '2');
+  await userEvent.click(totalWaterUsageText);
+  let irrigatedAreaInM2 = 21758 * 0.02;
+  await irrigatedAreaTest.hiddenInputToHaveValue(irrigatedAreaInM2);
+  await irrigatedAreaTest.visibleInputToHaveValue(
+    irrigatedAreaTest.convertDBValueToDisplayValue(irrigatedAreaInM2, 'ft2'),
+  );
+  let waterUsageInM3 = convert(1).from('in').to('m') * irrigatedAreaInM2;
+  await totalWaterUsageValueToBeInTheDocument(
+    roundToTwoDecimal(convertM3ToWaterUsageUnit(waterUsageInM3, 'gal')),
+    'imperial',
+  );
+
+  await userEvent.clear(percentageLocation);
+  await userEvent.type(percentageLocation, '50');
+  await userEvent.click(totalWaterUsageText);
+  irrigatedAreaInM2 = 21758 * 0.5;
+  await irrigatedAreaTest.hiddenInputToHaveValue(irrigatedAreaInM2);
+  await irrigatedAreaTest.visibleInputToHaveValue(
+    irrigatedAreaTest.convertDBValueToDisplayValue(irrigatedAreaInM2, 'ac'),
+  );
+  await irrigatedAreaTest.selectedUnitToBeInTheDocument('ac');
+  waterUsageInM3 = convert(1).from('in').to('m') * irrigatedAreaInM2;
+  await totalWaterUsageValueToBeInTheDocument(
+    roundToTwoDecimal(convertM3ToWaterUsageUnit(waterUsageInM3, 'gal')),
+    'imperial',
+  );
+};

--- a/packages/webapp/src/test-utils/storybook/unit.jsx
+++ b/packages/webapp/src/test-utils/storybook/unit.jsx
@@ -12,7 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
-import { within, userEvent, waitFor } from '@storybook/testing-library';
+import { within, userEvent, waitFor, screen } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import selectEvent from 'react-select-event';
 import { roundToTwoDecimal, convertFn } from '../../util/convert-units/unit';
@@ -21,10 +21,10 @@ import { getUnitOptionMap } from '../../util/convert-units/getUnitOptionMap';
 /** Class used for testing Unit component. */
 export default class UnitTest {
   constructor(canvasElement, testId, unitType = {}) {
-    this.canvas = within(canvasElement);
-    this.visibleInput = this.canvas.getByTestId(testId);
-    this.hiddenInput = this.canvas.getByTestId(`${testId}-hiddeninput`);
-    this.select = this.canvas.getByTestId(`${testId}-select`);
+    this.element = canvasElement ? within(canvasElement) : screen;
+    this.visibleInput = this.element.getByTestId(testId);
+    this.hiddenInput = this.element.getByTestId(`${testId}-hiddeninput`);
+    this.select = this.element.getByTestId(`${testId}-select`);
     this.testId = testId;
     this.unitType = unitType;
   }
@@ -39,7 +39,7 @@ export default class UnitTest {
   }
 
   async clearError() {
-    const clearButton = await this.canvas.findByTestId(`${this.testId}-errorclearbutton`);
+    const clearButton = await this.element.findByTestId(`${this.testId}-errorclearbutton`);
     await userEvent.click(clearButton);
   }
 
@@ -99,20 +99,22 @@ export default class UnitTest {
   }
 
   async haveRequiredError() {
-    const errorContainer = await this.canvas.findByTestId(`${this.testId}-errormessage`);
+    const errorContainer = await this.element.findByTestId(`${this.testId}-errormessage`);
     expect(errorContainer).toHaveTextContent('Required');
   }
 
   async haveMaxValueError() {
-    const errorContainer = await this.canvas.findByTestId(`${this.testId}-errormessage`);
+    const errorContainer = await this.element.findByTestId(`${this.testId}-errormessage`);
     expect(errorContainer).toHaveTextContent(/Please enter a value between 0-[0-9]./);
   }
 
   async haveNoError() {
     await waitFor(() => {
-      const clearButton = this.canvas.queryByTestId(`${this.testId}-errorclearbutton`);
-      const requiredErrorElement = this.canvas.queryByText('Required');
-      const maxValueErrorElement = this.canvas.queryByText(/Please enter a value between 0-[0-9]./);
+      const clearButton = this.element.queryByTestId(`${this.testId}-errorclearbutton`);
+      const requiredErrorElement = this.element.queryByText('Required');
+      const maxValueErrorElement = this.element.queryByText(
+        /Please enter a value between 0-[0-9]./,
+      );
       expect(clearButton).not.toBeInTheDocument();
       expect(requiredErrorElement).not.toBeInTheDocument();
       expect(maxValueErrorElement).not.toBeInTheDocument();

--- a/packages/webapp/src/util/convert-units/unit.js
+++ b/packages/webapp/src/util/convert-units/unit.js
@@ -144,9 +144,9 @@ export const irrigation_depth = {
 
 export const location_area = {
   metric: {
-    units: ['ha', 'm2'],
-    defaultUnit: 'ha',
-    breakpoints: [10000],
+    units: ['m2', 'ha'],
+    defaultUnit: 'm2',
+    breakpoints: [1000],
   },
   imperial: {
     units: ['ft2', 'ac'],


### PR DESCRIPTION
**Description**

- Fix total water usage calculation (Please check if the formulas are correct!)
- Use `defaultValue` and `to` props for `Unit` component to set default values (flow rate, location size, and application depth). `setValues` are removed.
- Update irrigated area unit depending on “% of location to be irrigated”
- Pass `location` from its parent component rather than doing `useSelector` in the child component (this is to be able to write storybook tests)
- Delete `location_size` before sending an API request for irrigation task creation (this should have been done in [LF-3055](https://lite-farm.atlassian.net/browse/LF-3055))
- Fixed `location_area` constant (now it’s the same as `area_total_area`)
- Update `UnitTest` class so that it can be used for modals. 
`canvas` cannot be used for this reason:
  > If you do have elements that get projected into document.body, then you should, for that particular case, use screen.getBy instead of canvas.getBy, and that should suffice.
  
   (https://github.com/storybookjs/testing-library/issues/25#issuecomment-1184255825)


Jira link: https://lite-farm.atlassian.net/browse/LF-3054

storybook UI: http://127.0.0.1:6006/?path=/docs/components-modals-waterusagecalculatormodal--docs
test: `pnpm test-storybook /src/stories/Modal/WaterUsageCalculatorModal.stories.jsx`

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3055]: https://lite-farm.atlassian.net/browse/LF-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ