### PR TITLE
LF-3115: Unable to mark a field work task completed without toggling "Did you have to make any changes to this task?"

### DIFF
--- a/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
+++ b/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
@@ -8,6 +8,18 @@ import { getFieldWorkTypes } from '../../../containers/Task/FieldWorkTask/saga';
 import { useDispatch, useSelector } from 'react-redux';
 import { fieldWorkSliceSliceSelector } from '../../../containers/fieldWorkSlice';
 
+const formatDefaultTypeValue = (typeValue) => {
+  const { farm_id, field_work_name, field_work_type_id, field_work_type_translation_key } =
+    typeValue[0];
+  return {
+    field_work_type_id,
+    farm_id,
+    label: field_work_name,
+    value: field_work_type_translation_key,
+    field_work_name,
+  };
+};
+
 const PureFieldWorkTask = ({ register, control, setValue, watch, disabled = false }) => {
   const { t } = useTranslation();
 
@@ -29,6 +41,12 @@ const PureFieldWorkTask = ({ register, control, setValue, watch, disabled = fals
   useEffect(() => {
     if (fieldWorkTypeExposedValue?.value !== 'OTHER') setValue(FIELD_WORK_OTHER_TYPE, null);
   }, [fieldWorkTypeExposedValue]);
+
+  useEffect(() => {
+    if (typeValue?.length) {
+      setValue(FIELD_WORK_TYPE, formatDefaultTypeValue(typeValue));
+    }
+  }, []);
 
   useEffect(() => {
     setFieldWorkTypeOptions((allOptions) => {


### PR DESCRIPTION
**Description**

This PR is to enable the user to complete a field work task without needing to make changes to the task. The form has data retrieved from database whose format is invalid. In this PR, the format of the retrieved data is reformatted in useEffect.

Details:
The format of "Type of filed work"(`typeValue`) retrieved from the database is different from what is expected.
The one in the red box in the screenshot is the retrieved data which is invalid. By clicking an option, `typeValue` gets the right format of data (the one in the blue box), and the field is considered as "valid".
![Screenshot 2023-04-11 at 10 23 28 AM](https://user-images.githubusercontent.com/33141219/231243687-311a169f-8988-476d-8566-23be7907a722.png)

The rule of this field is to have "value" field.
![Screenshot 2023-04-11 at 10 33 24 AM](https://user-images.githubusercontent.com/33141219/231243314-3bcae2ab-8476-42a7-ab39-6247043c1f4f.png)

Jira link: https://lite-farm.atlassian.net/browse/LF-3115

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
