### PR TITLE
Lf 3221 the icons for the different areas overflowed the disambiguation box

### DIFF
--- a/packages/webapp/src/components/Map/SelectionHandler/index.jsx
+++ b/packages/webapp/src/components/Map/SelectionHandler/index.jsx
@@ -72,6 +72,13 @@ const useStyles = makeStyles((theme) => ({
       transform: 'scale(1.25)',
     },
   },
+  areaIcon: {
+    '& svg': {
+      width: 24,
+      height: 24,
+      transform: 'scale(0.75)',
+    },
+  },
   itemName: {
     flexGrow: 1,
     padding: '0 8px',
@@ -174,7 +181,6 @@ export default function PureSelectionHandler({ locations, history, sensorReading
         {locations.map((location, idx) => {
           const { type, asset, name } = { ...location };
           let icon = imgMapping(asset, type);
-
           return (
             <div
               className={classes.itemHeader}
@@ -195,7 +201,11 @@ export default function PureSelectionHandler({ locations, history, sensorReading
             >
               <div className={classes.title}>
                 <div
-                  className={clsx(classes.itemIcon, isSensor(location.id) && classes.sensorIcon)}
+                  className={clsx(
+                    classes.itemIcon,
+                    isSensor(location.id) && classes.sensorIcon,
+                    location.asset === 'area' && classes.areaIcon,
+                  )}
                 >
                   {icon}
                 </div>

--- a/packages/webapp/src/components/Map/SelectionHandler/index.jsx
+++ b/packages/webapp/src/components/Map/SelectionHandler/index.jsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
     borderRightColor: 'transparent',
     borderStyle: 'solid',
     left: '45%',
-    marginTop: -20,
+    marginTop: -19,
     borderWidth: '10px 10px 10px 10px',
     borderBottomColor: 'white',
   },

--- a/packages/webapp/src/containers/Map/useSelectionHandler.js
+++ b/packages/webapp/src/containers/Map/useSelectionHandler.js
@@ -83,10 +83,10 @@ const useSelectionHandler = () => {
             locationArray.push(point);
           });
           overlappedLocations.line.forEach((line) => {
-            if (locationArray.length < 4) locationArray.push(line);
+            locationArray.push(line);
           });
           overlappedLocations.area.forEach((area) => {
-            if (locationArray.length < 4) locationArray.push(area);
+            locationArray.push(area);
           });
           dispatch(canShowSelection(true));
           dispatch(locations(locationArray));


### PR DESCRIPTION
**Description**

The area icons where css-fixed to fit on the space available on PureSelectionHandler (aka popup) when there more than one area on a specific place. 

As when the popup was redesign for sensors it was requested on the peer review that it shouldn't be limited only for 4 sensors, on this PR those limits are deleted for areas an lines too.

Lastly, Caro told me a while ago about a 1px mismatch between the arrow point and the popup.  It was going to be fixed in another open ticket regarding the popup with sensors, but I added that small change to this PR.

Jira link: https://lite-farm.atlassian.net/browse/LF-3221

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
