### PR TITLE
LF-3469: allow null depth in sensor model

### DIFF
--- a/packages/api/src/models/sensorModel.js
+++ b/packages/api/src/models/sensorModel.js
@@ -42,7 +42,7 @@ class Sensor extends Model {
         model: { type: 'string', maxLength: 255 },
         partner_id: { type: 'integer' },
         external_id: { type: 'string', maxLength: 255 },
-        depth: { type: 'number', format: 'float' },
+        depth: { type: ['number', 'null'], format: 'float' },
         depth_unit: { type: 'string', enum: ['cm', 'm', 'in', 'ft'] },
         elevation: { type: 'number', format: 'float' },
       },


### PR DESCRIPTION
**Description**

Depth is not a required header in the CSV when uploading a sensor. However, currently when editing a sensor where the depth has not been set, if it's kept null the PATCH request throws a validation error saying it should be a number. This updates the schema for the sensor model so it allows null on top of number type.

Jira link:
https://lite-farm.atlassian.net/jira/software/c/projects/LF/boards/10?modal=detail&selectedIssue=LF-3469

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested on my local environment. Uploaded a CSV without the depth header, then tried editing the sensor. After this change, editing goes through without errors.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
