### PR TITLE
LF-3187: No results are shown when the user searches for a crop using its Scientific Name when the Scientific name Consists of more than 1 word

### DIFF
--- a/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.ts
+++ b/packages/webapp/src/containers/CropCatalogue/useStringFilteredCrops.ts
@@ -49,8 +49,17 @@ export default function useStringFilteredCrops(
         'crop_cultivar', // crop_variety.crop_cultivar
       ];
       for (let i = 0; i < keys.length; i++) {
-        if (keys[i] in crop && check(crop[keys[i] as keyof typeof crop])) {
-          return true;
+        if (keys[i] in crop) {
+          if (!i) {
+            const scientificName =
+              crop[keys[0] as keyof typeof crop] + (crop[keys[1] as keyof typeof crop] || '');
+            if (scientificName && check(scientificName)) {
+              return true;
+            }
+            i++;
+          } else if (check(crop[keys[i] as keyof typeof crop])) {
+            return true;
+          }
         }
       }
       return false;


### PR DESCRIPTION
**Description**

Scientific name consists of "crop_genus"+ "crop_specie". This PR is to update `useStringFilteredCrops` to allow crops to be searched by scientific name.

Jira link: https://lite-farm.atlassian.net/browse/LF-3187

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
