### PR TITLE
LF-3381 Remove Cypress related environment variable

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -4,7 +4,7 @@
   "description": "LiteFarm Web application",
   "type": "module",
   "scripts": {
-    "dev": "CYPRESS_COVERAGE=TRUE vite --host",
+    "dev": "vite --host",
     "build": "tsc && NODE_OPTIONS=--max_old_space_size=3000 vite build",
     "preview": "vite preview",
     "lint": "eslint src",


### PR DESCRIPTION
> Optional boolean to change the environment variable to
>  CYPRESS_COVERAGE instead of VITE_COVERAGE. For ease of use with
> `@cypress/code-coverage``.
https://github.com/ifaxity/vite-plugin-istanbul#parameters

We don't have Cypress in the `webapp` package anymore

**Description**

The `CYPRESS_COVERAGE` could make sense when the `cypress` module was part of `webapp` package

Jira link: https://lite-farm.atlassian.net/browse/LF-3381

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
