### PR TITLE
LF-3166 Unclear and unhelpful error snackbar displays when maximum number of password reset emails have been sent

### DIFF
--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -187,6 +187,7 @@
       "EXISTS": "User already exists in LiteFarm Network",
       "INVITE": "Error creating user account, please contact LiteFarm for assistance.",
       "NOTHING_CHANGED": "No data has changed",
+      "MAX_RESET_EMAILS": "A password reset link has been emailed to you, please check your inbox and spam folder.",
       "RESET_PASSWORD": "Error with sending password reset email, please contact LiteFarm for assistance.",
       "RESTORE": "There was an error restoring access",
       "REVOKE": "There was an error revoking access",

--- a/packages/webapp/public/locales/es/message.json
+++ b/packages/webapp/public/locales/es/message.json
@@ -187,6 +187,7 @@
       "EXISTS": "Usuario ya existe en la red de trabajo de LiteFarm",
       "INVITE": "Error al crear cuenta de usuario. Por favor contacte LiteFarm por asistencia.",
       "NOTHING_CHANGED": "Nada ha cambiado",
+      "MAX_RESET_EMAILS": "MISSING",
       "RESET_PASSWORD": "Error al enviar email para cambiar contraseña. Por favor contacte LiteFarm por asistencia.",
       "RESTORE": "Hubo un error al restaurar acceso",
       "REVOKE": "Hubo un error al revocar acceso",

--- a/packages/webapp/public/locales/fr/message.json
+++ b/packages/webapp/public/locales/fr/message.json
@@ -187,6 +187,7 @@
       "EXISTS": "L'utilisateur existe déjà dans le réseau LiteFarm",
       "INVITE": "Erreur lors de la création du compte utilisateur; veuillez contacter LiteFarm pour obtenir de l'aide",
       "NOTHING_CHANGED": "Aucune donnée n'a changé",
+      "MAX_RESET_EMAILS": "MISSING",
       "RESET_PASSWORD": "Il y a un problème avec la réinitialisation du mot de passe par courriel; veuillez contacter LiteFarm pour obtenir de l'aide.",
       "RESTORE": "Une erreur s'est produite lors de la restauration de l'accès",
       "REVOKE": "Une erreur s'est produite lors de la révocation de l'accès",

--- a/packages/webapp/public/locales/pt/message.json
+++ b/packages/webapp/public/locales/pt/message.json
@@ -187,6 +187,7 @@
       "EXISTS": "O usuário já existe na rede de LiteFarm",
       "INVITE": "Erro ao criar conta de usuário, entre em contato com LiteFarm para assistência.",
       "NOTHING_CHANGED": "Nada mudou",
+      "MAX_RESET_EMAILS": "MISSING",
       "RESET_PASSWORD": "Erro ao enviar e-mail de redefinição de senha, favor entrar em contato com a LiteFarm para obter assistência.",
       "RESTORE": "Ocorreu um erro, o acesso não foi restaurado",
       "REVOKE": "Ocorreu um erro, o acesso não foi revogado",

--- a/packages/webapp/src/containers/CustomSignUp/saga.js
+++ b/packages/webapp/src/containers/CustomSignUp/saga.js
@@ -150,7 +150,11 @@ export function* sendResetPasswordEmailSaga({ payload: email }) {
   try {
     const result = yield call(axios.post, resetPasswordUrl(), { email });
   } catch (e) {
-    yield put(enqueueErrorSnackbar(i18n.t('message:USER.ERROR.RESET_PASSWORD')));
+    if (e.response.data === 'Reached maximum number of available reset tokens') {
+      yield put(enqueueErrorSnackbar(i18n.t('message:USER.ERROR.MAX_RESET_EMAILS')));
+    } else {
+      yield put(enqueueErrorSnackbar(i18n.t('message:USER.ERROR.RESET_PASSWORD')));
+    }
   }
 }
 


### PR DESCRIPTION
**Description**

Currently, once 3 password reset emails have been sent (the max that can be sent in 24 hours) the error snackbar reads: "Error with sending password reset email, please contact LiteFarm for assistance."

This is not correct; there was no error and LiteFarm should not be contacted. 

This PR creates a new snackbar message for this situation: "A password reset link has been emailed to you, please check your inbox and spam folder."

Notes:
- The original error message has been retained for when the API has returned an unspecified error (not something I have ever seen on this endpoint, but might as well keep it to be safe)
- Neither message fits very well in the snackbar, particularly on mobile; a separate ticket [LF-3188](https://lite-farm.atlassian.net/browse/LF-3188) has been opened for that

**To test:**
- Send yourself more than 3 requests for password reset in a row

Jira link: https://lite-farm.atlassian.net/browse/LF-3166

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3188]: https://lite-farm.atlassian.net/browse/LF-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ