### PR TITLE
Fix timezone handling in isNotInFuture util function

### DIFF
--- a/packages/webapp/src/components/Form/Input/utils.js
+++ b/packages/webapp/src/components/Form/Input/utils.js
@@ -11,7 +11,7 @@ const parseISOStringToLocalDate = (dateString) => {
   }
   // this string does not have a specified offset, so we should treat it as if it is in local time
   // note: by default, new Date(string) and Date.parse(String) WILL parse in UTC
-  const split = dateString.replace(/[zZ]$/, '').split(/\D/);
+  const split = dateString.split(/\D/);
   return new Date(split[0], split[1] - 1, ...split.slice(2));
 };
 

--- a/packages/webapp/src/components/Form/Input/utils.js
+++ b/packages/webapp/src/components/Form/Input/utils.js
@@ -4,13 +4,14 @@ import i18n from '../../../locales/i18n';
  * @returns {Date}
  */
 const parseISOStringToLocalDate = (dateString) => {
-  if (dateString.endsWith('z') || dateString.endsWith('Z')) {
-    // this string should be parsed in UTC and then converted to local time
+  const offsetPattern = /([+-]\d{2}|Z):?(\d{2})?\s*$/;
+  if (offsetPattern.test(dateString.slice(19))) {
+    // this string can be parsed normally as it has a specified offset, and then formatted into local time
     return new Intl.DateTimeFormat().format(new Date(dateString));
   }
-  // this string does not specify to parse in UTC, so we should parse properly ourselves
+  // this string does not have a specified offset, so we should treat it as if it is in local time
   // note: by default, new Date(string) and Date.parse(String) WILL parse in UTC
-  const split = dateString.replace(/[zZ]$/).split(/\D/);
+  const split = dateString.replace(/[zZ]$/, '').split(/\D/);
   return new Date(split[0], split[1] - 1, ...split.slice(2));
 };
 

--- a/packages/webapp/src/components/Form/Input/utils.js
+++ b/packages/webapp/src/components/Form/Input/utils.js
@@ -1,7 +1,22 @@
 import i18n from '../../../locales/i18n';
 
+/* @param {string} dateString - a date string to parse to local time
+ * @returns {Date}
+ */
+const parseISOStringToLocalDate = (dateString) => {
+  if (dateString.endsWith('z') || dateString.endsWith('Z')) {
+    // this string should be parsed in UTC and then converted to local time
+    return new Intl.DateTimeFormat().format(new Date(dateString));
+  }
+  // this string does not specify to parse in UTC, so we should parse properly ourselves
+  // note: by default, new Date(string) and Date.parse(String) WILL parse in UTC
+  const split = dateString.replace(/[zZ]$/).split(/\D/);
+  return new Date(split[0], split[1] - 1, ...split.slice(2));
+};
+
 export const isNotInFuture = (data) => {
-  return new Date(data) <= new Date()
+  // new Date() is in local time, so we need to ensure that we parse the date in local time
+  return parseISOStringToLocalDate(data) <= new Date()
     ? true
     : i18n.t('MANAGEMENT_PLAN.COMPLETE_PLAN.FUTURE_DATE_INVALID');
 };


### PR DESCRIPTION
**Description**

Jira link: https://lite-farm.atlassian.net/browse/LF-3393

The problem seems to have been with the default behaviour of `new Date(string)` and `Date.parse(string)`, which parses dates as if they were in UTC timezone if there is no timezone in the date string. This causes an issue when compared with `new Date()` which creates a date in your local timezone.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
