### PR TITLE
LF-3111 Birth year should only allow integers

### DIFF
--- a/packages/webapp/src/components/CreateUserAccount/index.jsx
+++ b/packages/webapp/src/components/CreateUserAccount/index.jsx
@@ -1,6 +1,6 @@
 import Form from '../Form';
 import Button from '../Form/Button';
-import Input from '../Form/Input';
+import Input, { integerOnKeyDown } from '../Form/Input';
 import React, { useEffect, useState } from 'react';
 import { Title } from '../Typography';
 import PropTypes from 'prop-types';
@@ -151,6 +151,7 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack }) {
         data-cy="createUser-birthYear"
         label={t('CREATE_USER.BIRTH_YEAR')}
         type="number"
+        onKeyPress={integerOnKeyDown}
         hookFormRegister={register(BIRTHYEAR, {
           min: 1900,
           max: new Date().getFullYear(),

--- a/packages/webapp/src/components/InvitedUserCreateAccount/index.jsx
+++ b/packages/webapp/src/components/InvitedUserCreateAccount/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import ReactSelect from '../Form/ReactSelect';
-import Input, { getInputErrors } from '../Form/Input';
+import Input, { getInputErrors, integerOnKeyDown } from '../Form/Input';
 import { PasswordError } from '../Form/Errors';
 import { validatePasswordWithErrors } from '../Signup/utils';
 
@@ -116,6 +116,7 @@ export default function PureInvitedUserCreateAccountPage({
       <Input
         label={t('INVITATION.BIRTH_YEAR')}
         type="number"
+        onKeyPress={integerOnKeyDown}
         hookFormRegister={register(BIRTHYEAR, {
           min: 1900,
           max: new Date().getFullYear(),


### PR DESCRIPTION
**Description**

This PR adds the missing `onKeyPress={integerOnKeyDown}` prop to the Birth Year Input in CreateUserAccount and InvitedUserCreateAccount.

Jira link: https://lite-farm.atlassian.net/browse/LF-3111

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
