### PR TITLE
LF-3185 Update deployment script to only pull integration rather than the whole repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v0.1.7
         with:
@@ -21,9 +24,4 @@ jobs:
           passphrase: ${{ secrets.BETA_SSH_PASS }}
           key: ${{ secrets.BETA_SSH_KEY }}
           command_timeout: 20m
-          script: |
-            set -eu
-            cd ~/LiteFarm
-            git checkout integration
-            git pull origin integration
-            docker-compose -f docker-compose.beta.yml up --build -d
+          script: ${{ github.workspace }}/beta-deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,9 @@ jobs:
           passphrase: ${{ secrets.BETA_SSH_PASS }}
           key: ${{ secrets.BETA_SSH_KEY }}
           command_timeout: 20m
-          script: ${{ secrets.DEPLOYMENT_SCRIPT }}
+          script: |
+            set -eu
+            cd ~/LiteFarm
+            git checkout integration
+            git pull origin integration
+            docker-compose -f docker-compose.beta.yml up --build -d

--- a/beta-deploy.sh
+++ b/beta-deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+cd ~/LiteFarm
+git checkout integration
+git pull origin integration
+docker-compose -f docker-compose.beta.yml up --build -d


### PR DESCRIPTION
**Description**

The code change here is very slight (`git pull origin integration` in place of `git pull`) but this PR also relocates the beta deployment script from `deploy.sh` on the droplet (outside of our repository code) into our repository.

The `set -eu` addition is part of [LF-3067](https://lite-farm.atlassian.net/browse/LF-3067); please see that ticket for details.

Jira link: https://lite-farm.atlassian.net/browse/LF-3185

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

This is another ticket that can only be tested by observing the beta deployment GitHub Actions workflow.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3067]: https://lite-farm.atlassian.net/browse/LF-3067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ