### PR TITLE
LF-3246: The field "Supplier" becomes optional after the user enters the "Edit" menu of the "Clean" task

### DIFF
--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -16,6 +16,7 @@
 import Layout from '../../Layout';
 import Button from '../../Form/Button';
 import React, { useMemo, useState } from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PageTitle from '../../PageTitle/v2';
 import Input from '../../Form/Input';
@@ -51,6 +52,8 @@ import { getDateInputFormat } from '../../../util/moment';
 import UpdateTaskDateModal from '../../Modals/UpdateTaskDateModal';
 import PureIrrigationTask from '../PureIrrigationTask';
 import DeleteBox from './DeleteBox';
+import { userFarmSelector } from '../../../containers/userFarmSlice';
+import { certifierSurveySelector } from '../../../containers/OrganicCertifierSurvey/slice';
 
 export default function PureTaskReadOnly({
   onGoBack,
@@ -142,6 +145,9 @@ export default function PureTaskReadOnly({
   const [showTaskAssignModal, setShowTaskAssignModal] = useState(false);
   const [showDueDateModal, setShowDueDateModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const { country_id } = useSelector(userFarmSelector);
+  const { interested, farm_id } = useSelector(certifierSurveySelector, shallowEqual);
 
   const canCompleteTask =
     user.user_id === task.assignee_user_id || (assignedToPseudoUser && user.is_admin);
@@ -409,7 +415,7 @@ export default function PureTaskReadOnly({
           formState: { errors, isValid },
           errors,
           disabled: true,
-          farm: user,
+          farm: { farm_id, country_id, interested },
           system,
           products,
           task,

--- a/packages/webapp/src/containers/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/containers/Task/TaskComplete/StepOne.jsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import PureCompleteStepOne from '../../../components/Task/TaskComplete/StepOne';
-import { useSelector } from 'react-redux';
-import { loginSelector, measurementSelector } from '../../userFarmSlice';
+import { useSelector, shallowEqual } from 'react-redux';
+import { userFarmSelector } from '../../userFarmSlice';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 import { taskWithProductSelector } from '../../taskSlice';
 import { productsSelector } from '../../productSlice';
+import { certifierSurveySelector } from '../../OrganicCertifierSurvey/slice';
 
 function TaskCompleteStepOne({ history, match, location }) {
-  const system = useSelector(measurementSelector);
-  const { farm_id } = useSelector(loginSelector);
+  const {
+    units: { measurement: system },
+    country_id,
+  } = useSelector(userFarmSelector);
+  const { interested, farm_id } = useSelector(certifierSurveySelector, shallowEqual);
   const task_id = match.params.task_id;
   const task = useSelector(taskWithProductSelector(task_id));
   const selectedTaskType = task.taskType;
@@ -29,7 +33,7 @@ function TaskCompleteStepOne({ history, match, location }) {
         onContinue={onContinue}
         onGoBack={onGoBack}
         system={system}
-        farm={farm_id}
+        farm={{ farm_id, country_id, interested }}
         selectedTaskType={selectedTaskType}
         products={products}
         persistedPaths={persistedPaths}


### PR DESCRIPTION
**Description**

`farm` prop that `AddProduct` component takes needs to have `farm_id`, `country_id` and `interested`. Two components are currently passing incomplete `farm` prop, and `AddProduct` component is not showing required/optional for the supplier field correctly. The code was copied from this file:
https://github.com/LiteFarmOrg/LiteFarm/blob/1c17d3a7fe058eb30076f6717052f8b389704c44/packages/webapp/src/containers/Task/TaskDetails/index.jsx

This fix can be tested in the read-only and complete task views for clean, pest control or soil amendment task (you need to have a product).

Jira link: https://lite-farm.atlassian.net/browse/LF-3246

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
