### PR TITLE
LF-3274 Valid sensor files don't upload in non-English languages

### DIFF
--- a/packages/shared/validation/sensorCSV.js
+++ b/packages/shared/validation/sensorCSV.js
@@ -58,7 +58,7 @@ const sensorCsvHeaderTranslations = {
     name: "Nom",
     latitude: "Latitude",
     longitude: "Longitude",
-    reading_types: "types_à_relevé",
+    reading_types: "Type_de_données_relevées",
     external_id: "ID_externe",
     depth: "Profondeur_cm",
     brand: "Marque",
@@ -89,7 +89,7 @@ const readingTypeTranslations = {
   },
   fr: {
     soil_water_content: "teneur_en_eau_du_sol",
-    soil_water_potential: "potential_hydrique_du_sol",
+    soil_water_potential: "potentiel_hydrique_du_sol",
     temperature: "température",
   },
   pt: {

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -539,11 +539,6 @@
         "BRAND": "Brand",
         "MODEL": "Model"
       },
-      "SENSOR_READING_TYPES": {
-        "SOIL_MOISTURE_CONTENT": "soil_water_content",
-        "SOIL_WATER_POTENTIAL": "soil_water_potential",
-        "TEMPERATURE": "temperature"
-      },
       "VALIDATION": {
         "FILE_ROW_LIMIT_EXCEEDED": "File row limit exceeded. The max number of sensors that can be uploaded from a file is 100.",
         "MISSING_COLUMNS": "Columns are required/missing.",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -538,11 +538,6 @@
         "BRAND": "Marca",
         "MODEL": "Modelo"
       },
-      "SENSOR_READING_TYPES": {
-        "SOIL_MOISTURE_CONTENT": "contenido_de_agua_en_el_suelo",
-        "SOIL_WATER_POTENTIAL": "potencial_hídrico_del_suelo",
-        "TEMPERATURE": "temperatura"
-      },
       "VALIDATION": {
         "FILE_ROW_LIMIT_EXCEEDED": "Límite de fila de archivos superado. El número máximo de sensores que se pueden cargar desde un archivo es 100.",
         "MISSING_COLUMNS": "Se requieren columnas/faltan.",
@@ -550,7 +545,7 @@
         "SENSOR_NAME": "Nombre del sensor no válido, debe estar entre 1 y 100 caracteres.",
         "SENSOR_LATITUDE": "Valor de latitud no válido, debe estar entre -85 y 85. y menos de 10 decimales.",
         "SENSOR_LONGITUDE": "Valor de longitud no válido, debe estar entre -180 y 180. y menos de 10 decimales.",
-        "SENSOR_READING_TYPES": "Tipo de lectura no válido detectado: {{ reading_types }} los valores válidos incluyen: soil_water_content, soil_water_potential, temperature.",
+        "SENSOR_READING_TYPES": "Tipo de lectura no válido detectado: {{ reading_types }} los valores válidos incluyen: contenido_de_agua_en_el_suelo, potencial_hídrico_del_suelo, temperatura.",
         "SENSOR_DEPTH": "Valor de profundidad no válido, debe estar entre 0 y 1000.",
         "SENSOR_BRAND": "Nombre de marca no válido, debe tener entre 1 y 100 caracteres.",
         "SENSOR_MODEL": "Nombre de modelo no válido, debe tener entre 1 y 100 caracteres.",
@@ -1745,7 +1740,7 @@
     "DEPTH": "Profundidad",
     "BRAND": "Marca",
     "VALIDATION": {
-      "READING_TYPES": "Sensor reading types are required"
+      "READING_TYPES": "MISSING"
     },
     "MODAL": {
       "TITLE": "¿Cambiar los tipos de lectura?",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -533,16 +533,11 @@
         "NAME": "Nom",
         "LATITUDE": "Latitude",
         "LONGITUDE": "Longitude",
-        "READING_TYPES": "Type_de_donnees_relevees",
+        "READING_TYPES": "Type_de_données_relevées",
         "SENSOR_EXTERNAL_ID": "ID_externe",
         "DEPTH": "Profondeur_cm",
         "BRAND": "Marque",
         "MODEL": "Modele"
-      },
-      "SENSOR_READING_TYPES": {
-        "SOIL_MOISTURE_CONTENT": "teneur_en_eau_du_sol",
-        "SOIL_WATER_POTENTIAL": "potentiel_hydrique_du_sol",
-        "TEMPERATURE": "temperature"
       },
       "VALIDATION": {
         "FILE_ROW_LIMIT_EXCEEDED": "Limite de lignes du fichier dépassée. Le nombre maximum de capteurs téléchargeable dans un fichier est de 100.",
@@ -551,7 +546,7 @@
         "SENSOR_NAME": "Nom de capteur non valide, if doit être compris entre 1 et 100 caractères.",
         "SENSOR_LATITUDE": "La valeur de latitude n'est pas valide, elle doit être comprise entre -85 et 85 et avec moins de 10 décimales.",
         "SENSOR_LONGITUDE": "La valeur de longitude n'est pas valide, elle doit être comprise entre -180 et 180 et avec moins de 10 décimales.",
-        "SENSOR_READING_TYPES": "Type de données relevées non valide détecté\u00a0: {{ reading_types }}. Les valeurs valides sont\u00a0: teneur_en_eau_du_sol, potentiel_hydrique_du_sol, temperature.",
+        "SENSOR_READING_TYPES": "Type de données relevées non valide détecté\u00a0: {{ reading_types }}. Les valeurs valides sont\u00a0: teneur_en_eau_du_sol, potentiel_hydrique_du_sol, température.",
         "SENSOR_DEPTH": "Valeur de profondeur non valide, elle doit être comprise entre 0 et 1000.",
         "SENSOR_BRAND": "Nom de marque non valide, il doit être compris entre 1 et 100 caractères.",
         "SENSOR_MODEL": "Nom de modèle non valide, il doit être compris entre 1 et 100 caractères.",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -538,11 +538,6 @@
         "BRAND": "Marca",
         "MODEL": "Modelo"
       },
-      "SENSOR_READING_TYPES": {
-        "SOIL_MOISTURE_CONTENT": "teor_de_água_no_solo",
-        "SOIL_WATER_POTENTIAL": "potencial_de_água_do_solo",
-        "TEMPERATURE": "temperatura"
-      },
       "VALIDATION": {
         "FILE_ROW_LIMIT_EXCEEDED": "Limite de linha de arquivo excedido. O número máximo de sensores que podem ser carregados de um arquivo é 100.",
         "MISSING_COLUMNS": "Colunas são necessárias/ausentes.",
@@ -550,7 +545,7 @@
         "SENSOR_NAME": "Nome do sensor inválido, deve ter entre 1 e 100 caracteres.",
         "SENSOR_LATITUDE": "Valor de latitude inválido, deve estar entre -85 e 85 e menos de 10 casas decimais.",
         "SENSOR_LONGITUDE": " Valor de longitude inválido, deve estar entre -180 e 180. e menos de 10 casas decimais.",
-        "SENSOR_READING_TYPES": "Tipo de leitura inválido detectado: {{ reading_types }}. Vvalores válidos incluem: solo_água_conteúdo, solo_água_potencial, temperatura.",
+        "SENSOR_READING_TYPES": "Tipo de leitura inválido detectado: {{ reading_types }}. Vvalores válidos incluem: teor_de_água_no_solo, potencial_de_água_do_solo, temperatura.",
         "SENSOR_DEPTH": "Valor de profundidade inválido, deve estar entre 0 e 1000.",
         "SENSOR_BRAND": "Nome de marca inválido, deve ter entre 1 e 100 caracteres.",
         "SENSOR_MODEL": "Nome de modelo inválido, deve ter entre 1 e 100 caracteres.",


### PR DESCRIPTION
**Description**

This PR harmonizes the sensor CSV columns and sensor reading types across the frontend translation files and the validation scripts in `/shared`. A new ticket, [LF-3286](https://lite-farm.atlassian.net/browse/LF-3286), has been opened to address the shared package folder and the issue of a single source of truth.

The specific changes include:

- Resolving all discrepancies favouring the correct version, typically the validation, after consultation with native speakers
- Removal of BULK_UPLOAD_SENSORS.SENSOR_READING_TYPES from the translation files as they were not used in the codebase
- Addition of a "MISSING" tag for a Spanish translation that incidentally held English.

Jira link: https://lite-farm.atlassian.net/browse/LF-3274

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Please see the Jira link for CSV files that can be tested in each language. You can also download the correct CSV template for each language and fill it with your own data.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3286]: https://lite-farm.atlassian.net/browse/LF-3286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ