### PR TITLE
LF-3385: Notification is not created once the user creates transplant planting or harvest task

### DIFF
--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -59,11 +59,12 @@ const managementPlanController = {
           if (!req.body.crop_management_plan.already_in_ground) {
             const due_date =
               req.body.crop_management_plan.plant_date || req.body.crop_management_plan.seed_date;
-            const { planting_management_plan_id } =
-              management_plan.crop_management_plan.planting_management_plans.find(
-                (planting_management_plan) =>
-                  planting_management_plan.planting_task_type === 'PLANT_TASK',
-              );
+            const {
+              planting_management_plan_id,
+            } = management_plan.crop_management_plan.planting_management_plans.find(
+              (planting_management_plan) =>
+                planting_management_plan.planting_task_type === 'PLANT_TASK',
+            );
 
             const plantTaskType = await TaskTypeModel.query(trx)
               .where({
@@ -83,16 +84,18 @@ const managementPlanController = {
 
           if (req.body.crop_management_plan.needs_transplant) {
             const due_date = req.body.crop_management_plan.transplant_date;
-            const { planting_management_plan_id } =
-              management_plan.crop_management_plan.planting_management_plans.find(
-                (planting_management_plan) =>
-                  planting_management_plan.planting_task_type === 'TRANSPLANT_TASK',
-              );
-            const { planting_management_plan_id: prev_planting_management_plan_id } =
-              management_plan.crop_management_plan.planting_management_plans.find(
-                (planting_management_plan) =>
-                  planting_management_plan.is_final_planting_management_plan === false,
-              );
+            const {
+              planting_management_plan_id,
+            } = management_plan.crop_management_plan.planting_management_plans.find(
+              (planting_management_plan) =>
+                planting_management_plan.planting_task_type === 'TRANSPLANT_TASK',
+            );
+            const {
+              planting_management_plan_id: prev_planting_management_plan_id,
+            } = management_plan.crop_management_plan.planting_management_plans.find(
+              (planting_management_plan) =>
+                planting_management_plan.is_final_planting_management_plan === false,
+            );
             //TODO: move get task_type_id to frontend LF-1965
             const transplantTaskType = await TaskTypeModel.query(trx)
               .where({

--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -23,6 +23,7 @@ import TransplantTaskModel from '../models/transplantTaskModel.js';
 import PlantTaskModel from '../models/plantTaskModel.js';
 import { raw } from 'objection';
 import lodash from 'lodash';
+import { sendTaskNotification, TaskNotificationTypes } from './taskController.js';
 
 const managementPlanController = {
   addManagementPlan() {
@@ -171,6 +172,25 @@ const managementPlanController = {
                 },
               );
             tasks.push(fieldWorkTask);
+          }
+
+          if (req.body.assignee_user_id) {
+            await Promise.all(
+              tasks.map(async (task) => {
+                const { assignee_user_id, task_type_id } = task;
+                const taskTypeTranslation = await TaskTypeModel.getTaskTranslationKeyById(
+                  task_type_id,
+                );
+                await sendTaskNotification(
+                  [assignee_user_id],
+                  req.auth.user_id,
+                  task.task_id,
+                  TaskNotificationTypes.TASK_ASSIGNED,
+                  taskTypeTranslation.task_translation_key,
+                  req.headers.farm_id,
+                );
+              }),
+            );
           }
 
           return { management_plan, tasks };

--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -175,22 +175,20 @@ const managementPlanController = {
           }
 
           if (req.body.assignee_user_id) {
-            await Promise.all(
-              tasks.map(async (task) => {
-                const { assignee_user_id, task_type_id } = task;
-                const taskTypeTranslation = await TaskTypeModel.getTaskTranslationKeyById(
-                  task_type_id,
-                );
-                await sendTaskNotification(
-                  [assignee_user_id],
-                  req.auth.user_id,
-                  task.task_id,
-                  TaskNotificationTypes.TASK_ASSIGNED,
-                  taskTypeTranslation.task_translation_key,
-                  req.headers.farm_id,
-                );
-              }),
-            );
+            tasks.forEach(async (task) => {
+              const { assignee_user_id, task_type_id } = task;
+              const taskTypeTranslation = await TaskTypeModel.getTaskTranslationKeyById(
+                task_type_id,
+              );
+              await sendTaskNotification(
+                [assignee_user_id],
+                req.auth.user_id,
+                task.task_id,
+                TaskNotificationTypes.TASK_ASSIGNED,
+                taskTypeTranslation.task_translation_key,
+                req.headers.farm_id,
+              );
+            });
           }
 
           return { management_plan, tasks };

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -396,6 +396,7 @@ const taskController = {
       const harvest_tasks = req.body;
       const { farm_id } = req.headers;
       const { user_id } = req.auth;
+      const notificationPromises = [];
 
       const result = await TaskModel.transaction(async (trx) => {
         const result = [];
@@ -430,20 +431,23 @@ const taskController = {
             if (!taskTypeTranslation) {
               taskTypeTranslation = await TaskTypeModel.getTaskTranslationKeyById(task_type_id);
             }
-            await sendTaskNotification(
-              [assignee_user_id],
-              user_id,
-              task_id,
-              TaskNotificationTypes.TASK_ASSIGNED,
-              taskTypeTranslation.task_translation_key,
-              req.headers.farm_id,
+            notificationPromises.push(
+              sendTaskNotification(
+                [assignee_user_id],
+                user_id,
+                task_id,
+                TaskNotificationTypes.TASK_ASSIGNED,
+                taskTypeTranslation.task_translation_key,
+                req.headers.farm_id,
+              ),
             );
           }
-
           result.push(removeNullTypes(task));
         }
         return result;
       });
+
+      await Promise.all(notificationPromises);
       return res.status(201).send(result);
     } catch (error) {
       console.log(error);

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -478,7 +478,20 @@ const taskController = {
             noInsert: nonModifiable,
           });
       });
-      // N.B. Notification not needed; these tasks are never assigned at creation.
+
+      if (result.assignee_user_id) {
+        const { assignee_user_id, task_id, task_type_id } = result;
+        const taskTypeTranslation = await TaskTypeModel.getTaskTranslationKeyById(task_type_id);
+        await sendTaskNotification(
+          [assignee_user_id],
+          user_id,
+          task_id,
+          TaskNotificationTypes.TASK_ASSIGNED,
+          taskTypeTranslation.task_translation_key,
+          req.headers.farm_id,
+        );
+      }
+
       return res.status(201).send(result);
     } catch (error) {
       console.log(error);

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -396,7 +396,6 @@ const taskController = {
       const harvest_tasks = req.body;
       const { farm_id } = req.headers;
       const { user_id } = req.auth;
-      const notificationPromises = [];
 
       const result = await TaskModel.transaction(async (trx) => {
         const result = [];
@@ -431,23 +430,20 @@ const taskController = {
             if (!taskTypeTranslation) {
               taskTypeTranslation = await TaskTypeModel.getTaskTranslationKeyById(task_type_id);
             }
-            notificationPromises.push(
-              sendTaskNotification(
-                [assignee_user_id],
-                user_id,
-                task_id,
-                TaskNotificationTypes.TASK_ASSIGNED,
-                taskTypeTranslation.task_translation_key,
-                req.headers.farm_id,
-              ),
+            await sendTaskNotification(
+              [assignee_user_id],
+              user_id,
+              task_id,
+              TaskNotificationTypes.TASK_ASSIGNED,
+              taskTypeTranslation.task_translation_key,
+              req.headers.farm_id,
             );
           }
+
           result.push(removeNullTypes(task));
         }
         return result;
       });
-
-      await Promise.all(notificationPromises);
       return res.status(201).send(result);
     } catch (error) {
       console.log(error);

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -840,7 +840,7 @@ async function patchManagementPlanStartDate(trx, req, typeOfTask, task = req.bod
   }
 }
 
-const TaskNotificationTypes = {
+export const TaskNotificationTypes = {
   TASK_ASSIGNED: 'TASK_ASSIGNED',
   TASK_ABANDONED: 'TASK_ABANDONED',
   TASK_REASSIGNED: 'TASK_REASSIGNED',
@@ -868,7 +868,7 @@ const TaskNotificationUserTypes = {
  * @param {String} farmId
  * @return {Promise<void>}
  */
-async function sendTaskNotification(
+export async function sendTaskNotification(
   receiverIds,
   usernameVariableId,
   taskId,


### PR DESCRIPTION
**Description**

Send a notification to the assignee of transplant/harvest task or management plan on its creation. (notification had not been implemented)

Jira link: https://lite-farm.atlassian.net/browse/LF-3385

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Create a transplant/harvest task or a management plan and assign it. The assignee should see a badge on the notification icon.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
