### PR TITLE
Lf 2975 increase character limit for item name in expenses to 100 characters bm

### DIFF
--- a/packages/webapp/src/containers/Finances/EditExpense/TempEditExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/EditExpense/TempEditExpense/index.jsx
@@ -85,7 +85,12 @@ class TempEditExpense extends Component {
                       <br />
                       {this.props.t('EXPENSE.NAME')}
                     </label>
-                    <Control.text type="text" model={`.expenseDetail.note`} maxLength="25" />
+                    <Control.textarea
+                      type="text"
+                      model={`.expenseDetail.note`}
+                      maxLength="100"
+                      rows={3}
+                    />
                   </div>
                   <div className={styles.labelInput}>
                     <label>{this.props.t('EXPENSE.VALUE')}</label>

--- a/packages/webapp/src/containers/Finances/EditExpense/TempEditExpense/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/EditExpense/TempEditExpense/styles.module.scss
@@ -51,14 +51,14 @@
     letter-spacing: 0.324px;
     color: #4d4d4d;
   }
-
-  input {
+  input, textarea {
+    font-size: 16px;
     width: 60%;
-    height: 37px;
     border: 1px solid #efefef;
     box-sizing: border-box;
     border-radius: 4px;
-    padding: 0 5%;
+    padding: 2% 5%;
+    font-family: 'Open Sans', 'SansSerif', serif;
   }
 
   display: flex;

--- a/packages/webapp/src/containers/Finances/ExpenseDetail/index.jsx
+++ b/packages/webapp/src/containers/Finances/ExpenseDetail/index.jsx
@@ -179,7 +179,7 @@ class ExpenseDetail extends Component {
             <Semibold>{expense.type}</Semibold>
           </div>
           <div key={expense.note + expense.amount.toString()} className={styles.itemContainer}>
-            <div>{'- ' + expense.note}</div>
+            <div style={{ overflowWrap: 'anywhere' }}>{'- ' + expense.note}</div>
             <div className={styles.greenText}>{expense.amount}</div>
           </div>
         </div>

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -19,7 +19,6 @@ import { userFarmSelector } from '../../../userFarmSlice';
 import { withTranslation } from 'react-i18next';
 import { numberOnKeyDown } from '../../../../components/Form/Input';
 import grabCurrencySymbol from '../../../../util/grabCurrencySymbol';
-import InputAutoSize from '../../../../components/Form/InputAutoSize';
 
 class AddExpense extends Component {
   constructor(props) {
@@ -184,14 +183,11 @@ class AddExpense extends Component {
                               <br />
                               {this.props.t('EXPENSE.NAME')}
                             </label>
-                            <InputAutoSize
+                            <Control.textarea
                               type="text"
-                              className={styles.textArea}
                               model={`.expenseDetail[${k}][${i}].note`}
                               maxLength="100"
-                              style={{ width: '60%' }}
-                              maxRows={4}
-                              minRows={1}
+                              rows={1}
                             />
                           </div>
 

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -187,7 +187,7 @@ class AddExpense extends Component {
                               type="text"
                               model={`.expenseDetail[${k}][${i}].note`}
                               maxLength="100"
-                              rows={1}
+                              rows={3}
                             />
                           </div>
 

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -186,7 +186,7 @@ class AddExpense extends Component {
                             <Control.text
                               type="text"
                               model={`.expenseDetail[${k}][${i}].note`}
-                              maxLength="25"
+                              maxLength="100"
                             />
                           </div>
 

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -19,6 +19,7 @@ import { userFarmSelector } from '../../../userFarmSlice';
 import { withTranslation } from 'react-i18next';
 import { numberOnKeyDown } from '../../../../components/Form/Input';
 import grabCurrencySymbol from '../../../../util/grabCurrencySymbol';
+import InputAutoSize from '../../../../components/Form/InputAutoSize';
 
 class AddExpense extends Component {
   constructor(props) {
@@ -183,10 +184,14 @@ class AddExpense extends Component {
                               <br />
                               {this.props.t('EXPENSE.NAME')}
                             </label>
-                            <Control.text
+                            <InputAutoSize
                               type="text"
+                              className={styles.textArea}
                               model={`.expenseDetail[${k}][${i}].note`}
                               maxLength="100"
+                              style={{ width: '60%' }}
+                              maxRows={4}
+                              minRows={1}
                             />
                           </div>
 

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/styles.module.scss
@@ -58,12 +58,12 @@
     color: #4d4d4d;
   }
   input, textarea {
+    font-size: 16px;
     width: 60%;
     border: 1px solid #efefef;
     box-sizing: border-box;
     border-radius: 4px;
-    padding: 0 5%;
-    line-height: 37px;
+    padding: 2% 5%;
     font-family: 'Open Sans', 'SansSerif', serif;
   }
   display: flex;

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/styles.module.scss
@@ -57,23 +57,14 @@
     letter-spacing: 0.324px;
     color: #4d4d4d;
   }
-  input {
+  input, textarea {
     width: 60%;
-    height: 37px;
     border: 1px solid #efefef;
     box-sizing: border-box;
     border-radius: 4px;
     padding: 0 5%;
-  }
-  .textArea {
-    font-size: 16px;
-    line-height: 24px;
+    line-height: 37px;
     font-family: 'Open Sans', 'SansSerif', serif;
-    height: 37px;
-    border: 1px solid #efefef;
-    box-sizing: border-box;
-    border-radius: 4px;
-    padding: 0 5%;
   }
   display: flex;
   flex-direction: row;

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/styles.module.scss
@@ -65,6 +65,16 @@
     border-radius: 4px;
     padding: 0 5%;
   }
+  .textArea {
+    font-size: 16px;
+    line-height: 24px;
+    font-family: 'Open Sans', 'SansSerif', serif;
+    height: 37px;
+    border: 1px solid #efefef;
+    box-sizing: border-box;
+    border-radius: 4px;
+    padding: 0 5%;
+  }
   display: flex;
   flex-direction: row;
   width: 100%;
@@ -82,3 +92,5 @@
   color: #ef3b7d;
   width: 100%;
 }
+
+


### PR DESCRIPTION
**Description**

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

New expense item character limit increased to 100. Input box autosizes up to 4 lines (in mobile, only 2 in web, as that's where it hits 100 characters). Imported InputAutoSize from Form component to accomplish autosizing.

Jira link:
https://lite-farm.atlassian.net/browse/LF-2975

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
