### PR TITLE
LF-3486

### DIFF
--- a/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
+++ b/packages/webapp/src/containers/Crop/RepeatCropPlan/index.jsx
@@ -13,10 +13,13 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PureRepeatCropPlan from '../../../components/RepeatCropPlan';
-import { useSelector } from 'react-redux';
-import { hookFormPersistSelector } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  hookFormPersistSelector,
+  setPersistedPaths,
+} from '../../hooks/useHookFormPersist/hookFormPersistSlice';
 import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 import {
   managementPlanSelector,
@@ -26,9 +29,17 @@ import { tasksByManagementPlanIdSelector } from '../../taskSlice';
 import { getDateInputFormat } from '../../../util/moment';
 
 function RepeatCropPlan({ history, match }) {
+  const dispatch = useDispatch();
+  const { management_plan_id, variety_id } = match.params;
+  useEffect(() => {
+    dispatch(
+      setPersistedPaths([
+        `/crop/${variety_id}/management_plan/${management_plan_id}/repeat`,
+        `/crop/${variety_id}/management_plan/${management_plan_id}/repeat_confirmation`,
+      ]),
+    );
+  }, []);
   const persistedFormData = useSelector(hookFormPersistSelector);
-
-  const management_plan_id = match.params.management_plan_id;
 
   const plan = useSelector(managementPlanSelector(management_plan_id));
 
@@ -51,11 +62,6 @@ function RepeatCropPlan({ history, match }) {
     );
   };
 
-  const persistedPaths = [
-    `/crop/${plan.crop_variety_id}/management_plan/${management_plan_id}/repeat`,
-    `/crop/${plan.crop_variety_id}/management_plan/${management_plan_id}/repeat_confirmation`,
-  ];
-
   return (
     <HookFormPersistProvider>
       <PureRepeatCropPlan
@@ -66,7 +72,6 @@ function RepeatCropPlan({ history, match }) {
         onGoBack={() => history.back()}
         onContinue={onContinue}
         persistedFormData={persistedFormData}
-        persistedPaths={persistedPaths}
       />
     </HookFormPersistProvider>
   );


### PR DESCRIPTION
add persisted path to repeatCropPlan container.
Replace day of week useEffect reset hook with onClick callbacks to avoid unintended resets