### PR TITLE
LF-3189 Pop up message showing mismatch between organic / non-organic crop and location is firing incorrectly

### DIFF
--- a/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
@@ -25,6 +25,7 @@ export default function PurePlantingLocation({
   default_initial_location_id,
   farmCenterCoordinate,
   isCropOrganic,
+  isPursuingCertification,
 }) {
   const { t } = useTranslation(['translation', 'common', 'crop']);
   const { getValues, watch, setValue } = useForm({
@@ -123,11 +124,14 @@ export default function PurePlantingLocation({
       getValues()?.crop_management_plan?.planting_management_plans[locationPrefix]?.location_id;
     const selectedLocation = cropLocations.find((c) => c.location_id === selectedLocationId);
     const isSelectedLocationOrganic = selectedLocation?.organic_status?.toLowerCase() === ORGANIC;
-    if (isCropOrganic !== isSelectedLocationOrganic) {
+    if (isCropOrganic !== isSelectedLocationOrganic && isPursuingCertification) {
       let content = {};
       if (isSelectedLocationOrganic) {
         content.title = t('CROP_STATUS_ORGANIC_MISMATCH_MODAL.TITLE');
         content.subTitle = t('CROP_STATUS_ORGANIC_MISMATCH_MODAL.SUBTITLE');
+      } else if (!isSelectedLocationOrganic && isCropOrganic == null) {
+        // Do not trigger modal on organic locations for organic status null crops
+        proceedToNextStep();
       } else {
         content.title = t('CROP_STATUS_NON_ORGANIC_MISMATCH_MODAL.TITLE');
         content.subTitle = t('CROP_STATUS_NON_ORGANIC_MISMATCH_MODAL.SUBTITLE');

--- a/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantingLocation/index.jsx
@@ -130,7 +130,7 @@ export default function PurePlantingLocation({
         content.title = t('CROP_STATUS_ORGANIC_MISMATCH_MODAL.TITLE');
         content.subTitle = t('CROP_STATUS_ORGANIC_MISMATCH_MODAL.SUBTITLE');
       } else if (!isSelectedLocationOrganic && isCropOrganic == null) {
-        // Do not trigger modal on organic locations for organic status null crops
+        // Do not trigger modal on non-organic locations for organic status null crops
         proceedToNextStep();
       } else {
         content.title = t('CROP_STATUS_NON_ORGANIC_MISMATCH_MODAL.TITLE');

--- a/packages/webapp/src/containers/Crop/AddManagementPlan/PlantingLocation/index.jsx
+++ b/packages/webapp/src/containers/Crop/AddManagementPlan/PlantingLocation/index.jsx
@@ -4,6 +4,7 @@ import PurePlantingLocation from '../../../../components/Crop/PlantingLocation';
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
 import { cropLocationsSelector } from '../../../locationSlice';
 import { userFarmSelector } from '../../../userFarmSlice';
+import { certifierSurveySelector } from '../../../OrganicCertifierSurvey/slice';
 import { hookFormPersistSelector } from '../../../hooks/useHookFormPersist/hookFormPersistSlice';
 import TransplantSpotlight from './TransplantSpotlight';
 import { cropVarietySelector } from '../../../cropVarietySlice.js';
@@ -19,6 +20,7 @@ export default function PlantingLocation({ history, match }) {
     crop_management_plan: { already_in_ground, is_wild, for_cover, needs_transplant, is_seed },
   } = useSelector(hookFormPersistSelector);
   const { grid_points } = useSelector(userFarmSelector);
+  const { interested } = useSelector(certifierSurveySelector);
 
   return (
     <>
@@ -31,6 +33,7 @@ export default function PlantingLocation({ history, match }) {
           default_initial_location_id={default_initial_location_id}
           farmCenterCoordinate={grid_points}
           isCropOrganic={crop.organic}
+          isPursuingCertification={interested}
         />
       </HookFormPersistProvider>
       {needs_transplant && !already_in_ground && <TransplantSpotlight is_seed={is_seed} />}


### PR DESCRIPTION
**Description**

This PR corrects a bug in the location mismatch modal ("You've indicated you'll be planting a (non-)organic crop in a (non-)organic location. Do you want to proceed?") whereby crops with organic status `null` triggered the modal on both organic and non-organic locations.

(Note: Crops with organic status `null` are those created while a farm was not pursuing organic certification.)

This PR updates the modal logic so that:
- the modal is never shown for farms not currently pursuing organic certification
- crops with organic status `null` trigger the modal only on organic locations; i.e. are treated as non-organic for the purposes of this modal


Jira link: https://lite-farm.atlassian.net/jira/software/c/projects/LF/issues/LF-3189

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
