### PR TITLE
LF-3123: First number put into Estimated flow rate input in water calculator disappears

### DIFF
--- a/packages/webapp/src/components/Form/Unit/useUnit.jsx
+++ b/packages/webapp/src/components/Form/Unit/useUnit.jsx
@@ -170,7 +170,9 @@ const useUnit = ({
   // 3. set default visibleInputValue
   const [visibleInputValue, setVisibleInputValue] = useState(defaultVisibleInputValue);
 
-  const hookFormValue = hookFromWatch(name, defaultValue);
+  // when the hidden input is empty, hookFormValue becomes NaN.
+  // Set initial value to NaN when defaultValue is undefined to avoid triggering useEffect unnecessarily
+  const hookFormValue = hookFromWatch(name, defaultValue || NaN);
 
   useEffect(() => {
     if (!hookFormUnit || noValue(hookFormValue)) {


### PR DESCRIPTION
**Description**

When `hookFormValue` in `useUnit` is set to `undefined`, it is automatically changed to `NaN`. This triggers a `useEffect` unexpectedly. This PR is to set the initial `hookFormValue` to `NaN` instead of `undefined`.
(Please see the ticket for what issue this causes.)

Jira link: https://lite-farm.atlassian.net/browse/LF-3123

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
