### PR TITLE
LF-3447 Adds `repetition_count` to `/management_plan/farm/:id`

### DIFF
--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -475,12 +475,13 @@ const managementPlanController = {
 };
 
 const planGraphFetchedQueryString =
-  '[crop_variety, crop_management_plan.[planting_management_plans.[bed_method, container_method, broadcast_method, row_method]]]';
+  '[crop_variety, management_plan_group, crop_management_plan.[planting_management_plans.[bed_method, container_method, broadcast_method, row_method]]]';
 const graphJoinedOptions = {
   aliases: {
     crop_management_plan: 'cmp',
     planting_management_plan: 'pmp',
     planting_management_plans: 'pmps',
+    management_plan_group: 'mpg',
   },
 };
 

--- a/packages/api/src/models/managementPlanGroupModel.js
+++ b/packages/api/src/models/managementPlanGroupModel.js
@@ -60,6 +60,9 @@ class ManagementPlanGroup extends baseModel {
       },
     };
   }
+  static get hidden() {
+    return baseModel.hidden.concat(['repetition_config']);
+  }
 }
 
 export default ManagementPlanGroup;

--- a/packages/api/src/models/managementPlanModel.js
+++ b/packages/api/src/models/managementPlanModel.js
@@ -17,6 +17,7 @@ import baseModel from './baseModel.js';
 import moment from 'moment';
 import cropVarietyModel from './cropVarietyModel.js';
 import cropManagementPlanModel from './cropManagementPlanModel.js';
+import managementPlanGroup from './managementPlanGroupModel.js';
 
 class ManagementPlan extends baseModel {
   static get tableName() {
@@ -79,6 +80,14 @@ class ManagementPlan extends baseModel {
         join: {
           from: 'management_plan.management_plan_id',
           to: 'crop_management_plan.management_plan_id',
+        },
+      },
+      management_plan_group: {
+        relation: baseModel.BelongsToOneRelation,
+        modelClass: managementPlanGroup,
+        join: {
+          from: 'management_plan.management_plan_group_id',
+          to: 'management_plan_group.management_plan_group_id',
         },
       },
     };


### PR DESCRIPTION
- We want to avoid sending the `repetition_config` to the client as it could be a big JSON blob
  - Added the property to the _hidden_ list

**Description**

Adds a new key `management_plan_group` to the response, e.g.

```json
[
  {
    "management_plan_id": 3,
    "crop_variety_id": "45c6d744-2a3b-11ee-ad45-0242ac150006",
    "notes": "",
    "name": "Plan 1",
    "start_date": null,
    "complete_date": null,
    "abandon_date": null,
    "complete_notes": null,
    "rating": null,
    "abandon_reason": null,
    "management_plan_group_id": "fcf6f165-d1dd-48b8-9e48-7af339f25a25",
    "repetition_number": 1,
    "management_plan_group": {
      "management_plan_group_id": "fcf6f165-d1dd-48b8-9e48-7af339f25a25",
      "repetition_count": 1
    },
    "crop_management_plan": {
      "management_plan_id": 3,
      "***rest***": "properties..."
      "planting_management_plans": [
        {
          "planting_management_plan_id": "732d2f57-44b2-47df-a75e-7db6c8405b0b",
             "***rest***": "properties..."   
          }        
      ]
    }
  }
]
```


Jira link: https://lite-farm.atlassian.net/browse/LF-3447

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
