### PR TITLE
LF-3486: Going < from repeat confirmation does not maintain custom day of the week

### DIFF
--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -8,8 +8,6 @@ import PropTypes from 'prop-types';
 import styles from './styles.module.scss';
 import IncompleteTaskModal from '../../Modals/IncompleteTaskModal';
 import RouterTab from '../../RouterTab';
-import { useDispatch } from 'react-redux';
-import { setPersistedPaths } from '../../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 import DeleteBox from '../../Task/TaskReadOnly/DeleteBox';
 import { FiAlertTriangle } from 'react-icons/fi';
 import { ReactComponent as TrashIcon } from '../../../assets/images/document/trash.svg';
@@ -34,17 +32,9 @@ export default function PureManagementTasks({
 }) {
   const { t } = useTranslation();
 
-  const dispatch = useDispatch();
-
   const title = plan?.name;
 
   const onRepeatPlan = (crop_id, plan_id) => {
-    dispatch(
-      setPersistedPaths([
-        `/crop/${crop_id}/management_plan/${plan_id}/repeat`,
-        `/crop/${crop_id}/management_plan/${plan_id}/repeat_confirmation`,
-      ]),
-    );
     history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`);
   };
 

--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -110,8 +110,8 @@ export default function PureRepeatCropPlan({
   const previousPlanStartDateRef = useRef(planStartDate);
   const previousRepeatIntervalRef = useRef(repeatInterval);
 
-  // Trigger validation of the crop plan name on initial load
   useEffect(() => {
+    // Trigger validation of the crop plan name on initial load
     trigger(CROP_PLAN_NAME);
     dispatch(setPersistedPaths(persistedPaths));
   }, []);

--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -14,10 +14,12 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import styles from './styles.module.scss';
 import PropTypes from 'prop-types';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { setPersistedPaths } from '../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 import MultiStepPageTitle from '../PageTitle/MultiStepPageTitle';
 import Form from '../Form';
 import Button from '../Form/Button';
@@ -57,6 +59,7 @@ export default function PureRepeatCropPlan({
   persistedPaths,
 }) {
   const { t } = useTranslation(['translation', 'common']);
+  const dispatch = useDispatch();
   const {
     register,
     handleSubmit,
@@ -110,6 +113,7 @@ export default function PureRepeatCropPlan({
   // Trigger validation of the crop plan name on initial load
   useEffect(() => {
     trigger(CROP_PLAN_NAME);
+    dispatch(setPersistedPaths(persistedPaths));
   }, []);
 
   // Update DaysOfWeekSelect selection

--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -118,12 +118,11 @@ export default function PureRepeatCropPlan({
 
   // Update DaysOfWeekSelect selection
   useEffect(() => {
-    if (
-      repeatInterval.value !== 'week' ||
-      // should not reset selected weekday when coming back from the confirmation view
-      (previousPlanStartDateRef.current === planStartDate &&
-        previousRepeatIntervalRef.current === repeatInterval)
-    ) {
+    const fromConfirmation =
+      previousPlanStartDateRef.current === planStartDate &&
+      previousRepeatIntervalRef.current === repeatInterval;
+
+    if (repeatInterval.value !== 'week' || fromConfirmation) {
       return;
     }
     const dayOfWeekString = getWeekday(planStartDate);

--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -104,6 +104,9 @@ export default function PureRepeatCropPlan({
   const finish = watch(FINISH);
   const finishOnDate = watch(FINISH_ON_DATE);
 
+  const previousPlanStartDateRef = useRef(planStartDate);
+  const previousRepeatIntervalRef = useRef(repeatInterval);
+
   // Trigger validation of the crop plan name on initial load
   useEffect(() => {
     trigger(CROP_PLAN_NAME);
@@ -111,12 +114,20 @@ export default function PureRepeatCropPlan({
 
   // Update DaysOfWeekSelect selection
   useEffect(() => {
-    if (repeatInterval.value !== 'week') {
+    if (
+      repeatInterval.value !== 'week' ||
+      // should not reset selected weekday when coming back from the confirmation view
+      (previousPlanStartDateRef.current === planStartDate &&
+        previousRepeatIntervalRef.current === repeatInterval)
+    ) {
       return;
     }
     const dayOfWeekString = getWeekday(planStartDate);
 
     setValue(DAYS_OF_WEEK, [dayOfWeekString]);
+
+    previousPlanStartDateRef.current = planStartDate;
+    previousRepeatIntervalRef.current = repeatInterval;
   }, [planStartDate, repeatInterval]);
 
   // Populate monthly options React Select


### PR DESCRIPTION
**Description**

- call `setPersistedPaths` in RepeatCropPlan component so that the form data will persist when coming back from the confirmation view.
- remove `setPersistedPaths` in ManagementPlanTask since it would happen twice because of the change above.
- check previous state of start date and repeat interval in RepeatCropPlan's useEffect so that "weekday" will not be reset when coming back from the confirmation view.

Jira link: https://lite-farm.atlassian.net/browse/LF-3486

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
