### PR TITLE
LF-3344: Added check for deleted tasks in validation of endpoint

### DIFF
--- a/packages/api/src/middleware/validation/completeManagementPlanTaskCheck.js
+++ b/packages/api/src/middleware/validation/completeManagementPlanTaskCheck.js
@@ -25,10 +25,12 @@ const validateManagementPlanTasks = async (req, res, next) => {
       'management_tasks.planting_management_plan_id',
     )
     .where('planting_management_plan.management_plan_id', req.params.management_plan_id)
+    .where('deleted', false)
     .whereNull('complete_date')
     .whereNull('abandon_date');
-  if (tasks.length)
+  if (tasks.length) {
     return res.status(400).send(`Can't complete or abandon management plans with pending tasks`);
+  }
   return next();
 };
 

--- a/packages/api/tests/managementPlan.test.js
+++ b/packages/api/tests/managementPlan.test.js
@@ -692,6 +692,37 @@ describe('ManagementPlan Tests', () => {
           done();
         });
       });
+
+      test('Complete management plan with deleted and completed tasks', async (done)  => {
+        const reqBody = getCompleteReqBody();
+        const deletedTask = await mocks.management_tasksFactory({
+          promisedManagementPlan: [transplantManagementPlan],
+          promisedTask: mocks.taskFactory(
+            { promisedUser: [owner] },
+            { ...mocks.fakeTask({ deleted: true, complete_date: null, abandon_date: null }) },
+          ),
+        });
+        const completedTask = await mocks.management_tasksFactory({
+          promisedManagementPlan: [transplantManagementPlan],
+          promisedTask: mocks.taskFactory(
+            { promisedUser: [owner] },
+            { ...mocks.fakeTask({ complete_date: faker.date.past() }) },
+          ),
+        });
+
+        completeManagementPlanRequest(reqBody, {}, async (err, res) => {
+          console.log(res);
+          expect(res.status).toBe(200);
+          const newManagementPlan = await managementPlanModel
+            .query()
+            .context({ showHidden: true })
+            .where('management_plan_id', transplantManagementPlan.management_plan_id)
+            .first();
+          expect(newManagementPlan.complete_notes).toBe(reqBody.complete_notes);
+          done();
+        });
+      });
+
       const getDateInputFormat = (date) => moment(date).format('YYYY-MM-DD');
 
       test('Abandon management plan with one pending task that reference this management plan and another management_plan', async (done) => {

--- a/packages/api/tests/managementPlan.test.js
+++ b/packages/api/tests/managementPlan.test.js
@@ -711,7 +711,6 @@ describe('ManagementPlan Tests', () => {
         });
 
         completeManagementPlanRequest(reqBody, {}, async (err, res) => {
-          console.log(res);
           expect(res.status).toBe(200);
           const newManagementPlan = await managementPlanModel
             .query()


### PR DESCRIPTION
**Description**

Issue: User could not complete crop plan when one or more tasks was deleted, and other tasks were abandoned or completed. 

Fix: The issue was because of the validation check for the complete management plan endpoint did not check whether a task is marked deleted or not, so deleted tasks were counted as pending tasks. This check is now added.

Jira link:

https://lite-farm.atlassian.net/browse/LF-3344

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
