### PR TITLE
LF-3244: Quantity input for harvest task shows an error when disabled

### DIFF
--- a/packages/webapp/src/components/Task/HarvestingTask/index.jsx
+++ b/packages/webapp/src/components/Task/HarvestingTask/index.jsx
@@ -155,7 +155,7 @@ function HarvestForm({
           defaultChecked={field[HARVEST_EVERYTHING]}
           label={t('ADD_TASK.HARVEST_EVERYTHING')}
           hookFormRegister={register(`harvest_tasks.${index}.` + HARVEST_EVERYTHING)}
-          onChange={(e) => e.target.checked && setValue(quantityName, '')}
+          onChange={(e) => e.target.checked && setValue(quantityName, '', { shouldValidate: true })}
           sm
         />
         <Input

--- a/packages/webapp/src/components/Task/HarvestingTask/index.jsx
+++ b/packages/webapp/src/components/Task/HarvestingTask/index.jsx
@@ -150,6 +150,7 @@ function HarvestForm({
           control={control}
           disabled={is_harvest_everything}
           optional
+          data-testid={`harvesttask-quantity-${index}`}
         />
         <Checkbox
           defaultChecked={field[HARVEST_EVERYTHING]}

--- a/packages/webapp/src/stories/Pages/Task/TaskDetail/TaskDetail.stories.jsx
+++ b/packages/webapp/src/stories/Pages/Task/TaskDetail/TaskDetail.stories.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { within, userEvent } from '@storybook/testing-library';
 import decorators from '../../config/Decorators';
 import { chromaticSmallScreen } from '../../config/chromatic';
 import PureTaskDetails from '../../../../components/Task/PureTaskDetails';
 import UnitTest from '../../../../test-utils/storybook/unit';
+import { harvestAmounts } from '../../../../util/convert-units/unit';
 
 export default {
   title: 'Page/AddCleaningTask',
@@ -816,23 +818,13 @@ HarvestTask.args = {
     type: 8,
     due_date: '2021-08-23',
     locations: [
-      {
-        location_id: '1f31e024-2e98-44e4-9837-80f52d8ab010',
-      },
-      {
-        location_id: '61f7cd2c-c09d-43cf-9687-a0502236acfd',
-      },
+      { location_id: '1f31e024-2e98-44e4-9837-80f52d8ab010' },
+      { location_id: '61f7cd2c-c09d-43cf-9687-a0502236acfd' },
     ],
     managementPlans: [
-      {
-        management_plan_id: 1166,
-      },
-      {
-        management_plan_id: 1177,
-      },
-      {
-        management_plan_id: 1179,
-      },
+      { management_plan_id: 1166 },
+      { management_plan_id: 1177 },
+      { management_plan_id: 1179 },
     ],
     harvest_tasks: [],
   },
@@ -849,4 +841,61 @@ HarvestTask.args = {
 };
 HarvestTask.parameters = {
   ...chromaticSmallScreen,
+};
+HarvestTask.play = async ({ canvasElement }) => {
+  const quantityTest0 = new UnitTest(canvasElement, 'harvesttask-quantity-0', harvestAmounts);
+  const quantityTest1 = new UnitTest(canvasElement, 'harvesttask-quantity-1', harvestAmounts);
+
+  const canvas = within(canvasElement);
+  const [abiuCheckbox, achachaCheckbox] = canvas.getAllByRole('checkbox');
+
+  await quantityTest0.inputNotToHaveValue();
+  await quantityTest1.inputNotToHaveValue();
+  await quantityTest0.selectedUnitToBeInTheDocument('kg');
+  await quantityTest1.selectedUnitToBeInTheDocument('kg');
+  await quantityTest0.visibleInputAndComboboxIsEnabled();
+  await quantityTest1.visibleInputAndComboboxIsEnabled();
+
+  await quantityTest0.inputValueAndBlur('0.5');
+  await quantityTest0.visibleInputToHaveValue(0.5);
+  await quantityTest0.hiddenInputToHaveValue(0.5);
+  await quantityTest1.inputNotToHaveValue();
+
+  await quantityTest0.selectUnit('mt');
+  await quantityTest0.selectedUnitToBeInTheDocument('mt');
+  await quantityTest0.visibleInputToHaveValue(0.5);
+  await quantityTest0.hiddenInputToHaveValue(
+    quantityTest0.convertDisplayValueToHiddenValue(0.5, 'mt'),
+  );
+  await quantityTest1.inputNotToHaveValue();
+  await quantityTest1.selectedUnitToBeInTheDocument('kg');
+
+  await userEvent.click(abiuCheckbox);
+  await quantityTest0.inputNotToHaveValue();
+  await quantityTest0.visibleInputAndComboxIsDisabled();
+  await quantityTest0.selectedUnitToBeInTheDocument('mt');
+
+  await userEvent.click(achachaCheckbox);
+  await quantityTest1.inputNotToHaveValue();
+  await quantityTest1.selectedUnitToBeInTheDocument('kg');
+  await quantityTest1.visibleInputAndComboxIsDisabled();
+
+  await userEvent.click(achachaCheckbox);
+  await quantityTest1.inputNotToHaveValue();
+  await quantityTest1.selectedUnitToBeInTheDocument('kg');
+  await quantityTest1.visibleInputAndComboboxIsEnabled();
+
+  await quantityTest1.inputValueAndBlur('20');
+  await quantityTest1.visibleInputToHaveValue(20);
+  await quantityTest1.hiddenInputToHaveValue(20);
+  await quantityTest0.inputNotToHaveValue();
+  await quantityTest0.visibleInputAndComboxIsDisabled();
+  await quantityTest0.selectedUnitToBeInTheDocument('mt');
+
+  await quantityTest1.inputValueAndBlur('1000000001');
+  await quantityTest1.haveMaxValueError();
+
+  await userEvent.click(achachaCheckbox);
+  await quantityTest1.inputNotToHaveValue();
+  await quantityTest1.haveNoError();
 };

--- a/packages/webapp/src/test-utils/storybook/unit.jsx
+++ b/packages/webapp/src/test-utils/storybook/unit.jsx
@@ -91,6 +91,13 @@ export default class UnitTest {
     });
   }
 
+  async visibleInputAndComboboxIsEnabled() {
+    await waitFor(() => {
+      expect(this.visibleInput).toBeEnabled();
+      expect(within(this.select).getByRole('combobox')).toBeEnabled();
+    });
+  }
+
   async visibleInputAndComboxIsDisabled() {
     await waitFor(() => {
       expect(this.visibleInput).toBeDisabled();


### PR DESCRIPTION
**Description**

The harvest quantity input shows an error after inputting a large number and checking the checkbox below (the field is disabled) even though the value is reset to `''`. This PR adds validation after the value is reset.

I merged https://github.com/LiteFarmOrg/LiteFarm/pull/2540 to add tests. To run:
- ```pnpm test-storybook /src/stories/Pages/Task/TaskDetail/TaskDetail.stories.jsx```
- [storybook UI](http://localhost:6006/?path=/story/page-addcleaningtask--harvest-task)

Jira link: https://lite-farm.atlassian.net/browse/LF-3244

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
