### PR TITLE
LF-3061: Redraw does not work for watercourse and buffer zone once confirmed

### DIFF
--- a/packages/webapp/src/components/Form/Unit/useUnit.jsx
+++ b/packages/webapp/src/components/Form/Unit/useUnit.jsx
@@ -242,15 +242,23 @@ const useUnit = ({
   // set visible value when hidden input is updated from parent component
   // (this happens when the component shows a result of a calculation)
   useEffect(() => {
-    if ((noValue(visibleInputValue) && noValue(hookFormValue)) || !databaseUnit || !hookFormUnit) {
+    // hookFormValue is sometimes not up to date with the actual value right after rendering.
+    // call hookFormGetValue to use the current value.
+    const currentHookFormValue = hookFormGetValue(name);
+
+    if (
+      (noValue(visibleInputValue) && noValue(currentHookFormValue)) ||
+      !databaseUnit ||
+      !hookFormUnit
+    ) {
       return;
     }
 
     const newValue = roundToTwoDecimal(
-      convertFn(unitType, hookFormValue, databaseUnit, hookFormUnit),
+      convertFn(unitType, currentHookFormValue, databaseUnit, hookFormUnit),
     );
     if (newValue !== visibleInputValue) {
-      setVisibleInputValue(hookFormValue > 0 || hookFormValue === 0 ? newValue : '');
+      setVisibleInputValue(currentHookFormValue > 0 || currentHookFormValue === 0 ? newValue : '');
     }
   }, [hookFormValue]);
 

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -442,7 +442,7 @@ export default function Map({ history }) {
 
   const handleLineConfirm = (lineData) => {
     setShowingConfirmButtons(false);
-    const data = { ...getOverlayInfo(), ...lineData };
+    const data = { ...lineData, ...getOverlayInfo() };
     dispatch(upsertFormData(data));
     history.push(`/create_location/${drawingState.type}`);
   };

--- a/packages/webapp/src/stories/Form/Unit/Unit.stories.jsx
+++ b/packages/webapp/src/stories/Form/Unit/Unit.stories.jsx
@@ -25,6 +25,7 @@ import {
   water_valve_flow_rate,
   seedYield,
   pricePerSeedYield,
+  convertFn,
 } from '../../../util/convert-units/unit';
 import { useForm } from 'react-hook-form';
 import { convert } from '../../../util/convert-units/convert';
@@ -580,41 +581,41 @@ WeeksCropAge.play = async ({ canvasElement }) => {
 
   await test.inputValueAndBlur('4');
   await test.visibleInputToHaveValue(4);
-  await test.hiddenInputToHaveValue(4, 'week', 'min');
+  await test.hiddenInputToHaveValue(4, 'week', 'd');
 
   await test.inputValueAndBlur('40');
   await test.visibleInputToHaveValue(40);
-  await test.hiddenInputToHaveValue(40, 'week', 'min');
+  await test.hiddenInputToHaveValue(40, 'week', 'd');
   await test.selectedUnitToBeInTheDocument('weeks');
 
   await test.selectUnit('months');
   await test.selectedUnitToBeInTheDocument('months');
   await test.visibleInputToHaveValue(40);
-  await test.hiddenInputToHaveValue(40, 'month', 'min');
+  await test.hiddenInputToHaveValue(40, 'month', 'd');
 
   await test.inputValueAndBlur('10');
   await test.visibleInputToHaveValue(10);
-  await test.hiddenInputToHaveValue(10, 'month', 'min');
+  await test.hiddenInputToHaveValue(10, 'month', 'd');
   await test.selectedUnitToBeInTheDocument('months');
 
   await test.selectUnit('years');
   await test.selectedUnitToBeInTheDocument('years');
   await test.visibleInputToHaveValue(10);
-  await test.hiddenInputToHaveValue(10, 'year', 'min');
+  await test.hiddenInputToHaveValue(10, 'year', 'd');
 
   await test.inputValueAndBlur('1');
   await test.visibleInputToHaveValue(1);
-  await test.hiddenInputToHaveValue(1, 'year', 'min');
+  await test.hiddenInputToHaveValue(1, 'year', 'd');
   await test.selectedUnitToBeInTheDocument('years');
 
   await test.selectUnit('days');
   await test.selectedUnitToBeInTheDocument('days');
   await test.visibleInputToHaveValue(1);
-  await test.hiddenInputToHaveValue(1, 'd', 'min');
+  await test.hiddenInputToHaveValue(1);
 
   await test.inputValueAndBlur('14');
   await test.visibleInputToHaveValue(14);
-  await test.hiddenInputToHaveValue(14, 'd', 'min');
+  await test.hiddenInputToHaveValue(14);
   await test.selectedUnitToBeInTheDocument('days');
 };
 
@@ -637,19 +638,15 @@ DaysCropAge.play = async ({ canvasElement }) => {
 
   await test.inputValueAndBlur('1000');
   await test.haveMaxValueError();
-  await test.hiddenInputToHaveValue(1000, 'd', 'min');
 
   await test.selectUnit('weeks');
   await test.haveMaxValueError();
-  await test.hiddenInputToHaveValue(1000, 'week', 'min');
 
   await test.selectUnit('months');
   await test.haveMaxValueError();
-  await test.hiddenInputToHaveValue(1000, 'month', 'min');
 
   await test.selectUnit('years');
   await test.haveMaxValueError();
-  await test.hiddenInputToHaveValue(1000, 'year', 'min');
 
   await test.clearError();
   await test.haveNoError();

--- a/packages/webapp/src/stories/Form/Unit/Unit.stories.jsx
+++ b/packages/webapp/src/stories/Form/Unit/Unit.stories.jsx
@@ -25,7 +25,6 @@ import {
   water_valve_flow_rate,
   seedYield,
   pricePerSeedYield,
-  convertFn,
 } from '../../../util/convert-units/unit';
 import { useForm } from 'react-hook-form';
 import { convert } from '../../../util/convert-units/convert';
@@ -638,15 +637,19 @@ DaysCropAge.play = async ({ canvasElement }) => {
 
   await test.inputValueAndBlur('1000');
   await test.haveMaxValueError();
+  await test.hiddenInputToHaveValue(1000);
 
   await test.selectUnit('weeks');
   await test.haveMaxValueError();
+  await test.hiddenInputToHaveValue(1000, 'week', 'd');
 
   await test.selectUnit('months');
   await test.haveMaxValueError();
+  await test.hiddenInputToHaveValue(1000, 'month', 'd');
 
   await test.selectUnit('years');
   await test.haveMaxValueError();
+  await test.hiddenInputToHaveValue(1000, 'year', 'd');
 
   await test.clearError();
   await test.haveNoError();


### PR DESCRIPTION
**Description**

- When "Confirm" button on the "Line box" modal is clicked, override the existing data with the latest data. (the bug is that the latest data is overridden with the old data)
- Revert and update storybook tests I updated in this commit https://github.com/LiteFarmOrg/LiteFarm/pull/2584/commits/4fe0d3ee3ecae5ecf14df75ab38d55c06ccce06b. (It looks like I forgot to run the tests after making all the changes, so I didn't realize that they were failing...)
- When confirming on the modal and redrawing, the visible value disappears although the hidden value exists. (please see the recording) This happens because in one of the `useEffect` in `useUnit` hook, `hookFormValue` (= hidden value gotten by `watch()`) is different from the current hidden value (can be gotten by `getValues()`). This PR also addresses this issue.
  
https://user-images.githubusercontent.com/33141219/234430442-049aa73c-e758-47e8-9e4e-1e97979e3afa.mov

Jira link: https://lite-farm.atlassian.net/browse/LF-3061

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)
   ran existing storybook tests for Unit displays to make sure the change in the hook will not affect anything.
     ```
     npm run test-storybook /src/stories/Form/Unit
     npm run test-storybook /src/stories/Modal/WaterUsageCalculatorModal.stories.jsx
     ```

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
