### PR TITLE
Lf 3370 repeat crop plan update crop plan card to denote a repeated plan

### DIFF
--- a/packages/webapp/src/components/CardWithStatus/ManagementPlanCard/ManagementPlanCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/ManagementPlanCard/ManagementPlanCard.jsx
@@ -33,6 +33,9 @@ export function ManagementPlanCard({
   classes = { card: {} },
   onClick,
   score,
+  repetition_count,
+  repetition_number,
+  repeatPlanInfoOnClick,
 }) {
   const { t } = useTranslation();
 
@@ -47,7 +50,18 @@ export function ManagementPlanCard({
       score={score}
     >
       <div className={styles.info}>
-        <div className={styles.mainTypographySansColor}>{managementPlanName}</div>
+        <div className={styles.mainTypographySansColor}>
+          {managementPlanName}
+
+          {repetition_count && repetition_number && (
+            <span
+              className={clsx(styles.repeatPlan, { [styles.underline]: repeatPlanInfoOnClick })}
+              onClick={repeatPlanInfoOnClick}
+            >
+              ({repetition_number}/{repetition_count})
+            </span>
+          )}
+        </div>
         <div className={styles.subMain}>
           {locationName} {notes ? ` | ${notes}` : ''}
         </div>
@@ -91,4 +105,8 @@ ManagementPlanCard.propTypes = {
   endDate: PropTypes.any,
   numberOfPendingTask: PropTypes.number,
   management_plan_id: PropTypes.number,
+  management_plan_group_id: PropTypes.string,
+  repetition_count: PropTypes.number,
+  repetition_number: PropTypes.number,
+  repeatPlanInfoOnClick: PropTypes.func,
 };

--- a/packages/webapp/src/components/CardWithStatus/ManagementPlanCard/styles.module.scss
+++ b/packages/webapp/src/components/CardWithStatus/ManagementPlanCard/styles.module.scss
@@ -32,6 +32,15 @@
   color: var(--fontColor);
 }
 
+.repeatPlan{
+  margin-left: 8px;
+  color: var(--teal700);
+}
+
+.underline{
+  text-decoration: underline;
+}
+
 @media (max-width: 359px) {
   .dateUserContainer {
     flex-direction: column;

--- a/packages/webapp/src/components/Crop/Management.jsx
+++ b/packages/webapp/src/components/Crop/Management.jsx
@@ -95,18 +95,30 @@ export default function PureCropManagement({
       )}
       {managementPlanCardContents && (
         <CardWithStatusContainer style={{ paddingTop: '16px' }}>
-          {filteredManagementPlanCardContents.map((managementPlan, index) => (
-            <ManagementPlanCard
-              onClick={() =>
-                history.push(
-                  `/crop/${variety.crop_variety_id}/management_plan/${managementPlan.management_plan_id}/tasks`,
-                  location.state,
-                )
-              }
-              {...managementPlan}
-              key={index}
-            />
-          ))}
+          {filteredManagementPlanCardContents.map((managementPlan, index) => {
+            // Handle repeat plan info click event
+            const repeatPlanInfoOnClick =
+              managementPlan.repetition_count && managementPlan.repetition_number
+                ? (e) => {
+                    // TODO: Open model once LF-3370 is complete
+                    e.stopPropagation(); // to stop click propagating to parent
+                  }
+                : undefined;
+
+            return (
+              <ManagementPlanCard
+                onClick={() =>
+                  history.push(
+                    `/crop/${variety.crop_variety_id}/management_plan/${managementPlan.management_plan_id}/tasks`,
+                    location.state,
+                  )
+                }
+                {...managementPlan}
+                key={index}
+                repeatPlanInfoOnClick={repeatPlanInfoOnClick}
+              />
+            );
+          })}
         </CardWithStatusContainer>
       )}
     </Layout>
@@ -124,6 +136,9 @@ PureCropManagement.propTypes = {
       numberOfPendingTask: PropTypes.number,
       status: PropTypes.oneOf(['active', 'planned', 'completed', 'abandoned']),
       management_plan_id: PropTypes.number,
+      management_plan_group_id: PropTypes.string,
+      repetition_count: PropTypes.number,
+      repetition_number: PropTypes.number,
     }),
   ),
   history: PropTypes.object,


### PR DESCRIPTION
**Description**

This PR update the `ManagementPlanCard` component to show repeat crop plan info. The text link on click will open model as in https://lite-farm.atlassian.net/browse/LF-3371. This PR has dependency on the ticket LF-3371 to be merged before the text to be shown. 
NOTE: As of now the text links does not perform any action and needs to be updated to open the model from LF-3371 once it is merged.

Jira link: https://lite-farm.atlassian.net/browse/LF-3370

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
