### PR TITLE
LF-2841: On task tile, date displayed in EN (both format and language) when in non-EN language

### DIFF
--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -32,6 +32,10 @@ export const taskStatusTranslateKey = {
   abandoned: 'ABANDONED',
 };
 
+const getDate = (date, language = 'en') => {
+  return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(new Date(date));
+};
+
 export const PureTaskCard = ({
   taskType,
   status,
@@ -48,6 +52,7 @@ export const PureTaskCard = ({
   classes = { card: {} },
   isAdmin,
   isAssignee,
+  language,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -61,12 +66,6 @@ export const PureTaskCard = ({
     e.stopPropagation();
     onClickCompleteOrDueDate?.();
   };
-
-  let trueDate = completeOrDueDate;
-  if (status == 'abandoned') {
-    let [day, month, date, year] = new Date(props['abandonDate']).toDateString().split(' ');
-    trueDate = `${month} ${date}, ${year}`;
-  }
 
   return (
     <CardWithStatus
@@ -107,7 +106,9 @@ export const PureTaskCard = ({
             }
           >
             <CalendarIcon />
-            <div data-cy="taskCard-dueDate">{trueDate}</div>
+            <div data-cy="taskCard-dueDate">
+              {getDate(status === 'abandoned' ? props['abandonDate'] : completeOrDueDate, language)}
+            </div>
           </div>
           {assignee ? (
             <div
@@ -154,4 +155,5 @@ PureTaskCard.propTypes = {
   onClickAssignee: PropTypes.func,
   onClickCompleteOrDueDate: PropTypes.func,
   selected: PropTypes.bool,
+  language: PropTypes.oneOf(['en', 'es', 'fr', 'pt']),
 };

--- a/packages/webapp/src/containers/Task/TaskCard/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCard/index.jsx
@@ -14,6 +14,7 @@ import {
   updateUserFarmWage,
   setUserFarmWageDoNotAskAgain,
 } from '../saga';
+import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 
 const TaskCard = ({
   task_id,
@@ -52,6 +53,7 @@ const TaskCard = ({
   let isAssignee = false;
   let isAdmin = false;
   let taskUnassigned = false;
+  const language = getLanguageFromLocalStorage();
 
   if (user) {
     isAdmin = user.is_admin;
@@ -89,6 +91,7 @@ const TaskCard = ({
         classes={classes}
         isAdmin={isAdmin}
         isAssignee={isAssignee}
+        language={language}
       />
       {showTaskAssignModal && (
         <TaskQuickAssignModal

--- a/packages/webapp/src/stories/TaskCard/TaskCard.stories.jsx
+++ b/packages/webapp/src/stories/TaskCard/TaskCard.stories.jsx
@@ -66,6 +66,7 @@ export const Abandoned = Template.bind({});
 Abandoned.args = {
   ...templateData,
   status: 'abandoned',
+  abandonDate: '2023-04-12T00:00:00.000',
 };
 
 export const ClickableCard = Template.bind({});
@@ -109,4 +110,5 @@ AbandonedSelected.args = {
   ...templateData,
   status: 'abandoned',
   selected: true,
+  abandonDate: '2023-04-12T00:00:00.000',
 };


### PR DESCRIPTION
**Description**

- format date in `TaskCard` based on user's preferred language
- send `language` from its parent component
- update TaskCard stories

Jira link: https://lite-farm.atlassian.net/browse/LF-2841

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

The fastest way to test is to change the language in local storage.

![Screenshot 2023-06-28 at 3 09 16 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/c8eaf087-ea25-4d69-8407-96d6d1519d55)


**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
