### PR TITLE
LF-3489a On mobile devices decimal values can be input for crop plan repetitions, creating scary output on confirmation screen

### DIFF
--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -263,10 +263,20 @@ export default function PureRepeatCropPlan({
             <Input
               hookFormRegister={register(REPEAT_FREQUENCY, {
                 required: true,
+                validate: (value) => {
+                  // These errors aren't displayed so no translation is necessary
+                  if (value < 1 || value > 50) {
+                    return 'must be between 1 and 50';
+                  }
+                  if (Math.floor(value) != value) {
+                    return 'must be an integer';
+                  }
+                  return true;
+                },
               })}
               type="number"
               stepper
-              onBlur={(e) => (e.target.value = Math.floor(e.target.value))}
+              onChange={(e) => (e.target.value = Math.floor(e.target.value))}
               onKeyDown={integerOnKeyDown}
               min={1}
               max={50}
@@ -356,15 +366,22 @@ export default function PureRepeatCropPlan({
                           if (!value && getValues(FINISH) === 'after') {
                             return t('common:REQUIRED');
                           }
+                          // These errors aren't displayed so no translation is necessary
+                          if (value < 1 || value > 20) {
+                            return 'must be between 1 and 20';
+                          }
+                          if (Math.floor(value) != value) {
+                            return 'must be an integer';
+                          }
                           return true;
                         },
                       })}
                       style={{ width: '72px' }}
-                      onChange={() => {
+                      onChange={(e) => {
+                        e.target.value = Math.floor(e.target.value);
                         setValue(FINISH, 'after');
                         trigger(FINISH_ON_DATE);
                       }}
-                      onBlur={(e) => (e.target.value = Math.floor(e.target.value))}
                     />
                     <p>{t('REPEAT_PLAN.REPETITIONS')}</p>
                   </div>


### PR DESCRIPTION
**Description**

Thank you @SayakaOno for pointing out that the `onBlur` handler (used for setting min/max in all cases and for flooring decimal values on mobile) will never be triggered if the form is submitted directly from the input with the `enter` key or `-->` on Android!

This PR fixes this by:
- moving the decimal removal to `onChange`. I tried for quite a while to replicate the UX of `integerOnKeyDown` but could not; this doesn't remove the decimal until the _next_ key has been entered, but I think that's the best that can be done
- added validation for min/max and for integer values to prevent form submission via `enter` or `-->` before the `onBlur` has had time to register (the integer validation should be redundant with the `onChange` handler but it's there just in case)

Jira link: https://lite-farm.atlassian.net/browse/LF-3489

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
