### PR TITLE
LF-3028: Mismatch between visualized high and low temps and reported high and low temps

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1546,7 +1546,7 @@
     },
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Soil temperature",
-      "SUBTITLE": "Today’s ambient high and low temperature: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
+      "SUBTITLE": "Today’s forecasted ambient high and low temperature: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
       "Y_AXIS_LABEL": "Temperature in {{tempUnit}}",
       "WEATHER_STATION": "Weather station: {{weatherStationLocation}}",
       "NO_DATA": "(no data)",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1790,7 +1790,7 @@
     },
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Temperatura del suelo",
-      "SUBTITLE": "Temperatura ambiente alta y baja de hoy: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
+      "SUBTITLE": "Temperatura MISSING ambiente alta y baja de hoy: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
       "Y_AXIS_LABEL": "Temperatura en {{tempUnit}}",
       "WEATHER_STATION": "Estación meteorológica: {{weatherStationLocation}}",
       "NO_DATA": "(sin datos)",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1791,7 +1791,7 @@
     },
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Température du sol",
-      "SUBTITLE": "Température ambiante haute et basse d'aujourd'hui\u00a0: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
+      "SUBTITLE": "Température MISSING ambiante haute et basse d'aujourd'hui\u00a0: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
       "Y_AXIS_LABEL": "Température en {{tempUnit}}",
       "WEATHER_STATION": "Station météorologique\u00a0: {{weatherStationLocation}}",
       "NO_DATA": "(aucune donnée)",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1791,7 +1791,7 @@
     },
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Temperatura do solo",
-      "SUBTITLE": "Temperatura ambiente máxima e mínima de hoje: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
+      "SUBTITLE": "Temperatura MISSING ambiente máxima e mínima de hoje: {{high}}{{tempUnit}} / {{low}}{{tempUnit}}",
       "Y_AXIS_LABEL": "Temperatura em {{tempUnit}}",
       "WEATHER_STATION": "Estação meteorológica: {{weatherStationLocation}}",
       "NO_DATA": "(sem dados))",

--- a/packages/webapp/src/containers/SensorReadings/constants.js
+++ b/packages/webapp/src/containers/SensorReadings/constants.js
@@ -10,10 +10,13 @@ export const GRAPH_TIMESTAMPS = ['02:00:00', '08:00:00', '14:00:00', '20:00:00']
 export const AMBIENT_TEMPERATURE = 'Ambient temperature';
 export const CURRENT_DATE_TIME = 'current_date_time';
 
+export const DAILY_FORECAST_API_URL = 'https://api.openweathermap.org/data/2.5/forecast/daily';
+
 export const OPEN_WEATHER_API_URL_FOR_SENSORS = [
   'https://api.openweathermap.org/data/2.5/weather',
   'https://history.openweathermap.org/data/2.5/history/city',
   'https://pro.openweathermap.org/data/2.5/forecast/hourly',
+  DAILY_FORECAST_API_URL,
 ];
 export const HOUR = 'hour';
 export const TEMPERATURE = 'temperature';

--- a/packages/webapp/src/containers/SensorReadings/constants.js
+++ b/packages/webapp/src/containers/SensorReadings/constants.js
@@ -13,7 +13,6 @@ export const CURRENT_DATE_TIME = 'current_date_time';
 export const DAILY_FORECAST_API_URL = 'https://api.openweathermap.org/data/2.5/forecast/daily';
 
 export const OPEN_WEATHER_API_URL_FOR_SENSORS = [
-  'https://api.openweathermap.org/data/2.5/weather',
   'https://history.openweathermap.org/data/2.5/history/city',
   'https://pro.openweathermap.org/data/2.5/forecast/hourly',
   DAILY_FORECAST_API_URL,

--- a/packages/webapp/src/containers/SensorReadings/index.jsx
+++ b/packages/webapp/src/containers/SensorReadings/index.jsx
@@ -76,7 +76,7 @@ function SensorReadings({ history, match }) {
         },
       });
     }
-  }, [sensorInfo, reading_types, history]);
+  }, [sensorInfo, reading_types, history, latestMaxTemperature, latestMinTemperature]);
 
   return (
     <>

--- a/packages/webapp/src/containers/SensorReadings/saga.js
+++ b/packages/webapp/src/containers/SensorReadings/saga.js
@@ -23,6 +23,7 @@ import {
   OPEN_WEATHER_API_URL_FOR_SENSORS,
   HOUR,
   SOIL_WATER_POTENTIAL,
+  DAILY_FORECAST_API_URL,
 } from './constants';
 import {
   bulkSensorReadingsLoading,
@@ -122,11 +123,18 @@ export function* getSensorsReadingsSaga({ payload }) {
           for (const key in params) {
             openWeatherUrl.searchParams.append(key, params[key]);
           }
+          if (weatherURL === DAILY_FORECAST_API_URL) {
+            openWeatherUrl.searchParams.append('cnt', 1);
+          }
           openWeatherPromiseList.push(call(axios.get, openWeatherUrl?.toString()));
         }
 
-        const [currentDayWeatherResponse, openWeatherResponse, predictedWeatherResponse] =
-          yield all(openWeatherPromiseList);
+        const [
+          currentDayWeatherResponse,
+          openWeatherResponse,
+          predictedWeatherResponse,
+          predictedDailyWeatherResponse,
+        ] = yield all(openWeatherPromiseList);
         stationName = currentDayWeatherResponse?.data?.name;
         const weatherResData = [
           ...openWeatherResponse.data.list,
@@ -181,8 +189,8 @@ export function* getSensorsReadingsSaga({ payload }) {
         }, ambientDataWithSensorsReadings);
 
         latestTemperatureReadings = {
-          tempMin: currentDayWeatherResponse?.data?.main?.temp_min,
-          tempMax: currentDayWeatherResponse?.data?.main?.temp_max,
+          tempMin: predictedDailyWeatherResponse?.data?.list?.[0]?.temp?.min,
+          tempMax: predictedDailyWeatherResponse?.data?.list?.[0]?.temp?.max,
         };
 
         if (result?.data?.sensorsPoints) {

--- a/packages/webapp/src/containers/SensorReadings/saga.js
+++ b/packages/webapp/src/containers/SensorReadings/saga.js
@@ -129,13 +129,9 @@ export function* getSensorsReadingsSaga({ payload }) {
           openWeatherPromiseList.push(call(axios.get, openWeatherUrl?.toString()));
         }
 
-        const [
-          currentDayWeatherResponse,
-          openWeatherResponse,
-          predictedWeatherResponse,
-          predictedDailyWeatherResponse,
-        ] = yield all(openWeatherPromiseList);
-        stationName = currentDayWeatherResponse?.data?.name;
+        const [openWeatherResponse, predictedWeatherResponse, predictedDailyWeatherResponse] =
+          yield all(openWeatherPromiseList);
+        stationName = predictedDailyWeatherResponse?.data?.city.name;
         const weatherResData = [
           ...openWeatherResponse.data.list,
           ...predictedWeatherResponse.data.list,


### PR DESCRIPTION
**Description**

In the temperature chart, the current lowest and highest observed temperature are shown whereas they should be the forecasted high and low temperature for the day.
- call the [daily forecast API](https://openweathermap.org/forecast16) to get the forecasted high and low temperature for the day
- update useEffect dependency to show high/low temperature in the sensor chart

Jira link:
- https://lite-farm.atlassian.net/browse/LF-3028
- https://lite-farm.atlassian.net/browse/LF-3256

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
