### PR TITLE
LF-2915: Fix checkbox label overflow

### DIFF
--- a/packages/webapp/src/components/Form/Checkbox/checkbox.module.scss
+++ b/packages/webapp/src/components/Form/Checkbox/checkbox.module.scss
@@ -1,7 +1,7 @@
 @import '../../../assets/mixin';
 .container {
-  display: inline-block;
-  position: relative;
+  display: flex;
+  gap: 7px;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -10,7 +10,8 @@
 }
 
 .label {
-  transform: translate(25px, -3px);
+  transform: translate(0, -3px);
+  flex: 1;
 }
 
 .smallLabel {
@@ -28,9 +29,7 @@
 
 /* Create a custom Checkbox */
 .checkmark {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
   height: 18px;
   width: 18px;
   background-color: white;

--- a/packages/webapp/src/components/Form/Checkbox/index.jsx
+++ b/packages/webapp/src/components/Form/Checkbox/index.jsx
@@ -39,6 +39,7 @@ const Checkbox = ({
         {...props}
         disabled={disabled}
       />
+      <span className={clsx(styles.checkmark)} style={classes.checkbox} />
       <Main
         className={clsx(styles.label, sm && styles.smallLabel)}
         style={classes.label}
@@ -46,7 +47,6 @@ const Checkbox = ({
       >
         {label}
       </Main>
-      <span className={clsx(styles.checkmark)} style={classes.checkbox} />
       {errors ? (
         <Error className={clsx(styles.error)} style={classes.error}>
           {errors}


### PR DESCRIPTION
**Description**

In Checkbox component, css `transform` is used to adjust the position of the label, but the width of the label is not adjusted. To make the fix simpler, use "flex" instead of "position: absolute". 

Jira link: https://lite-farm.atlassian.net/browse/LF-2915

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
