### PR TITLE
LF-3500 Crop plan repeat action can't be done more than once for the same plan

### DIFF
--- a/packages/webapp/src/components/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/components/RepeatCropPlan/index.jsx
@@ -104,6 +104,11 @@ export default function PureRepeatCropPlan({
   const finish = watch(FINISH);
   const finishOnDate = watch(FINISH_ON_DATE);
 
+  // Trigger validation of the crop plan name on initial load
+  useEffect(() => {
+    trigger(CROP_PLAN_NAME);
+  }, []);
+
   // Update DaysOfWeekSelect selection
   useEffect(() => {
     if (repeatInterval.value !== 'week') {


### PR DESCRIPTION
**Description**

The unique crop plan name validation error was only shown upon interaction with that field according to original ticket requirements.

This can give the user the confusing state of the continue button being invalid for unexplained reasons when repeating the same crop plan twice, after having used the default "Repetitions of... " name on the initial repetition.

This PR updates the validation error to also show immediately upon load.

Jira link: https://lite-farm.atlassian.net/browse/LF-3500

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
