### PR TITLE
LF-3398 Adds `management_plan_group`

### DIFF
--- a/packages/api/db/migration/20230714100652_add_management_plan_group.js
+++ b/packages/api/db/migration/20230714100652_add_management_plan_group.js
@@ -33,9 +33,9 @@ export const up = async function (knex) {
 };
 
 export const down = async function (knex) {
-  await knex.schema.dropTable('management_plan_group');
   await knex.schema.alterTable('management_plan', (t) => {
     t.dropColumn('management_plan_group_id');
     t.dropColumn('repetition_number');
   });
+  await knex.schema.dropTable('management_plan_group');
 };

--- a/packages/api/db/migration/20230714100652_add_management_plan_group.js
+++ b/packages/api/db/migration/20230714100652_add_management_plan_group.js
@@ -14,17 +14,28 @@
  */
 
 export const up = async function (knex) {
+  await knex.schema.createTable('management_plan_group', (t) => {
+    t.uuid('management_plan_group_id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    t.string('created_by_user_id').references('user_id').inTable('users');
+    t.string('updated_by_user_id').references('user_id').inTable('users');
+    t.dateTime('created_at').notNullable();
+    t.dateTime('updated_at').notNullable();
+    t.smallint('repetition_count').notNullable();
+    t.boolean('deleted').notNullable().defaultTo(false);
+  });
   await knex.schema.alterTable('management_plan', (t) => {
-    t.integer('group_id').nullable().defaultTo(null);
-    t.smallint('repetition_number').nullable().defaultTo(null);
-    t.smallint('repetition_count').nullable().defaultTo(null);
+    t.uuid('management_plan_group_id')
+      .references('management_plan_group_id')
+      .inTable('management_plan_group')
+      .nullable();
+    t.smallint('repetition_number').nullable();
   });
 };
 
 export const down = async function (knex) {
+  await knex.schema.dropTable('management_plan_group');
   await knex.schema.alterTable('management_plan', (t) => {
-    t.dropColumn('group_id');
+    t.dropColumn('management_plan_group_id');
     t.dropColumn('repetition_number');
-    t.dropColumn('repetition_count');
   });
 };

--- a/packages/api/db/migration/20230714100652_add_management_plan_group.js
+++ b/packages/api/db/migration/20230714100652_add_management_plan_group.js
@@ -21,6 +21,7 @@ export const up = async function (knex) {
     t.dateTime('created_at').notNullable();
     t.dateTime('updated_at').notNullable();
     t.smallint('repetition_count').notNullable();
+    t.jsonb('repetition_config').notNullable();
     t.boolean('deleted').notNullable().defaultTo(false);
   });
   await knex.schema.alterTable('management_plan', (t) => {

--- a/packages/api/db/migration/20230714100652_add_management_plan_group.js
+++ b/packages/api/db/migration/20230714100652_add_management_plan_group.js
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex.schema.alterTable('management_plan', (t) => {
+    t.integer('group_id').nullable().defaultTo(null);
+    t.smallint('repetition_number').nullable().defaultTo(null);
+    t.smallint('repetition_count').nullable().defaultTo(null);
+  });
+};
+
+export const down = async function (knex) {
+  await knex.schema.alterTable('management_plan', (t) => {
+    t.dropColumn('group_id');
+    t.dropColumn('repetition_number');
+    t.dropColumn('repetition_count');
+  });
+};


### PR DESCRIPTION
* We have explored the idea of having a different table holding the information of a management plan group.
* ~~The most straight forward version is to just include 3 columns: `group_id`, `repetition_number`, `repetition_count`. With this 3 columns we are able to know if a plan was removed (e.g. count of current plans with the same `group_id` < `repetition_count`) and we don't introduce extra complexity for the frontend.~~
* After a conversation with the team, we agreed to add `management_plan_group` table

**Description**

* Adds a `management_plan_group` table
* Adds a FK from `management_plan->management_plan_group` 

Jira link: https://lite-farm.atlassian.net/browse/LF-3398

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
