### PR TITLE
LF-3552: Create reusable tile view component

### DIFF
--- a/packages/webapp/src/components/Tile/IconLabelTile.jsx
+++ b/packages/webapp/src/components/Tile/IconLabelTile.jsx
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import styles from './styles.module.scss';
+
+export default function IconLabelTile({ tileKey, icon, label, onClick, selected, ...props }) {
+  return (
+    <div
+      key={tileKey}
+      onClick={onClick}
+      className={clsx(styles.typeContainer, selected && styles.typeContainerSelected)}
+      {...props}
+    >
+      {icon}
+      <div className={styles.taskTypeLabelContainer}>{label}</div>
+    </div>
+  );
+}
+
+IconLabelTile.propTypes = {
+  tileKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  icon: PropTypes.node,
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  selected: PropTypes.bool,
+};

--- a/packages/webapp/src/components/Tile/Tiles.jsx
+++ b/packages/webapp/src/components/Tile/Tiles.jsx
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import IconLabelTile from './IconLabelTile';
+import { tyleTypes } from './constants';
+import styles from './styles.module.scss';
+
+const tileComponents = {
+  [tyleTypes.ICON_LABEL]: (props) => <IconLabelTile {...props} />,
+};
+
+/**
+ * A component that places tiles so that the empty space is evenly distributed for any window sizes.
+ * Either "children" or "tileType" and "tileData" props are required.
+ * See packages/webapp/src/stories/Tile/Tiles.stories.jsx for examples.
+ */
+export default function Tiles({ children, tileType, tileData, formatTileData, ...props }) {
+  const tiles = useMemo(() => {
+    if (children || !tileType || !tileData) {
+      return children || null;
+    }
+
+    return tileData.map((data) => {
+      const tileProps = formatTileData ? formatTileData(data) : data;
+      return tileComponents[tileType](tileProps);
+    });
+  }, [children, tileType, tileData, formatTileData]);
+
+  return (
+    <div className={styles.matrixContainer} {...props}>
+      {tiles}
+    </div>
+  );
+}
+
+Tiles.propTypes = {
+  children: PropTypes.node,
+  tileType: PropTypes.oneOf(Object.keys(tileComponents)),
+  tileData: PropTypes.array,
+  /* formatTileData must return an object that has "key" */
+  formatTileData: PropTypes.func,
+};

--- a/packages/webapp/src/components/Tile/Tiles.jsx
+++ b/packages/webapp/src/components/Tile/Tiles.jsx
@@ -15,11 +15,11 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import IconLabelTile from './IconLabelTile';
-import { tyleTypes } from './constants';
+import { tileTypes } from './constants';
 import styles from './styles.module.scss';
 
 const tileComponents = {
-  [tyleTypes.ICON_LABEL]: (props) => <IconLabelTile {...props} />,
+  [tileTypes.ICON_LABEL]: (props) => <IconLabelTile {...props} />,
 };
 
 /**

--- a/packages/webapp/src/components/Tile/constants.js
+++ b/packages/webapp/src/components/Tile/constants.js
@@ -12,6 +12,6 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
-export const tyleTypes = {
+export const tileTypes = {
   ICON_LABEL: 'iconLabel',
 };

--- a/packages/webapp/src/components/Tile/constants.js
+++ b/packages/webapp/src/components/Tile/constants.js
@@ -1,0 +1,17 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+export const tyleTypes = {
+  ICON_LABEL: 'iconLabel',
+};

--- a/packages/webapp/src/components/Tile/styles.module.scss
+++ b/packages/webapp/src/components/Tile/styles.module.scss
@@ -28,7 +28,6 @@
   cursor: pointer;
   text-align: center;
 
-
   svg {
     width: 13.3vw;
     height: 13.3vw;
@@ -123,7 +122,6 @@
   }
 }
 
-
 @media only screen and (min-width: 876px) {
   .matrixContainer {
     --emptySpace: calc(100% - 708px);
@@ -131,7 +129,6 @@
     column-gap: var(--gap);
   }
 }
-
 
 @media only screen and (min-width: 1024px) {
   .matrixContainer {

--- a/packages/webapp/src/components/Tile/styles.module.scss
+++ b/packages/webapp/src/components/Tile/styles.module.scss
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+.typeContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #e8f0eb;
+  box-shadow: 0 2px 10px #ededed;
+  border-radius: 4px;
+  width: 24.4vw;
+  height: 24.4vw;
+  padding: 0 4px;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: center;
+
+
+  svg {
+    width: 13.3vw;
+    height: 13.3vw;
+    margin-bottom: 4px;
+  }
+
+  font-size: 3.3vw;
+  line-height: 4.4vw;
+  color: var(--fontColor);
+  font-family: 'Open Sans', 'SansSerif', serif;
+}
+
+.typeContainer:hover, .typeContainer:active {
+  border-color: var(--teal700);
+  background-color: var(--green100);
+  color: var(--teal900);
+}
+
+.typeContainerSelected {
+  border-color: var(--teal700);
+  background-color: var(--green100);
+  color: var(--teal900);
+}
+
+.taskTypeLabelContainer {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.matrixContainer {
+  display: inline-flex;
+  flex-flow: row wrap;
+  row-gap: 6.6vw;
+
+  --emptySpace: calc(26.8vw - 48px);
+  --gap: calc(var(--emptySpace) / 2);
+  column-gap: var(--gap);
+}
+
+@media only screen and (min-width: 480px) {
+  .matrixContainer {
+    row-gap: 5.2vw;
+    --emptySpace: calc(23.76vw - 48px);
+    --gap: calc(var(--emptySpace) / 3);
+    column-gap: var(--gap);
+  }
+  .typeContainer {
+    width: 19.06vw;
+    height: 19.06vw;
+
+    svg {
+      width: 10.4vw;
+      height: 10.4vw;
+    }
+
+    font-size: 2.6vw;
+    line-height: 3.47vw;
+  }
+}
+
+@media only screen and (min-width: 600px) {
+  .matrixContainer {
+    justify-content: flex-start;
+
+    --emptySpace: calc(100% - 472px);
+    --gap: calc(var(--emptySpace) / 3);
+    column-gap: var(--gap);
+    row-gap: 24px;
+  }
+
+  .typeContainer {
+    width: 118px;
+    height: 118px;
+
+    svg {
+      width: 60px;
+      height: 60px;
+    }
+
+    font-size: 14px;
+    line-height: 20px;
+  }
+}
+
+@media only screen and (min-width: 734px) {
+  .matrixContainer {
+    --emptySpace: calc(100% - 590px);
+    --gap: calc(var(--emptySpace) / 4);
+    column-gap: var(--gap);
+  }
+}
+
+
+@media only screen and (min-width: 876px) {
+  .matrixContainer {
+    --emptySpace: calc(100% - 708px);
+    --gap: calc(var(--emptySpace) / 5);
+    column-gap: var(--gap);
+  }
+}
+
+
+@media only screen and (min-width: 1024px) {
+  .matrixContainer {
+    gap: 25px
+  }
+}

--- a/packages/webapp/src/components/Tile/styles.module.scss
+++ b/packages/webapp/src/components/Tile/styles.module.scss
@@ -60,6 +60,7 @@
 }
 
 .matrixContainer {
+  width: 100%;
   display: inline-flex;
   flex-flow: row wrap;
   row-gap: 6.6vw;

--- a/packages/webapp/src/stories/Tile/IconLabelTile.stories.jsx
+++ b/packages/webapp/src/stories/Tile/IconLabelTile.stories.jsx
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import IconLabelTile from '../../components/Tile/IconLabelTile';
+import { componentDecorators } from '../Pages/config/Decorators';
+import { ReactComponent as SoilAmendment } from '../../assets/images/task/SoilAmendment.svg';
+
+export default {
+  title: 'Components/Tile/IconLabelTile',
+  component: IconLabelTile,
+  decorators: componentDecorators,
+};
+
+export const Default = {
+  args: {
+    tileKey: 'key',
+    icon: <SoilAmendment />,
+    label: 'Label',
+    onClick: () => console.log('clicked!'),
+    selected: false,
+  },
+};
+
+export const Selected = {
+  args: {
+    tileKey: 'key',
+    icon: <SoilAmendment />,
+    label: 'Label',
+    onClick: () => console.log('clicked!'),
+    selected: true,
+  },
+};

--- a/packages/webapp/src/stories/Tile/Tiles.stories.jsx
+++ b/packages/webapp/src/stories/Tile/Tiles.stories.jsx
@@ -18,7 +18,7 @@ import { within } from '@storybook/testing-library';
 import { componentDecorators } from '../Pages/config/Decorators';
 import Tiles from '../../components/Tile/Tiles';
 import IconLabelTile from '../../components/Tile/IconLabelTile';
-import { tyleTypes } from '../../components/Tile/constants';
+import { tileTypes } from '../../components/Tile/constants';
 import { ReactComponent as SoilAmendment } from '../../assets/images/task/SoilAmendment.svg';
 
 export default {
@@ -57,9 +57,9 @@ export const IconLabeTilesAsChildren = {
   play: tileLengthTest(6, ['Label']),
 };
 
-export const IconLabeTilesAsData = {
+export const IconLabelTilesAsData = {
   args: {
-    tileType: tyleTypes.ICON_LABEL,
+    tileType: tileTypes.ICON_LABEL,
     tileData: new Array(6).fill().map((item, index) => {
       return {
         key: index,
@@ -73,9 +73,9 @@ export const IconLabeTilesAsData = {
   play: tileLengthTest(6, ['Label']),
 };
 
-export const IconLabeTilesAsDataWithFormatFunction = {
+export const IconLabelTilesAsDataWithFormatFunction = {
   args: {
-    tileType: tyleTypes.ICON_LABEL,
+    tileType: tileTypes.ICON_LABEL,
     tileData: new Array(6).fill().map((item, index) => {
       return {
         index,

--- a/packages/webapp/src/stories/Tile/Tiles.stories.jsx
+++ b/packages/webapp/src/stories/Tile/Tiles.stories.jsx
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { expect } from '@storybook/jest';
+import { within } from '@storybook/testing-library';
+import { componentDecorators } from '../Pages/config/Decorators';
+import Tiles from '../../components/Tile/Tiles';
+import IconLabelTile from '../../components/Tile/IconLabelTile';
+import { tyleTypes } from '../../components/Tile/constants';
+import { ReactComponent as SoilAmendment } from '../../assets/images/task/SoilAmendment.svg';
+
+export default {
+  title: 'Components/Tile/Tiles',
+  component: Tiles,
+  decorators: componentDecorators,
+};
+
+const tileLengthTest =
+  (tileLength, labelTexts) =>
+  async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    let tiles = [];
+    for (let i = 0; i < labelTexts.length; i++) {
+      const label = labelTexts[i];
+      const tilesForLabel = await canvas.queryAllByText(label);
+      tiles = tiles.concat(tilesForLabel);
+    }
+    expect(tiles.length).toBe(tileLength);
+  };
+
+export const IconLabeTilesAsChildren = {
+  args: {
+    children: new Array(6).fill().map((item, index) => {
+      return (
+        <IconLabelTile
+          key={index}
+          icon={<SoilAmendment />}
+          label={'Label'}
+          onClick={() => console.log('clicked!')}
+          selected={false}
+        />
+      );
+    }),
+  },
+  play: tileLengthTest(6, ['Label']),
+};
+
+export const IconLabeTilesAsData = {
+  args: {
+    tileType: tyleTypes.ICON_LABEL,
+    tileData: new Array(6).fill().map((item, index) => {
+      return {
+        key: index,
+        icon: <SoilAmendment />,
+        label: 'Label',
+        onClick: () => console.log('clicked!'),
+        selected: false,
+      };
+    }),
+  },
+  play: tileLengthTest(6, ['Label']),
+};
+
+export const IconLabeTilesAsDataWithFormatFunction = {
+  args: {
+    tileType: tyleTypes.ICON_LABEL,
+    tileData: new Array(6).fill().map((item, index) => {
+      return {
+        index,
+        svg: <SoilAmendment />,
+        type: 'Label',
+      };
+    }),
+    formatTileData: (data) => {
+      const exampleSelectedIndex = 8;
+      const { index, svg, type } = data;
+
+      return {
+        key: index.toString(),
+        tileKey: index.toString(),
+        icon: svg,
+        label: type,
+        onClick: () => console.log(`${index} clicked!`),
+        selected: exampleSelectedIndex === index,
+      };
+    },
+  },
+  play: tileLengthTest(6, ['Label']),
+};


### PR DESCRIPTION
**Description**

- Create `LabelIconTile` and `Tiles` component that can be used for:
  - task type view (refactor [ticket](https://lite-farm.atlassian.net/browse/LF-3567))
  - expense type view
  - revenue type view
- [IconLabelTile stories](http://localhost:6006/?path=/docs/components-tile-iconlabeltile--docs)
- [Tiles stories and tests](http://localhost:6006/?path=/docs/components-tile-tiles--docs)
- (the scss file was copied from `packages/webapp/src/components/Task/PureTaskTypeSelection/styles.module.scss`)

Jira link: https://lite-farm.atlassian.net/browse/LF-3552

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

storybook tests (the link is in the description)

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
