### PR TITLE
LF-3496: Move away from dynamic import in webapp

### DIFF
--- a/packages/webapp/src/components/RepeatCropPlan/Confirmation.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/Confirmation.jsx
@@ -12,7 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation, Trans } from 'react-i18next';
 import { Info, Main } from '../Typography';
@@ -45,20 +45,15 @@ function PureRepeatCropPlanConfirmation({
   const { t } = useTranslation();
   const { historyCancel } = useHookFormPersist();
 
-  const [
-    {
-      planName,
-      beginning,
-      finishingText,
-      numberOfPlans,
-      numberOfTasks,
-      willRepeatText,
-      occurrences,
-    },
-    setData,
-  ] = useState({});
-
-  const formatAndSetData = async () => {
+  const {
+    planName,
+    beginning,
+    finishingText,
+    numberOfPlans,
+    numberOfTasks,
+    willRepeatText,
+    occurrences,
+  } = useMemo(() => {
     const planName = persistedFormData[CROP_PLAN_NAME];
     const planStartDate = persistedFormData[PLAN_START_DATE];
     const repeatFrequencyNumber = persistedFormData[REPEAT_FREQUENCY];
@@ -83,7 +78,7 @@ function PureRepeatCropPlanConfirmation({
       );
     }
 
-    const { text: willRepeatText, occurrences } = await getTextAndOccurrences(
+    const { text: willRepeatText, occurrences } = getTextAndOccurrences(
       repeatInterval.value,
       origStartDate,
       planStartDate,
@@ -98,7 +93,7 @@ function PureRepeatCropPlanConfirmation({
     const numberOfPlans = occurrences.length;
     const numberOfTasks = tasks.length * numberOfPlans;
 
-    setData({
+    return {
       planName,
       beginning: getDateWithDayOfWeek(planStartDate),
       finishingText,
@@ -106,11 +101,7 @@ function PureRepeatCropPlanConfirmation({
       numberOfTasks,
       willRepeatText,
       occurrences,
-    });
-  };
-
-  useEffect(() => {
-    formatAndSetData();
+    };
   }, [persistedFormData]);
 
   const handleSubmit = (e) => {

--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -126,29 +126,26 @@ export default function PureRepeatCropPlan({
       return;
     }
 
-    const getAndSetMonthlyOptions = async () => {
-      // Utility function uses rrule to generate natural language strings
-      const options = await calculateMonthlyOptions(planStartDate, repeatFrequency);
+    // Utility function uses rrule to generate natural language strings
+    const options = calculateMonthlyOptions(planStartDate, repeatFrequency);
 
-      // If already on this screen, store which pattern is currently selected.
-      // When returning from next screen, store the selected option
-      const currentSelection = (monthlyOptions.length ? monthlyOptions : options)?.findIndex(
-        (option) =>
-          // e.g. {"value":8,"label":"every month on the 8th"}
-          JSON.stringify(option) === JSON.stringify(monthRepeatOn),
-      );
+    // If already on this screen, store which pattern is currently selected.
+    // When returning from next screen, store the selected option
+    const currentSelection = (monthlyOptions.length ? monthlyOptions : options)?.findIndex(
+      (option) =>
+        // e.g. {"value":8,"label":"every month on the 8th"}
+        JSON.stringify(option) === JSON.stringify(monthRepeatOn),
+    );
 
-      setMonthlyOptions(options);
+    setMonthlyOptions(options);
 
-      // Persist original selection if there is one
-      if (options[currentSelection]) {
-        setValue(MONTH_REPEAT_ON, options[currentSelection]);
-      } else {
-        // or select first option by default
-        setValue(MONTH_REPEAT_ON, options[0]);
-      }
-    };
-    getAndSetMonthlyOptions();
+    // Persist original selection if there is one
+    if (options[currentSelection]) {
+      setValue(MONTH_REPEAT_ON, options[currentSelection]);
+    } else {
+      // or select first option by default
+      setValue(MONTH_REPEAT_ON, options[0]);
+    }
   }, [planStartDate, repeatFrequency, repeatInterval]);
 
   // Count occurences to given "finish on" date

--- a/packages/webapp/src/components/RepeatCropPlan/utils.js
+++ b/packages/webapp/src/components/RepeatCropPlan/utils.js
@@ -14,7 +14,7 @@
  */
 
 import { RRule, datetime } from 'rrule';
-import { getRruleLanguage } from '../../util/rruleTranslation';
+import { getRruleLanguage as getTranslations } from '../../util/rruleTranslation';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
 import { parseISOStringToLocalDate } from '../Form/Input/utils';
 
@@ -26,18 +26,6 @@ export const RRULEDAYS = {
   Thursday: 'TH',
   Friday: 'FR',
   Saturday: 'SA',
-};
-
-const translationCache = {};
-
-// Returns rrule language definition if already imported, otherwise loads and saves it to memory
-const getTranslations = async (lang) => {
-  if (translationCache[lang]) {
-    return translationCache[lang];
-  }
-  const translation = await getRruleLanguage(lang);
-  translationCache[lang] = translation;
-  return translation;
 };
 
 export const getWeekday = (planStartDate) => {
@@ -106,10 +94,10 @@ const changeUTCToLocaleDate = (localeDate) => {
   return new Date(year, month, day);
 };
 
-export const calculateMonthlyOptions = async (planStartDate, repeatFrequency) => {
+export const calculateMonthlyOptions = (planStartDate, repeatFrequency) => {
   const currentLang = getLanguageFromLocalStorage();
 
-  const translations = await getTranslations(currentLang);
+  const translations = getTranslations(currentLang);
 
   const dt = parseISOStringToLocalDate(planStartDate);
   const weekday = RRULEDAYS[dt.toLocaleString('en', { weekday: 'long' })];
@@ -293,7 +281,7 @@ const getOccurrencesRuleOptions = (
   return options;
 };
 
-export const getTextAndOccurrences = async (
+export const getTextAndOccurrences = (
   repeatInterval,
   originalStartDate,
   startDate,
@@ -323,7 +311,7 @@ export const getTextAndOccurrences = async (
   );
 
   const currentLang = getLanguageFromLocalStorage();
-  const { getText, language } = await getTranslations(currentLang);
+  const { getText, language } = getTranslations(currentLang);
 
   return {
     text: new RRule(textRuleOptions).toText(getText, language),

--- a/packages/webapp/src/util/rruleTranslation/index.js
+++ b/packages/webapp/src/util/rruleTranslation/index.js
@@ -12,16 +12,15 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
+import fr from './fr';
+import pt from './pt';
+import es from './es';
 
-const languageFiles = {
-  fr: './fr.js',
-  pt: './pt.js',
-  es: './es.js',
-};
+const languageFiles = { fr, pt, es };
 
-export const getRruleLanguage = async (language) => {
+export const getRruleLanguage = (language) => {
   if (!Object.keys(languageFiles).includes(language)) {
     return { getText: (id) => id, language: null };
   }
-  return await import(languageFiles[language]).then((language) => language.default);
+  return languageFiles[language];
 };


### PR DESCRIPTION
**Description**

Dynamic import fails in beta.
https://litefarm.sentry.io/issues/4356319551/?project=5761919&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

From the error in Sentry (_Failed to fetch dynamically imported module: https://beta.litefarm.org/assets/es.js_), it seems that the files need to be located under `assets`, but I could not make it work. I updated the file to import all language files.

(Sorry @kathyavini , I loved the translation cache, but I had to remove it 😢)

Jira link: https://lite-farm.atlassian.net/browse/LF-3496

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
