### PR TITLE
LF-3176 Back arrow loop

### DIFF
--- a/packages/webapp/src/containers/EditCropVariety/index.jsx
+++ b/packages/webapp/src/containers/EditCropVariety/index.jsx
@@ -47,7 +47,7 @@ function EditCropVarietyForm({ history, match }) {
             <AddLink>{t('CROP.ADD_IMAGE')}</AddLink>
           </ImagePickerWrapper>
         }
-        handleGoBack={() => history.push(`/crop/${variety_id}/detail`)}
+        handleGoBack={() => history.back()}
         cropVariety={cropVariety}
         persistedPath={persistedPath}
       />


### PR DESCRIPTION
**Description**

The `handleGoBack` for PureEditCropVariety had a hardcoded URL, causing an infinite back loop.

This PR updates it to `history.back()` as is used in the other handleGoBack methods.

Jira link: https://lite-farm.atlassian.net/browse/LF-3176

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
