### PR TITLE
LF-3160: Misleading temperature line for sensors without temperature data

### DIFF
--- a/packages/webapp/src/components/Map/PreviewPopup/utils.js
+++ b/packages/webapp/src/components/Map/PreviewPopup/utils.js
@@ -1,3 +1,5 @@
+import { convert } from '../../../util/convert-units/convert';
+
 const metric = ['metric', 'celsius', 'kpa'];
 const imperial = ['imperial', 'fahrenheit', 'psi'];
 
@@ -5,18 +7,13 @@ export const getTemperatureValue = (value, unit) => {
   if (typeof value !== 'number') {
     return NaN;
   }
-  if (imperial.includes(unit.toLowerCase())) return convertCelsiusToFahrenheit(value);
-  return roundToTwo(value);
+  const to = imperial.includes(unit.toLowerCase()) ? 'F' : 'C';
+  return roundToTwo(convert(value).from('C').to(to));
 };
 
 export const getTemperatureUnit = (unit) => {
   if (imperial.includes(unit.toLowerCase())) return 'º F';
   return 'º C';
-};
-
-const convertCelsiusToFahrenheit = (temperature) => {
-  const fahrenheit = typeof temperature === 'number' ? temperature * 1.8 + 32 : null;
-  return roundToTwo(fahrenheit);
 };
 
 const roundToTwo = (num) => {

--- a/packages/webapp/src/components/Map/PreviewPopup/utils.js
+++ b/packages/webapp/src/components/Map/PreviewPopup/utils.js
@@ -2,6 +2,9 @@ const metric = ['metric', 'celsius', 'kpa'];
 const imperial = ['imperial', 'fahrenheit', 'psi'];
 
 export const getTemperatureValue = (value, unit) => {
+  if (typeof value !== 'number') {
+    return NaN;
+  }
   if (imperial.includes(unit.toLowerCase())) return convertCelsiusToFahrenheit(value);
   return roundToTwo(value);
 };

--- a/packages/webapp/src/components/Map/PreviewPopup/utils.js
+++ b/packages/webapp/src/components/Map/PreviewPopup/utils.js
@@ -15,7 +15,7 @@ export const getTemperatureUnit = (unit) => {
 };
 
 const convertCelsiusToFahrenheit = (temperature) => {
-  const fahrenheit = temperature * 1.8 + 32;
+  const fahrenheit = typeof temperature === 'number' ? temperature * 1.8 + 32 : null;
   return roundToTwo(fahrenheit);
 };
 


### PR DESCRIPTION
**Description**

When farm's unit system is `imperial` and temperature data is "null", `convertCelsiusToFahrenheit` function returns `32` (see the old line 15), and the temperature chart shows 32F when there is no data. This PR updates `convertCelsiusToFahrenheit` and `getTemperatureValue` to return `NaN` when a non-number is passed to the function.

Jira link: https://lite-farm.atlassian.net/browse/LF-3160

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
