### PR TITLE
LF-3489 On mobile devices decimal values can be input for crop plan repetitions, creating scary output on confirmation screen

### DIFF
--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -266,6 +266,7 @@ export default function PureRepeatCropPlan({
               })}
               type="number"
               stepper
+              onBlur={(e) => (e.target.value = Math.floor(e.target.value))}
               onKeyDown={integerOnKeyDown}
               min={1}
               max={50}
@@ -363,6 +364,7 @@ export default function PureRepeatCropPlan({
                         setValue(FINISH, 'after');
                         trigger(FINISH_ON_DATE);
                       }}
+                      onBlur={(e) => (e.target.value = Math.floor(e.target.value))}
                     />
                     <p>{t('REPEAT_PLAN.REPETITIONS')}</p>
                   </div>


### PR DESCRIPTION
**Description**

Putting a decimal input into the repeat crop plan `repetitions` Input (which can be done *only on mobile* due to the existing and known bug that `integerOnKeyDown` doesn't function on Chrome Android) causes a crazy number of repetitions to be generated by RRule.

There are probably several ways to fix this, including flooring/sanitizing the value when it's used in the calculation functions, but I have taken the basic approach of flooring the Input value `onBlur` for the two Number with Stepper inputs in this form.

I think the same approach could probably be used for the more general case of decimals on Chrome Android, but that is a separate ticket so should be addressed if/when it comes up in the release queue 🙂 

Jira link: https://lite-farm.atlassian.net/browse/LF-3489

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
