### PR TITLE
LF-3027 Sensor readings continuing into predicted region when farm system of measurement is set to imperial

### DIFF
--- a/packages/webapp/src/components/Map/PreviewPopup/utils.js
+++ b/packages/webapp/src/components/Map/PreviewPopup/utils.js
@@ -21,16 +21,14 @@ const roundToTwo = (num) => {
 };
 
 export const getSoilWaterPotentialValue = (value, unit) => {
-  if (imperial.includes(unit.toLowerCase())) return convertKPaToPsi(value);
-  return roundToTwo(value);
+  if (typeof value !== 'number') {
+    return NaN;
+  }
+  const to = imperial.includes(unit.toLowerCase()) ? 'psi' : 'kPa';
+  return roundToTwo(convert(value).from('kPa').to(to));
 };
 
 export const getSoilWaterPotentialUnit = (unit) => {
   if (imperial.includes(unit.toLowerCase())) return ' psi';
   return ' kPa';
-};
-
-const convertKPaToPsi = (soilWaterPotentialInKPa) => {
-  const soilWaterPotentialInPSI = soilWaterPotentialInKPa * 0.1450377377;
-  return roundToTwo(soilWaterPotentialInPSI);
 };


### PR DESCRIPTION
**Description**

This is the exact same issue as was addressed in this PR:

- https://github.com/LiteFarmOrg/LiteFarm/pull/2669

The only difference is that here soil water potential (units of pressure) needed the null check rather than temperature. Therefore I have copied @SayakaOno's code precisely, for complete parallelism 😁 

Jira link: https://lite-farm.atlassian.net/browse/LF-3027

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
