### PR TITLE
LF-3310 An Empty soil water content diagram is shown to the user when he changes the language of his farm to anything else than ENGLISH

### DIFF
--- a/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
+++ b/packages/webapp/src/containers/SensorReadingsLineChart/index.jsx
@@ -18,12 +18,13 @@ const SensorReadingsLineChart = ({ readingType, noDataFoundMessage, data }) => {
   };
   const title = t(`SENSOR.${readingType.toUpperCase()}_READINGS_OF_SENSOR.TITLE`);
   const readingTypeDataExists = data?.sensorReadingData?.find(
-    (rd) => rd[data.selectedSensorName] && rd[data.selectedSensorName] != '(no data)',
+    (rd) =>
+      rd[data.selectedSensorName] && rd[data.selectedSensorName] != t('translation:SENSOR.NO_DATA'),
   );
   let isActive = readingTypeDataExists ? true : false;
   if (readingType === TEMPERATURE) {
     const weatherStationDataExists = data?.sensorReadingData?.find(
-      (rd) => rd[data.stationName] != '(no data)',
+      (rd) => rd[data.stationName] != t('translation:SENSOR.NO_DATA'),
     );
     isActive = weatherStationDataExists || isActive;
   }


### PR DESCRIPTION
**Description**

The check for the existence of "no data" in the sensors was using the hardcoded (English) string `(no data)` instead of the string translated into each language.

This PR updates the check to be against the translated string instead.

Jira link: https://lite-farm.atlassian.net/browse/LF-3310

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
