### PR TITLE
LF-2971: Handle undefined weatherStationName

### DIFF
--- a/packages/webapp/src/containers/bulkSensorReadingsSlice.js
+++ b/packages/webapp/src/containers/bulkSensorReadingsSlice.js
@@ -62,7 +62,7 @@ const bulkSensorsReadingsSlice = createSlice({
       }
     },
     bulkSensorReadingsFailure: (state, action) => {
-      state.loading = true;
+      state.loading = false;
       state.sensorsReadings = {};
       state.selectedSensorName = '';
       state.nearestStationName = '';


### PR DESCRIPTION
**Description**

Sensor readings view keeps showing the loading animation when an open weather API returns an error because `bulkSensorReadingsFailure` action does not change `loading` state to `false`. 

You can find a csv to add a sensor that can be used for testing the fix [here](https://lite-farm.atlassian.net/browse/LF-2971?focusedCommentId=15160).

Actual error:
<img width="1380" alt="Screenshot 2023-04-12 at 3 31 47 PM" src="https://user-images.githubusercontent.com/33141219/231604003-6bd4e6ab-9d26-49a8-a13d-8b0895a91d86.png">

Jira link: https://lite-farm.atlassian.net/browse/LF-2971

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
