### PR TITLE
Lf 3091 the user is able to create a duplicate of the crop that already exists in the farm if he lefts fields genus species blank db

### DIFF
--- a/packages/api/src/controllers/cropController.js
+++ b/packages/api/src/controllers/cropController.js
@@ -77,6 +77,7 @@ const cropController = {
           deleted: false,
         });
         if (isDuplicateCrop) {
+          await trx.rollback();
           return res.status(400).json({
             error: 'This crop already exists, please edit your crop name, genus or species',
           });

--- a/packages/api/src/controllers/cropController.js
+++ b/packages/api/src/controllers/cropController.js
@@ -68,7 +68,19 @@ const cropController = {
     return async (req, res) => {
       const trx = await transaction.start(Model.knex());
       try {
-        const { crop, variety } = req.body;
+        const { crop, variety, farm_id } = req.body;
+        const isDuplicateCrop = await CropModel.query().findOne({
+          farm_id,
+          crop_common_name: crop.crop_common_name,
+          crop_genus: crop.crop_genus || null, // Use null if the value is undefined
+          crop_specie: crop.crop_specie || null, // Use null if the value is undefined
+          deleted: false,
+        });
+        if (isDuplicateCrop) {
+          return res.status(400).json({
+            error: 'This crop already exists, please edit your crop name, genus or species',
+          });
+        }
         crop.user_added = true;
         crop.crop_translation_key = crop.crop_common_name;
         const newCrop = await baseController.postWithResponse(CropModel, crop, req, { trx });

--- a/packages/webapp/src/containers/AddCropVariety/saga.js
+++ b/packages/webapp/src/containers/AddCropVariety/saga.js
@@ -96,9 +96,7 @@ export function* postCropAndVarietalSaga({ payload: cropData }) {
   } catch (e) {
     if (e.response.data.violationError) {
       yield put(enqueueErrorSnackbar(i18n.t('message:CROP_VARIETY.ERROR.ADD_ALREADY_EXISTS')));
-      console.log('failed to add varietal to database');
     } else {
-      console.log('failed to add varietal to database');
       yield put(enqueueErrorSnackbar(i18n.t('message:CROP_VARIETY.ERROR.ADD')));
     }
   }


### PR DESCRIPTION
**Description**

Backend piece of LF-3091. I did not add new error messaging as it is now handled differently on the frontend. i did not edit updateCrop() in the controller as it has no frontend use case currently.

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain):
 - disabled frontend check in PureAddNew in checkUniqueCropAndSubmit function changing showDuplicateCropError() to handleContinue()
 - add new crop will fail

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
