### PR TITLE
LF-3358: avoid crash when no farm_id is given

### DIFF
--- a/packages/api/src/middleware/acl/hasFarmAccess.js
+++ b/packages/api/src/middleware/acl/hasFarmAccess.js
@@ -52,8 +52,13 @@ export default ({ params = null, body = null, mixed = null }) => async (req, res
     return next();
   }
 
-  const { farm_id } = req.headers;
   try {
+    const { farm_id } = req.headers;
+
+    if (farm_id === undefined) {
+      return noFarmIdErrorResponse(res);
+    }
+
     const farmIdObjectFromEntity = await entitiesGetters[id_name](id, next);
     // Is getting a seeded table and accessing community data. Go through.
     if (
@@ -253,6 +258,10 @@ function sameFarm(object, farm) {
 
 function notAuthorizedResponse(res) {
   res.status(403).send('user not authorized to access farm');
+}
+
+function noFarmIdErrorResponse(res) {
+  res.status(400).json({ error: 'no farm_id given' });
 }
 
 async function fromTaskManagementPlanAndLocation(req) {


### PR DESCRIPTION
**Description**

Whenever a controller needs farm_id in the headers, different errors are thrown, i.e. "user not authorize to access farm" in plain text but in some other cases the backend crashes because we tried to operate an undefined object reference. 
This is an attempt to fix the issue hoping it doesn't break the workflow.
Notice that instead of doing 
```
  res.status(403).send('no farm_id given');
```
I'm returning a json object with an error that will look like
```
  res.status(400).json({ error: 'no farm_id given' });
``` 
this has to return 
```
{
	"error": "no farm_id given"
}
```
with a 400 status code.



Jira link:
https://lite-farm.atlassian.net/browse/LF-3358

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **MAYBE?** Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
I'm not sure this is a valid scenario that comes from the frontend but definitely something that we need to validate for every controller, the existence of required headers. I did some manual tests only using a REST client like the scenario described on the ticket and 



- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
