### PR TITLE
LF-3513: Harvest to date label should be on one line

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -118,7 +118,7 @@ const Unit = ({
             {hasLeaf && <Leaf className={styles.leaf} />}
           </Label>
           {toolTipContent && (
-            <div className={styles.tooltipIconContainer}>
+            <div>
               <Infoi content={toolTipContent} />
             </div>
           )}

--- a/packages/webapp/src/components/Form/Unit/unit.module.scss
+++ b/packages/webapp/src/components/Form/Unit/unit.module.scss
@@ -93,7 +93,7 @@
 .labelContainer {
   display: flex;
   justify-content: space-between;
-  position: relative;
+  gap: 5px;
 }
 
 .hiddenInput {
@@ -137,12 +137,6 @@
 
 .noBorderRadius {
   border-radius: 0px;
-}
-
-.tooltipIconContainer {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
 }
 
 .leaf {


### PR DESCRIPTION
**Description**

Make "Harvest to date" label one line.


Jira link: https://lite-farm.atlassian.net/browse/LF-3513

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
