### PR TITLE
LF-3294: The upload button becomes active once the user uploads the template form without making any changes

### DIFF
--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -145,9 +145,10 @@ export function useValidateBulkSensorData(onUpload, t) {
         setUploadErrorMessage(t('FARM_MAP.BULK_UPLOAD_SENSORS.EMPTY_FILE_UPLOAD_ERROR_MESSAGE'));
       }
 
-      setErrorCount(data.length === 0 ? 1 : translatedErrors.length);
+      const newErrorCount = data.length === 0 ? 1 : translatedErrors.length;
+      setErrorCount(newErrorCount);
       setSheetErrors(translatedErrors);
-      setDisabled(() => (translatedErrors.length === 0 ? 1 : 0));
+      setDisabled(() => (newErrorCount === 0 ? 1 : 0));
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
**Description**

After uploading sensor csv, button's "disabled" status is determined by checking `translatedErrors`. `errorCount` will be checked instead of `translatedErrors`.

Jira link: https://lite-farm.atlassian.net/browse/LF-3294

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
