### PR TITLE
LF-3114 When creating a varietal without adding a new image, the image should be inherited from the crop_type

### DIFF
--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -39,12 +39,12 @@ export default function PureAddCropVariety({
     getValues,
     watch,
     setError,
-    formState: { errors, isValid },
+    formState: { errors, isValid, dirtyFields },
   } = useForm({
     mode: 'onChange',
     shouldUnregister: true,
     defaultValues: {
-      crop_variety_photo_url: null,
+      crop_variety_photo_url: crop.crop_photo_url,
       [LIFE_CYCLE]: crop[LIFE_CYCLE],
       [HS_CODE_ID]: crop?.[HS_CODE_ID],
       ...persistedFormData,
@@ -181,7 +181,8 @@ export default function PureAddCropVariety({
       {showSpinner ? (
         <Spinner />
       ) : (
-        crop_variety_photo_url && (
+        crop_variety_photo_url &&
+        dirtyFields.crop_variety_photo_url && (
           <img
             src={crop_variety_photo_url}
             alt={crop.crop_common_name}

--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -39,7 +39,7 @@ export default function PureAddCropVariety({
     getValues,
     watch,
     setError,
-    formState: { errors, isValid, dirtyFields },
+    formState: { errors, isValid },
   } = useForm({
     mode: 'onChange',
     shouldUnregister: true,
@@ -182,7 +182,7 @@ export default function PureAddCropVariety({
         <Spinner />
       ) : (
         crop_variety_photo_url &&
-        dirtyFields.crop_variety_photo_url && (
+        crop_variety_photo_url != crop.crop_photo_url && (
           <img
             src={crop_variety_photo_url}
             alt={crop.crop_common_name}

--- a/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
+++ b/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
@@ -34,9 +34,6 @@ function AddCropVarietyForm({ history, match }) {
       ...persistedFormData,
       ...data,
       crop_variety_name: data.crop_variety_name.trim(),
-      crop_variety_photo_url: data.crop_variety_photo_url
-        ? data.crop_variety_photo_url
-        : crop.crop_photo_url,
       supplier: data.supplier.trim(),
       compliance_file_url: '',
       organic: null,


### PR DESCRIPTION
**Description**

When no custom varietal image is uploaded, the varietal should inherit the image of the parent crop.

Logic to handle this inheritance did exist, but it was in the data-transformation step which is only applied to non-certification farms. Therefore, certification-pursuing farms did not see crop image inheritance.

This PR moves that logic to Add Crop Variety by setting the parent crop image as the default value in the React Hook Form, so image inheritance will be applied regardless of certification status. The image preview was updated to only display if the crop variety image was changed off of this default.

Jira link: https://lite-farm.atlassian.net/browse/LF-3114

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
