### PR TITLE
LF-3499 Email triggered from "Convert this worker to a user with account" flow doesn't include user's name

### DIFF
--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -577,6 +577,7 @@ const userFarmController = {
           const user = await UserModel.getUserByEmail(email);
           await EmailModel.createTokenSendEmail(
             {
+              first_name: user ? user.first_name : '',
               email,
               gender,
               birth_year,


### PR DESCRIPTION
**Description**

The `upgradePseudoUser` controller didn't send a `first_name` within the first argument object expected by `createTokenSendEmail()`. It should be sent as it is used it the email.

I kept the existence check for `user` in this pattern as it is used in the same object for `user.language_preference`. I'm not sure why user would ever be undefined in this flow but I assume there was a reason it was set up like that, so I'll keep it! 🙂 

Jira link: https://lite-farm.atlassian.net/browse/LF-3499

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
