### PR TITLE
LF-3371 (1): Repeat crop plan show repeated plan disambiguation modal

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -327,7 +327,10 @@
     "PERFORM_SEARCH": "Did you perform a commercial availability search?",
     "PHYSIOLOGY_AND_ANATOMY": "Physiology and Anatomy",
     "TREATED": "Have the seeds for this crop been treated?",
-    "UPLOAD_LATER": "You can upload files at a later time as well"
+    "UPLOAD_LATER": "You can upload files at a later time as well",
+    "REPEATED_PLANS_MODAL": {
+      "DELETED_PLANS": "Deleted crop plans that were part of this repetition won’t be shown."
+    }
   },
   "CROP_CATALOGUE": {
     "ADD_CROP": "Add a new crop",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -328,7 +328,7 @@
     "PHYSIOLOGY_AND_ANATOMY": "Physiology and Anatomy",
     "TREATED": "Have the seeds for this crop been treated?",
     "UPLOAD_LATER": "You can upload files at a later time as well",
-    "REPEATED_PLANS_MODAL": {
+    "REPEAT_PLAN_MODAL": {
       "DELETED_PLANS": "Deleted crop plans that were part of this repetition won’t be shown."
     }
   },

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -327,7 +327,10 @@
     "PERFORM_SEARCH": "¿Realizó una búsqueda de disponibilidad comercial?",
     "PHYSIOLOGY_AND_ANATOMY": "Fisiología y anatomía",
     "TREATED": "¿Se han tratado las semillas de este cultivo?",
-    "UPLOAD_LATER": "También puede cargar archivos en otro momento."
+    "UPLOAD_LATER": "También puede cargar archivos en otro momento.",
+    "REPEATED_PLANS_MODAL": {
+      "DELETED_PLANS": "MISSING"
+    }
   },
   "CROP_CATALOGUE": {
     "ADD_CROP": "Agregar un nuevo cultivo",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -328,7 +328,7 @@
     "PHYSIOLOGY_AND_ANATOMY": "Fisiología y anatomía",
     "TREATED": "¿Se han tratado las semillas de este cultivo?",
     "UPLOAD_LATER": "También puede cargar archivos en otro momento.",
-    "REPEATED_PLANS_MODAL": {
+    "REPEAT_PLAN_MODAL": {
       "DELETED_PLANS": "MISSING"
     }
   },

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -327,7 +327,10 @@
     "PERFORM_SEARCH": "Avez-vous effectué une recherche de disponibilité commerciale\u00a0?",
     "PHYSIOLOGY_AND_ANATOMY": "Physiologie et anatomie",
     "TREATED": "Les semences de cette culture ont-elles été traitées\u00a0?",
-    "UPLOAD_LATER": "Vous pourrez également télécharger des fichiers plus tard"
+    "UPLOAD_LATER": "Vous pourrez également télécharger des fichiers plus tard",
+    "REPEATED_PLANS_MODAL": {
+      "DELETED_PLANS": "MISSING"
+    }
   },
   "CROP_CATALOGUE": {
     "ADD_CROP": "Ajoutez une nouvelle culture",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -328,7 +328,7 @@
     "PHYSIOLOGY_AND_ANATOMY": "Physiologie et anatomie",
     "TREATED": "Les semences de cette culture ont-elles été traitées\u00a0?",
     "UPLOAD_LATER": "Vous pourrez également télécharger des fichiers plus tard",
-    "REPEATED_PLANS_MODAL": {
+    "REPEAT_PLAN_MODAL": {
       "DELETED_PLANS": "MISSING"
     }
   },

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -327,7 +327,10 @@
     "PERFORM_SEARCH": "Você fez uma busca de disponibilidade comercial?",
     "PHYSIOLOGY_AND_ANATOMY": "Fisiologia e Anatomia",
     "TREATED": "As sementes desta cultivo foram tratadas?",
-    "UPLOAD_LATER": "Você também pode fazer upload de arquivos posteriormente"
+    "UPLOAD_LATER": "Você também pode fazer upload de arquivos posteriormente",
+    "REPEATED_PLANS_MODAL": {
+      "DELETED_PLANS": "MISSING"
+    }
   },
   "CROP_CATALOGUE": {
     "ADD_CROP": "Adicionar um novo cultivo",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -328,7 +328,7 @@
     "PHYSIOLOGY_AND_ANATOMY": "Fisiologia e Anatomia",
     "TREATED": "As sementes desta cultivo foram tratadas?",
     "UPLOAD_LATER": "Você também pode fazer upload de arquivos posteriormente",
-    "REPEATED_PLANS_MODAL": {
+    "REPEAT_PLAN_MODAL": {
       "DELETED_PLANS": "MISSING"
     }
   },

--- a/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
+++ b/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React, { useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import { Main } from '../../Typography';
+import ModalComponent from '../ModalComponent/v2';
+import { ManagementPlanCard } from '../../CardWithStatus/ManagementPlanCard/ManagementPlanCard';
+import { CardWithStatusContainer } from '../../CardWithStatus/CardWithStatusContainer/CardWithStatusContainer';
+import useWindowInnerHeight from '../../../containers/hooks/useWindowInnerHeight';
+import useElementHeight from '../../hooks/useElementHeight';
+import styles from './styles.module.scss';
+
+const MODAL_MARGIN = 32;
+const MODAL_PADDING = 24;
+const TITLE_HEIGHT = 42;
+
+export default function CropPlansModal({
+  history,
+  variety,
+  managementPlanCardContents,
+  dismissModal,
+}) {
+  const { t } = useTranslation();
+  const infoRef = useRef();
+
+  const windowHeight = useWindowInnerHeight();
+  const { elementHeight: infoHeight } = useElementHeight(infoRef);
+
+  const contentHeight = useMemo(() => {
+    return windowHeight - (MODAL_MARGIN * 2 + MODAL_PADDING * 2 + TITLE_HEIGHT + (infoHeight || 0));
+  }, [windowHeight, infoHeight]);
+
+  const hasAllIterations = useMemo(() => {
+    //TODO:
+    return false;
+  }, [managementPlanCardContents]);
+
+  return (
+    <ModalComponent
+      title={managementPlanCardContents[0].managementPlanName}
+      dismissModal={dismissModal}
+    >
+      <div ref={infoRef}>
+        {!hasAllIterations && (
+          <Main className={styles.infoText}>{t('CROP.REPEATED_PLANS_MODAL.DELETED_PLANS')}</Main>
+        )}
+      </div>
+      <div className={styles.content} style={{ maxHeight: contentHeight }}>
+        <CardWithStatusContainer style={{ gridTemplateColumns: 'repeat(1, 1fr)' }}>
+          {managementPlanCardContents.map((managementPlan, index) => {
+            return (
+              <ManagementPlanCard
+                key={index}
+                {...managementPlan}
+                onClick={() =>
+                  history.push(
+                    `/crop/${variety.crop_variety_id}/management_plan/${managementPlan.management_plan_id}/tasks`,
+                    location.state,
+                  )
+                }
+              />
+            );
+          })}
+        </CardWithStatusContainer>
+      </div>
+    </ModalComponent>
+  );
+}
+
+CropPlansModal.propTypes = {
+  managementPlanCardContents: PropTypes.arrayOf(
+    PropTypes.shape({
+      managementPlanName: PropTypes.string,
+      locationName: PropTypes.string,
+      notes: PropTypes.string,
+      startDate: PropTypes.any,
+      endDate: PropTypes.any,
+      numberOfPendingTask: PropTypes.number,
+      status: PropTypes.oneOf(['active', 'planned', 'completed', 'abandoned']),
+      management_plan_id: PropTypes.number,
+    }),
+  ),
+  history: PropTypes.object,
+  variety: PropTypes.object,
+  dismissModal: PropTypes.func,
+};

--- a/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
+++ b/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
@@ -62,6 +62,7 @@ export default function CropPlansModal({
           {managementPlanCardContents.map((managementPlan, index) => {
             return (
               <ManagementPlanCard
+                // TODO: Adjust once LF-3370 is complete
                 key={index}
                 {...managementPlan}
                 onClick={() =>

--- a/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
+++ b/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
@@ -54,7 +54,7 @@ export default function CropPlansModal({
     >
       <div ref={infoRef}>
         {!hasAllIterations && (
-          <Main className={styles.infoText}>{t('CROP.REPEATED_PLANS_MODAL.DELETED_PLANS')}</Main>
+          <Main className={styles.infoText}>{t('CROP.REPEAT_PLAN_MODAL.DELETED_PLANS')}</Main>
         )}
       </div>
       <div className={styles.content} style={{ maxHeight: contentHeight }}>

--- a/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
+++ b/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
@@ -44,8 +44,7 @@ export default function CropPlansModal({
   }, [windowHeight, infoHeight]);
 
   const hasAllIterations = useMemo(() => {
-    //TODO:
-    return false;
+    return managementPlanCardContents[0].repetition_count === managementPlanCardContents.length;
   }, [managementPlanCardContents]);
 
   return (
@@ -91,9 +90,12 @@ CropPlansModal.propTypes = {
       numberOfPendingTask: PropTypes.number,
       status: PropTypes.oneOf(['active', 'planned', 'completed', 'abandoned']),
       management_plan_id: PropTypes.number,
+      management_plan_group_id: PropTypes.string,
+      repetition_count: PropTypes.number,
+      repetition_number: PropTypes.number,
     }),
-  ),
-  history: PropTypes.object,
-  variety: PropTypes.object,
-  dismissModal: PropTypes.func,
+  ).isRequired,
+  history: PropTypes.object.isRequired,
+  variety: PropTypes.object.isRequired,
+  dismissModal: PropTypes.func.isRequired,
 };

--- a/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
+++ b/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  Copyright 2023 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify

--- a/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
+++ b/packages/webapp/src/components/Modals/CropModals/CropPlansModal.jsx
@@ -34,7 +34,7 @@ export default function CropPlansModal({
   dismissModal,
 }) {
   const { t } = useTranslation();
-  const infoRef = useRef();
+  const infoRef = useRef(null);
 
   const windowHeight = useWindowInnerHeight();
   const { elementHeight: infoHeight } = useElementHeight(infoRef);

--- a/packages/webapp/src/components/Modals/CropModals/styles.module.scss
+++ b/packages/webapp/src/components/Modals/CropModals/styles.module.scss
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+.infoText {
+  margin-top: -12px;
+  margin-bottom: 24px;
+  line-height: 20px;
+}
+.content {
+  overflow-y: scroll;
+}
+

--- a/packages/webapp/src/components/Modals/CropModals/styles.module.scss
+++ b/packages/webapp/src/components/Modals/CropModals/styles.module.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  Copyright 2023 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify

--- a/packages/webapp/src/components/hooks/useElementHeight.jsx
+++ b/packages/webapp/src/components/hooks/useElementHeight.jsx
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useMemo } from 'react';
+
+const useElementHeight = (ref) => {
+  const elementHeight = useMemo(() => {
+    if (!ref?.current) {
+      return;
+    }
+
+    return ref.current.offsetHeight;
+  }, [ref.current]);
+
+  return { elementHeight };
+};
+
+export default useElementHeight;

--- a/packages/webapp/src/components/hooks/useElementHeight.jsx
+++ b/packages/webapp/src/components/hooks/useElementHeight.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
+ *  Copyright 2023 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify

--- a/packages/webapp/src/containers/Crop/CropManagement/useManagementPlanCardContents.js
+++ b/packages/webapp/src/containers/Crop/CropManagement/useManagementPlanCardContents.js
@@ -26,6 +26,17 @@ export const useManagementPlanCardContents = (crop_variety_id) => {
         const planting_management_plan =
           managementPlanEntities[management_plan.management_plan_id].planting_management_plan;
         const tasks = tasksByManagementPlanId[management_plan.management_plan_id] || [];
+        const { management_plan_group, management_plan_group_id, repetition_number } =
+          management_plan;
+        const groupInfo =
+          management_plan_group?.repetition_count > 1
+            ? {
+                management_plan_group_id,
+                repetition_number,
+                repetition_count: management_plan_group.repetition_count,
+              }
+            : {};
+
         return {
           managementPlanName: management_plan.name,
           locationName: getLocationName(planting_management_plan),
@@ -37,6 +48,7 @@ export const useManagementPlanCardContents = (crop_variety_id) => {
           status,
           score: management_plan.rating,
           management_plan_id: management_plan.management_plan_id,
+          ...groupInfo,
         };
       })
       .sort(

--- a/packages/webapp/src/containers/Crop/CropManagement/useManagementPlanCardContents.js
+++ b/packages/webapp/src/containers/Crop/CropManagement/useManagementPlanCardContents.js
@@ -9,9 +9,7 @@ import {
 import { useMemo } from 'react';
 import { lastActiveDatetimeSelector } from '../../userLogSlice';
 import { getTasksMinMaxDate } from '../../Task/getTasksMinMaxDate';
-import {
-  managementPlanWithCurrentLocationEntitiesSelector,
-} from '../../Task/TaskCrops/managementPlansWithLocationSelector';
+import { managementPlanWithCurrentLocationEntitiesSelector } from '../../Task/TaskCrops/managementPlansWithLocationSelector';
 
 export const useManagementPlanCardContents = (crop_variety_id) => {
   const tasksByManagementPlanId = useSelector(taskEntitiesByManagementPlanIdSelector);
@@ -93,6 +91,10 @@ const getNotes = (planting_management_plan) => {
 const getManagementPlanStartEndDate = (management_plan, tasks) => {
   const { startDate, endDate } = getTasksMinMaxDate(tasks);
   const { complete_date, abandon_date } = management_plan;
-  const managementPlanEndDate = complete_date ? complete_date : abandon_date ? abandon_date : endDate;
+  const managementPlanEndDate = complete_date
+    ? complete_date
+    : abandon_date
+    ? abandon_date
+    : endDate;
   return { startDate, endDate: managementPlanEndDate };
 };

--- a/packages/webapp/src/containers/managementPlanSlice.js
+++ b/packages/webapp/src/containers/managementPlanSlice.js
@@ -200,7 +200,6 @@ export const isCompletedManagementPlan = (managementPlan) => {
 export const getCompletedManagementPlans = (managementPlans) =>
   managementPlans.filter((managementPlan) => isCompletedManagementPlan(managementPlan));
 
-
 export const currentManagementPlansSelector = createSelector(
   [managementPlansSelector, lastActiveDatetimeSelector],
   (managementPlans, lastActiveDatetime) => {
@@ -298,15 +297,13 @@ export const currentManagementPlanByCropIdSelector = (crop_id) =>
 export const abandonedManagementPlanByCropIdSelector = (crop_id) =>
   createSelector(
     [managementPlanByCropIdSelector(crop_id), cropCatalogueFilterDateSelector],
-    (managementPlans) =>
-      getAbandonedManagementPlans(managementPlans),
+    (managementPlans) => getAbandonedManagementPlans(managementPlans),
   );
 
 export const completedManagementPlanByCropIdSelector = (crop_id) =>
   createSelector(
     [managementPlanByCropIdSelector(crop_id), cropCatalogueFilterDateSelector],
-    (managementPlans) =>
-      getCompletedManagementPlans(managementPlans),
+    (managementPlans) => getCompletedManagementPlans(managementPlans),
   );
 
 export const plannedManagementPlanByCropIdSelector = (crop_id) =>

--- a/packages/webapp/src/containers/managementPlanSlice.js
+++ b/packages/webapp/src/containers/managementPlanSlice.js
@@ -21,6 +21,9 @@ export const getManagementPlan = (obj) => {
       'rating',
       'complete_notes',
       'abandon_reason',
+      'management_plan_group_id',
+      'repetition_number',
+      'management_plan_group',
     ],
   );
 };

--- a/packages/webapp/src/stories/Modal/CropPlansModal.stories.jsx
+++ b/packages/webapp/src/stories/Modal/CropPlansModal.stories.jsx
@@ -25,19 +25,7 @@ export default {
 
 const Template = (args) => <CropPlansModal {...args} />;
 
-const planBaseContents = {
-  managementPlanName: 'Management Plan',
-  locationName: 'Field 1',
-  notes: 'Row 1',
-  startDate: '01-01-2021',
-  endDate: '01-02-2021',
-  numberOfPendingTask: 0,
-  status: 'active',
-  management_plan_group_id: '97643f51-6105-4462-aa21-a5048117017f',
-};
-
-export const ModalWithTwoCard = Template.bind({});
-ModalWithTwoCard.args = {
+const commonArgs = {
   history: {
     location: { pathname: '/crop/variety_id/management' },
   },
@@ -54,6 +42,20 @@ ModalWithTwoCard.args = {
       'https://litefarm.nyc3.cdn.digitaloceanspaces.com/default_crop/v2/blueberry.webp',
   },
   dismissModal: () => console.log('dismiss'),
+};
+
+const planBaseContents = {
+  managementPlanName: 'Management Plan',
+  locationName: 'Field 1',
+  notes: 'Row 1',
+  numberOfPendingTask: 0,
+  status: 'active',
+  management_plan_group_id: '97643f51-6105-4462-aa21-a5048117017f',
+};
+
+export const ModalWithTwoCard = Template.bind({});
+ModalWithTwoCard.args = {
+  ...commonArgs,
   managementPlanCardContents: [...Array(2)].map((item, index) => {
     return {
       ...planBaseContents,
@@ -71,21 +73,7 @@ ModalWithTwoCard.parameters = {
 
 export const ModalWithManyCards = Template.bind({});
 ModalWithManyCards.args = {
-  history: {
-    location: { pathname: '/crop/variety_id/management' },
-  },
-  match: {
-    params: {
-      variety_id: 'variety_id',
-    },
-  },
-  variety: {
-    crop_translation_key: 'Blueberry',
-    crop_variety_name: 'Nantes',
-    supplier: 'Buckerfields',
-    crop_variety_photo_url:
-      'https://litefarm.nyc3.cdn.digitaloceanspaces.com/default_crop/v2/blueberry.webp',
-  },
+  ...commonArgs,
   managementPlanCardContents: [...Array(20)].map((item, index) => {
     return {
       ...planBaseContents,
@@ -102,21 +90,7 @@ ModalWithManyCards.parameters = {
 
 export const ModalWithDeletedIteration = Template.bind({});
 ModalWithDeletedIteration.args = {
-  history: {
-    location: { pathname: '/crop/variety_id/management' },
-  },
-  match: {
-    params: {
-      variety_id: 'variety_id',
-    },
-  },
-  variety: {
-    crop_translation_key: 'Blueberry',
-    crop_variety_name: 'Nantes',
-    supplier: 'Buckerfields',
-    crop_variety_photo_url:
-      'https://litefarm.nyc3.cdn.digitaloceanspaces.com/default_crop/v2/blueberry.webp',
-  },
+  ...commonArgs,
   managementPlanCardContents: [...Array(4)].map((item, index) => {
     return {
       ...planBaseContents,

--- a/packages/webapp/src/stories/Modal/CropPlansModal.stories.jsx
+++ b/packages/webapp/src/stories/Modal/CropPlansModal.stories.jsx
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import CropPlansModal from '../../components/Modals/CropModals/CropPlansModal';
+import { componentDecorators } from '../Pages/config/Decorators';
+import { chromaticSmallScreen } from '../Pages/config/chromatic';
+
+export default {
+  title: 'Components/Modals/CropPlansModal',
+  decorators: componentDecorators,
+  component: CropPlansModal,
+};
+
+const Template = (args) => <CropPlansModal {...args} />;
+
+const planBaseContents = {
+  managementPlanName: 'Management Plan',
+  locationName: 'Field 1',
+  notes: 'Row 1',
+  startDate: '01-01-2021',
+  endDate: '01-02-2021',
+  numberOfPendingTask: 0,
+  status: 'active',
+  management_plan_group_id: '97643f51-6105-4462-aa21-a5048117017f',
+};
+
+export const ModalWithTwoCard = Template.bind({});
+ModalWithTwoCard.args = {
+  history: {
+    location: { pathname: '/crop/variety_id/management' },
+  },
+  match: {
+    params: {
+      variety_id: 'variety_id',
+    },
+  },
+  variety: {
+    crop_translation_key: 'Blueberry',
+    crop_variety_name: 'Nantes',
+    supplier: 'Buckerfields',
+    crop_variety_photo_url:
+      'https://litefarm.nyc3.cdn.digitaloceanspaces.com/default_crop/v2/blueberry.webp',
+  },
+  dismissModal: () => console.log('dismiss'),
+  managementPlanCardContents: [...Array(2)].map((item, index) => {
+    return {
+      ...planBaseContents,
+      repetition_count: 2,
+      repetition_number: index + 1,
+      startDate: `0${index + 7}-01-2023`,
+      endDate: `0${index + 8}-02-2023`,
+    };
+  }),
+};
+
+ModalWithTwoCard.parameters = {
+  ...chromaticSmallScreen,
+};
+
+export const ModalWithManyCards = Template.bind({});
+ModalWithManyCards.args = {
+  history: {
+    location: { pathname: '/crop/variety_id/management' },
+  },
+  match: {
+    params: {
+      variety_id: 'variety_id',
+    },
+  },
+  variety: {
+    crop_translation_key: 'Blueberry',
+    crop_variety_name: 'Nantes',
+    supplier: 'Buckerfields',
+    crop_variety_photo_url:
+      'https://litefarm.nyc3.cdn.digitaloceanspaces.com/default_crop/v2/blueberry.webp',
+  },
+  managementPlanCardContents: [...Array(20)].map((item, index) => {
+    return {
+      ...planBaseContents,
+      repetition_count: 20,
+      repetition_number: index + 1,
+      startDate: `08-${(index + 1).toString().padStart(2, '0')}-2023`,
+      endDate: `08-${(index + 2).toString().padStart(2, '0')}-2023`,
+    };
+  }),
+};
+ModalWithManyCards.parameters = {
+  ...chromaticSmallScreen,
+};
+
+export const ModalWithDeletedIteration = Template.bind({});
+ModalWithDeletedIteration.args = {
+  history: {
+    location: { pathname: '/crop/variety_id/management' },
+  },
+  match: {
+    params: {
+      variety_id: 'variety_id',
+    },
+  },
+  variety: {
+    crop_translation_key: 'Blueberry',
+    crop_variety_name: 'Nantes',
+    supplier: 'Buckerfields',
+    crop_variety_photo_url:
+      'https://litefarm.nyc3.cdn.digitaloceanspaces.com/default_crop/v2/blueberry.webp',
+  },
+  managementPlanCardContents: [...Array(4)].map((item, index) => {
+    return {
+      ...planBaseContents,
+      repetition_count: 5,
+      repetition_number: index + (index < 2 ? 1 : 2),
+      startDate: `0${index + 7}-01-2023`,
+      endDate: `0${index + 8}-02-2023`,
+    };
+  }),
+};
+ModalWithDeletedIteration.parameters = {
+  ...chromaticSmallScreen,
+};


### PR DESCRIPTION
**Description**

- create `CropPlansModal`
- create `useElementHeight` hook that calculate element height
- create stories
- save repeat group info in Redux store (`useManagementPlanCardContents.js` and `managementPlanSlice.js` are updated)
  ![Screenshot 2023-07-26 at 9 43 24 AM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/077d4ea3-6d67-48cf-a8ec-bee7722833b4)


_The ticket will not be completed until https://lite-farm.atlassian.net/browse/LF-3370 is done. (link texts are not shown, so there is no way to open the modal in the app)_

After running storybook, stories can be found here: http://localhost:6006/?path=/story/components-modals-cropplansmodal--modal-with-two-card

Jira link: https://lite-farm.atlassian.net/browse/LF-3371

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
