### PR TITLE
Add check to API to prevent crash on partially deleted tasks

### DIFF
--- a/packages/api/src/middleware/validation/assignTask.js
+++ b/packages/api/src/middleware/validation/assignTask.js
@@ -49,6 +49,11 @@ async function checkTaskStatusForAssignment(req, res, next) {
   const { task_id } = req.params;
 
   const checkTaskStatus = await TaskModel.getTaskStatus(task_id);
+
+  if (!checkTaskStatus) {
+    return res.status(404).send('Task not found');
+  }
+
   if (checkTaskStatus.complete_date || checkTaskStatus.abandon_date) {
     return res.status(400).send('Task has already been completed or abandoned');
   }


### PR DESCRIPTION
**Description**

This PR adds a check for an undefined task in assignTask.js that is capable of crashing the API with a TypeError.

A React Hooks-related error in the frontend was making it easier to create partially deleted tasks that were deleted in the database but not the Redux store. Reassigning these tasks would cause a TypeError that crashes the API.

With the React Hooks error addressed (see PR #2633) these partially-deleted tasks will be much harder to generate. But there is no downside to including this check 🙂 

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I crashed the API on my local reliably and verified that this file was at fault.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
