### PR TITLE
LF-3216: Overlap between currency symbol and units on estimated revenue view

### DIFF
--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -12,6 +12,7 @@ import { ReactComponent as Leaf } from '../../../assets/images/signUp/leaf.svg';
 import Infoi from '../../Tooltip/Infoi';
 import { get } from 'react-hook-form';
 import i18n from '../../../locales/i18n';
+import useElementWidth from '../../hooks/useElementWidth';
 
 const Input = ({
   link,
@@ -42,6 +43,7 @@ const Input = ({
 }) => {
   const { t } = useTranslation(['translation', 'common']);
   const name = hookFormRegister?.name ?? props?.name;
+  const currencyRef = useRef(null);
 
   const [inputType, setType] = useState(type);
   const isPassword = type === 'password';
@@ -72,6 +74,8 @@ const Input = ({
       }
     }
   }, [openCalendar]);
+
+  const { elementWidth } = useElementWidth(currencyRef);
 
   return (
     <div
@@ -117,7 +121,11 @@ const Input = ({
           <MdVisibilityOff className={styles.visibilityIcon} onClick={setVisibility} />
         ))}
       {unit && <div className={styles.unit}>{unit}</div>}
-      {currency && <div className={styles.currency}>{currency}</div>}
+      {currency && (
+        <div ref={currencyRef} className={styles.currency}>
+          {currency}
+        </div>
+      )}
       <input
         disabled={disabled}
         className={clsx(
@@ -127,7 +135,7 @@ const Input = ({
         )}
         style={{
           paddingRight: `${unit ? unit.length * 8 + 8 : 4}px`,
-          paddingLeft: currency ? `${currency.length * 8 + 12}px` : undefined,
+          paddingLeft: currency ? `${elementWidth + 12}px` : undefined,
           ...classes.input,
         }}
         aria-invalid={showError ? 'true' : 'false'}

--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <<https://www.gnu.org/licenses/>.>
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import styles from './unit.module.scss';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
@@ -28,6 +28,7 @@ import { Controller } from 'react-hook-form';
 import { ReactComponent as Leaf } from '../../../assets/images/signUp/leaf.svg';
 import useUnit from './useUnit';
 import useReactSelectStyles from './useReactSelectStyles';
+import useElementWidth from '../../hooks/useElementWidth';
 
 const Unit = ({
   disabled = false,
@@ -100,6 +101,8 @@ const Unit = ({
 
   const reactSelectStyles = useReactSelectStyles(disabled, { reactSelectWidth });
   const testId = props['data-testid'] || 'unit';
+  const currencyRef = useRef(null);
+  const { elementWidth } = useElementWidth(currencyRef);
 
   return (
     <div className={clsx(styles.container)} style={{ ...style, ...classes.container }}>
@@ -124,7 +127,7 @@ const Unit = ({
       <div className={styles.inputContainer}>
         <div className={styles.inputWrapper}>
           {currency && (
-            <div className={styles.currency} data-testid={`${testId}-currency`}>
+            <div ref={currencyRef} className={styles.currency} data-testid={`${testId}-currency`}>
               {currency}
             </div>
           )}
@@ -132,7 +135,7 @@ const Unit = ({
             disabled={disabled}
             className={clsx(styles.input)}
             style={{
-              paddingLeft: currency ? `${currency.length * 8 + 12}px` : undefined,
+              paddingLeft: currency ? `${elementWidth + 12}px` : undefined,
               ...classes.input,
             }}
             aria-invalid={showError ? 'true' : 'false'}

--- a/packages/webapp/src/components/hooks/useElementWidth.jsx
+++ b/packages/webapp/src/components/hooks/useElementWidth.jsx
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useMemo } from 'react';
+
+const useElementWidth = (ref) => {
+  const elementWidth = useMemo(() => {
+    if (!ref?.current) {
+      return;
+    }
+
+    return ref.current.offsetWidth;
+  }, [ref.current]);
+
+  return { elementWidth };
+};
+
+export default useElementWidth;


### PR DESCRIPTION
**Description**

Calculate the currency width to adjust padding left of `Unit` and `Input` components so that any currency gets appropriate space.
- create `useElementWidth` hook
- replace the calculation `currency.length * 8` with the width returned by `useElementWidth`

Jira link: https://lite-farm.atlassian.net/browse/LF-3216

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)
   hard-cord `currency` in `/packages/webapp/src/components/Finances/UpdateEstimatedCropRevenue/index.jsx`
   ![Screenshot 2023-04-26 at 4 57 00 PM](https://user-images.githubusercontent.com/33141219/234727025-669a6d91-97c5-41ef-b0ad-1c67dd59f582.png)


**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
