### PR TITLE
LF-3284 Modify visualization algorithm for sensor readings data

### DIFF
--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -36,7 +36,6 @@ const PureSensorReadingsLineChart = ({
   xAxisDataKey,
   yAxisDataKeys,
   lineColors,
-  graphDatapoints,
 }) => {
   const { t } = useTranslation();
   const [legendsList, setLegendsList] = useState({});
@@ -110,7 +109,8 @@ const PureSensorReadingsLineChart = ({
     const displayDate = dateFormat.format(tickDate);
     const displayDay = dayFormat.format(tickDate);
 
-    if (index % graphDatapoints.length == graphDatapoints.length / 2) {
+    // Hourly datapoints
+    if (index % 24 == 12) {
       return (
         <>
           <text x={x} y={y - 16} textAnchor="middle">
@@ -123,7 +123,7 @@ const PureSensorReadingsLineChart = ({
       );
     }
 
-    if (index % graphDatapoints.length === 0 && index !== 0) {
+    if (index % 24 === 0 && index !== 0) {
       const pathX = Math.floor(x) + 0.5;
 
       return <path d={`M${pathX},${y - 22}v${-16}`} stroke="black" />;

--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styles from './styles.module.scss';
 import {
   LineChart,
@@ -20,6 +20,7 @@ import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStor
 import { SensorReadingChartSpotlightProvider } from './SensorReadingChartSpotlightProvider';
 import produce from 'immer';
 import { useTranslation } from 'react-i18next';
+import useElementWidth from '../hooks/useElementWidth';
 
 const PureSensorReadingsLineChart = ({
   showSpotLight,
@@ -35,6 +36,7 @@ const PureSensorReadingsLineChart = ({
   xAxisDataKey,
   yAxisDataKeys,
   lineColors,
+  graphDatapoints,
 }) => {
   const { t } = useTranslation();
   const [legendsList, setLegendsList] = useState({});
@@ -42,6 +44,9 @@ const PureSensorReadingsLineChart = ({
   const language = getLanguageFromLocalStorage();
   const dateFormat = new Intl.DateTimeFormat(language, { day: '2-digit' });
   const dayFormat = new Intl.DateTimeFormat(language, { weekday: 'short' });
+
+  const chartRef = useRef(null);
+  const { chartWidth } = useElementWidth(chartRef);
 
   useEffect(() => {
     if (yAxisDataKeys.length) {
@@ -100,12 +105,12 @@ const PureSensorReadingsLineChart = ({
 
   const renderDateOnXAxis = (tickProps) => {
     const { x, y, payload, index } = tickProps;
-    const { value, offset } = payload;
+    const { value } = payload;
     const tickDate = new Date(value);
     const displayDate = dateFormat.format(tickDate);
     const displayDay = dayFormat.format(tickDate);
 
-    if (index % 4 == 2) {
+    if (index % graphDatapoints.length == graphDatapoints.length / 2) {
       return (
         <>
           <text x={x} y={y - 16} textAnchor="middle">
@@ -117,8 +122,10 @@ const PureSensorReadingsLineChart = ({
         </>
       );
     }
-    if (index % 4 === 0 && index !== 0) {
-      const pathX = Math.floor(x + offset) + 0.5;
+
+    if (index % graphDatapoints.length === 0 && index !== 0) {
+      const pathX = Math.floor(x) + 0.5;
+
       return <path d={`M${pathX},${y - 22}v${-16}`} stroke="black" />;
     }
     return null;
@@ -129,6 +136,20 @@ const PureSensorReadingsLineChart = ({
     let tickArr = newTick.split(' ');
     tickArr = tickArr.slice(0, -1);
     return tickArr.join(' ');
+  };
+
+  // Returns density of specified data in datapoints / hour
+  const dataDensity = (data, sensorName) => {
+    const validDatapoints = data.filter((datapoint) => typeof datapoint[sensorName] === 'number');
+
+    if (validDatapoints?.length <= 1) return 0; // one or no datapoints
+
+    const firstTimestamp = new Date(validDatapoints[0]?.current_date_time);
+    const lastTimestamp = new Date(validDatapoints[validDatapoints.length - 1]?.current_date_time);
+
+    const totalIntervalinHours = (lastTimestamp - firstTimestamp) / (1000 * 60 * 60);
+
+    return (validDatapoints.length - 1) / totalIntervalinHours;
   };
 
   return (
@@ -150,7 +171,7 @@ const PureSensorReadingsLineChart = ({
       {subTitle && <Label className={styles.subTitle}>{subTitle}</Label>}
       {weatherStationName && <Label className={styles.subTitle}>{weatherStationName}</Label>}
 
-      <ResponsiveContainer width="100%" height={380}>
+      <ResponsiveContainer width="100%" height={380} ref={chartRef}>
         <LineChart
           data={sensorReadings}
           margin={{
@@ -182,7 +203,6 @@ const PureSensorReadingsLineChart = ({
             interval={0}
             tick={renderDateOnXAxis}
             height={1}
-            scale="band"
             xAxisId="quarter"
           />
           <YAxis
@@ -207,8 +227,16 @@ const PureSensorReadingsLineChart = ({
                   strokeWidth={2}
                   dataKey={attribute.value}
                   stroke={attribute.color}
-                  activeDot={{ r: 6 }}
                   isAnimationActive={false}
+                  activeDot={{ r: 5 }}
+                  dot={dataDensity(sensorReadings, attribute.value) < 0.9}
+                  type={
+                    dataDensity(sensorReadings, attribute.value) >= 0.9 ||
+                    (chartWidth < 400 && dataDensity(sensorReadings, attribute.value) > 0.5)
+                      ? 'natural'
+                      : 'linear'
+                  }
+                  connectNulls
                 />
               ))}
           <ReferenceArea fill={'#EBECED'} shape={<PredictedRect />} x1={predictedXAxisLabel} />

--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -45,7 +45,7 @@ const PureSensorReadingsLineChart = ({
   const dayFormat = new Intl.DateTimeFormat(language, { weekday: 'short' });
 
   const chartRef = useRef(null);
-  const { chartWidth } = useElementWidth(chartRef);
+  const { elementWidth: chartWidth } = useElementWidth(chartRef);
 
   useEffect(() => {
     if (yAxisDataKeys.length) {
@@ -154,7 +154,7 @@ const PureSensorReadingsLineChart = ({
 
   return (
     <>
-      <div className={styles.titleWrapper}>
+      <div className={styles.titleWrapper} ref={chartRef}>
         <label>
           <Semibold className={styles.title}>{title}</Semibold>
         </label>
@@ -171,7 +171,7 @@ const PureSensorReadingsLineChart = ({
       {subTitle && <Label className={styles.subTitle}>{subTitle}</Label>}
       {weatherStationName && <Label className={styles.subTitle}>{weatherStationName}</Label>}
 
-      <ResponsiveContainer width="100%" height={380} ref={chartRef}>
+      <ResponsiveContainer width="100%" height={380}>
         <LineChart
           data={sensorReadings}
           margin={{

--- a/packages/webapp/src/containers/SensorReadings/constants.js
+++ b/packages/webapp/src/containers/SensorReadings/constants.js
@@ -6,7 +6,14 @@ export const DEFAULT_ZOOM = 15;
 export const GMAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 export const ENVIRONMENT = import.meta.env.NODE_ENV;
 export const CHART_LINE_COLORS = ['#3ea992', '#8f26f0', '#f58282', '#AA5F04', '#0669e1', '#3E2723'];
-export const CHOSEN_GRAPH_DATAPOINTS = ['02:00:00', '08:00:00', '14:00:00', '20:00:00'];
+
+// Graph datapoints should by an array of hours in 'HH:MM:SS' format, e.g. ['02:00:00', '08:00:00', '14:00:00', '20:00:00']
+export const CHOSEN_GRAPH_DATAPOINTS = [];
+for (let i = 0; i < 24; i++) {
+  const twoDigitHour = i < 10 ? '0' + i : i;
+  CHOSEN_GRAPH_DATAPOINTS.push(twoDigitHour + ':00:00');
+}
+
 export const AMBIENT_TEMPERATURE = 'Ambient temperature';
 export const CURRENT_DATE_TIME = 'current_date_time';
 

--- a/packages/webapp/src/containers/SensorReadings/constants.js
+++ b/packages/webapp/src/containers/SensorReadings/constants.js
@@ -7,13 +7,6 @@ export const GMAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 export const ENVIRONMENT = import.meta.env.NODE_ENV;
 export const CHART_LINE_COLORS = ['#3ea992', '#8f26f0', '#f58282', '#AA5F04', '#0669e1', '#3E2723'];
 
-// Graph datapoints should by an array of hours in 'HH:MM:SS' format, e.g. ['02:00:00', '08:00:00', '14:00:00', '20:00:00']
-export const CHOSEN_GRAPH_DATAPOINTS = [];
-for (let i = 0; i < 24; i++) {
-  const twoDigitHour = i < 10 ? '0' + i : i;
-  CHOSEN_GRAPH_DATAPOINTS.push(twoDigitHour + ':00:00');
-}
-
 export const AMBIENT_TEMPERATURE = 'Ambient temperature';
 export const CURRENT_DATE_TIME = 'current_date_time';
 

--- a/packages/webapp/src/containers/SensorReadings/utils.js
+++ b/packages/webapp/src/containers/SensorReadings/utils.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { CHOSEN_GRAPH_DATAPOINTS } from './constants';
 
 export const getMiddle = (prop, markers) => {
   let values = markers.map((m) => m[prop]);
@@ -55,21 +54,9 @@ export const getDates = () => {
   };
 };
 
-export const roundDownToNearestChosenPoint = (currentUnixTime) => {
+export const roundDownToNearestHour = (currentUnixTime) => {
   const currentHour = new Date(currentUnixTime).getHours();
-  const chosenHours = CHOSEN_GRAPH_DATAPOINTS.map((point) => {
-    const arr = point.split(':');
-    return +arr[0];
-  });
-
-  let hour = chosenHours[chosenHours.length - 1];
-  for (let i = 0; i < chosenHours.length; i++) {
-    if (currentHour < chosenHours[i]) {
-      break;
-    }
-    hour = chosenHours[i];
-  }
-  const nearestChosenUnixTime = new Date(currentUnixTime).setHours(hour, 0, 0, 0);
+  const nearestChosenUnixTime = new Date(currentUnixTime).setHours(currentHour, 0, 0, 0);
 
   return moment(nearestChosenUnixTime).format('ddd MMMM D YYYY HH:mm');
 };

--- a/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
@@ -14,7 +14,6 @@ import {
   SOIL_WATER_POTENTIAL,
   SOIL_WATER_CONTENT,
   TEMPERATURE,
-  CHOSEN_GRAPH_DATAPOINTS,
 } from '../SensorReadings/constants';
 import { useTranslation } from 'react-i18next';
 import styles from './styles.module.scss';
@@ -89,7 +88,6 @@ const SensorReadingsLineChart = ({ readingType, noDataFoundMessage, data }) => {
             (f) => f !== CURRENT_DATE_TIME,
           )} // or != xAxisDataKey
           lineColors={CHART_LINE_COLORS}
-          graphDatapoints={CHOSEN_GRAPH_DATAPOINTS}
         />
       )}
     </>
@@ -110,7 +108,6 @@ SensorReadingsLineChart.propTypes = {
     sensorReadingData: PropTypes.array.isRequired,
     stationName: PropTypes.string,
     xAxisLabel: PropTypes.string.isRequired,
-    graphDatapoints: PropTypes.arrayOf(PropTypes.string),
   }),
 };
 

--- a/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
@@ -14,6 +14,7 @@ import {
   SOIL_WATER_POTENTIAL,
   SOIL_WATER_CONTENT,
   TEMPERATURE,
+  CHOSEN_GRAPH_DATAPOINTS,
 } from '../SensorReadings/constants';
 import { useTranslation } from 'react-i18next';
 import styles from './styles.module.scss';
@@ -88,6 +89,7 @@ const SensorReadingsLineChart = ({ readingType, noDataFoundMessage, data }) => {
             (f) => f !== CURRENT_DATE_TIME,
           )} // or != xAxisDataKey
           lineColors={CHART_LINE_COLORS}
+          graphDatapoints={CHOSEN_GRAPH_DATAPOINTS}
         />
       )}
     </>
@@ -108,6 +110,7 @@ SensorReadingsLineChart.propTypes = {
     sensorReadingData: PropTypes.array.isRequired,
     stationName: PropTypes.string,
     xAxisLabel: PropTypes.string.isRequired,
+    graphDatapoints: PropTypes.arrayOf(PropTypes.string),
   }),
 };
 


### PR DESCRIPTION
**Description**

This moves the sensor charts to hourly time points. Dots are added to the line chart when fewer than 90% of hourly time points are present.

A small final adjustment uses a smoother curve on data containing more than 50%, but less than 90%, of hourly data points on small chart widths (i.e. mobile screens).

Please note the sparse data display conditions are a bit of a placeholder -- they should be revisited when real data feeds are available. The chart in general will also look best if viewed after the xAxis and yAxis changes in LF-3291 are applied.

Jira link: https://lite-farm.atlassian.net/browse/LF-3284

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
