### PR TITLE
LF-3528: The white screen is displayed when the user tries to create the repeated crop plan for a crop plan without any tasks in it.

### DIFF
--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -33,6 +33,7 @@ export default function PureManagementTasks({
   const { t } = useTranslation();
 
   const title = plan?.name;
+  const hasTasks = !!children?.length;
 
   const onRepeatPlan = (crop_id, plan_id) => {
     history.push(`/crop/${crop_id}/management_plan/${plan_id}/repeat`);
@@ -80,7 +81,7 @@ export default function PureManagementTasks({
         <Label className={styles.title} style={{ marginTop: '24px' }}>
           {title}
         </Label>
-        {isAdmin && (
+        {isAdmin && hasTasks && (
           <BsThreeDotsVertical
             className={styles.menuIcon}
             onClick={() => {


### PR DESCRIPTION
**Description**

Hide the copy repeat menu for a plan that has no tasks.

Jira link: https://lite-farm.atlassian.net/browse/LF-3528

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
