### PR TITLE
LF-3098 Comment out "defaults" from all irrigation task screens

### DIFF
--- a/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
+++ b/packages/webapp/src/components/Modals/WaterUsageCalculatorModal/index.jsx
@@ -108,9 +108,11 @@ const WaterUseVolumeCalculator = ({
       <Checkbox
         label={t('ADD_TASK.IRRIGATION_VIEW.DEFAULT_LOCATION_FLOW_RATE')}
         sm
-        style={{ marginTop: '10px', marginBottom: '30px' }}
+        // style={{ marginTop: '10px', marginBottom: '30px' }}
+        style={{ display: 'none' }} // temporarily hiding for April 2023 release
         hookFormRegister={register(DEFAULT_LOCATION_FLOW_RATE)}
       />
+      <div style={{ paddingBlock: '10px' }} />
 
       <Unit
         register={register}
@@ -218,9 +220,12 @@ const WaterUseDepthCalculator = ({
       <Checkbox
         label={t('ADD_TASK.IRRIGATION_VIEW.DEFAULT_APPLICATION_DEPTH')}
         sm
-        style={{ marginTop: '10px', marginBottom: '30px' }}
+        // style={{ marginTop: '10px', marginBottom: '30px' }}
+        style={{ display: 'none' }} // temporarily hiding for April 2023 release
         hookFormRegister={register(DEFAULT_LOCATION_APPLICATION_DEPTH)}
       />
+      <div style={{ paddingBlock: '10px' }} />
+
       <Input
         label={t('ADD_TASK.IRRIGATION_VIEW.PERCENTAGE_LOCATION_TO_BE_IRRIGATED')}
         type="number"

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -238,10 +238,13 @@ export default function PureIrrigationTask({
       <Checkbox
         label={t('ADD_TASK.IRRIGATION_VIEW.SET_AS_DEFAULT_TYPE_FOR_THIS_LOCATION')}
         sm
-        style={{ marginTop: '6px', marginBottom: '40px' }}
+        // style={{ marginTop: '6px', marginBottom: '40px' }}
+        style={{ display: 'none' }} // temporarily hiding for April 2023 release
         hookFormRegister={register(DEFAULT_IRRIGATION_TASK_LOCATION)}
         disabled={disabled || isModified}
       />
+      <div style={{ paddingBlock: '10px' }} />
+
       <Label className={styles.label} style={{ marginBottom: '24px', fontSize: '16px' }}>
         {t('ADD_TASK.IRRIGATION_VIEW.HOW_DO_YOU_MEASURE_WATER_USE_FOR_THIS_IRRIGATION_TYPE')}
       </Label>
@@ -274,6 +277,7 @@ export default function PureIrrigationTask({
         sm
         hookFormRegister={register(DEFAULT_IRRIGATION_MEASUREMENT)}
         disabled={disabled || isModified}
+        style={{ display: 'none' }} // temporarily hiding for April 2023 release
       />
 
       <Unit


### PR DESCRIPTION
**Description**

This sets the display of all 4 location default checkboxes in the Irrigation Task + Water Use Calculator to "none".

This leaves intact their relationships in the React Hook Form and the backend so that they behave in all cases all though they were unchecked (false). In this case, that means no data will be added to the `location_defaults` table.

Small notes: original CSS was commented out rather than deleted to make it easier to rollback without having to go into git history. I also added a small spacer component where necessary to fix the view, and an explanatory comment for future developers.

Jira link: https://lite-farm.atlassian.net/browse/LF-3098

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
