### PR TITLE
LF-3498: Add download button for non previewable files

### DIFF
--- a/packages/webapp/src/components/Documents/Main/index.jsx
+++ b/packages/webapp/src/components/Documents/Main/index.jsx
@@ -109,7 +109,15 @@ function MainDocumentView({
               })}
             </div>
           ) : (
-            <CertifierSelectionMenuItem key={index} certifierName={file_name} />
+            <div className={styles.fileItemWrapper} key={index}>
+              {fileDownloadComponent({
+                className: styles.downloadContainer,
+                title: `${document.name}.${url.split('.').at(-1)}`,
+                fileUrl: url,
+                mediaType: mediaEnum.DOCUMENT,
+              })}
+              <CertifierSelectionMenuItem certifierName={file_name} />
+            </div>
           ),
         )}
       </div>

--- a/packages/webapp/src/components/Documents/Main/styles.module.scss
+++ b/packages/webapp/src/components/Documents/Main/styles.module.scss
@@ -10,3 +10,8 @@
 .previewWrapper {
   position: relative;
 }
+
+.fileItemWrapper {
+  position: relative;
+  width: 100%;
+}


### PR DESCRIPTION
**Description**

In the detail page for a document, added Download button for files that are not previewable.

Jira link:
https://lite-farm.atlassian.net/jira/software/c/projects/LF/boards/10?modal=detail&selectedIssue=LF-3498

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested on local environment, checked that non previewable files now display the Download icon on the document detail page and that the files can be downloaded.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
