### PR TITLE
LF-3514 - Add null case to model to allow for wild crop.

### DIFF
--- a/packages/api/src/models/irrigationTaskModel.js
+++ b/packages/api/src/models/irrigationTaskModel.js
@@ -41,7 +41,7 @@ class IrrigationTaskModel extends Model {
         estimated_duration_unit: { type: ['string', 'null'] },
         estimated_flow_rate: { type: ['number', 'null'] },
         estimated_flow_rate_unit: { type: ['string', 'null'] },
-        location_id: { type: 'string' },
+        location_id: { type: ['string', 'null'] },
         estimated_water_usage: { type: ['number', 'null'] },
         estimated_water_usage_unit: { type: ['string', 'null'] },
         application_depth: { type: ['number', 'null'] },


### PR DESCRIPTION
**Description**

Fixes the case where a wild crop cannot be repeated due to irrgation task model. This is a new case of validation error from resulting from the Node18 eol.

Worth considering why we have location_id on the irrigation task model.

Jira link: [LF-3514](https://lite-farm.atlassian.net/browse/LF-3514)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-3514]: https://lite-farm.atlassian.net/browse/LF-3514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ