### PR TITLE
LF-3258: APIs keep being called in sensor details view

### DIFF
--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/index.jsx
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SensorDetail/index.jsx
@@ -15,13 +15,12 @@
 import PureSensorDetail from '../../../../components/LocationDetailLayout/PointDetails/Sensor/index';
 import { measurementSelector } from '../../../userFarmSlice';
 import { useSelector, useDispatch } from 'react-redux';
-import { useTranslation } from 'react-i18next';
 import { useEffect } from 'react';
 import { sensorsSelector } from '../../../sensorSlice';
 import { isAdminSelector } from '../../../userFarmSlice';
 import { getSensorReadingTypes, getSensorBrand, retireSensor } from './saga';
 
-export default function SensorDetail({ history, user, match }) {
+export default function SensorDetail({ history, match }) {
   const dispatch = useDispatch();
   const location_id = match.params.location_id;
   const sensorInfo = useSelector(sensorsSelector(location_id));
@@ -36,7 +35,7 @@ export default function SensorDetail({ history, user, match }) {
       const partner_id = sensorInfo?.partner_id;
       dispatch(getSensorBrand({ location_id, partner_id }));
     }
-  }, [sensorInfo]);
+  }, [sensorInfo?.partner_id]);
 
   const confirmRetire = () => {
     dispatch(retireSensor({ sensorInfo }));


### PR DESCRIPTION
**Description**

In the sensor details tab, two APIs keep being called. This PR updates dependency of the useEffect that causes the issue. (in the useEffect, the two APIs are called and `sensorInfo` is  updated, but `sensorInfo` is also dependency of the useEffect)

Jira link: https://lite-farm.atlassian.net/browse/LF-3258

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
