### PR TITLE
Removing download icon from document tile view. Adding info icon

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -440,6 +440,7 @@
     "CANCEL_MODAL": "document creation",
     "COMPLIANCE_DOCUMENTS_AND_CERTIFICATION": "Compliance documents and your certification",
     "DOCUMENTS": "Documents",
+    "VIEW_DETAIL": "View detail page to download multiple files",
     "EDIT_DOCUMENT": "Edit document",
     "FILTER": {
       "TITLE": "Documents Filter",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -439,6 +439,7 @@
     "CANCEL_MODAL": "creación de documentos",
     "COMPLIANCE_DOCUMENTS_AND_CERTIFICATION": "Documentos de cumplimiento y su certificación",
     "DOCUMENTS": "Documentos",
+    "VIEW_DETAIL": "MISSING",
     "EDIT_DOCUMENT": "Editar documento",
     "FILTER": {
       "TITLE": "Filtro de documentos",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -440,6 +440,7 @@
     "CANCEL_MODAL": "création de document",
     "COMPLIANCE_DOCUMENTS_AND_CERTIFICATION": "Documents de conformité et votre certification",
     "DOCUMENTS": "Documents",
+    "VIEW_DETAIL": "MISSING",
     "EDIT_DOCUMENT": "Modifier le document",
     "FILTER": {
       "TITLE": "Filtre de documents",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -439,6 +439,7 @@
     "CANCEL_MODAL": "criação de documento",
     "COMPLIANCE_DOCUMENTS_AND_CERTIFICATION": "Documentos de conformidade e sua certificação",
     "DOCUMENTS": "Documentos",
+    "VIEW_DETAIL": "MISSING",
     "EDIT_DOCUMENT": "Editar documento",
     "FILTER": {
       "TITLE": "Filtro de documentos",

--- a/packages/webapp/src/containers/Documents/DocumentTile/index.jsx
+++ b/packages/webapp/src/containers/Documents/DocumentTile/index.jsx
@@ -21,17 +21,26 @@ export default function PureDocumentTile({
   fileUrl,
   imageComponent = (props) => <MediaWithAuthentication {...props} />,
   fileDownloadComponent = (props) => <MediaWithAuthentication {...props} />,
+  multipleFiles = false,
 }) {
   const { t } = useTranslation();
 
   return (
     <div className={styles.previewWrapper}>
       <div className={clsx(styles.container, className)} onClick={onClick}>
-        <Infoi
-          style={{ position: 'absolute', right: 0, top: 0 }}
-          placement={'right-start'}
-          content={t('DOCUMENTS.VIEW_DETAIL')}
-        ></Infoi>
+        {multipleFiles && (
+          <Infoi
+            style={{
+              position: 'absolute',
+              right: 0,
+              top: 0,
+              backgroundColor: 'white',
+              borderRadius: '50%',
+            }}
+            placement={'right-start'}
+            content={t('DOCUMENTS.VIEW_DETAIL')}
+          ></Infoi>
+        )}
         {preview ? (
           imageComponent({
             className: styles.img,
@@ -72,6 +81,14 @@ export default function PureDocumentTile({
           )}
         </div>
       </div>
+      {fileUrl &&
+        !multipleFiles &&
+        fileDownloadComponent({
+          className: styles.downloadContainer,
+          fileUrl,
+          title: `${title}.${extensionName}`,
+          mediaType: mediaEnum.DOCUMENT,
+        })}
     </div>
   );
 }

--- a/packages/webapp/src/containers/Documents/DocumentTile/index.jsx
+++ b/packages/webapp/src/containers/Documents/DocumentTile/index.jsx
@@ -32,9 +32,10 @@ export default function PureDocumentTile({
           <Infoi
             style={{
               position: 'absolute',
-              right: 0,
-              top: 0,
-              backgroundColor: 'white',
+              right: 1,
+              top: 1,
+              backgroundColor: '#028577',
+              fill: 'white',
               borderRadius: '50%',
             }}
             placement={'right-start'}

--- a/packages/webapp/src/containers/Documents/DocumentTile/index.jsx
+++ b/packages/webapp/src/containers/Documents/DocumentTile/index.jsx
@@ -7,6 +7,7 @@ import { MediaWithAuthentication } from '../../../containers/MediaWithAuthentica
 import { mediaEnum } from '../../../containers/MediaWithAuthentication/constants';
 import { useTranslation } from 'react-i18next';
 import { DocumentIcon } from '../../../components/Icons/DocumentIcon';
+import Infoi from '../../../components/Tooltip/Infoi';
 
 export default function PureDocumentTile({
   className,
@@ -26,6 +27,11 @@ export default function PureDocumentTile({
   return (
     <div className={styles.previewWrapper}>
       <div className={clsx(styles.container, className)} onClick={onClick}>
+        <Infoi
+          style={{ position: 'absolute', right: 0, top: 0 }}
+          placement={'right-start'}
+          content={t('DOCUMENTS.VIEW_DETAIL')}
+        ></Infoi>
         {preview ? (
           imageComponent({
             className: styles.img,
@@ -66,13 +72,6 @@ export default function PureDocumentTile({
           )}
         </div>
       </div>
-      {fileUrl &&
-        fileDownloadComponent({
-          className: styles.downloadContainer,
-          fileUrl,
-          title: `${title}.${extensionName}`,
-          mediaType: mediaEnum.DOCUMENT,
-        })}
     </div>
   );
 }

--- a/packages/webapp/src/containers/Documents/index.jsx
+++ b/packages/webapp/src/containers/Documents/index.jsx
@@ -133,6 +133,7 @@ export default function Documents({ history }) {
                       extensionName={document?.files?.[0]?.file_name.split('.').pop()}
                       onClick={() => tileClick(document.document_id)}
                       key={document.document_id}
+                      multipleFiles={document?.files?.length > 1}
                       fileUrl={document?.files?.at(-1)?.url}
                     />
                   );
@@ -159,6 +160,7 @@ export default function Documents({ history }) {
                       extensionName={document?.files?.[0]?.file_name.split('.').pop()}
                       onClick={() => tileClick(document.document_id)}
                       key={document.document_id}
+                      multipleFiles={document?.files?.length > 1}
                       fileUrl={document?.files?.at(-1)?.url}
                     />
                   );


### PR DESCRIPTION
**Description**

Removed the failing download icon and added an info icon that reads:  View detail page to download multiple files. 

Jira link: https://lite-farm.atlassian.net/browse/LF-3457

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
