### PR TITLE
LF-3478: The user is not able to complete the repeat crop plan flow

### DIFF
--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -47,6 +47,7 @@ export default function PureRepeatCropPlan({
   onContinue = () => {},
   useHookFormPersist,
   persistedFormData,
+  persistedPaths,
 }) {
   const { t } = useTranslation(['translation', 'common']);
   const {
@@ -75,7 +76,7 @@ export default function PureRepeatCropPlan({
     },
   });
 
-  const { historyCancel } = useHookFormPersist(getValues);
+  const { historyCancel } = useHookFormPersist(getValues, persistedPaths);
 
   const intervalOptions = [
     { value: 'day', label: t('REPEAT_PLAN.INTERVAL.DAY') },

--- a/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
@@ -50,6 +50,11 @@ function RepeatCropPlan({ history, match }) {
     );
   };
 
+  const persistedPaths = [
+    `/crop/${plan.crop_variety_id}/management_plan/${management_plan_id}/repeat`,
+    `/crop/${plan.crop_variety_id}/management_plan/${management_plan_id}/repeat_confirmation`,
+  ];
+
   return (
     <HookFormPersistProvider>
       <PureRepeatCropPlan
@@ -59,6 +64,7 @@ function RepeatCropPlan({ history, match }) {
         onGoBack={() => history.back()}
         onContinue={onContinue}
         persistedFormData={persistedFormData}
+        persistedPaths={persistedPaths}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/Crop/saga.js
+++ b/packages/webapp/src/containers/Crop/saga.js
@@ -32,7 +32,6 @@ import i18n from '../../locales/i18n';
 import history from '../../history';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
 import { getTasksSuccessSaga } from '../Task/saga';
-import { setPersistedPaths } from './../hooks/useHookFormPersist/hookFormPersistSlice';
 import { CROP_PLAN_NAME } from '../../components/RepeatCropPlan/constants';
 
 const DEC = 10;
@@ -71,15 +70,6 @@ export function* postManagementPlanSaga({ payload: managementPlanData }) {
 
     // conditionally render pathname
     const path = repeat_crop_plan ? 'repeat' : 'tasks';
-
-    // set up repeat crop plan form state persistence
-    repeat_crop_plan &&
-      (yield put(
-        setPersistedPaths([
-          `/crop/${managementPlan.crop_variety_id}/management_plan/${management_plan_id}/repeat`,
-          `/crop/${managementPlan.crop_variety_id}/management_plan/${management_plan_id}/repeat_confirmation`,
-        ]),
-      ));
 
     yield call(onReqSuccessSaga, {
       pathname: `/crop/${managementPlan.crop_variety_id}/management_plan/${management_plan_id}/${path}`,


### PR DESCRIPTION
**Description**

What I found:
When clicking the save button, `persistedPaths` were being set in the saga.
![Screenshot 2023-07-28 at 11 18 15 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/a122cc2b-2d56-431b-a347-d270c1a42c88)
But when the component is unmounted (I believe), `persistedPaths` state is set to the initialState which is an empty array.
![Screenshot 2023-07-28 at 11 22 44 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/2e6abc85-accd-4343-90f8-f897391a0329)
And `useLayoutEffect` in `useHookFormPersist` got messed up.

Solution: pass `persistedPathNames` to `useHookFormPersist` in `RepeatCropPlan` component.

Jira link: https://lite-farm.atlassian.net/browse/LF-3478

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
