### PR TITLE
LF-3291 Small visual tweaks to soil water potential reading component

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1543,13 +1543,17 @@
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Soil temperature",
       "SUBTITLE": "Today’s forecasted ambient high and low temperature: {{high}}{{units}} / {{low}}{{units}}",
-      "Y_AXIS_LABEL": "Temperature in {{units}}",
+      "Y_AXIS_LABEL": "in {{units}}",
+      "C": "Celsius (°C)",
+      "F": "Fahrenheit (°F)",
       "WEATHER_STATION": "Weather station: {{weatherStationLocation}}",
       "AMBIENT_TEMPERATURE_FOR": "Ambient temperature for"
     },
     "SOIL_WATER_POTENTIAL_READINGS_OF_SENSOR": {
       "TITLE": "Soil water potential",
-      "Y_AXIS_LABEL": "Soil water potential in {{units}}"
+      "Y_AXIS_LABEL": "in {{units}}",
+      "KPA": "kilopascals (kPa)",
+      "PSI": "pounds per square inch (psi)"
     },
     "SOIL_WATER_CONTENT_READINGS_OF_SENSOR": {
       "TITLE": "Soil water content",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1787,13 +1787,17 @@
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Temperatura del suelo",
       "SUBTITLE": "Temperatura MISSING ambiente alta y baja de hoy: {{high}}{{units}} / {{low}}{{units}}",
-      "Y_AXIS_LABEL": "Temperatura en {{units}}",
+      "Y_AXIS_LABEL": "en {{units}}",
+      "C": "Celsius (°C)",
+      "F": "Fahrenheit (°F)",
       "WEATHER_STATION": "Estación meteorológica: {{weatherStationLocation}}",
       "AMBIENT_TEMPERATURE_FOR": "Temperatura ambiente para"
     },
     "SOIL_WATER_POTENTIAL_READINGS_OF_SENSOR": {
       "TITLE": "Potencial de agua del suelo",
-      "Y_AXIS_LABEL": "Potencial de agua del suelo en {{units}}"
+      "Y_AXIS_LABEL": "en {{units}}",
+      "KPA": "kilopascales (kPa)",
+      "PSI": "libras por pulgada cuadrada (psi)"
     },
     "SOIL_WATER_CONTENT_READINGS_OF_SENSOR": {
       "TITLE": "MISSING",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1788,13 +1788,17 @@
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Température du sol",
       "SUBTITLE": "Température MISSING ambiante haute et basse d'aujourd'hui\u00a0: {{high}}{{units}} / {{low}}{{units}}",
-      "Y_AXIS_LABEL": "Température en {{units}}",
+      "Y_AXIS_LABEL": "en {{units}}",
+      "C": "Celsius (°C)",
+      "F": "Fahrenheit (°F)",
       "WEATHER_STATION": "Station météorologique\u00a0: {{weatherStationLocation}}",
       "AMBIENT_TEMPERATURE_FOR": "Température ambiante pour"
     },
     "SOIL_WATER_POTENTIAL_READINGS_OF_SENSOR": {
       "TITLE": "Potentiel hydrique du sol",
-      "Y_AXIS_LABEL": "potentiel hydrique du sol en {{units}}"
+      "Y_AXIS_LABEL": "en {{units}}",
+      "KPA": "kilopascals (kPa)",
+      "PSI": "livres par pouce carré (psi)"
     },
     "SOIL_WATER_CONTENT_READINGS_OF_SENSOR": {
       "TITLE": "MISSING",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1754,7 +1754,7 @@
     "PART_NUMBER": "Número da peça",
     "HARDWARE_VERSION": "Versão do Hardware",
     "NO_DATA_FOUND": "Nenhuma leitura do sensor encontrada",
-    "NO_DATA": "(sem dados))",
+    "NO_DATA": "(sem dados)",
     "LAST_UPDATED": "Última atualização {{latestReadingUpdate}}",
     "DETAIL": {
       "RETIRE": "Remover",
@@ -1788,13 +1788,17 @@
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "TITLE": "Temperatura do solo",
       "SUBTITLE": "Temperatura MISSING ambiente máxima e mínima de hoje: {{high}}{{units}} / {{low}}{{units}}",
-      "Y_AXIS_LABEL": "Temperatura em {{units}}",
+      "Y_AXIS_LABEL": "em {{units}}",
+      "C": "Celsius (°C)",
+      "F": "Fahrenheit (°F)",
       "WEATHER_STATION": "Estação meteorológica: {{weatherStationLocation}}",
       "AMBIENT_TEMPERATURE_FOR": "Temperatura ambiente para"
     },
     "SOIL_WATER_POTENTIAL_READINGS_OF_SENSOR": {
       "TITLE": "Potencial hídrico do solo",
-      "Y_AXIS_LABEL": "Potencial hídrico do solo em {{units}}"
+      "Y_AXIS_LABEL": "em {{units}}",
+      "KPA": "quilopascals (kPa)",
+      "PSI": "libras por polegada quadrada (psi)"
     },
     "SOIL_WATER_CONTENT_READINGS_OF_SENSOR": {
       "TITLE": "MISSING",

--- a/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/components/SensorReadingsLineChart/index.jsx
@@ -13,7 +13,7 @@ import {
   Symbols,
   ReferenceArea,
 } from 'recharts';
-import { Label, Semibold } from '../Typography';
+import { Semibold } from '../Typography';
 import PropTypes from 'prop-types';
 import PredictedRect from './PredictedRect';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
@@ -27,9 +27,6 @@ const PureSensorReadingsLineChart = ({
   sensorReadings,
   title,
   subTitle,
-  weatherStationName,
-  yAxisLabel,
-  xAxisLabel,
   predictedXAxisLabel,
   lastUpdatedReadings,
   xAxisDataKey,
@@ -136,6 +133,7 @@ const PureSensorReadingsLineChart = ({
       <div className={styles.titleWrapper}>
         <label>
           <Semibold className={styles.title}>{title}</Semibold>
+          <Semibold className={styles.subTitle}>{subTitle}</Semibold>
         </label>
         {lastUpdatedReadings && (
           <label>
@@ -147,17 +145,14 @@ const PureSensorReadingsLineChart = ({
           </label>
         )}
       </div>
-      {subTitle && <Label className={styles.subTitle}>{subTitle}</Label>}
-      {weatherStationName && <Label className={styles.subTitle}>{weatherStationName}</Label>}
-
       <ResponsiveContainer width="100%" height={380}>
         <LineChart
           data={sensorReadings}
           margin={{
             top: 20,
-            right: 30,
-            left: 20,
-            bottom: 60,
+            right: 10,
+            left: -30,
+            bottom: 20,
           }}
         >
           <pattern
@@ -175,7 +170,6 @@ const PureSensorReadingsLineChart = ({
           <CartesianGrid strokeDasharray="1 1" />
           <XAxis dataKey={xAxisDataKey} tick={false} tickFormatter={dateTickFormatter} />
           <XAxis
-            label={{ value: xAxisLabel, position: 'insideBottom', dy: 45 }}
             dataKey={xAxisDataKey}
             axisLine={false}
             tickLine={false}
@@ -185,16 +179,12 @@ const PureSensorReadingsLineChart = ({
             scale="band"
             xAxisId="quarter"
           />
-          <YAxis
-            domain={['auto', 'auto']}
-            label={{ value: yAxisLabel, position: 'insideCenter', angle: -90, dx: -20 }}
-          />
+          <YAxis domain={['auto', 'auto']} />
           <Tooltip />
           <Legend
             layout="horizontal"
-            verticalAlign="top"
+            verticalAlign="bottom"
             align="center"
-            wrapperStyle={{ top: 10, left: 50 }}
             payload={Object.values(legendsList)}
             content={renderCusomizedLegend}
           />
@@ -222,9 +212,6 @@ PureSensorReadingsLineChart.propTypes = {
   title: PropTypes.string.isRequired,
   subTitle: PropTypes.string,
   lastUpdatedReadings: PropTypes.string,
-  yAxisLabel: PropTypes.string.isRequired,
-  xAxisLabel: PropTypes.string.isRequired,
-  weatherStationName: PropTypes.string,
   predictedXAxisLabel: PropTypes.string.isRequired,
   yAxisDataKeys: PropTypes.array.isRequired,
   lineColors: PropTypes.array.isRequired,

--- a/packages/webapp/src/components/SensorReadingsLineChart/styles.module.scss
+++ b/packages/webapp/src/components/SensorReadingsLineChart/styles.module.scss
@@ -1,44 +1,43 @@
-.lineChartWrapper{
+.lineChartWrapper {
   max-height: 650px;
 }
 .title {
   font-style: normal;
   font-weight: normal;
-  color: var(--green);
-  font-size: 20px;
+  font-size: 24px;
   line-height: 24px;
   font-family: 'Open Sans', 'SansSerif', serif;
   text-transform: capitalize;
 }
 
-.subTitle{
+.subTitle {
   font-style: normal;
   font-weight: normal;
-  color: var(--grey900);
-  font-size: 16px;
+  color: var(--grey600);
+  font-size: 18px;
   line-height: 24px;
   font-family: 'Open Sans', 'SansSerif', serif;
-  margin-left: 12px;
-  margin-top: 8px;
+  margin-block: 8px;
 }
 
-.legendWrapper{
+.legendWrapper {
   display: flex;
-  margin-right: 32px;
+  flex-flow: column nowrap;
   justify-content: start;
-  flex-wrap: wrap;
+  margin-top: 30px;
+  margin-left: 50px;
+  line-height: 24px;
 }
 
 @media (min-width: 500px) {
-  .legendWrapper{
+  .legendWrapper {
     display: flex;
-    margin-right: 32px;
+    flex-flow: row wrap;
     justify-content: center;
-    flex-wrap: wrap;
   }
 }
 
-.legendContainer{
+.legendContainer {
   margin-right: 10px;
   cursor: pointer;
 }
@@ -50,17 +49,19 @@
   font-size: 14px;
   line-height: 24px;
   font-family: 'Open Sans', 'SansSerif', serif;
+  padding-top: 8px;
 }
 
-.titleWrapper{
-  margin: 24px 24px 0 12px;
+.titleWrapper {
+  margin: 60px 24px 10px 12px;
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   flex-wrap: wrap;
+  gap: 8px;
 }
 
-.graphWrapper{
+.graphWrapper {
   display: flex;
   flex-direction: row;
   height: 100%;

--- a/packages/webapp/src/containers/SensorReadings/index.jsx
+++ b/packages/webapp/src/containers/SensorReadings/index.jsx
@@ -53,14 +53,14 @@ function SensorReadings({ history, match }) {
   return (
     <>
       {sensorInfo && !sensorInfo.deleted && (
-        <div style={{ padding: '24px 16px 24px 24px', height: '100%' }}>
+        <div className={styles.container}>
           <PageTitle
             title={sensorInfo?.name || ''}
             onGoBack={() => history.push('/map')}
             style={{ marginBottom: '24px' }}
           />
           <RouterTab
-            classes={{ container: { margin: '30px 8px 26px 0px' } }}
+            classes={{ container: { margin: '30px 8px 26px 8px' } }}
             history={history}
             tabs={[
               {

--- a/packages/webapp/src/containers/SensorReadings/saga.js
+++ b/packages/webapp/src/containers/SensorReadings/saga.js
@@ -161,7 +161,9 @@ export function* getSensorsReadingsSaga({ payload }) {
             if (acc[currentValueUnixTime]) {
               acc[currentValueUnixTime] = {
                 ...acc[currentValueUnixTime],
-                [`${readings.stationName}`]: cv?.main?.temp,
+                [`${i18n.t('SENSOR.TEMPERATURE_READINGS_OF_SENSOR.AMBIENT_TEMPERATURE_FOR')} ${
+                  readings.stationName
+                }`]: cv?.main?.temp,
               };
             }
             return acc;

--- a/packages/webapp/src/containers/SensorReadings/styles.module.scss
+++ b/packages/webapp/src/containers/SensorReadings/styles.module.scss
@@ -1,6 +1,18 @@
-.loaderWrapper{
+.loaderWrapper {
   height: 65vh;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.container {
+  padding-block: 24px;
+  padding-inline: 16px;
+  height: '100%';
+}
+
+@media (min-width: 500px) {
+  .container {
+    padding: 24px;
+  }
 }

--- a/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
@@ -35,6 +35,10 @@ const SensorReadingsLineChart = ({ readingType, noDataFoundMessage, data }) => {
 
   if (readingType === TEMPERATURE) {
     unit = getUnitOptionMap()[ambientTemperature[unitSystem].defaultUnit].value;
+    const weatherStationDataExists = data?.sensorReadingData?.find(
+      (rd) => rd[data.stationName] != '(no data)',
+    );
+    isActive = weatherStationDataExists || isActive;
   }
   if (readingType === SOIL_WATER_POTENTIAL) {
     unit = getUnitOptionMap()[soilWaterPotential[unitSystem].defaultUnit].value;

--- a/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
@@ -32,27 +32,13 @@ const SensorReadingsLineChart = ({ readingType, noDataFoundMessage, data }) => {
   );
   let isActive = readingTypeDataExists ? true : false;
   let unit;
-  let subTitle;
-  let weatherStationName;
-  // Reading type differences --
+
   if (readingType === TEMPERATURE) {
-    const weatherStationDataExists = data?.sensorReadingData?.find(
-      (rd) => rd[data.stationName] != '(no data)',
-    );
-    unit = getUnitOptionMap()[ambientTemperature[unitSystem].defaultUnit].label;
-    isActive = weatherStationDataExists || isActive;
-    subTitle = t(`SENSOR.${readingType.toUpperCase()}_READINGS_OF_SENSOR.SUBTITLE`, {
-      high: data?.latestTemperatureReadings.tempMax,
-      low: data?.latestTemperatureReadings.tempMin,
-      units: unit,
-    });
-    weatherStationName =
-      t(`SENSOR.${readingType.toUpperCase()}_READINGS_OF_SENSOR.WEATHER_STATION`, {
-        weatherStationLocation: data?.stationName,
-      }) || null;
+    unit = getUnitOptionMap()[ambientTemperature[unitSystem].defaultUnit].value;
   }
-  if (readingType === SOIL_WATER_POTENTIAL)
-    unit = getUnitOptionMap()[soilWaterPotential[unitSystem].defaultUnit].label;
+  if (readingType === SOIL_WATER_POTENTIAL) {
+    unit = getUnitOptionMap()[soilWaterPotential[unitSystem].defaultUnit].value;
+  }
   if (readingType === SOIL_WATER_CONTENT) unit = '%';
 
   return (
@@ -74,12 +60,11 @@ const SensorReadingsLineChart = ({ readingType, noDataFoundMessage, data }) => {
           showSpotLight={!sensor_reading_chart}
           resetSpotlight={resetSpotlight}
           title={title}
-          subTitle={subTitle}
-          weatherStationName={weatherStationName}
-          yAxisLabel={t(`SENSOR.${readingType.toUpperCase()}_READINGS_OF_SENSOR.Y_AXIS_LABEL`, {
-            units: unit,
+          subTitle={t(`SENSOR.${readingType.toUpperCase()}_READINGS_OF_SENSOR.Y_AXIS_LABEL`, {
+            units: t(
+              `SENSOR.${readingType.toUpperCase()}_READINGS_OF_SENSOR.${unit.toUpperCase()}`,
+            ),
           })}
-          xAxisLabel={data.xAxisLabel}
           predictedXAxisLabel={data.predictedXAxisLabel}
           sensorReadings={data.sensorReadingData}
           lastUpdatedReadings={data.lastUpdatedReadingsTime}

--- a/packages/webapp/src/containers/SensorReadingsLineChart/styles.module.scss
+++ b/packages/webapp/src/containers/SensorReadingsLineChart/styles.module.scss
@@ -1,4 +1,4 @@
-.titleWrapper{
+.titleWrapper {
   margin: 24px 24px 0 12px;
   display: flex;
   justify-content: space-between;
@@ -9,14 +9,13 @@
 .title {
   font-style: normal;
   font-weight: normal;
-  color: var(--green);
-  font-size: 20px;
+  font-size: 24px;
   line-height: 24px;
   text-transform: capitalize;
   font-family: 'Open Sans', 'SansSerif', serif;
 }
 
-.emptyRect{
+.emptyRect {
   margin-top: 12px;
   width: 100%;
   height: 100px;
@@ -27,6 +26,6 @@
   align-items: center;
 }
 
-.emptyRectMessasge{
+.emptyRectMessasge {
   font-size: 16px;
 }


### PR DESCRIPTION
**Description**

This PR implements the new chart styling, with the x-axis and y-axis labels removed, units implemented as a chart subtitle, legend moved below the chart, and significantly increased width on small screens.

I also removed the forecasted weather data from PureSensorReadingLineChart as there is a ticket (LF-3290) to make it its own component, which I'm assuming will be imported into SensorReadings. @SayakaOno please let me know if I messed something up for how you were thinking of implementing that!

Jira link: https://lite-farm.atlassian.net/browse/LF-3291

P.S. I re-implemented "Ambient weather for" because it was on the UI image from the Jira ticket; whether that should be kept or not probably requires a quick group chat/check.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
