### PR TITLE
LF-3030: Cannot select wild crop for irrigation task

### DIFF
--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -39,7 +39,7 @@ export default function PureIrrigationTask({
   const { irrigationTaskTypes = [] } = useSelector(irrigationTaskTypesSliceSelector);
   const cropLocations = useSelector(cropLocationsSelector);
   const location =
-    locations &&
+    locations?.length &&
     cropLocations.filter(
       (cropLocation) => cropLocation.location_id === locations[0].location_id,
     )[0];
@@ -193,6 +193,11 @@ export default function PureIrrigationTask({
     }
   }, [showWaterUseCalculatorModal]);
 
+  const waterCalculatorDisabled =
+    !showWaterUseCalculatorModal ||
+    !measurement_type ||
+    (measurement_type === 'DEPTH' && !location);
+
   return (
     <>
       <Controller
@@ -308,7 +313,7 @@ export default function PureIrrigationTask({
         </>
       )}
 
-      {showWaterUseCalculatorModal && measurement_type && (
+      {!waterCalculatorDisabled && (
         <WaterUsageCalculatorModal
           dismissModal={onDismissWaterUseCalculatorModel}
           measurementType={measurement_type}

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -122,7 +122,9 @@ export default function PureTaskComplete({
             actual_quantity_unit: persistedFormData?.actual_quantity_unit.value,
           };
         }
-        if (isIrrigationLocation) data.location_id = persistedFormData.locations[0].location_id;
+        if (isIrrigationLocation && persistedFormData.locations?.length) {
+          data.location_id = persistedFormData.locations[0].location_id;
+        }
         onSave(data);
       })}
     >

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -629,7 +629,7 @@ const getCompleteIrrigationTaskBody = (task_translation_key) => (data) => {
               ? data.taskData[taskType].irrigation_task_type_other
               : data.taskData[taskType].irrigation_type_name.value;
         }
-        data.taskData[taskType].location_id = data.location_id;
+
         data.taskData.location_defaults = [
           {
             location_id: data.location_id,
@@ -648,7 +648,11 @@ const getCompleteIrrigationTaskBody = (task_translation_key) => (data) => {
         !data.taskData[taskType].estimated_water_usage &&
           delete data.taskData[taskType]?.estimated_water_usage_unit;
 
-        delete data.location_id;
+        if (data.location_id) {
+          data.taskData[taskType].location_id = data.location_id;
+          delete data.location_id;
+        }
+
         for (const element in data.taskData[taskType]) {
           [
             'irrigation_task_type_other',


### PR DESCRIPTION
**Description**

`PureIrrigationTask` was not compatible with wild crops that do not have `locations`.
- handle empty locations `[]`
- disable the depth calculator for wild crops (wild crops do not have locations, and the depth calculator uses location's `total_area` for its calculation)
- handle a task for wild crops which does not have location_id when forming an API payload for task completion

Jira link: https://lite-farm.atlassian.net/browse/LF-3030

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
