### PR TITLE
LF-3115(2): Unable to mark a field work task completed without toggling "Did you have to make any changes to this task?"

### DIFF
--- a/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
+++ b/packages/webapp/src/components/Task/FieldWorkTask/index.jsx
@@ -70,7 +70,9 @@ const PureFieldWorkTask = ({ register, control, setValue, watch, disabled = fals
   useEffect(() => {
     if (typeValue?.length && fieldWorkTypeOptions?.length) {
       // in read-only and before_complete views, default typeValue is an array which needs to be formatted.
-      setValue(FIELD_WORK_TYPE, formatDefaultTypeValue(typeValue, fieldWorkTypeOptions));
+      setValue(FIELD_WORK_TYPE, formatDefaultTypeValue(typeValue, fieldWorkTypeOptions), {
+        shouldValidate: true,
+      });
     }
   }, [typeValue, fieldWorkTypeOptions]);
 


### PR DESCRIPTION
**Description**

This bug was fixed in https://github.com/LiteFarmOrg/LiteFarm/pull/2571 and re-introduced in https://github.com/LiteFarmOrg/LiteFarm/pull/2684. (my PRs 🙈)
`FIELD_WORK_TYPE` does not initially have `value` which is invalid and "Continue" button is disabled. After `FIELD_WORK_TYPE` is formatted and gets `value`, validation is not run automatically, and the button remains disabled. This PR adds `shouldValidate` for `setValue` to run validation for the new `FIELD_WORK_TYPE`.

Jira link: https://lite-farm.atlassian.net/browse/LF-3115

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
