### PR TITLE
LF-3527 TypeError: o.crop_variety is undefined

### DIFF
--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -27,7 +27,7 @@ import {
   userFarmSelector,
 } from '../userFarmSlice';
 import { resetAndUnLockFormData } from '../hooks/useHookFormPersist/hookFormPersistSlice';
-import { getManagementPlansAndTasks } from '../saga';
+import { getCropsAndManagementPlans } from '../saga';
 import TaskCard from './TaskCard';
 import { onAddTask } from './onAddTask';
 import MuiFullPagePopup from '../../components/MuiFullPagePopup/v2';
@@ -48,7 +48,7 @@ import { IS_ASCENDING } from '../Filter/constants';
 import { WEEKLY_UNASSIGNED_TASKS, DAILY_TASKS_DUE_TODAY } from '../Notification/constants';
 import { filteredTaskCardContentSelector } from './taskCardContentSelector';
 import TaskCount from '../../components/Task/TaskCount';
-import { getTaskTypes } from './saga';
+import { getHarvestUseTypes, getProducts, getTasks, getTaskTypes } from './saga';
 import { getAllUserFarmsByFarmId } from '../Profile/People/saga';
 import { defaultTaskTypesSelector, userCreatedTaskTypesSelector } from '../taskTypeSlice';
 import { getSupportedTaskTypesSet } from '../../components/Task/getSupportedTaskTypesSet';
@@ -99,10 +99,13 @@ export default function TaskPage({ history }) {
   }, [activeUsers.length, taskTypes.length]);
 
   useEffect(() => {
+    dispatch(getTasks());
     dispatch(getTaskTypes());
+    dispatch(getProducts());
+    dispatch(getHarvestUseTypes());
     dispatch(getAllUserFarmsByFarmId());
-    dispatch(getManagementPlansAndTasks());
     dispatch(resetAndUnLockFormData());
+    dispatch(getCropsAndManagementPlans());
 
     const context = history.location?.state;
 


### PR DESCRIPTION
**Description**

Co-authors @SayakaOno and @Duncan-Brain 

This fixes the white screen type error crash on the task view page that happens from tasks referencing deleted management plans.

This PR updates the task redux store state prior to updating the management plan store state.

Jira link: https://lite-farm.atlassian.net/browse/LF-3527

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
