### PR TITLE
LF-3501 - Draft fix for conflict between delete and upserts.

### DIFF
--- a/packages/webapp/src/containers/managementPlanSlice.js
+++ b/packages/webapp/src/containers/managementPlanSlice.js
@@ -40,11 +40,21 @@ const updateOneManagementPlan = (state, { payload }) => {
   managementPlanAdapter.upsertOne(state, getManagementPlan(payload));
 };
 
-const addManyManagementPlan = (state, { payload: managementPlans }) => {
+const addAllManagementPlan = (state, { payload: managementPlans }) => {
   state.loading = false;
   state.error = null;
   state.loaded = true;
   managementPlanAdapter.setAll(
+    state,
+    managementPlans.map((managementPlan) => getManagementPlan(managementPlan)),
+  );
+};
+
+const addManyManagementPlan = (state, { payload: managementPlans }) => {
+  state.loading = false;
+  state.error = null;
+  state.loaded = true;
+  managementPlanAdapter.upsertMany(
     state,
     managementPlans.map((managementPlan) => getManagementPlan(managementPlan)),
   );
@@ -64,6 +74,7 @@ const managementPlanSlice = createSlice({
   reducers: {
     onLoadingManagementPlanStart: onLoadingStart,
     onLoadingManagementPlanFail: onLoadingFail,
+    getAllManagementPlansSuccess: addAllManagementPlan,
     getManagementPlansSuccess: addManyManagementPlan,
     deleteManagementPlanSuccess: managementPlanAdapter.removeOne,
     deleteManagementPlansSuccess: managementPlanAdapter.removeMany,
@@ -72,6 +83,7 @@ const managementPlanSlice = createSlice({
 });
 export const {
   getManagementPlansSuccess,
+  getAllManagementPlansSuccess,
   onLoadingManagementPlanStart,
   onLoadingManagementPlanFail,
   deleteManagementPlanSuccess,


### PR DESCRIPTION
**Description**

Draft to see if I can preserve the concurrency fix from @kathyavini  and fix some issues caused by setAll update.

setAll() vs upsertMany() causes the patch saga to replace the managementPlanEntities with just one management plan. 

I tried to create a new reducer to handle the desired state of refreshing the managementPlans to reduce concurrency.

Jira link: [LF-3501](https://lite-farm.atlassian.net/browse/LF-3501)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
