### PR TITLE
LF-3131 Radio toggle checkbox not centered

### DIFF
--- a/packages/webapp/src/components/Form/Radio/index.jsx
+++ b/packages/webapp/src/components/Form/Radio/index.jsx
@@ -49,7 +49,12 @@ const Radio = ({
       </span>
       {toolTipContent && <Infoi content={toolTipContent} />}
 
-      <span className={clsx(styles.checkmark)} style={classes.checkbox} />
+      <span className={clsx(styles.checkmark)} style={classes.checkbox}>
+        <svg viewBox="0 0 16 16">
+          <circle cx="8" cy="8" r="7" />
+          <circle cx="8" cy="8" r="4" />
+        </svg>
+      </span>
       {children}
     </label>
   );

--- a/packages/webapp/src/components/Form/Radio/radio.module.scss
+++ b/packages/webapp/src/components/Form/Radio/radio.module.scss
@@ -1,4 +1,5 @@
 @import '../../../assets/mixin';
+
 .container {
   display: flex;
   column-gap: 4px;
@@ -27,58 +28,55 @@
   left: 0;
   height: 16px;
   width: 16px;
-  background-color: white;
-  border-radius: 50%;
-  border: solid 2px var(--grey600);
 }
 
-/* When the radio button is checked, add a blue background */
-.container input:checked ~ .checkmark {
-  border: solid 2px var(--teal700);
+.checkmark svg {
+  overflow: visible; /* To fix the SVG bounding box slightly cutting off the stroke in Safari at some zoom levels */
+}
+
+/* The outer circle */
+.checkmark svg circle:first-child {
+  stroke: var(--grey600);
+  stroke-width: 2;
+  fill: white;
+}
+
+/* Create the indicator (the dot/circle - hidden when not checked) */
+.checkmark svg circle:last-child {
+  fill: var(--teal700);
+  visibility: hidden;
+}
+
+/* Show the indicator (dot/circle) when checked */
+.container input:checked ~ .checkmark svg circle:last-child {
+  visibility: visible;
 }
 
 .container input:checked ~ .label {
   color: var(--grey900);
 }
 
-/* Create the indicator (the dot/circle - hidden when not checked) */
-.checkmark:after {
-  content: '';
-  position: absolute;
-  display: none;
-}
-
-/* Show the indicator (dot/circle) when checked */
-.container input:checked ~ .checkmark:after {
-  display: block;
-}
-
-/* Style the indicator (dot/circle) */
-.container .checkmark:after {
-  top: 2px;
-  left: 2px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: var(--teal700);
+/* When the radio button is checked, make border blue */
+.container input:checked ~ .checkmark svg circle:first-child {
+  stroke: var(--teal700);
 }
 
 .disabled {
   cursor: auto;
 }
 
-.container input:disabled ~ .checkmark {
-  background-color: var(--grey200);
-  border: solid 2px var(--grey400);
+.container input:disabled ~ .checkmark svg circle:first-child {
+  fill: var(--grey200);
+  stroke: var(--grey400);
 }
 
 .container input:disabled ~ .label {
   color: var(--grey600);
 }
 
-.container input[disabled]:checked ~ .checkmark {
-  background-color: var(--teal500);
-  border: solid 2px var(--teal700);
+.container input[disabled]:checked ~ .checkmark svg circle:first-child {
+  fill: var(--teal500);
+  stroke: var(--teal700);
 }
 
 .label {


### PR DESCRIPTION
**Description**

The custom styling we apply to our radio buttons was being created in CSS with a pseudo-element applied to a span. This solution works at 100%, but is brittle and breaks at other zooms, including the system-wide scaling that might be applied by Windows.

This PR replaces the pseudo-element solution with a simple SVG, which performs much more reliably at different scalings.

Jira link: https://lite-farm.atlassian.net/browse/LF-3131

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

@Duncan-Brain can you please test this on your Windows computer with the system-wise scaling set to 125%? I don't have a windows computer to check that case.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
