### PR TITLE
LF-3474-Add deleteTransplantTaskSuccess to delete task saga

### DIFF
--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -58,6 +58,7 @@ import {
   onLoadingPlantTaskStart,
 } from '../slice/taskSlice/plantTaskSlice';
 import {
+  deleteTransplantTaskSuccess,
   getTransplantTasksSuccess,
   onLoadingTransplantTaskFail,
   onLoadingTransplantTaskStart,
@@ -842,7 +843,11 @@ export function* deleteTaskSaga({ payload: data }) {
   try {
     const result = yield call(axios.delete, `${taskUrl}/${task_id}`, header);
     if (result) {
+      const task_type = yield select(taskTypeSelector(result.data.task_type_id));
       history.back();
+      if (task_type.task_translation_key === 'TRANSPLANT_TASK') {
+        yield put(deleteTransplantTaskSuccess(result.data.task_id));
+      }
       yield put(deleteTaskSuccess(result.data));
       yield put(enqueueSuccessSnackbar(i18n.t('TASK.DELETE.SUCCESS')));
     }


### PR DESCRIPTION
**Description**

This adds the deleteTransplantTaskSuccess to the delete task saga.

It took me a while for some reason to find this existing function. Other things tried/considered:
- refreshing managementPlan and tasks
- selector for plantingManagementPlans that did not include pmp's where associated task id is deleted
- hard deleting planting management plan of transplant task

Jira link: [LF-3474](https://lite-farm.atlassian.net/browse/LF-3474)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3474]: https://lite-farm.atlassian.net/browse/LF-3474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ