### PR TITLE
LF-3158: Searching in non latin alphabet does not return matches appropriately

### DIFF
--- a/packages/webapp/src/components/Profile/People/index.jsx
+++ b/packages/webapp/src/components/Profile/People/index.jsx
@@ -65,14 +65,14 @@ export default function PurePeople({ users, history, isAdmin }) {
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
         .toLowerCase()
-        .replace(/\W/g, '')
+        .replace(/[^\p{L}0-9]/gu, '')
         .trim()
         .includes(
           searchString
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
             .toLowerCase()
-            .replace(/\W/g, '')
+            .replace(/[^\p{L}0-9]/gu, '')
             .trim(),
         );
     });

--- a/packages/webapp/src/containers/Documents/util.js
+++ b/packages/webapp/src/containers/Documents/util.js
@@ -25,7 +25,6 @@ export function useStringFilteredDocuments(documents, filterString) {
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
         .replace(/[^\p{L}0-9]/gu, '')
-        .replace(/_/g, '')
         .trim() || '';
     const check = (names) => {
       for (const name of names) {
@@ -35,7 +34,6 @@ export function useStringFilteredDocuments(documents, filterString) {
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
             .replace(/[^\p{L}0-9]/gu, '')
-            .replace(/_/g, '')
             .trim()
             .includes(lowerCaseFilter)
         )

--- a/packages/webapp/src/containers/Documents/util.js
+++ b/packages/webapp/src/containers/Documents/util.js
@@ -24,7 +24,7 @@ export function useStringFilteredDocuments(documents, filterString) {
         ?.toLowerCase()
         .normalize('NFD')
         .replace(/\p{Diacritic}/gu, '')
-        .replace(/\W/g, '')
+        .replace(/[^\p{L}0-9]/gu, '')
         .replace(/_/g, '')
         .trim() || '';
     const check = (names) => {
@@ -34,7 +34,7 @@ export function useStringFilteredDocuments(documents, filterString) {
             ?.toLowerCase()
             .normalize('NFD')
             .replace(/\p{Diacritic}/gu, '')
-            .replace(/\W/g, '')
+            .replace(/[^\p{L}0-9]/gu, '')
             .replace(/_/g, '')
             .trim()
             .includes(lowerCaseFilter)


### PR DESCRIPTION
**Description**

Update filtering logic to make it work for non alphanumerical letters.

Jira link:
- https://lite-farm.atlassian.net/browse/LF-3158
- https://lite-farm.atlassian.net/browse/LF-3159

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
