### PR TITLE
LF-2954 Limit the number of API requests in a certain timespan

### DIFF
--- a/packages/webapp/nginx.conf
+++ b/packages/webapp/nginx.conf
@@ -35,10 +35,14 @@ http {
 
     # include /etc/nginx/conf.d/*.conf;
 
+    limit_req_zone $binary_remote_addr zone=one:10m rate=10r/s;
+
     server {
         server_name beta.litefarm.org;
 
         location / {
+            limit_req zone=one burst=5 nodelay;
+
             root /var/www/litefarm;
             try_files $uri /index.html;
         }

--- a/packages/webapp/nginx.conf
+++ b/packages/webapp/nginx.conf
@@ -41,8 +41,6 @@ http {
         server_name beta.litefarm.org;
 
         location / {
-            limit_req zone=one burst=5 nodelay;
-
             root /var/www/litefarm;
             try_files $uri /index.html;
         }
@@ -58,6 +56,8 @@ http {
         underscores_in_headers on;
 
         location / {
+          limit_req zone=one burst=5 nodelay;
+
           proxy_set_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
           proxy_pass_request_headers      on;
           proxy_set_header 'Access-Control-Allow-Origin' '*';


### PR DESCRIPTION
**Description**

Set a rate limiter (10 requests per second) on Nginx.

```
limit_req_zone <key> zone=<name>:<size> rate=<rate>
```
https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone

Jira link: https://lite-farm.atlassian.net/browse/LF-2954

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)
        I used [Iván's sample project](https://github.com/iperdomo/nginx-rate-limit-example) to test the rate limiting set up. (I have not been able to setup the repo with Docker yet) I ran:
```
watch --interval 0.2 curl http://api.localhost
```
in multiple tabs. (I have not found the best way)

@kathyavini 
It would be appreciated if you could try running this command to see if requests are limited:
```
seq 1 30 | xargs -n1 -I -P5  curl "http://localhost:5001/login/user/test@test.com"
```

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
