### PR TITLE
LF-3298 Repair sensor reading route authentication

### DIFF
--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -417,7 +417,7 @@ const sensorController = {
     }
     try {
       const infoBody = [];
-      const partnerId = parseInt(req.params.partner_id) || 1;
+      const partnerId = parseInt(req.params.partner_id);
       const farmId = req.params.farm_id || '';
       if (!farmId.length) return res.status(400).send('farm id not found');
       const {

--- a/packages/api/src/middleware/validation/validateWebhook.js
+++ b/packages/api/src/middleware/validation/validateWebhook.js
@@ -1,7 +1,7 @@
 async function validateRequest(req, res, next) {
   const partnerId = parseInt(req.params.partner_id);
   if (partnerId !== 1) {
-    next();
+    return res.status(400).send('Partner not registered with Litefarm');
   } else {
     const farmId = req.params.farm_id;
     const authKey = `${farmId}${process.env.SENSOR_SECRET}`;


### PR DESCRIPTION
**Description**

Previously our validation middleware for the Ensemble sensor webhook had a loophole such that it could be circumvented by supplying (in the route) anything that would `parseInt` to a falsy value for the `partner_id`. The middleware would call `next()` and the controller would default the falsy value to 1, allowing readings to be posted without the validation check. This PR removes that loophole.

Thanks for spotting @Duncan-Brain!

Jira link: https://lite-farm.atlassian.net/browse/LF-3298

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I tested by registering a fresh Ensemble sensor webhook and verifying that it still works. I did not test the hacking via route because it would have to be Ensemble (or someone spoofing Ensemble) that does that 🙂 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
