### PR TITLE
Lf 3106 details from drawn shape are not persisted when going back to draw step in flow

### DIFF
--- a/packages/webapp/src/components/LocationDetailLayout/LocationPageHeader.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/LocationPageHeader.jsx
@@ -6,6 +6,7 @@ import {
   setZoomLevel,
   setZoomLevelSelector,
 } from '../../containers/mapSlice';
+import { upsertFormData } from '../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
@@ -17,6 +18,7 @@ export default function LocationPageHeader({
   isEditLocationPage,
   title,
   onCancel,
+  formMethods,
 }) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -25,7 +27,10 @@ export default function LocationPageHeader({
   const onGoBack = () => {
     dispatch(setZoomLevel(null));
     dispatch(setPosition(null));
-    isCreateLocationPage && history.replace('/map', { isStepBack: true, hideLocationPin: true });
+    if (isCreateLocationPage) {
+      dispatch(upsertFormData(formMethods.getValues()));
+      history.replace('/map', { isStepBack: true, hideLocationPin: true });
+    }
     isViewLocationPage &&
       history.replace('/map', { cameraInfo: { zoom: currentZoomLevel, location: position } });
     isEditLocationPage && history.back();

--- a/packages/webapp/src/components/LocationDetailLayout/PureLocationDetailLayout.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/PureLocationDetailLayout.jsx
@@ -118,6 +118,7 @@ export function PureLocationDetailLayout({
           history={history}
           match={match}
           onCancel={historyCancel}
+          formMethods={formMethods}
         />
         {isViewLocationPage && (
           <RouterTab

--- a/packages/webapp/src/components/Map/DrawingManager/index.jsx
+++ b/packages/webapp/src/components/Map/DrawingManager/index.jsx
@@ -26,6 +26,7 @@ export default function PureDrawingManager({
   system,
   typeOfLine,
   lineData,
+  onLineParameterChange,
 }) {
   const { t } = useTranslation();
   const showConfirmButtons =
@@ -74,6 +75,7 @@ export default function PureDrawingManager({
                   onClickTryAgain={onClickTryAgain}
                   onClickBack={onClickBack}
                   typeOfLine={typeOfLine}
+                  onLineParameterChange={onLineParameterChange}
                 />
               </>
             )}

--- a/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
+++ b/packages/webapp/src/components/Map/LineMapBoxes/index.jsx
@@ -23,6 +23,7 @@ export default function PureLineBox({
   onClickTryAgain,
   onClickBack,
   locationData,
+  onLineParameterChange,
   ...props
 }) {
   const {
@@ -68,6 +69,10 @@ export default function PureLineBox({
         (bufferWidthValue ? (bufferWidthValue <= maxValue ? bufferWidthValue : maxValue) : 0),
     );
   }, [widthValue, bufferWidthValue]);
+
+  useEffect(() => {
+    if (isDirty) onLineParameterChange();
+  }, [isDirty]);
 
   return (
     <div className={clsx(styles.box)} {...props}>

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -63,6 +63,8 @@ import {
   resetAndUnLockFormData,
   setPersistedPaths,
   upsertFormData,
+  setIsRedrawing,
+  hookFormPersistIsRedrawingSelector,
 } from '../hooks/useHookFormPersist/hookFormPersistSlice';
 import {
   bulkSensorsUploadSliceSelector,
@@ -93,6 +95,7 @@ export default function Map({ history }) {
   const [gMap, setGMap] = useState(null);
   const [gMaps, setGMaps] = useState(null);
   const [gMapBounds, setGMapBounds] = useState(null);
+  const isRedrawing = useSelector(hookFormPersistIsRedrawingSelector);
 
   const lineTypesWithWidth = [locationEnum.buffer_zone, locationEnum.watercourse];
   const { t } = useTranslation();
@@ -435,7 +438,10 @@ export default function Map({ history }) {
     setShowingConfirmButtons(false);
     if (!isLineWithWidth()) {
       const locationData = getOverlayInfo();
-      dispatch(upsertFormData(locationData));
+      if (Object.keys(overlayData).length === 0 || isRedrawing === true) {
+        dispatch(upsertFormData(locationData));
+        dispatch(setIsRedrawing(false));
+      }
       history.push(`/create_location/${drawingState.type}`);
     }
   };
@@ -522,6 +528,7 @@ export default function Map({ history }) {
                   resetDrawing();
                   startDrawing(drawingState.type);
                   setShowingConfirmButtons(false);
+                  dispatch(setIsRedrawing(true));
                 }}
                 onClickConfirm={handleConfirm}
                 showZeroAreaWarning={showZeroAreaWarning}

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -168,6 +168,10 @@ export default function Map({ history }) {
   ] = useDrawingManager();
 
   useEffect(() => {
+    if (drawingState.pointChanged) dispatch(setIsRedrawing(true));
+  }, [drawingState.pointChanged]);
+
+  useEffect(() => {
     dispatch(getLocations());
   }, []);
 

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -448,8 +448,12 @@ export default function Map({ history }) {
 
   const handleLineConfirm = (lineData) => {
     setShowingConfirmButtons(false);
-    const data = { ...lineData, ...getOverlayInfo() };
-    dispatch(upsertFormData(data));
+    if (!overlayData.hasOwnProperty('type') || isRedrawing === true) {
+      dispatch(upsertFormData({ ...lineData, ...getOverlayInfo() }));
+      dispatch(setIsRedrawing(false));
+    } else {
+      dispatch(upsertFormData({ ...lineData }));
+    }
     history.push(`/create_location/${drawingState.type}`);
   };
 
@@ -538,6 +542,9 @@ export default function Map({ history }) {
                 system={system}
                 lineData={overlayData}
                 typeOfLine={drawingState.type}
+                onLineParameterChange={() => {
+                  dispatch(setIsRedrawing(true));
+                }}
               />
             </div>
           )}

--- a/packages/webapp/src/containers/Map/useDrawingManager.js
+++ b/packages/webapp/src/containers/Map/useDrawingManager.js
@@ -67,7 +67,7 @@ export default function useDrawingManager() {
 
   useEffect(() => {
     if (!onSteppedBack) return;
-    let polygonDragListener, markerDragListener;
+    let polygonDragListener, markerDragListener, polygonNewPointDragListener;
     let bounds;
     const { type } = overlayData;
     setDrawLocationType(type);
@@ -81,6 +81,13 @@ export default function useDrawingManager() {
       polygonDragListener = maps.event.addListener(redrawnPolygon.getPath(), 'set_at', () => {
         setPointChanged(true);
       });
+      polygonNewPointDragListener = maps.event.addListener(
+        redrawnPolygon.getPath(),
+        'insert_at',
+        () => {
+          setPointChanged(true);
+        },
+      );
       setDrawingToCheck({
         type: maps.drawing.OverlayType.POLYGON,
         overlay: redrawnPolygon,
@@ -121,6 +128,7 @@ export default function useDrawingManager() {
     return () => {
       if (!onSteppedBack) return;
       if (polygonDragListener) maps.event.removeListener(polygonDragListener);
+      if (polygonNewPointDragListener) maps.event.removeListener(polygonNewPointDragListener);
       if (markerDragListener) maps.event.removeListener(markerDragListener);
       setOnSteppedBack(false);
     };
@@ -166,6 +174,7 @@ export default function useDrawingManager() {
       setDrawingToCheck({ ...drawing });
     });
     innerMap.event.addListener(overlay.getPath(), 'insert_at', (redrawnLine) => {
+      setPointChanged(true);
       setDrawingToCheck({ ...drawing });
     });
   };

--- a/packages/webapp/src/containers/Map/useDrawingManager.js
+++ b/packages/webapp/src/containers/Map/useDrawingManager.js
@@ -30,6 +30,8 @@ export default function useDrawingManager() {
   const [showAdjustAreaSpotlightModal, setShowAdjustAreaSpotlightModal] = useState(false);
   const [showAdjustLineSpotlightModal, setShowAdjustLineSpotlightModal] = useState(false);
 
+  const [pointChanged, setPointChanged] = useState(false);
+
   const showedSpotlight = useSelector(showedSpotlightSelector);
   const overlayData = useSelector(hookFormPersistSelector);
 
@@ -75,6 +77,9 @@ export default function useDrawingManager() {
         ...getDrawingOptions(type).polygonOptions,
       });
       redrawnPolygon.setMap(map);
+      maps.event.addListener(redrawnPolygon.getPath(), 'set_at', () => {
+        setPointChanged(true);
+      });
       setDrawingToCheck({
         type: maps.drawing.OverlayType.POLYGON,
         overlay: redrawnPolygon,
@@ -101,6 +106,9 @@ export default function useDrawingManager() {
         draggable: true,
       });
       redrawnMarker.setMap(map);
+      maps.event.addListener(redrawnMarker, 'dragend', () => {
+        setPointChanged(true);
+      });
       setDrawingToCheck({
         type: maps.drawing.OverlayType.MARKER,
         overlay: redrawnMarker,
@@ -147,6 +155,7 @@ export default function useDrawingManager() {
   const addLineListeners = (drawing, innerMap) => {
     const { overlay } = drawing;
     innerMap.event.addListener(overlay.getPath(), 'set_at', (redrawnLine) => {
+      setPointChanged(true);
       setDrawingToCheck({ ...drawing });
     });
     innerMap.event.addListener(overlay.getPath(), 'insert_at', (redrawnLine) => {
@@ -228,6 +237,7 @@ export default function useDrawingManager() {
     showAdjustLineSpotlightModal,
     showZeroLengthWarning,
     showZeroAreaWarning,
+    pointChanged: pointChanged,
   };
 
   const drawingFunctions = {

--- a/packages/webapp/src/containers/hooks/useHookFormPersist/hookFormPersistSlice.js
+++ b/packages/webapp/src/containers/hooks/useHookFormPersist/hookFormPersistSlice.js
@@ -4,9 +4,9 @@ import { createSelector } from 'reselect';
 
 export const initialState = {
   formData: {},
-
   persistedPaths: [],
   historyStack: [],
+  isRedrawing: false,
 };
 
 const getCorrectedPayload = (payload) => {
@@ -82,6 +82,9 @@ const hookFormPersistSlice = createSlice({
     replaceHistoryStack(state, { payload: path }) {
       state.historyStack[state.historyStack.length - 1] = path;
     },
+    setIsRedrawing: (state, { payload: isRedrawing }) => {
+      state.isRedrawing = isRedrawing;
+    },
   },
 });
 
@@ -101,6 +104,7 @@ export const {
   pushHistoryStack,
   popHistoryStack,
   replaceHistoryStack,
+  setIsRedrawing,
 } = hookFormPersistSlice.actions;
 export default hookFormPersistSlice.reducer;
 const hookFormPersistReducerSelector = (state) =>
@@ -113,3 +117,5 @@ export const hookFormPersistedPathsSetSelector = createSelector(
 );
 export const hookFormPersistHistoryStackSelector = (state) =>
   state?.tempStateReducer[hookFormPersistSlice.name].historyStack;
+export const hookFormPersistIsRedrawingSelector = (state) =>
+  state?.tempStateReducer[hookFormPersistSlice.name].isRedrawing;


### PR DESCRIPTION
**Description**

This PR is for fixing the bug that whenever you were on the form for creating any area (Residence, Barn, etc), line (watercourse, buffer zone, etc) or marker (gate, water valve), and you clicked Back, and the confirmed again, the form was with its original values and not the ones that you have modified.

To fix this the upsertFormData form hookFormPersistSlice is now dispatched when the user clicks back on the form to return to the map.  

But the form has some calculated values (areas, perimeters for the polygons but also for some of the line types).  To be able to use the recalculates values if the user changed something (by using "Redraw" button, moving points or inserting new values for the line types) it was added to the store the isRedrawing slice. 

Some event listeners where added to the map in order to be able to detect when the user drags a point for a marker, polygon or line. And the also the click on the redraw button, or the onDirty for the preForm that is display for the line types.

Jira link: https://lite-farm.atlassian.net/browse/LF-3106

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
