### PR TITLE
LF-1963: Add management plan ids farm id check on all task creation and patch routes

### DIFF
--- a/packages/api/src/middleware/acl/hasFarmAccess.js
+++ b/packages/api/src/middleware/acl/hasFarmAccess.js
@@ -370,7 +370,9 @@ async function fromTaskManagementPlanAndLocation(req) {
         .first();
       if (managementPlan.farm_id !== farm_id) return {};
 
-      locationIds.add(managementPlan.location_id);
+      if (managementPlan.location_id) {
+        locationIds.add(managementPlan.location_id);
+      }
     }
   }
   const farmIds = await knex('location')

--- a/packages/api/src/middleware/acl/hasFarmAccess.js
+++ b/packages/api/src/middleware/acl/hasFarmAccess.js
@@ -29,6 +29,7 @@ const entitiesGetters = {
   task_id: fromTaskId,
   taskManagementPlanAndLocation: fromTaskManagementPlanAndLocation,
   nomination_id: fromNomination,
+  transplant_task: fromTransPlantTask,
 };
 import userFarmModel from '../../models/userFarmModel.js';
 
@@ -372,6 +373,48 @@ async function fromTaskManagementPlanAndLocation(req) {
       locationIds.add(managementPlan.location_id);
     }
   }
+  const farmIds = await knex('location')
+    .whereIn('location_id', [...locationIds])
+    .pluck('farm_id');
+
+  if (
+    farmIds.length !== locationIds.size || // check if all locationIds exist in the DB
+    new Set(farmIds).size !== 1 ||
+    farmIds[0] !== farm_id
+  ) {
+    return {};
+  }
+
+  return { farm_id };
+}
+
+async function fromTransPlantTask(req) {
+  const farm_id = req.headers.farm_id;
+  const { planting_management_plan, prev_planting_management_plan_id } = req.body.transplant_task;
+
+  const { location_id, management_plan_id } = planting_management_plan;
+  const locationIds = new Set([location_id]);
+
+  const prevManagementPlan = await knex('management_plan')
+    .join(
+      'planting_management_plan',
+      'planting_management_plan.management_plan_id',
+      'management_plan.management_plan_id',
+    )
+    .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
+    .where('planting_management_plan.planting_management_plan_id', prev_planting_management_plan_id)
+    .first();
+  locationIds.add(prevManagementPlan.location_id);
+
+  const managementPlan = await knex('management_plan')
+    .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
+    .where('management_plan.management_plan_id', management_plan_id)
+    .first();
+
+  for (const plan of [managementPlan, prevManagementPlan]) {
+    if (plan.farm_id !== farm_id) return {};
+  }
+
   const farmIds = await knex('location')
     .whereIn('location_id', [...locationIds])
     .pluck('farm_id');

--- a/packages/api/src/routes/taskRoute.js
+++ b/packages/api/src/routes/taskRoute.js
@@ -147,7 +147,7 @@ router.post(
 router.post(
   '/transplant_task',
   modelMapping['transplant_task'],
-  hasFarmAccess({ mix: 'transplant_task' }),
+  hasFarmAccess({ mixed: 'transplant_task' }),
   isWorkerToSelfOrAdmin(),
   taskController.createTransplantTask,
 );

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -1178,6 +1178,34 @@ describe('Task tests', () => {
             });
           });
         });
+
+        test(`should fail to create a transplant task when plan's location is for a different farm`, async (done) => {
+          const [userFarm2] = await generateUserFarms(1);
+          const [{ location_id: locationIdInFarm2 }] = await mocks.fieldFactory({
+            promisedFarm: [{ farm_id: userFarm2.farm_id }],
+          });
+
+          const { transplant_task, userFarm } = await getBody('row_method');
+          transplant_task.transplant_task.planting_management_plan.location_id = locationIdInFarm2;
+          postTransplantTaskRequest(userFarm, transplant_task, async (err, res) => {
+            expect(res.status).toBe(403);
+            done();
+          });
+        });
+
+        test(`should fail to create a transplant task when previous plan is for different farm's location`, async (done) => {
+          const [userFarm2] = await generateUserFarms(1);
+          const { transplant_task, userFarm } = await getBody('row_method');
+          const [
+            { planting_management_plan_id: prev_planting_management_plan_id },
+          ] = await mocks.planting_management_planFactory({ promisedFarm: [userFarm2] });
+          transplant_task.transplant_task.prev_planting_management_plan_id = prev_planting_management_plan_id;
+
+          postTransplantTaskRequest(userFarm, transplant_task, async (err, res) => {
+            expect(res.status).toBe(403);
+            done();
+          });
+        });
       });
 
       // Object.keys(fakeTaskData).map((type) => {


### PR DESCRIPTION
**Description**

Most of the tasks of the ticket is covered in https://github.com/LiteFarmOrg/LiteFarm/pull/2716.
- Add management plan ids and location_id check on transplant task creation endpoint.
- Fix `fromTaskManagementPlanAndLocation` function to handle empty `location_id`. (I just noticed that `location_id` of planting management plan could be null.

Note: There is no routes to update location_id or management plan id of tasks.

Jira link: https://lite-farm.atlassian.net/browse/LF-1963

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
