### PR TITLE
Lf 2042 no cancel pop up when creating a new crop

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -333,6 +333,7 @@
     "ADD_CROPS_T0_YOUR_FARM": "Add crops to your farm",
     "ADD_TO_YOUR_FARM": "Add to your farm",
     "CAN_NOT_FIND": "Can't find what you're looking for?",
+    "CANCEL": "crop creation",
     "COVER_CROP": "Can this be grown as a cover crop?",
     "CREATE_MANAGEMENT_PLANS": "Create crop plans",
     "CROP_CATALOGUE": "Crop catalogue",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -333,6 +333,7 @@
     "ADD_CROPS_T0_YOUR_FARM": "Agregar un cultivo a su granja",
     "ADD_TO_YOUR_FARM": "Agregar a su granja",
     "CAN_NOT_FIND": "¿No encuentra lo que busca?",
+    "CANCEL": "MISSING",
     "COVER_CROP": "¿Se puede cultivar como cultivo de cobertura?",
     "CREATE_MANAGEMENT_PLANS": "Crear plan de cultivo",
     "CROP_CATALOGUE": "Catálogo de cultivos",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -333,6 +333,7 @@
     "ADD_CROPS_T0_YOUR_FARM": "Ajouter des cultures à votre ferme",
     "ADD_TO_YOUR_FARM": "Ajouter à votre ferme",
     "CAN_NOT_FIND": "Vous ne trouvez pas ce que vous cherchez ?",
+    "CANCEL": "MISSING",
     "COVER_CROP": "Est-ce que cela peut être cultivé comme plante de couverture\u00a0?",
     "CREATE_MANAGEMENT_PLANS": "Créer des plans de gestion",
     "CROP_CATALOGUE": "Catalogue des cultures",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -333,6 +333,7 @@
     "ADD_CROPS_T0_YOUR_FARM": "Adicionar cultivos à sua fazenda",
     "ADD_TO_YOUR_FARM": "Adicionar à sua fazenda",
     "CAN_NOT_FIND": "Não consegue encontrar o que está procurando?",
+    "CANCEL": "MISSING",
     "COVER_CROP": "Isso pode ser cultivado como uma cultivo de cobertura?",
     "CREATE_MANAGEMENT_PLANS": "Criar um plano de cultivo",
     "CROP_CATALOGUE": "Catálogo de cultivo",

--- a/packages/webapp/src/components/AddCropVariety/ComplianceInfo/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/ComplianceInfo/index.jsx
@@ -69,6 +69,7 @@ export default function ComplianceInfo({
         style={{
           marginBottom: '23px',
         }}
+        cancelModalTitle={t('CROP_CATALOGUE.CANCEL')}
       />
 
       <div>

--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -87,6 +87,7 @@ export default function PureAddCropVariety({
         onGoBack={handleGoBack}
         onCancel={historyCancel}
         title={t('CROP.ADD_CROP')}
+        cancelModalTitle={t('CROP_CATALOGUE.CANCEL')}
         value={progress}
       />
 

--- a/packages/webapp/src/components/AddNewCrop/index.jsx
+++ b/packages/webapp/src/components/AddNewCrop/index.jsx
@@ -123,6 +123,7 @@ export default function PureAddNewCrop({
         onCancel={historyCancel}
         title={t('CROP.ADD_CROP')}
         value={progress}
+        cancelModalTitle={t('CROP_CATALOGUE.CANCEL')}
       />
       <img
         src={crop_photo_url}


### PR DESCRIPTION
**Description**

Modal was not popping up on cancel in add crop and add crop variety workflow.

Translation should be lower case as it is inserted mid-sentence.

Jira link: [LF-2042](https://lite-farm.atlassian.net/browse/LF-2042)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-2042]: https://lite-farm.atlassian.net/browse/LF-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ