### PR TITLE
LF-3368 Copy crop plan | Add menu 

### DIFF
--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import CropHeader from '../CropHeader';
 import { useTranslation } from 'react-i18next';
 import Button from '../../Form/Button';
-import { AddLink, Label, Underlined } from '../../Typography';
+import { AddLink, Label, Underlined, Main } from '../../Typography';
 import Layout from '../../Layout';
 import PropTypes from 'prop-types';
 import styles from './styles.module.scss';
@@ -10,6 +10,7 @@ import IncompleteTaskModal from '../../Modals/IncompleteTaskModal';
 import RouterTab from '../../RouterTab';
 import { useDispatch } from 'react-redux';
 import { setPersistedPaths } from '../../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
+import { BsThreeDotsVertical } from 'react-icons/bs';
 
 export default function PureManagementTasks({
   onCompleted,
@@ -42,6 +43,7 @@ export default function PureManagementTasks({
   };
 
   const [showCompleteFailModal, setShowCompleteFailModal] = useState(false);
+  const [showCopyRepeatMenu, setShowCopyRepeatMenu] = useState(false);
 
   const onMarkComplete = () => {
     if (hasPendingTasks) {
@@ -72,6 +74,21 @@ export default function PureManagementTasks({
         <Label className={styles.title} style={{ marginTop: '24px' }}>
           {title}
         </Label>
+        <BsThreeDotsVertical
+          className={styles.menuIcon}
+          onClick={() => setShowCopyRepeatMenu((prev) => !prev)}
+        />
+        {showCopyRepeatMenu && (
+          <div className={styles.copyRepeatMenu}>
+            {/* <Main className={styles.menuItem}>Copy crop plan</Main> */}
+            <Main
+              className={styles.menuItem}
+              onClick={() => onRepeatPlan(plan.crop_variety_id, plan.management_plan_id)}
+            >
+              Repeat crop plan
+            </Main>
+          </div>
+        )}
       </div>
 
       <RouterTab
@@ -90,13 +107,6 @@ export default function PureManagementTasks({
           },
         ]}
       />
-
-      <Button
-        style={{ marginBlock: '20px' }}
-        onClick={() => onRepeatPlan(plan.crop_variety_id, plan.management_plan_id)}
-      >
-        Repeat Crop Plan
-      </Button>
 
       {isAdmin && isActiveOrPlanned && (
         <AddLink style={{ marginTop: '16px', marginBottom: '14px' }} onClick={onAddTask}>

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -68,64 +68,72 @@ export default function PureManagementTasks({
         )
       }
     >
-      <CropHeader onBackClick={() => history.go(-1)} variety={variety} />
+      <div onClick={() => setShowCopyRepeatMenu(false)} style={{ height: '100%' }}>
+        <CropHeader onBackClick={() => history.go(-1)} variety={variety} />
 
-      <div className={styles.titlewrapper}>
-        <Label className={styles.title} style={{ marginTop: '24px' }}>
-          {title}
-        </Label>
-        <BsThreeDotsVertical
-          className={styles.menuIcon}
-          onClick={() => setShowCopyRepeatMenu((prev) => !prev)}
+        <div className={styles.titlewrapper}>
+          <Label className={styles.title} style={{ marginTop: '24px' }}>
+            {title}
+          </Label>
+          <BsThreeDotsVertical
+            className={styles.menuIcon}
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowCopyRepeatMenu((prev) => !prev);
+            }}
+          />
+          {showCopyRepeatMenu && (
+            <div className={styles.copyRepeatMenu}>
+              {/* <Main className={styles.menuItem}>Copy crop plan</Main> */}
+              <Main
+                className={styles.menuItem}
+                onClick={() => onRepeatPlan(plan.crop_variety_id, plan.management_plan_id)}
+              >
+                Repeat crop plan
+              </Main>
+            </div>
+          )}
+        </div>
+
+        <RouterTab
+          classes={{ container: { margin: '24px 0 26px 0' } }}
+          history={history}
+          tabs={[
+            {
+              label: t('MANAGEMENT_DETAIL.TASKS'),
+              path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/tasks`,
+              state: location?.state,
+            },
+            {
+              label: t('MANAGEMENT_DETAIL.DETAILS'),
+              path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/details`,
+              state: location?.state,
+            },
+          ]}
         />
-        {showCopyRepeatMenu && (
-          <div className={styles.copyRepeatMenu}>
-            {/* <Main className={styles.menuItem}>Copy crop plan</Main> */}
-            <Main
-              className={styles.menuItem}
-              onClick={() => onRepeatPlan(plan.crop_variety_id, plan.management_plan_id)}
-            >
-              Repeat crop plan
-            </Main>
+
+        {isAdmin && isActiveOrPlanned && (
+          <AddLink style={{ marginTop: '16px', marginBottom: '14px' }} onClick={onAddTask}>
+            {t('MANAGEMENT_DETAIL.ADD_A_TASK')}
+          </AddLink>
+        )}
+        {children}
+
+        {isAdmin && isActiveOrPlanned && (
+          <div
+            className={styles.abandonwrapper}
+            style={{ marginTop: '24px', marginBottom: '26px' }}
+          >
+            <Label>{t('MANAGEMENT_DETAIL.FAILED_CROP')}</Label>
+            <Underlined style={{ marginLeft: '6px' }} onClick={onAbandon}>
+              {t('MANAGEMENT_DETAIL.ABANDON_PLAN')}
+            </Underlined>
           </div>
         )}
+        {showCompleteFailModal && (
+          <IncompleteTaskModal dismissModal={() => setShowCompleteFailModal(false)} />
+        )}
       </div>
-
-      <RouterTab
-        classes={{ container: { margin: '24px 0 26px 0' } }}
-        history={history}
-        tabs={[
-          {
-            label: t('MANAGEMENT_DETAIL.TASKS'),
-            path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/tasks`,
-            state: location?.state,
-          },
-          {
-            label: t('MANAGEMENT_DETAIL.DETAILS'),
-            path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/details`,
-            state: location?.state,
-          },
-        ]}
-      />
-
-      {isAdmin && isActiveOrPlanned && (
-        <AddLink style={{ marginTop: '16px', marginBottom: '14px' }} onClick={onAddTask}>
-          {t('MANAGEMENT_DETAIL.ADD_A_TASK')}
-        </AddLink>
-      )}
-      {children}
-
-      {isAdmin && isActiveOrPlanned && (
-        <div className={styles.abandonwrapper} style={{ marginTop: '24px', marginBottom: '26px' }}>
-          <Label>{t('MANAGEMENT_DETAIL.FAILED_CROP')}</Label>
-          <Underlined style={{ marginLeft: '6px' }} onClick={onAbandon}>
-            {t('MANAGEMENT_DETAIL.ABANDON_PLAN')}
-          </Underlined>
-        </div>
-      )}
-      {showCompleteFailModal && (
-        <IncompleteTaskModal dismissModal={() => setShowCompleteFailModal(false)} />
-      )}
     </Layout>
   );
 }

--- a/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
+++ b/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
@@ -80,7 +80,6 @@
   justify-content: center;
   align-items: flex-start;
   flex-shrink: 0;
-  gap: -4px;
   border-radius: 4px;
   background: var(--white, #fff);
   box-shadow: 0px 4px 12px 0px rgba(102, 115, 138, 0.4);

--- a/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
+++ b/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
@@ -12,6 +12,7 @@
   flex-direction: row;
   align-items: baseline;
   justify-content: space-between;
+  position: relative;
 }
 
 .subtitle {
@@ -38,8 +39,8 @@
   height: 48px;
   left: 0px;
   top: 20px;
-  background: #FAFAFD;
-  border: 1px solid #D4DAE3;
+  background: #fafafd;
+  border: 1px solid #d4dae3;
   box-sizing: border-box;
   border-radius: 4px;
 }
@@ -59,4 +60,52 @@
 
 .rating {
   display: table-row;
+}
+
+.menuIcon {
+  width: 48px;
+  font-size: 20px;
+  color: var(--grey600);
+  cursor: pointer;
+}
+
+.copyRepeatMenu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  display: flex;
+  width: 260px;
+
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  flex-shrink: 0;
+  gap: -4px;
+  border-radius: 4px;
+  background: var(--white, #fff);
+  box-shadow: 0px 4px 12px 0px rgba(102, 115, 138, 0.4);
+}
+
+.menuItem {
+  border-radius: 4px;
+  padding-inline: 16px;
+  padding-block: 8px;
+  width: 100%;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--grey100);
+  }
+
+  &:active {
+    background-color: var(--grey200);
+  }
+
+  &:first-child {
+    padding-top: 12px;
+  }
+
+  &:last-child {
+    padding-bottom: 12px;
+  }
 }


### PR DESCRIPTION
**Description**

This PR replaces the placeholder UI (big yellow button) Repeat Crop Plan with the final three dots menu we will use for Copy Crop Plan + Repeat Crop plan.

The menu item for Copy Crop Plan has been commented out for this release, so the menu currently has just one item.

Jira link: https://lite-farm.atlassian.net/browse/LF-3368

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
