### PR TITLE
LF-2969 Migrate Cook Islands currency and iso

### DIFF
--- a/packages/api/db/migration/20230425182236_update_cook_islands_currency.js
+++ b/packages/api/db/migration/20230425182236_update_cook_islands_currency.js
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex('countries')
+    .where('country_name', 'Cook Islands')
+    .update({ currency: 'New Zealand dollar', iso: 'NZD' });
+};
+
+export const down = async function (knex) {
+  await knex('countries')
+    .where('country_name', 'Cook Islands')
+    .update({ currency: 'Cook Islands dollar', iso: 'CKD[G]' });
+};


### PR DESCRIPTION
**Description**

This PR creates a migration for the database change that has already been manually implemented on production (but not Beta) where the Cook Islands currency has been updated to the New Zealand Dollar.

Jira link: https://lite-farm.atlassian.net/browse/LF-2969

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested by running the migration script and viewing the database. Tested against both versions of the database -- the change already live (as in prod) or the change not yet updated (as in beta).

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
