### PR TITLE
LF-3351-White-screen-is-displayed-once-the-user-changes-Pest-control-method-type-during-the-Completion-flow-of-the-Pest-Control-task

### DIFF
--- a/packages/webapp/src/components/Task/PestControlTask/index.jsx
+++ b/packages/webapp/src/components/Task/PestControlTask/index.jsx
@@ -43,10 +43,11 @@ const PurePestControlTask = ({
       : { value: controlMethodValue, label: controlMethod[controlMethodValue] };
   }, [controlMethodValue]);
 
+  //TODO: Need performance optimization check as it is setting values to null
+  //for few conditions even when not required.
   useEffect(() => {
     if (
       controlMethodExposedValue?.value &&
-      getValues('pest_control_task.product') &&
       !productPests.includes(controlMethodExposedValue?.value)
     ) {
       setValue('pest_control_task.product', null);


### PR DESCRIPTION
**Description**

This PR handles the white screen issue which occurs when 'Pest control methods' is changed from ( Biological Control , Flame Weeding , Hand Weeding , Pruning , Other ) to ( Foliar Spray, Soil Fumigation or Systemic Spray )

Jira link: https://lite-farm.atlassian.net/browse/LF-3351

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Now you should be able to change between the 'Pest control methods' on 'Mark Complete' flow of a task.

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
