### PR TITLE
Lf 3091 the user is able to create a duplicate of the crop that already exists in the farm if he lefts fields genus species blanc

### DIFF
--- a/packages/api/src/models/cropModel.js
+++ b/packages/api/src/models/cropModel.js
@@ -81,8 +81,8 @@ class Crop extends BaseModel {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['crop_common_name', 'farm_id'],
-
+      // genus and species are required for database uniqueness
+      required: ['crop_common_name', 'farm_id', 'crop_genus', 'crop_specie'],
       properties: {
         crop_id: { type: 'integer' },
         farm_id: { type: 'string' },

--- a/packages/webapp/src/components/AddNewCrop/index.jsx
+++ b/packages/webapp/src/components/AddNewCrop/index.jsx
@@ -179,7 +179,7 @@ export default function PureAddNewCrop({
         hookFormRegister={register('crop_specie', {
           maxLength: { value: 255, message: t('FORM_VALIDATION.OVER_255_CHARS') },
           setValueAs: (v) => {
-            return v?.toLowerCase() || ' ';
+            return v.toLowerCase() || ' ';
           },
         })}
         errors={getInputErrors(errors, 'crop_specie')}

--- a/packages/webapp/src/components/AddNewCrop/index.jsx
+++ b/packages/webapp/src/components/AddNewCrop/index.jsx
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { Semibold } from '../Typography';
 import Input, { getInputErrors } from '../Form/Input';
-//import styles from './styles.module.scss';
 import Form from '../Form';
 import { Controller, useForm } from 'react-hook-form';
 import ReactSelect from '../Form/ReactSelect';
@@ -166,7 +165,7 @@ export default function PureAddNewCrop({
         hookFormRegister={register('crop_genus', {
           maxLength: { value: 255, message: t('FORM_VALIDATION.OVER_255_CHARS') },
           setValueAs: (v) => {
-            return v.charAt(0).toUpperCase() + v.slice(1).toLowerCase();
+            return v.charAt(0).toUpperCase() + v.slice(1).toLowerCase() || ' ';
           },
         })}
         errors={getInputErrors(errors, 'crop_genus')}
@@ -180,7 +179,7 @@ export default function PureAddNewCrop({
         hookFormRegister={register('crop_specie', {
           maxLength: { value: 255, message: t('FORM_VALIDATION.OVER_255_CHARS') },
           setValueAs: (v) => {
-            return v.toLowerCase();
+            return v?.toLowerCase() || ' ';
           },
         })}
         errors={getInputErrors(errors, 'crop_specie')}


### PR DESCRIPTION
**Description**
User is able to add duplicate crops when no genus or species is added.

The database stores crops as unique values for (common name, species, genus, farm id). Because species and genus are optional we regularly send null values. 

Since null != null (Ginger, null, null, this_is_my_farm id) != (Ginger, null, null, this_is_my_farm id)

By requiring a value and using form validation to set the value as a single space ' ' we fix this condition and make it harder to add bad data. (Ginger, ' ', ' ', this_is_my_farm id) == (Ginger, ' ', ' ', this_is_my_farm id)

An alternate solution could be:
Exploring setting the defaultTo('') in the database

Jira link: [LF-3091](https://lite-farm.atlassian.net/browse/LF-3091)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain):
- tested with empty values for each and entered values for each.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3091]: https://lite-farm.atlassian.net/browse/LF-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ