### PR TITLE
LF-3368 Copy Crop menu | Fix role permissions and clickable close area

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1354,6 +1354,7 @@
     "CLEAR_ALL": "Clear all"
   },
   "REPEAT_PLAN": {
+    "MENU": "Repeat crop plan",
     "TITLE": "Repeat a crop plan",
     "REPEAT_PLAN_FLOW": "crop plan repetition",
     "SUBTITLE": "Copy this crop plan and all its tasks according to the following schedule",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1355,6 +1355,7 @@
     "CLEAR_ALL": "Borrar todo"
   },
   "REPEAT_PLAN": {
+    "MENU": "MISSING",
     "TITLE": "MISSING",
     "REPEAT_PLAN_FLOW": "MISSING",
     "SUBTITLE": "MISSING",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1356,6 +1356,7 @@
     "CLEAR_ALL": "Supprimer tout"
   },
   "REPEAT_PLAN": {
+    "MENU": "MISSING",
     "TITLE": "MISSING",
     "REPEAT_PLAN_FLOW": "MISSING",
     "SUBTITLE": "MISSING",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1356,6 +1356,7 @@
     "CLEAR_ALL": "Limpar tudo"
   },
   "REPEAT_PLAN": {
+    "MENU": "MISSING",
     "TITLE": "MISSING",
     "REPEAT_PLAN_FLOW": "MISSING",
     "SUBTITLE": "MISSING",

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -91,7 +91,7 @@ export default function PureManagementTasks({
                 className={styles.menuItem}
                 onClick={() => onRepeatPlan(plan.crop_variety_id, plan.management_plan_id)}
               >
-                Repeat crop plan
+                {t('REPEAT_PLAN.MENU')}
               </Main>
             </div>
           </>

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -11,6 +11,7 @@ import RouterTab from '../../RouterTab';
 import { useDispatch } from 'react-redux';
 import { setPersistedPaths } from '../../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 import { BsThreeDotsVertical } from 'react-icons/bs';
+import { ClickAwayListener } from '@mui/material';
 
 export default function PureManagementTasks({
   onCompleted,
@@ -76,15 +77,13 @@ export default function PureManagementTasks({
         {isAdmin && (
           <BsThreeDotsVertical
             className={styles.menuIcon}
-            onClick={(event) => {
-              event.stopPropagation();
+            onClick={() => {
               setShowCopyRepeatMenu((prev) => !prev);
             }}
           />
         )}
         {isAdmin && showCopyRepeatMenu && (
-          <>
-            <div onClick={() => setShowCopyRepeatMenu(false)} className={styles.menuCloseOverlay} />
+          <ClickAwayListener onClickAway={() => setShowCopyRepeatMenu(false)}>
             <div className={styles.copyRepeatMenu}>
               {/* <Main className={styles.menuItem}>Copy crop plan</Main> */}
               <Main
@@ -94,7 +93,7 @@ export default function PureManagementTasks({
                 {t('REPEAT_PLAN.MENU')}
               </Main>
             </div>
-          </>
+          </ClickAwayListener>
         )}
       </div>
       <RouterTab

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -68,13 +68,12 @@ export default function PureManagementTasks({
         )
       }
     >
-      <div onClick={() => setShowCopyRepeatMenu(false)} style={{ height: '100%' }}>
-        <CropHeader onBackClick={() => history.go(-1)} variety={variety} />
-
-        <div className={styles.titlewrapper}>
-          <Label className={styles.title} style={{ marginTop: '24px' }}>
-            {title}
-          </Label>
+      <CropHeader onBackClick={() => history.go(-1)} variety={variety} />
+      <div className={styles.titlewrapper}>
+        <Label className={styles.title} style={{ marginTop: '24px' }}>
+          {title}
+        </Label>
+        {isAdmin && (
           <BsThreeDotsVertical
             className={styles.menuIcon}
             onClick={(event) => {
@@ -82,7 +81,10 @@ export default function PureManagementTasks({
               setShowCopyRepeatMenu((prev) => !prev);
             }}
           />
-          {showCopyRepeatMenu && (
+        )}
+        {isAdmin && showCopyRepeatMenu && (
+          <>
+            <div onClick={() => setShowCopyRepeatMenu(false)} className={styles.menuCloseOverlay} />
             <div className={styles.copyRepeatMenu}>
               {/* <Main className={styles.menuItem}>Copy crop plan</Main> */}
               <Main
@@ -92,48 +94,42 @@ export default function PureManagementTasks({
                 Repeat crop plan
               </Main>
             </div>
-          )}
-        </div>
-
-        <RouterTab
-          classes={{ container: { margin: '24px 0 26px 0' } }}
-          history={history}
-          tabs={[
-            {
-              label: t('MANAGEMENT_DETAIL.TASKS'),
-              path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/tasks`,
-              state: location?.state,
-            },
-            {
-              label: t('MANAGEMENT_DETAIL.DETAILS'),
-              path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/details`,
-              state: location?.state,
-            },
-          ]}
-        />
-
-        {isAdmin && isActiveOrPlanned && (
-          <AddLink style={{ marginTop: '16px', marginBottom: '14px' }} onClick={onAddTask}>
-            {t('MANAGEMENT_DETAIL.ADD_A_TASK')}
-          </AddLink>
-        )}
-        {children}
-
-        {isAdmin && isActiveOrPlanned && (
-          <div
-            className={styles.abandonwrapper}
-            style={{ marginTop: '24px', marginBottom: '26px' }}
-          >
-            <Label>{t('MANAGEMENT_DETAIL.FAILED_CROP')}</Label>
-            <Underlined style={{ marginLeft: '6px' }} onClick={onAbandon}>
-              {t('MANAGEMENT_DETAIL.ABANDON_PLAN')}
-            </Underlined>
-          </div>
-        )}
-        {showCompleteFailModal && (
-          <IncompleteTaskModal dismissModal={() => setShowCompleteFailModal(false)} />
+          </>
         )}
       </div>
+      <RouterTab
+        classes={{ container: { margin: '24px 0 26px 0' } }}
+        history={history}
+        tabs={[
+          {
+            label: t('MANAGEMENT_DETAIL.TASKS'),
+            path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/tasks`,
+            state: location?.state,
+          },
+          {
+            label: t('MANAGEMENT_DETAIL.DETAILS'),
+            path: `/crop/${match.params.variety_id}/management_plan/${match.params.management_plan_id}/details`,
+            state: location?.state,
+          },
+        ]}
+      />
+      {isAdmin && isActiveOrPlanned && (
+        <AddLink style={{ marginTop: '16px', marginBottom: '14px' }} onClick={onAddTask}>
+          {t('MANAGEMENT_DETAIL.ADD_A_TASK')}
+        </AddLink>
+      )}
+      {children}
+      {isAdmin && isActiveOrPlanned && (
+        <div className={styles.abandonwrapper} style={{ marginTop: '24px', marginBottom: '26px' }}>
+          <Label>{t('MANAGEMENT_DETAIL.FAILED_CROP')}</Label>
+          <Underlined style={{ marginLeft: '6px' }} onClick={onAbandon}>
+            {t('MANAGEMENT_DETAIL.ABANDON_PLAN')}
+          </Underlined>
+        </div>
+      )}
+      {showCompleteFailModal && (
+        <IncompleteTaskModal dismissModal={() => setShowCompleteFailModal(false)} />
+      )}
     </Layout>
   );
 }

--- a/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
+++ b/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
@@ -108,3 +108,11 @@
     padding-bottom: 12px;
   }
 }
+
+.menuCloseOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+}

--- a/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
+++ b/packages/webapp/src/components/Crop/ManagementDetail/styles.module.scss
@@ -108,11 +108,3 @@
     padding-bottom: 12px;
   }
 }
-
-.menuCloseOverlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  width: 100vw;
-}


### PR DESCRIPTION
**Description**

Missed three things here:

- Only admins should be able to see the menu
- (Denis spotted this of course 😉 ) If someone has their viewport set wider than the full application width, they should be able to click on the white side margins to close the window as well (I had only filled the application width with clickable area previously)
- Also menu text should be translated!
 
Jira link: https://lite-farm.atlassian.net/browse/LF-3368

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
