### PR TITLE
LF-3240 The uploading the sensors group causes the crash of the beta

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -206,16 +206,20 @@ const sensorController = {
         );
 
         // Save sensors in database
-        const sensorLocations = await Promise.allSettled(
-          registeredSensors.map(async (sensor) => {
-            return await SensorModel.createSensor(
+        const sensorLocations = [];
+        for (const sensor of registeredSensors) {
+          try {
+            const value = await SensorModel.createSensor(
               sensor,
               farm_id,
               user_id,
               esids.includes(sensor.external_id) ? 1 : 0,
             );
-          }),
-        );
+            sensorLocations.push({ status: 'fulfilled', value });
+          } catch (error) {
+            sensorLocations.push({ status: 'rejected', reason: error });
+          }
+        }
 
         const successSensors = sensorLocations.reduce((prev, curr, idx) => {
           if (curr.status === 'fulfilled') {


### PR DESCRIPTION
**Description**

As demo-ed in standup this morning, May 8, 2023... but there is an update! 🙂

The transaction that saves newly created sensors to the database is called in the controller using `promise.allSettled()`, meaning all the transactions are initiated concurrently. In theory, as many concurrent transactions can be created as the size of the [connection pool](https://knexjs.org/guide/#pool) defined in the knex configuration, but in our case even relatively low numbers (below our defined pool size) caused knex timeouts and even an API crash (sometimes) if done multiple times in a row.

Update: actually, a closer read of our `knexfile.js` shows that the connection pool was only set on the testing databases and for migration, meaning that for all other environments, we are using the default value of 10. Therefore, there are a few possible approaches to fixing this error:

1. Add the configuration `pool: { min: 0, max: 101 }` to the development, integration, and production environments in the knexfile (100 is the max number of sensors that can be uploaded at once and +1 for the API connection)
2. Limit the number of sensors that can be uploaded at once to 9 (again +1 for the API connection)
3. What I recommend and have implemented: remove the concurrency

The reason I recommend (3) is that timeouts with the connection pool are a [common knex GitHub issue](https://github.com/knex/knex/issues?q=is%3Aissue+timeout+connection+pool), and sometimes other factors beyond connection pool size (such as the docker postgres configuration) can come into play. Creating new records in the database for the permitted number of sensors that can be uploaded in one CSV is a fast operation. It doesn't need to be done concurrently, particularly with the failsafe of our async (notification) mode.

Also, I would be hesitant to modify the knex configuration for only for this ticket, as it does not look like we use `promise.all()` or `promise.allSettled()` to initiate concurrent transactions elsewhere in the app. **However, I recommend we keep the pool maximum in mind for the future, and I have created a new placeholder Jira ticket for future connection pool/knex timeout issues here: [LF-3253](https://lite-farm.atlassian.net/browse/LF-3253)**

Jira link: https://lite-farm.atlassian.net/browse/LF-3240

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)


This has been tested with the CSV in this Jira ticket and the CSV in [LF-3193](https://lite-farm.atlassian.net/browse/LF-3193). Please test with other sensor combinations as well. If you want to see the API crash, checkout integration and upload either of those CSVs several times in a row -- it doesn't happen every time, but it should happen eventually.

**Bonus**: If you would like to see the effect of the max connections pool in realtime, checkout integration and remove two sensors from the CSV so that only 9 concurrent transactions are created. You'll want to shut down pgAdmin4 / any other programs that keep open connections to the database so that there is only the API's one connection live. See that the sensors will upload successfully. Then open a database connection via pgAdmin4 and see how that causes a knex timeout failure on the upload of the same file 🙂 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
