### PR TITLE
LF-3156: Searching for crops created using non-Latin characters doesn't return results as expected

### DIFF
--- a/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.ts
+++ b/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.ts
@@ -25,16 +25,14 @@ export default function useStringFilteredCrops(
         ?.toLowerCase()
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
-        .replace(/\W/g, '')
-        .replace(/_/g, '')
+        .replace(/[^\p{L}0-9]/gu, '')
         .trim() || '';
     const check = (name: string | null | undefined) => {
       return name
         ?.toLowerCase()
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
-        .replace(/\W/g, '')
-        .replace(/_/g, '')
+        .replace(/[^\p{L}0-9}]/gu, '')
         .trim()
         .includes(lowerCaseFilter);
     };


### PR DESCRIPTION
**Description**

The function that filters crops was ignoring non-word characters (`\W` = `[^A-Za-z0-9_]`) including Cyrillic alphabets and Chinese characters etc. This PR updates the function to replace strings that are neither a letter in any language (`\p{L}`) nor a number.

Jira link: https://lite-farm.atlassian.net/browse/LF-3156

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other
       - create crop with non-alphabetical letters (eg. `Пшениця`)
       - search the crop

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
