### PR TITLE
LF-3092 The user is able to create a duplicate variety of the same crop

### DIFF
--- a/packages/api/src/controllers/cropVarietyController.js
+++ b/packages/api/src/controllers/cropVarietyController.js
@@ -72,7 +72,7 @@ const cropVarietyController = {
         const [relatedCrop] = await CropModel.query()
           .context({ showHidden: true })
           .where({ crop_id });
-        if ((farm_id, crop_id, crop_variety_name)) {
+        if (farm_id && crop_id && crop_variety_name) {
           const duplicateVariety = await CropVarietyModel.query().findOne({
             farm_id,
             crop_id,
@@ -98,7 +98,7 @@ const cropVarietyController = {
       const { crop_variety_id } = req.params;
       const { farm_id, crop_id, crop_variety_name } = req.body;
       try {
-        if ((farm_id, crop_id, crop_variety_name, crop_variety_id)) {
+        if (farm_id && crop_id && crop_variety_name && crop_variety_id) {
           const duplicateVariety = await CropVarietyModel.query()
             .whereNot('crop_variety_id', crop_variety_id)
             .findOne({

--- a/packages/api/src/controllers/cropVarietyController.js
+++ b/packages/api/src/controllers/cropVarietyController.js
@@ -72,16 +72,18 @@ const cropVarietyController = {
         const [relatedCrop] = await CropModel.query()
           .context({ showHidden: true })
           .where({ crop_id });
-        const duplicateVariety = await CropVarietyModel.query().findOne({
-          farm_id,
-          crop_id,
-          crop_variety_name,
-          deleted: false,
-        });
-        if (duplicateVariety) {
-          return res.status(400).json({
-            error: 'This crop variety already exists, please choose a different variety name',
+        if ((farm_id, crop_id, crop_variety_name)) {
+          const duplicateVariety = await CropVarietyModel.query().findOne({
+            farm_id,
+            crop_id,
+            crop_variety_name,
+            deleted: false,
           });
+          if (duplicateVariety) {
+            return res.status(400).json({
+              error: 'This crop variety already exists, please choose a different variety name',
+            });
+          }
         }
         const result = await post(CropVarietyModel, { ...relatedCrop, ...req.body }, req);
         return res.status(201).json(result);
@@ -96,18 +98,20 @@ const cropVarietyController = {
       const { crop_variety_id } = req.params;
       const { farm_id, crop_id, crop_variety_name } = req.body;
       try {
-        const duplicateVariety = await CropVarietyModel.query()
-          .whereNot('crop_variety_id', crop_variety_id)
-          .findOne({
-            farm_id,
-            crop_id,
-            crop_variety_name,
-            deleted: false,
-          });
-        if (duplicateVariety) {
-          return res.status(400).json({
-            error: 'This crop variety already exists, please choose a different variety name',
-          });
+        if ((farm_id, crop_id, crop_variety_name, crop_variety_id)) {
+          const duplicateVariety = await CropVarietyModel.query()
+            .whereNot('crop_variety_id', crop_variety_id)
+            .findOne({
+              farm_id,
+              crop_id,
+              crop_variety_name,
+              deleted: false,
+            });
+          if (duplicateVariety) {
+            return res.status(400).json({
+              error: 'This crop variety already exists, please choose a different variety name',
+            });
+          }
         }
         const result = await CropVarietyModel.query()
           .context(req.user)

--- a/packages/api/src/controllers/cropVarietyController.js
+++ b/packages/api/src/controllers/cropVarietyController.js
@@ -68,10 +68,21 @@ const cropVarietyController = {
   createCropVariety() {
     return async (req, res, next) => {
       try {
-        const { crop_id } = req.body;
+        const { crop_id, crop_variety_name, farm_id } = req.body;
         const [relatedCrop] = await CropModel.query()
           .context({ showHidden: true })
           .where({ crop_id });
+        const duplicateVariety = await CropVarietyModel.query().findOne({
+          farm_id,
+          crop_id,
+          crop_variety_name,
+          deleted: false,
+        });
+        if (duplicateVariety) {
+          return res.status(400).json({
+            error: 'This crop variety already exists, please choose a different variety name',
+          });
+        }
         const result = await post(CropVarietyModel, { ...relatedCrop, ...req.body }, req);
         return res.status(201).json(result);
       } catch (error) {
@@ -83,7 +94,21 @@ const cropVarietyController = {
   updateCropVariety() {
     return async (req, res, next) => {
       const { crop_variety_id } = req.params;
+      const { farm_id, crop_id, crop_variety_name } = req.body;
       try {
+        const duplicateVariety = await CropVarietyModel.query()
+          .whereNot('crop_variety_id', crop_variety_id)
+          .findOne({
+            farm_id,
+            crop_id,
+            crop_variety_name,
+            deleted: false,
+          });
+        if (duplicateVariety) {
+          return res.status(400).json({
+            error: 'This crop variety already exists, please choose a different variety name',
+          });
+        }
         const result = await CropVarietyModel.query()
           .context(req.user)
           .findById(crop_variety_id)

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -303,7 +303,7 @@
     "VARIETAL_IMAGE": "Customize image for varietal or cultivar",
     "VARIETAL_IMAGE_INFO": "If you would like this varietal or cultivar to have a different image from the default crop, you can customize the image here.",
     "VARIETY_COMMON_NAME": "Common Name",
-    "DUPLICATE_VARIETY": "A variety of this crop with this name already exists on your farm",
+    "DUPLICATE_VARIETY": "A variety of this crop with the same name already exists on your farm",
     "VARIETY_VARIETAL": "Varietal",
     "VARIETY_CULTIVAR": "Cultivar",
     "CULTIVAR_SUBTEXT": "Learn more about cultivars",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -303,6 +303,7 @@
     "VARIETAL_IMAGE": "Customize image for varietal or cultivar",
     "VARIETAL_IMAGE_INFO": "If you would like this varietal or cultivar to have a different image from the default crop, you can customize the image here.",
     "VARIETY_COMMON_NAME": "Common Name",
+    "DUPLICATE_VARIETY": "You already have a variety for this crop with this name",
     "VARIETY_VARIETAL": "Varietal",
     "VARIETY_CULTIVAR": "Cultivar",
     "CULTIVAR_SUBTEXT": "Learn more about cultivars",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -303,7 +303,7 @@
     "VARIETAL_IMAGE": "Customize image for varietal or cultivar",
     "VARIETAL_IMAGE_INFO": "If you would like this varietal or cultivar to have a different image from the default crop, you can customize the image here.",
     "VARIETY_COMMON_NAME": "Common Name",
-    "DUPLICATE_VARIETY": "You already have a variety for this crop with this name",
+    "DUPLICATE_VARIETY": "A variety of this crop with this name already exists on your farm",
     "VARIETY_VARIETAL": "Varietal",
     "VARIETY_CULTIVAR": "Cultivar",
     "CULTIVAR_SUBTEXT": "Learn more about cultivars",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -303,6 +303,7 @@
     "VARIETAL_SUBTITLE": "Cuéntenos sobre la variedad o cultivar específico que pretende cultivar",
     "VARIETAL_IMAGE_INFO": "Si desea que este varietal o cultivar tenga una imagen diferente del recorte predeterminado, puede personalizar la imagen aquí.",
     "VARIETY_COMMON_NAME": "Nombre común",
+    "DUPLICATE_VARIETY": "MISSING",
     "VARIETY_VARIETAL": "Varietal",
     "VARIETY_CULTIVAR": "Cultivar",
     "CULTIVAR_SUBTEXT": "Aprender más sobre cultivares",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -303,6 +303,7 @@
     "VARIETAL_IMAGE": "Personnaliser l’image pour la variété ou le cultivar",
     "VARIETAL_IMAGE_INFO": "Si vous souhaitez que cette variété ou ce cultivar ait une image différente de la culture par défaut, vous pouvez personnaliser l’image ici.",
     "VARIETY_COMMON_NAME": "Nom commun",
+    "DUPLICATE_VARIETY": "MISSING",
     "VARIETY_VARIETAL": "Variété",
     "VARIETY_CULTIVAR": "Cultivar",
     "CULTIVAR_SUBTEXT": "En savoir plus sur les cultivars",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -303,6 +303,7 @@
     "VARIETAL_SUBTITLE": "Conte-nos sobre a variedade ou cultivar específica que você pretende cultivar",
     "VARIETAL_IMAGE_INFO": "Se você deseja que esta variedade ou cultivar tenha uma imagem diferente da cultura padrão, você pode personalizar a imagem aqui.",
     "VARIETY_COMMON_NAME": "Nome Comum",
+    "DUPLICATE_VARIETY": "MISSING",
     "VARIETY_VARIETAL": "Variedade",
     "VARIETY_CULTIVAR": "Cultivar",
     "CULTIVAR_SUBTEXT": "Saiba mais sobre cultivares",

--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -21,6 +21,7 @@ export default function PureAddCropVariety({
   crop,
   imageUploader,
   handleGoBack,
+  farmCropVarieties,
 }) {
   const { t } = useTranslation(['translation', 'common', 'crop']);
   const COMMON_NAME = 'crop_variety_name';
@@ -35,6 +36,7 @@ export default function PureAddCropVariety({
     handleSubmit,
     getValues,
     watch,
+    setError,
     formState: { errors, isValid },
   } = useForm({
     mode: 'onChange',
@@ -73,6 +75,33 @@ export default function PureAddCropVariety({
     truncateText(crop.crop_genus, 22) + ' ' + truncateText(crop.crop_specie, 22);
   const progress = 33;
 
+  const uniqueVarietyName = () => {
+    const formVarietyName = getValues('crop_variety_name');
+
+    const hasRepeatedVarieties = farmCropVarieties.some((variety) => {
+      const commonNameMatch = variety.crop_variety_name === formVarietyName;
+      const cropMatch = variety.crop_id === crop.crop_id;
+      return commonNameMatch && cropMatch;
+    });
+
+    return !hasRepeatedVarieties;
+  };
+
+  const showDuplicateVarietyError = () => {
+    setError(
+      'crop_variety_name',
+      {
+        type: 'custom',
+        message: t('CROP.DUPLICATE_VARIETY'),
+      },
+      { shouldFocus: true },
+    );
+  };
+
+  const checkUniqueVarietyAndSubmit = () => {
+    uniqueVarietyName() ? onSubmit() : showDuplicateVarietyError();
+  };
+
   return (
     <Form
       buttonGroup={
@@ -80,7 +109,7 @@ export default function PureAddCropVariety({
           {isSeekingCert ? t('common:CONTINUE') : t('common:SAVE')}
         </Button>
       }
-      onSubmit={handleSubmit(onSubmit, onError)}
+      onSubmit={handleSubmit(checkUniqueVarietyAndSubmit)}
     >
       <MultiStepPageTitle
         style={{ marginBottom: '24px' }}
@@ -117,6 +146,7 @@ export default function PureAddCropVariety({
         type="text"
         hookFormRegister={commonNameRegister}
         hasLeaf={false}
+        errors={getInputErrors(errors, 'crop_variety_name')}
       />
       <Input
         data-cy="crop-varietal"

--- a/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
+++ b/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PureAddCropVariety from '../../components/AddCropVariety';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { cropSelector } from '../cropSlice';
+import { cropVarietiesSelector } from '../cropVarietySlice';
 import { postCropAndVarietal, postVarietal } from './saga';
 import { certifierSurveySelector } from '../OrganicCertifierSurvey/slice';
 import { hookFormPersistSelector } from '../hooks/useHookFormPersist/hookFormPersistSlice';
@@ -25,6 +26,8 @@ function AddCropVarietyForm({ history, match }) {
   const onContinue = (data) => {
     history.push(`/crop/${crop_id}/add_crop_variety/compliance`);
   };
+
+  const farmCropVarieties = useSelector(cropVarietiesSelector);
 
   const onSubmit = (data) => {
     const cropData = {
@@ -63,6 +66,7 @@ function AddCropVarietyForm({ history, match }) {
           </ImagePickerWrapper>
         }
         handleGoBack={() => history.back()}
+        farmCropVarieties={farmCropVarieties}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/AddCropVariety/saga.js
+++ b/packages/webapp/src/containers/AddCropVariety/saga.js
@@ -106,7 +106,7 @@ export function* postCropAndVarietalSaga({ payload: cropData }) {
 
 export const patchVarietal = createAction(`patchVarietalSaga`);
 
-export function* patchVarietalSaga({ payload: { variety_id, data } }) {
+export function* patchVarietalSaga({ payload: { variety_id, crop_id, data } }) {
   const { cropVarietyURL } = apiConfig;
   let { user_id, farm_id } = yield select(loginSelector);
   const header = getHeader(user_id, farm_id);
@@ -115,7 +115,7 @@ export function* patchVarietalSaga({ payload: { variety_id, data } }) {
     const result = yield call(
       axios.patch,
       `${cropVarietyURL}/${variety_id}`,
-      { ...data, farm_id },
+      { ...data, farm_id, crop_id },
       header,
     );
     yield put(putCropVarietySuccess({ crop_variety_id: variety_id, ...data }));

--- a/packages/webapp/src/containers/AddCropVariety/saga.js
+++ b/packages/webapp/src/containers/AddCropVariety/saga.js
@@ -122,8 +122,14 @@ export function* patchVarietalSaga({ payload: { variety_id, crop_id, data } }) {
     history.push(`/crop/${variety_id}/detail`);
     yield put(enqueueSuccessSnackbar(i18n.t('message:CROP_VARIETY.SUCCESS.UPDATE')));
   } catch (e) {
-    yield put(enqueueErrorSnackbar(i18n.t('message:CROP_VARIETY.ERROR.UPDATE')));
-    console.log('failed to update crop variety');
+    if (
+      e.response.data.error ===
+      'This crop variety already exists, please choose a different variety name'
+    ) {
+      yield put(enqueueErrorSnackbar(i18n.t('translation:CROP.DUPLICATE_VARIETY')));
+    } else {
+      yield put(enqueueErrorSnackbar(i18n.t('message:CROP_VARIETY.ERROR.UPDATE')));
+    }
   }
 }
 

--- a/packages/webapp/src/containers/EditCropVariety/index.jsx
+++ b/packages/webapp/src/containers/EditCropVariety/index.jsx
@@ -30,7 +30,7 @@ function EditCropVarietyForm({ history, match }) {
       treated: null,
       ...data,
     };
-    dispatch(patchVarietal({ variety_id, data: varietyData }));
+    dispatch(patchVarietal({ variety_id, crop_id: cropVariety.crop_id, data: varietyData }));
   };
 
   // TODO - Add persisted path (LF-1430)


### PR DESCRIPTION
**Description**

This PR adds a uniqueness constraint to adding a variety in the frontend, so that the Add Variety form cannot be submitted if the given Variety Common Name already exists for that given crop on this farm.

The same constraint has also been added to the API for both the Add Variety and Edit Variety screens. _The frontend validation for Edit Variety should be added at some point in the future._

**This ticket has a language component for the validation error displayed when a Variety is not unique.**

Jira link: https://lite-farm.atlassian.net/browse/LF-3092


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
