### PR TITLE
Fix REVERSE_GEOCODING_API_URL

### DIFF
--- a/packages/webapp/src/containers/SensorReadings/constants.js
+++ b/packages/webapp/src/containers/SensorReadings/constants.js
@@ -13,7 +13,7 @@ export const CURRENT_DATE_TIME = 'current_date_time';
 export const DAILY_FORECAST_API_URL = 'https://api.openweathermap.org/data/2.5/forecast/daily';
 
 // https://openweathermap.org/api/geocoding-api#reverse - the most relevant values (array) based on coordinates are returned
-export const REVERSE_GEOCODING_API_URL = 'http://api.openweathermap.org/geo/1.0/reverse';
+export const REVERSE_GEOCODING_API_URL = 'https://api.openweathermap.org/geo/1.0/reverse';
 
 export const OPEN_WEATHER_API_URL_FOR_SENSORS = [
   'https://history.openweathermap.org/data/2.5/history/city',


### PR DESCRIPTION
**Description**

Update geocoding API URL to `https`.

Error:

<img width="578" alt="Screenshot 2023-05-24 at 3 11 49 PM" src="https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/9bc6949a-268e-4c56-a946-bb5c658340ba">


Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
