### PR TITLE
LF-3157 Images and documents that are too large fail without explanation

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -767,7 +767,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Files can not exceed 10MB or 5 pages.",
+    "BODY": "Files cannot be larger than 10MB.",
     "TITLE": "File size too large"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -767,7 +767,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Files can not exceed 25MB or 5 pages.",
+    "BODY": "Files can not exceed 10MB or 5 pages.",
     "TITLE": "File size too large"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -766,7 +766,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Los archivos no pueden exceder los 10 MB o 5 páginas.",
+    "BODY": "Los archivos no pueden exceder los 10 MB.",
     "TITLE": "Tamaño de archivo demasiado grande"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -766,7 +766,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Los archivos no pueden exceder los 25 MB o 5 páginas.",
+    "BODY": "Los archivos no pueden exceder los 10 MB o 5 páginas.",
     "TITLE": "Tamaño de archivo demasiado grande"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -767,7 +767,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Les fichiers ne peuvent pas dépasser 25MB ou 5 pages.",
+    "BODY": "Les fichiers ne peuvent pas dépasser 10MB ou 5 pages.",
     "TITLE": "Taille du fichier trop grande"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -767,7 +767,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Les fichiers ne peuvent pas dépasser 10MB ou 5 pages.",
+    "BODY": "Les fichiers ne peuvent pas dépasser 10MB.",
     "TITLE": "Taille du fichier trop grande"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -766,7 +766,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Os arquivos não podem exceder 10 MB ou 5 páginas.",
+    "BODY": "Os arquivos não podem exceder 10 MB.",
     "TITLE": "Tamanho de arquivo muito grande"
   },
   "FILTER": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -766,7 +766,7 @@
     }
   },
   "FILE_SIZE_MODAL": {
-    "BODY": "Os arquivos não podem exceder 25 MB ou 5 páginas.",
+    "BODY": "Os arquivos não podem exceder 10 MB ou 5 páginas.",
     "TITLE": "Tamanho de arquivo muito grande"
   },
   "FILTER": {

--- a/packages/webapp/src/components/Documents/Add/index.jsx
+++ b/packages/webapp/src/components/Documents/Add/index.jsx
@@ -229,7 +229,7 @@ function PureDocumentDetailView({
           <Loading style={{ minHeight: '192px', width: '100%', maxWidth: '312px' }} />
         )}
       </div>
-      {uploadedFiles?.length <= 5 &&
+      {uploadedFiles?.length < 5 &&
         documentUploader({
           style: { paddingBottom: '32px' },
           linkText: t('DOCUMENTS.ADD.ADD_MORE_PAGES'),

--- a/packages/webapp/src/containers/Documents/DocumentUploader/index.jsx
+++ b/packages/webapp/src/containers/Documents/DocumentUploader/index.jsx
@@ -15,7 +15,7 @@ export function DocumentUploader({ style, linkstyle, onUpload, linkText, onUploa
     const file = e?.target?.files?.[0];
     if (!isValidFile(file)) {
       dispatch(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
-    } else if (e?.target?.files?.[0]?.size > 26214400) {
+    } else if (e?.target?.files?.[0]?.size > 10485760) {
       setShowErrorModal(true);
     } else if (e?.target?.files?.[0]) {
       onUpload?.();


### PR DESCRIPTION
**Description**

This PR decreases the filesize upload limit for the document view from 25MB to 10MB. Kevin has investigated this and determined it as a reasonable limit. 10MB also reflects the point at which thumbnail creation on the Imaginary starts to fail within this flow.

It also removes the warning about page limit from the filesize modal (where it does not logically belong) and fixes the page (i.e files that can be uploaded per document) limit at 5 instead of 6.

Jira link: https://lite-farm.atlassian.net/browse/LF-3157

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
