### PR TITLE
LF-2980 Add "loading" image when uploading a custom varietal image

### DIFF
--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -1,5 +1,5 @@
 import Button from '../Form/Button';
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { Label } from '../Typography';
@@ -11,6 +11,8 @@ import { useForm } from 'react-hook-form';
 import MultiStepPageTitle from '../PageTitle/MultiStepPageTitle';
 import Infoi from '../Tooltip/Infoi';
 import { truncateText } from '../../util';
+import Spinner from '../Spinner';
+
 export default function PureAddCropVariety({
   match,
   onSubmit,
@@ -48,6 +50,11 @@ export default function PureAddCropVariety({
       ...persistedFormData,
     },
   });
+
+  const [showSpinner, setShowSpinner] = useState(false);
+  const handleSpinnerState = (state) => {
+    setShowSpinner(state);
+  };
 
   const { historyCancel } = useHookFormPersist(getValues);
 
@@ -174,16 +181,20 @@ export default function PureAddCropVariety({
         link={'https://www.litefarm.org/post/cultivars-and-varietals'}
         placeholder={t('CROP.CULTIVAR_PLACEHOLDER')}
       />
-      {crop_variety_photo_url && (
-        <img
-          src={crop_variety_photo_url}
-          alt={crop.crop_common_name}
-          className={styles.circleImg}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = 'crop-images/default.jpg';
-          }}
-        />
+      {showSpinner ? (
+        <Spinner />
+      ) : (
+        crop_variety_photo_url && (
+          <img
+            src={crop_variety_photo_url}
+            alt={crop.crop_common_name}
+            className={styles.circleImg}
+            onError={(e) => {
+              e.target.onerror = null;
+              e.target.src = 'crop-images/default.jpg';
+            }}
+          />
+        )
       )}
       <div
         style={{
@@ -201,6 +212,7 @@ export default function PureAddCropVariety({
         {React.cloneElement(imageUploader, {
           hookFormRegister: imageUrlRegister,
           targetRoute: 'crop_variety',
+          onLoading: handleSpinnerState,
         })}
         <Infoi
           style={{

--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -52,9 +52,6 @@ export default function PureAddCropVariety({
   });
 
   const [showSpinner, setShowSpinner] = useState(false);
-  const handleSpinnerState = (state) => {
-    setShowSpinner(state);
-  };
 
   const { historyCancel } = useHookFormPersist(getValues);
 
@@ -212,7 +209,7 @@ export default function PureAddCropVariety({
         {React.cloneElement(imageUploader, {
           hookFormRegister: imageUrlRegister,
           targetRoute: 'crop_variety',
-          onLoading: handleSpinnerState,
+          onLoading: setShowSpinner,
         })}
         <Infoi
           style={{

--- a/packages/webapp/src/components/AddNewCrop/index.jsx
+++ b/packages/webapp/src/components/AddNewCrop/index.jsx
@@ -50,6 +50,7 @@ import MultiStepPageTitle from '../PageTitle/MultiStepPageTitle';
 import RadioGroup from '../Form/RadioGroup';
 import styles from './styles.module.scss';
 import Checkbox from '../Form/Checkbox';
+import Spinner from '../Spinner';
 
 export default function PureAddNewCrop({
   handleContinue,
@@ -84,6 +85,11 @@ export default function PureAddNewCrop({
   const allCropGroupAverages = useSelector(cropGroupAveragesSelector);
   const cropImageUrlRegister = register(CROP_PHOTO_URL, { required: true });
   const crop_photo_url = watch(CROP_PHOTO_URL);
+
+  const [showSpinner, setShowSpinner] = useState(false);
+  const handleSpinnerState = (state) => {
+    setShowSpinner(state);
+  };
 
   const farmCrops = useSelector(cropsOnMyFarmSelector);
 
@@ -163,15 +169,20 @@ export default function PureAddNewCrop({
         value={progress}
         cancelModalTitle={t('CROP_CATALOGUE.CANCEL')}
       />
-      <img
-        src={crop_photo_url}
-        alt={t('translation:CROP.ADD_IMAGE')}
-        className={styles.circleImg}
-        onError={(e) => {
-          e.target.onerror = null;
-          e.target.src = 'crop-images/default.jpg';
-        }}
-      />
+      {showSpinner ? (
+        <Spinner />
+      ) : (
+        <img
+          src={crop_photo_url}
+          alt={t('translation:CROP.ADD_IMAGE')}
+          className={styles.circleImg}
+          onError={(e) => {
+            e.target.onerror = null;
+            e.target.src = 'crop-images/default.jpg';
+          }}
+        />
+      )}
+
       <div
         style={{
           marginLeft: 'auto',
@@ -188,6 +199,7 @@ export default function PureAddNewCrop({
         {React.cloneElement(imageUploader, {
           hookFormRegister: cropImageUrlRegister,
           targetRoute: 'crop',
+          onLoading: handleSpinnerState,
         })}
       </div>
       <Input

--- a/packages/webapp/src/components/AddNewCrop/index.jsx
+++ b/packages/webapp/src/components/AddNewCrop/index.jsx
@@ -87,9 +87,6 @@ export default function PureAddNewCrop({
   const crop_photo_url = watch(CROP_PHOTO_URL);
 
   const [showSpinner, setShowSpinner] = useState(false);
-  const handleSpinnerState = (state) => {
-    setShowSpinner(state);
-  };
 
   const farmCrops = useSelector(cropsOnMyFarmSelector);
 
@@ -199,7 +196,7 @@ export default function PureAddNewCrop({
         {React.cloneElement(imageUploader, {
           hookFormRegister: cropImageUrlRegister,
           targetRoute: 'crop',
-          onLoading: handleSpinnerState,
+          onLoading: setShowSpinner,
         })}
       </div>
       <Input

--- a/packages/webapp/src/components/EditCropVariety/index.jsx
+++ b/packages/webapp/src/components/EditCropVariety/index.jsx
@@ -1,5 +1,5 @@
 import Button from '../Form/Button';
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { Label } from '../Typography';
@@ -12,6 +12,7 @@ import PageTitle from '../PageTitle/v2';
 import RadioGroup from '../Form/RadioGroup';
 import Infoi from '../Tooltip/Infoi';
 import Leaf from '../../assets/images/farmMapFilter/Leaf.svg';
+import Spinner from '../Spinner';
 
 export default function PureEditCropVariety({
   onSubmit,
@@ -85,6 +86,11 @@ export default function PureEditCropVariety({
     ? t(`crop:${cropTranslationKey}`)
     : cropVariety.crop_common_name;
 
+  const [showSpinner, setShowSpinner] = useState(false);
+  const handleSpinnerState = (state) => {
+    setShowSpinner(state);
+  };
+
   return (
     <Form
       buttonGroup={
@@ -101,15 +107,22 @@ export default function PureEditCropVariety({
       />
 
       <div className={styles.cropLabel}>{cropNameLabel}</div>
-      <img
-        src={crop_variety_photo_url}
-        alt={cropVariety.crop_common_name}
-        className={styles.circleImg}
-        onError={(e) => {
-          e.target.onerror = null;
-          e.target.src = 'crop-images/default.jpg';
-        }}
-      />
+
+      {showSpinner ? (
+        <div style={{ height: 'fit-content' }}>
+          <Spinner />
+        </div>
+      ) : (
+        <img
+          src={crop_variety_photo_url}
+          alt={cropVariety.crop_common_name}
+          className={styles.circleImg}
+          onError={(e) => {
+            e.target.onerror = null;
+            e.target.src = 'crop-images/default.jpg';
+          }}
+        />
+      )}
 
       <div
         style={{
@@ -127,6 +140,7 @@ export default function PureEditCropVariety({
         {React.cloneElement(imageUploader, {
           hookFormRegister: imageUrlRegister,
           targetRoute: 'crop_variety',
+          onLoading: handleSpinnerState,
         })}
       </div>
 

--- a/packages/webapp/src/components/EditCropVariety/index.jsx
+++ b/packages/webapp/src/components/EditCropVariety/index.jsx
@@ -87,9 +87,6 @@ export default function PureEditCropVariety({
     : cropVariety.crop_common_name;
 
   const [showSpinner, setShowSpinner] = useState(false);
-  const handleSpinnerState = (state) => {
-    setShowSpinner(state);
-  };
 
   return (
     <Form
@@ -140,7 +137,7 @@ export default function PureEditCropVariety({
         {React.cloneElement(imageUploader, {
           hookFormRegister: imageUrlRegister,
           targetRoute: 'crop_variety',
-          onLoading: handleSpinnerState,
+          onLoading: setShowSpinner,
         })}
       </div>
 

--- a/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
+++ b/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
@@ -37,6 +37,7 @@ export default function ImagePickerWrapper({
   uploadDirectory, //deprecated but supported for storybook
   targetRoute,
   compressorProps = {},
+  onLoading,
   ...props
 }) {
   const classes = useStyles();
@@ -44,13 +45,13 @@ export default function ImagePickerWrapper({
   const name = hookFormRegister?.name ?? props?.name;
   const dispatch = useDispatch();
   const onFileUpload = async (e) => {
-    props.onLoading?.(true);
+    onLoading?.(true);
     if (e?.target?.files?.[0]) {
       const blob = e.target.files[0];
       const isNotImage = !/^image\/.*/.test(blob.type);
       if (isNotImage) {
         dispatch(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
-        props.onLoading?.(false);
+        onLoading?.(false);
       } else if (blob.size < 200000) {
         dispatch(
           uploadImage({ file: blob, onUploadSuccess, targetRoute: targetRoute ?? uploadDirectory }),
@@ -71,21 +72,21 @@ export default function ImagePickerWrapper({
           },
           error(err) {
             console.log(err.message);
-            props.onLoading?.(false);
+            onLoading?.(false);
           },
           ...compressorProps,
         });
       }
     } else {
       // E.g. file picker is cancelled so no files are present
-      props.onLoading?.(false);
+      onLoading?.(false);
     }
   };
   const onUploadSuccess = (url) => {
     input.current.value = url;
     onChange?.({ target: input.current });
     hookFormRegister?.onChange({ target: input.current });
-    props.onLoading?.(false);
+    onLoading?.(false);
   };
   return (
     <div className={className} style={style}>
@@ -136,4 +137,5 @@ ImagePickerWrapper.propTypes = {
   uploadDirectory: PropTypes.string,
   targetRoute: PropTypes.string,
   compressorProps: PropTypes.object,
+  onLoading: PropTypes.func,
 };

--- a/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
+++ b/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
@@ -51,10 +51,15 @@ export default function ImagePickerWrapper({
       const isNotImage = !/^image\/.*/.test(blob.type);
       if (isNotImage) {
         dispatch(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
-        onLoading?.(false);
+        onUploadFail('Not an image file');
       } else if (blob.size < 200000) {
         dispatch(
-          uploadImage({ file: blob, onUploadSuccess, targetRoute: targetRoute ?? uploadDirectory }),
+          uploadImage({
+            file: blob,
+            onUploadSuccess,
+            onUploadFail,
+            targetRoute: targetRoute ?? uploadDirectory,
+          }),
         );
       } else {
         const Compressor = await import('compressorjs').then((Compressor) => Compressor.default);
@@ -66,13 +71,13 @@ export default function ImagePickerWrapper({
               uploadImage({
                 file: compressedBlob,
                 onUploadSuccess,
+                onUploadFail,
                 targetRoute: targetRoute ?? uploadDirectory,
               }),
             );
           },
           error(err) {
-            console.log(err.message);
-            onLoading?.(false);
+            onUploadFail(err.message);
           },
           ...compressorProps,
         });
@@ -86,6 +91,10 @@ export default function ImagePickerWrapper({
     input.current.value = url;
     onChange?.({ target: input.current });
     hookFormRegister?.onChange({ target: input.current });
+    onLoading?.(false);
+  };
+  const onUploadFail = (error) => {
+    if (error) console.log(error);
     onLoading?.(false);
   };
   return (

--- a/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
+++ b/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
@@ -44,11 +44,13 @@ export default function ImagePickerWrapper({
   const name = hookFormRegister?.name ?? props?.name;
   const dispatch = useDispatch();
   const onFileUpload = async (e) => {
+    props.onLoading?.(true);
     if (e?.target?.files?.[0]) {
       const blob = e.target.files[0];
       const isNotImage = !/^image\/.*/.test(blob.type);
       if (isNotImage) {
         dispatch(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
+        props.onLoading?.(false);
       } else if (blob.size < 200000) {
         dispatch(
           uploadImage({ file: blob, onUploadSuccess, targetRoute: targetRoute ?? uploadDirectory }),
@@ -69,16 +71,21 @@ export default function ImagePickerWrapper({
           },
           error(err) {
             console.log(err.message);
+            props.onLoading?.(false);
           },
           ...compressorProps,
         });
       }
+    } else {
+      // E.g. file picker is cancelled so no files are present
+      props.onLoading?.(false);
     }
   };
   const onUploadSuccess = (url) => {
     input.current.value = url;
     onChange?.({ target: input.current });
     hookFormRegister?.onChange({ target: input.current });
+    props.onLoading?.(false);
   };
   return (
     <div className={className} style={style}>

--- a/packages/webapp/src/containers/ImagePickerWrapper/saga.js
+++ b/packages/webapp/src/containers/ImagePickerWrapper/saga.js
@@ -16,7 +16,9 @@ const imageRouteURL = {
 
 export const uploadImage = createAction(`uploadImageSaga`);
 
-export function* uploadImageSaga({ payload: { file, onUploadSuccess, targetRoute } }) {
+export function* uploadImageSaga({
+  payload: { file, onUploadSuccess, onUploadFail, targetRoute },
+}) {
   let { user_id, farm_id } = yield select(loginSelector);
   const header = getHeader(user_id, farm_id, {
     headers: { 'Content-Type': 'multipart/form-data' },
@@ -26,14 +28,11 @@ export function* uploadImageSaga({ payload: { file, onUploadSuccess, targetRoute
     const formData = new FormData();
     formData.append('_file_', file);
     const result = yield call(axios.post, `${imageRoute}/upload/farm/${farm_id}`, formData, header);
-    if (result) {
-      onUploadSuccess?.(result.data.url);
-    } else {
-      yield put(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
-    }
+    onUploadSuccess?.(result.data.url);
   } catch (e) {
     yield put(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
     console.log(e);
+    onUploadFail?.(e.response?.data);
   }
 }
 


### PR DESCRIPTION
**Description**

This PR adds a loading spinner to image selection and replacement in AddCrop, AddCropVariety, and EditCropVariety. Logic to manage the loading spinner state has been added to ImagePickerWrapper, the image uploader component that all three of these views use.

Due to differences in page layout, only EditCropVariety also needed a wrapper div to contain the loading spinner.

Note: To test the full behaviour successfully, you will need the LiteFarm imaginary token (for thumbnail creation) + MinIO.

Jira link: https://lite-farm.atlassian.net/browse/LF-2980

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
