### PR TITLE
When user gets out of a multi step form by clicking browser back butt…

### DIFF
--- a/packages/webapp/src/containers/hooks/useHookFormPersist/index.jsx
+++ b/packages/webapp/src/containers/hooks/useHookFormPersist/index.jsx
@@ -51,19 +51,25 @@ export default function useHookFormPersist(getValues = () => ({}), persistedPath
             break;
         }
       } else {
+        const pathname = history.location.pathname;
+        const state = history.location.state;
+        dispatch(resetAndUnLockFormData());
         if (history.action === 'PUSH') {
-          const pathname = history.location.pathname;
-          const state = history.location.state;
           const unlisten = history.listen(() => {
             if (history.action === 'POP') {
               unlisten();
               history.push(pathname, state);
-              dispatch(resetAndUnLockFormData());
             }
           });
           history.go(-(historyStack.length || 1) - 1);
-        } else {
-          dispatch(resetAndUnLockFormData());
+        } else if (history.action === 'POP') {
+          const unlisten = history.listen(() => {
+            if (history.action === 'POP') {
+              unlisten();
+              history.push(pathname, state);
+            }
+          });
+          history.back();
         }
       }
     };


### PR DESCRIPTION
**Description**

When user gets out of a multi step form by clicking browser back button or cancel button and then click forward button, the form page will break since persistedForm in redux store is cleared.

Jira link:
https://lite-farm.atlassian.net/browse/LF-3451
https://lite-farm.atlassian.net/browse/LF-3440

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Tested in management creation flow

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
