### PR TITLE
added check for deleted tasks to location dependency validator

### DIFF
--- a/packages/api/src/middleware/validation/deleteLocation.js
+++ b/packages/api/src/middleware/validation/deleteLocation.js
@@ -29,6 +29,7 @@ async function validateLocationDependency(req, res, next) {
         WHERE lt.location_id = :location_id
           AND t.complete_date is null
           AND t.abandon_date is null
+          AND t.deleted = false
         UNION
         SELECT DISTINCT mt.task_id, pmp.location_id
         FROM management_tasks mt
@@ -37,6 +38,7 @@ async function validateLocationDependency(req, res, next) {
         WHERE pmp.location_id = :location_id
           AND t.complete_date is null
           AND t.abandon_date is null
+          AND t.deleted = false
         UNION
         SELECT DISTINCT pt.task_id, pmp.location_id
         from plant_task pt
@@ -45,6 +47,7 @@ async function validateLocationDependency(req, res, next) {
         WHERE pmp.location_id = :location_id
           AND t.complete_date is null
           AND t.abandon_date is null
+          AND t.deleted = false
         UNION
         SELECT DISTINCT tt.task_id, pmp.location_id
         from transplant_task tt
@@ -53,6 +56,7 @@ async function validateLocationDependency(req, res, next) {
         WHERE pmp.location_id = :location_id
           AND t.complete_date is null
           AND t.abandon_date is null
+          AND t.deleted = false
     `,
     { location_id },
   );


### PR DESCRIPTION
**Description**

This PR fixes the bug where users were unable to retire locations on the farm map if said location has deleted tasks

Jira link:

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
