### PR TITLE
LF-3227: Tasks assigned to inactive users still display their name

### DIFF
--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -68,6 +68,18 @@ export const PureTaskCard = ({
     trueDate = `${month} ${date}, ${year}`;
   }
 
+  let assigneeName = '';
+  let assigneeLabel = '';
+  if (assignee !== null) {
+    assigneeName = `${assignee.first_name} ${
+      assignee.last_name.length > 0 ? assignee.last_name.charAt(0) + '.' : ''
+    }`;
+    assigneeLabel =
+      assignee.status === 'Inactive'
+        ? `${assigneeName} (${assignee.status.toLowerCase()})`
+        : assigneeName;
+  }
+
   return (
     <CardWithStatus
       data-cy="taskCard"
@@ -118,10 +130,18 @@ export const PureTaskCard = ({
               }
               onClick={onAssignTask}
             >
-              <div className={clsx(styles.firstInitial, styles.icon)}>
+              <div
+                className={clsx(
+                  styles.firstInitial,
+                  styles.icon,
+                  assignee.status === 'Inactive' ? styles.inactive : '',
+                )}
+              >
                 {assignee.first_name.toUpperCase().charAt(0)}
               </div>
-              <div>{`${assignee.first_name} ${assignee.last_name.charAt(0)}.`}</div>
+              <div className={clsx(assignee.status === 'Inactive' ? styles.inactive : '')}>
+                {assigneeLabel}
+              </div>
             </div>
           ) : (
             <div

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -70,14 +70,15 @@ export const PureTaskCard = ({
 
   let assigneeName = '';
   let assigneeLabel = '';
+  let isAssigneeInactive = false;
   if (assignee !== null) {
+    isAssigneeInactive = assignee.status === 'Inactive';
     assigneeName = `${assignee.first_name} ${
       assignee.last_name.length > 0 ? assignee.last_name.charAt(0) + '.' : ''
     }`;
-    assigneeLabel =
-      assignee.status === 'Inactive'
-        ? `${assigneeName} (${assignee.status.toLowerCase()})`
-        : assigneeName;
+    assigneeLabel = isAssigneeInactive
+      ? `${assigneeName} (${assignee.status.toLowerCase()})`
+      : assigneeName;
   }
 
   return (
@@ -134,14 +135,12 @@ export const PureTaskCard = ({
                 className={clsx(
                   styles.firstInitial,
                   styles.icon,
-                  assignee.status === 'Inactive' ? styles.inactive : '',
+                  isAssigneeInactive ? styles.inactive : '',
                 )}
               >
                 {assignee.first_name.toUpperCase().charAt(0)}
               </div>
-              <div className={clsx(assignee.status === 'Inactive' ? styles.inactive : '')}>
-                {assigneeLabel}
-              </div>
+              <div className={clsx(isAssigneeInactive ? styles.inactive : '')}>{assigneeLabel}</div>
             </div>
           ) : (
             <div

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/styles.module.scss
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/styles.module.scss
@@ -88,3 +88,12 @@
   color: var(--red700);
   border-bottom: 1px solid var(--red700);
 }
+
+.inactive {
+  color: var(--grey500);
+}
+
+.firstInitial.inactive {
+  background-color: var(--grey500);
+  color: white;
+}


### PR DESCRIPTION
**Description**

Added a couple validations to TaskCard so when a revoked user still assigned to a task, their name will be displayed with a "(inactive)" mark and also greys out the icon and name. This was an issue in terms of not handling the behavior described in the ticket  but it was discussed in the same ticket this should be the behavior although I might be loosing some bits of the conversation.

Jira link:
https://lite-farm.atlassian.net/browse/LF-3227

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

3 scenarios were tested on the Task view:
1. Task assigned to an active user -> name displays as always
1. Task unassigned -> unassigned format displays as always
1. Task assigned to inactive user -> new format in place

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files

Screenshot of the implementation:
![image](https://github.com/LiteFarmOrg/LiteFarm/assets/1503456/4571898d-d65f-4666-ae2d-1c2a601a8d2c)
![image](https://github.com/LiteFarmOrg/LiteFarm/assets/1503456/a3932345-b424-49d3-93f8-9a8b2c90f570)

  