### PR TITLE
LF-3228 Add migration script for updating Turkey to Türkiye

### DIFF
--- a/packages/api/db/migration/20230426222612_update_turkey_name.js
+++ b/packages/api/db/migration/20230426222612_update_turkey_name.js
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex('countries').where('country_name', 'Turkey').update({ country_name: 'Türkiye' });
+};
+
+export const down = async function (knex) {
+  await knex('countries').where('country_name', 'Türkiye').update({ country_name: 'Turkey' });
+};


### PR DESCRIPTION
**Description**

This PR updates the `countries` table to reflect Türkiye's official change of name.

The discrepancy between our database table and what Google Maps returned was causing an error on new farm creation (see [LF-3225](https://lite-farm.atlassian.net/browse/LF-3225)). Neither this error nor this change affects previously established farms.

Jira link: https://lite-farm.atlassian.net/browse/LF-3228

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

You can test creating a new farm in Türkiye using this latitude and longitude (or you may type in an address of your choosing within the country):

```
39.738027, 29.909981
```


**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3225]: https://lite-farm.atlassian.net/browse/LF-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ