### PR TITLE
LF-3203 Comment out sensor from the farm map "+" drawer

### DIFF
--- a/packages/webapp/src/components/MapDrawer/index.jsx
+++ b/packages/webapp/src/components/MapDrawer/index.jsx
@@ -208,13 +208,14 @@ export default function MapDrawer({
           icon: () => <WaterValve className={classes.icon} />,
           key: locationEnum.water_valve,
         },
-        {
-          name: t('FARM_MAP.MAP_FILTER.SENSOR'),
-          icon: () => (
-            <Sensor className={classes.icon} style={{ transform: 'translate(-5px, 5px)' }} />
-          ),
-          key: locationEnum.sensor,
-        },
+        // Disabling temporarily for April 2023 (3.3) Release
+        // {
+        //   name: t('FARM_MAP.MAP_FILTER.SENSOR'),
+        //   icon: () => (
+        //     <Sensor className={classes.icon} style={{ transform: 'translate(-5px, 5px)' }} />
+        //   ),
+        //   key: locationEnum.sensor,
+        // },
       ]
         .sort((firstLocationType, secondLocationType) =>
           firstLocationType.name.localeCompare(secondLocationType.name),


### PR DESCRIPTION
**Description**

This PR removes the ability to add sensors from the farm map by commenting out the sensor option in the map drawer.

Jira link: https://lite-farm.atlassian.net/browse/LF-3203

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
