### PR TITLE
LF-3289: "Type" of Field work not dynamic on details page

### DIFF
--- a/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
+++ b/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import i18next from 'i18next';
 import Input from '../../Form/Input';
 import ReactSelect from '../../Form/ReactSelect';
 import { Controller } from 'react-hook-form';
@@ -8,7 +7,16 @@ import { getFieldWorkTypes } from '../../../containers/Task/FieldWorkTask/saga';
 import { useDispatch, useSelector } from 'react-redux';
 import { fieldWorkSliceSliceSelector } from '../../../containers/fieldWorkSlice';
 
-const formatDefaultTypeValue = (typeValue) => {
+const formatDefaultTypeValue = (typeValue, fieldWorkTypeOptions) => {
+  // in read-only view, typeValue is an array at first.
+  const option = fieldWorkTypeOptions.filter(({ field_work_type_id }) => {
+    return field_work_type_id === typeValue[0].field_work_type_id;
+  });
+  if (option.length) {
+    return option[0];
+  }
+
+  // This is for a task with a new custom type that has not been added to "fieldWorkTypeOptions".
   const [{ farm_id, field_work_name, field_work_type_id, field_work_type_translation_key }] =
     typeValue;
   return {
@@ -57,20 +65,13 @@ const PureFieldWorkTask = ({ register, control, setValue, watch, disabled = fals
 
   useEffect(() => {
     dispatch(getFieldWorkTypes());
-    if (typeValue?.length) {
-      setValue(FIELD_WORK_TYPE, formatDefaultTypeValue(typeValue));
-    }
   }, []);
-  const displayLabel = (values) => {
-    if (!values.length) return '';
-    const value = values[0]?.field_work_name || '';
-    const translationKey = `ADD_TASK.FIELD_WORK_VIEW.TYPE.${value}`;
-    if (i18next.exists(translationKey)) {
-      return t(translationKey);
-    } else {
-      return value;
+
+  useEffect(() => {
+    if (typeValue?.length && fieldWorkTypeOptions?.length) {
+      setValue(FIELD_WORK_TYPE, formatDefaultTypeValue(typeValue, fieldWorkTypeOptions));
     }
-  };
+  }, [fieldWorkTypeOptions, typeValue]);
 
   return (
     <>
@@ -89,11 +90,7 @@ const PureFieldWorkTask = ({ register, control, setValue, watch, disabled = fals
               setValue(FIELD_WORK_TYPE, e, { shouldValidate: true });
             }}
             isDisabled={disabled}
-            value={
-              // TODO: refactor value reading here and in pest control
-              // this solution keeps placeholder while accommodating the read-only view
-              !value ? value : value?.value ? value : { value, label: displayLabel(value) }
-            }
+            value={value}
           />
         )}
       />

--- a/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
+++ b/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
@@ -8,7 +8,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fieldWorkSliceSliceSelector } from '../../../containers/fieldWorkSlice';
 
 const formatDefaultTypeValue = (typeValue, fieldWorkTypeOptions) => {
-  // in read-only view, typeValue is an array at first.
   const option = fieldWorkTypeOptions.filter(({ field_work_type_id }) => {
     return field_work_type_id === typeValue[0].field_work_type_id;
   });
@@ -16,7 +15,8 @@ const formatDefaultTypeValue = (typeValue, fieldWorkTypeOptions) => {
     return option[0];
   }
 
-  // This is for a task with a new custom type that has not been added to "fieldWorkTypeOptions".
+  // This is for a task with a brand-new custom type.
+  // The new type has not been added to "fieldWorkTypeOptions" by the time this function gets called.
   const [{ farm_id, field_work_name, field_work_type_id, field_work_type_translation_key }] =
     typeValue;
   return {
@@ -69,9 +69,10 @@ const PureFieldWorkTask = ({ register, control, setValue, watch, disabled = fals
 
   useEffect(() => {
     if (typeValue?.length && fieldWorkTypeOptions?.length) {
+      // in read-only and before_complete views, default typeValue is an array which needs to be formatted.
       setValue(FIELD_WORK_TYPE, formatDefaultTypeValue(typeValue, fieldWorkTypeOptions));
     }
-  }, [fieldWorkTypeOptions, typeValue]);
+  }, [typeValue, fieldWorkTypeOptions]);
 
   return (
     <>


### PR DESCRIPTION
**Description**

In the field work task read-only and before_complete views, the value used for `ReactSelect` is an array at first where it should be an object. There were two functions 1. `formatDefaultTypeValue` that would take out the first item from the array and 2. `displayLabel` that would correct the label of the object. This PR combines these two functions.

It looks like this was "TODO" according to the old comment. Since "pest control" is mentioned, I will ask QA to test it.

Jira link: https://lite-farm.atlassian.net/browse/LF-3289

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
