### PR TITLE
LF-3464(2): Fix getAndSetMonthlyOptions in RepeatCropPlan component

### DIFF
--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -132,7 +132,7 @@ export default function PureRepeatCropPlan({
 
       // If already on this screen, store which pattern is currently selected.
       // When returning from next screen, store the selected option
-      const currentSelection = [monthlyOptions.length ? monthlyOptions : options]?.findIndex(
+      const currentSelection = (monthlyOptions.length ? monthlyOptions : options)?.findIndex(
         (option) =>
           // e.g. {"value":8,"label":"every month on the 8th"}
           JSON.stringify(option) === JSON.stringify(monthRepeatOn),


### PR DESCRIPTION
**Description**

Fix for https://github.com/LiteFarmOrg/LiteFarm/pull/2794#discussion_r1278352682
Thank you @kathyavini !!

Jira link: https://lite-farm.atlassian.net/browse/LF-3464

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
