### PR TITLE
LF-3267: show the inactive user in the read only task view

### DIFF
--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
@@ -130,7 +130,13 @@ export default function PureTaskReadOnly({
   };
 
   const assignee = users.find((user) => user.user_id === task.assignee_user_id);
-  const assigneeName = assignee && `${assignee.first_name} ${assignee.last_name}`;
+  const isInactiveAssignee = assignee?.status === 'Inactive';
+  let assigneeName = '';
+  if (assignee !== undefined) {
+    const fullName = `${assignee.first_name} ${assignee.last_name}`.trim();
+    assigneeName = isInactiveAssignee ? `${fullName} (${t('STATUS.INACTIVE')})` : fullName;
+  }
+
   const assignedToPseudoUser = assignee && assignee.role_id === 4;
 
   const isCompleted = !!task.complete_date;

--- a/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019, 2020, 2021, 2022 LiteFarm.org
+ *  Copyright 2019, 2020, 2021, 2022, 2023 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
@@ -47,7 +47,7 @@ function TaskReadOnly({ history, match, location }) {
   const system = useSelector(measurementSelector);
   const task = useReadonlyTask(task_id);
   const products = useSelector(productsSelector);
-  const users = useSelector(userFarmsByFarmSelector).filter((user) => user.status !== 'Inactive');
+  const users = useSelector(userFarmsByFarmSelector);
   const user = useSelector(userFarmSelector);
   const isAdmin = useSelector(isAdminSelector);
   const harvestUseTypes = useSelector(harvestUseTypesSelector);


### PR DESCRIPTION
**Description**

Updating the task read only view to be able to see inactive user and not showing the "unassigned" text when still assigned to inactive user. 

Jira link:
https://lite-farm.atlassian.net/browse/LF-3267

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Test described in the test plan attached to the ticket

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files

![image](https://github.com/LiteFarmOrg/LiteFarm/assets/1503456/9ad31bcc-6ffb-4baa-b318-d43814b32a74)

