### PR TITLE
LF-3431 Repeat crop plan | Repeat crop plan container

### DIFF
--- a/packages/webapp/src/Routes.jsx
+++ b/packages/webapp/src/Routes.jsx
@@ -242,6 +242,7 @@ const CompleteManagementPlan = React.lazy(() =>
 const AbandonManagementPlan = React.lazy(() =>
   import('./containers/Crop/CompleteManagementPlan/AbandonManagementPlan'),
 );
+const RepeatCropPlan = React.lazy(() => import('./containers/Crop/RepeatCropPlan'));
 
 const TaskAssignment = React.lazy(() => import('./containers/Task/TaskAssignment'));
 const TaskDetails = React.lazy(() => import('./containers/Task/TaskDetails'));
@@ -482,6 +483,11 @@ const Routes = () => {
               path="/crop/:variety_id/management_plan/:management_plan_id/details"
               exact
               component={ManagementDetails}
+            />
+            <Route
+              path="/crop/:variety_id/management_plan/:management_plan_id/repeat"
+              exact
+              component={RepeatCropPlan}
             />
             <Route
               path="/crop/:variety_id/management_plan/:management_plan_id/edit"
@@ -773,6 +779,11 @@ const Routes = () => {
               path="/crop/:variety_id/management_plan/:management_plan_id/edit"
               exact
               component={EditManagementDetails}
+            />
+            <Route
+              path="/crop/:variety_id/management_plan/:management_plan_id/repeat"
+              exact
+              component={RepeatCropPlan}
             />
             <Route
               path="/crop/:variety_id/:management_plan_id/complete_management_plan"

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -38,10 +38,7 @@ export default function PureManagementTasks({
         `/crop/${crop_id}/management_plan/${plan_id}/repeat_confirmation`,
       ]),
     );
-    history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`, {
-      // Rename state variable to avoid conflict with original fromCreation
-      fromCreation: false,
-    });
+    history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`);
   };
 
   const [showCompleteFailModal, setShowCompleteFailModal] = useState(false);

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import styles from './styles.module.scss';
 import IncompleteTaskModal from '../../Modals/IncompleteTaskModal';
 import RouterTab from '../../RouterTab';
+import { managementPlansByCropVarietyIdSelector } from '../../../containers/managementPlanSlice.js';
+import { taskCardContentByManagementPlanSelector } from '../../../containers/Task/taskCardContentSelector';
+
+import { useSelector, useDispatch } from 'react-redux';
+import { setPersistedPaths } from '../../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 
 export default function PureManagementTasks({
   onCompleted,
@@ -25,7 +30,27 @@ export default function PureManagementTasks({
 }) {
   const { t } = useTranslation();
 
+  const dispatch = useDispatch();
+
   const title = plan.name;
+
+  const farmManagementPlansForCropVariety = useSelector(
+    managementPlansByCropVarietyIdSelector(plan.crop_variety_id),
+  );
+
+  const taskCardContents = useSelector(
+    taskCardContentByManagementPlanSelector(plan.management_plan_id),
+  );
+
+  const onRepeatPlan = (crop_id, plan_id) => {
+    dispatch(
+      setPersistedPaths([
+        `/crop/${crop_id}/management_plan/${plan_id}/details`,
+        `/crop/${crop_id}/management_plan/${plan_id}/repeat`,
+      ]),
+    );
+    history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`, { fromCreation: false });
+  };
 
   const [showCompleteFailModal, setShowCompleteFailModal] = useState(false);
 
@@ -76,6 +101,13 @@ export default function PureManagementTasks({
           },
         ]}
       />
+
+      <Button
+        style={{ marginBlock: '20px' }}
+        onClick={() => onRepeatPlan(plan.crop_variety_id, plan.management_plan_id)}
+      >
+        Repeat Crop Plan
+      </Button>
 
       {isAdmin && isActiveOrPlanned && (
         <AddLink style={{ marginTop: '16px', marginBottom: '14px' }} onClick={onAddTask}>

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -8,10 +8,7 @@ import PropTypes from 'prop-types';
 import styles from './styles.module.scss';
 import IncompleteTaskModal from '../../Modals/IncompleteTaskModal';
 import RouterTab from '../../RouterTab';
-import { managementPlansByCropVarietyIdSelector } from '../../../containers/managementPlanSlice.js';
-import { taskCardContentByManagementPlanSelector } from '../../../containers/Task/taskCardContentSelector';
-
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { setPersistedPaths } from '../../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 
 export default function PureManagementTasks({
@@ -34,22 +31,17 @@ export default function PureManagementTasks({
 
   const title = plan.name;
 
-  const farmManagementPlansForCropVariety = useSelector(
-    managementPlansByCropVarietyIdSelector(plan.crop_variety_id),
-  );
-
-  const taskCardContents = useSelector(
-    taskCardContentByManagementPlanSelector(plan.management_plan_id),
-  );
-
   const onRepeatPlan = (crop_id, plan_id) => {
     dispatch(
       setPersistedPaths([
-        `/crop/${crop_id}/management_plan/${plan_id}/details`,
         `/crop/${crop_id}/management_plan/${plan_id}/repeat`,
+        // second page of form here
       ]),
     );
-    history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`, { fromCreation: false });
+    history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`, {
+      // Rename state variable to avoid conflict with original fromCreation
+      fromCreation: false,
+    });
   };
 
   const [showCompleteFailModal, setShowCompleteFailModal] = useState(false);

--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -379,7 +379,6 @@ PureRepeatCropPlan.prototype = {
   cropPlan: PropTypes.object,
   origStartDate: PropTypes.string,
   farmManagementPlansForCrop: PropTypes.array,
-  fromCreation: PropTypes.bool,
   useHookFormPersist: PropTypes.func,
   onGoBack: PropTypes.func,
   onContinue: PropTypes.func,

--- a/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import PureRepeatCropPlan from '../../../components/RepeatCropPlan';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { cropSelector } from '../../cropSlice';
+import { cropVarietiesSelector } from '../../cropVarietySlice';
+import { postManagementPlanSaga } from '../saga';
+import { certifierSurveySelector } from '../../OrganicCertifierSurvey/slice';
+import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
+import { useTranslation } from 'react-i18next';
+import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
+import {
+  managementPlanSelector,
+  managementPlansByCropVarietyIdSelector,
+} from '../../managementPlanSlice.js';
+import { taskCardContentByManagementPlanSelector } from '../../Task/taskCardContentSelector';
+import { getDateInputFormat } from '../../../util/moment';
+
+function RepeatCropPlan({ history, match, location }) {
+  const { t } = useTranslation(['translation']);
+  const dispatch = useDispatch();
+  const crop_id = match.params.crop_id;
+
+  const management_plan_id = match.params.management_plan_id;
+  const plan = useSelector(managementPlanSelector(management_plan_id));
+
+  const existingCropInfo = useSelector(cropSelector(crop_id));
+  const { interested } = useSelector(certifierSurveySelector, shallowEqual);
+  const persistedFormData = useSelector(hookFormPersistSelector);
+  const isNewCrop = crop_id === 'new';
+  const crop = isNewCrop ? persistedFormData : existingCropInfo;
+  const onError = (error) => {
+    console.log(error);
+  };
+  const onContinue = (data) => {
+    // history.push(`/crop/${crop_id}/add_crop_variety/compliance`);
+    console.log('Submitted data:', data);
+  };
+
+  const farmCropVarieties = useSelector(cropVarietiesSelector);
+
+  const farmManagementPlansForCropVariety = useSelector(
+    managementPlansByCropVarietyIdSelector(plan.crop_variety_id),
+  );
+
+  const taskCardContents = useSelector(
+    taskCardContentByManagementPlanSelector(plan.management_plan_id),
+  );
+
+  const onSubmit = (data) => {
+    console.log('Submitting data', data);
+  };
+
+  const firstTaskDate = getDateInputFormat(taskCardContents[0].date);
+
+  return (
+    <HookFormPersistProvider>
+      <PureRepeatCropPlan
+        cropPlan={plan}
+        farmManagementPlansForCrop={farmManagementPlansForCropVariety}
+        origStartDate={firstTaskDate}
+        onGoBack={() => history.back()}
+        onContinue={onSubmit}
+        fromCreation={location?.state?.fromCreation}
+        persistedFormData={persistedFormData}
+      />
+    </HookFormPersistProvider>
+  );
+}
+
+export default RepeatCropPlan;

--- a/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
@@ -17,7 +17,6 @@ import React from 'react';
 import PureRepeatCropPlan from '../../../components/RepeatCropPlan';
 import { useSelector } from 'react-redux';
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
-import { useTranslation } from 'react-i18next';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 import {
   managementPlanSelector,
@@ -26,13 +25,13 @@ import {
 import { taskCardContentByManagementPlanSelector } from '../../Task/taskCardContentSelector';
 import { getDateInputFormat } from '../../../util/moment';
 
-function RepeatCropPlan({ history, match, location }) {
-  const { t } = useTranslation(['translation']);
-
+function RepeatCropPlan({ history, match }) {
   const persistedFormData = useSelector(hookFormPersistSelector);
 
   const management_plan_id = match.params.management_plan_id;
+
   const plan = useSelector(managementPlanSelector(management_plan_id));
+
   const farmManagementPlansForCropVariety = useSelector(
     managementPlansByCropVarietyIdSelector(plan.crop_variety_id),
   );
@@ -59,7 +58,6 @@ function RepeatCropPlan({ history, match, location }) {
         origStartDate={firstTaskDate}
         onGoBack={() => history.back()}
         onContinue={onContinue}
-        fromCreation={location?.state?.fromCreation}
         persistedFormData={persistedFormData}
       />
     </HookFormPersistProvider>

--- a/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
@@ -22,7 +22,7 @@ import {
   managementPlanSelector,
   managementPlansByCropVarietyIdSelector,
 } from '../../managementPlanSlice.js';
-import { taskCardContentByManagementPlanSelector } from '../../Task/taskCardContentSelector';
+import { tasksByManagementPlanIdSelector } from '../../taskSlice';
 import { getDateInputFormat } from '../../../util/moment';
 
 function RepeatCropPlan({ history, match }) {
@@ -36,13 +36,13 @@ function RepeatCropPlan({ history, match }) {
     managementPlansByCropVarietyIdSelector(plan.crop_variety_id),
   );
 
-  const taskCardContents = useSelector(
-    taskCardContentByManagementPlanSelector(plan.management_plan_id),
-  );
-  const sortedTaskCards = taskCardContents.sort((a, b) => {
-    return new Date(a.date) - new Date(b.date);
+  const tasks = useSelector(tasksByManagementPlanIdSelector(plan.management_plan_id));
+
+  const sortedTasks = tasks.sort((a, b) => {
+    return new Date(a.due_date) - new Date(b.due_date);
   });
-  const firstTaskDate = getDateInputFormat(sortedTaskCards[0].date);
+
+  const firstTaskDate = getDateInputFormat(sortedTasks[0].complete_date || sortedTasks[0].due_date);
 
   const onContinue = () => {
     history.push(

--- a/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
@@ -15,11 +15,7 @@
 
 import React from 'react';
 import PureRepeatCropPlan from '../../../components/RepeatCropPlan';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { cropSelector } from '../../cropSlice';
-import { cropVarietiesSelector } from '../../cropVarietySlice';
-import { postManagementPlanSaga } from '../saga';
-import { certifierSurveySelector } from '../../OrganicCertifierSurvey/slice';
+import { useSelector } from 'react-redux';
 import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { useTranslation } from 'react-i18next';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
@@ -32,27 +28,16 @@ import { getDateInputFormat } from '../../../util/moment';
 
 function RepeatCropPlan({ history, match, location }) {
   const { t } = useTranslation(['translation']);
-  const dispatch = useDispatch();
-  const crop_id = match.params.crop_id;
 
-  const management_plan_id = match.params.management_plan_id;
-  const plan = useSelector(managementPlanSelector(management_plan_id));
-
-  const existingCropInfo = useSelector(cropSelector(crop_id));
-  const { interested } = useSelector(certifierSurveySelector, shallowEqual);
   const persistedFormData = useSelector(hookFormPersistSelector);
-  const isNewCrop = crop_id === 'new';
-  const crop = isNewCrop ? persistedFormData : existingCropInfo;
-  const onError = (error) => {
-    console.log(error);
-  };
+
   const onContinue = (data) => {
     // history.push(`/crop/${crop_id}/add_crop_variety/compliance`);
     console.log('Submitted data:', data);
   };
 
-  const farmCropVarieties = useSelector(cropVarietiesSelector);
-
+  const management_plan_id = match.params.management_plan_id;
+  const plan = useSelector(managementPlanSelector(management_plan_id));
   const farmManagementPlansForCropVariety = useSelector(
     managementPlansByCropVarietyIdSelector(plan.crop_variety_id),
   );
@@ -60,12 +45,10 @@ function RepeatCropPlan({ history, match, location }) {
   const taskCardContents = useSelector(
     taskCardContentByManagementPlanSelector(plan.management_plan_id),
   );
-
-  const onSubmit = (data) => {
-    console.log('Submitting data', data);
-  };
-
-  const firstTaskDate = getDateInputFormat(taskCardContents[0].date);
+  const sortedTaskCards = taskCardContents.sort((a, b) => {
+    return new Date(a.date) - new Date(b.date);
+  });
+  const firstTaskDate = getDateInputFormat(sortedTaskCards[0].date);
 
   return (
     <HookFormPersistProvider>
@@ -74,7 +57,7 @@ function RepeatCropPlan({ history, match, location }) {
         farmManagementPlansForCrop={farmManagementPlansForCropVariety}
         origStartDate={firstTaskDate}
         onGoBack={() => history.back()}
-        onContinue={onSubmit}
+        onContinue={onContinue}
         fromCreation={location?.state?.fromCreation}
         persistedFormData={persistedFormData}
       />


### PR DESCRIPTION
**Description**

This PR creates the Repeat Crop Plan container that contains and calls the Repeat Crop Plan Pure Component (LF-3362).

This ticket also sets up the persisted paths between LF-3362 and LF-3378 from the two routes into this flow (end of crop plan creation and crop plan management tasks view).

Note there is a placeholder UI -- a big yellow button -- to trigger the repeat flow from the crop plan management tasks view, as there is a separate ticket to create the new menu.

Jira link: https://lite-farm.atlassian.net/browse/LF-3431

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
