### PR TITLE
LF-3506/Wrong date in tasks list

### DIFF
--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -33,7 +33,11 @@ export const taskStatusTranslateKey = {
 };
 
 const getDate = (date, language = 'en') => {
-  return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(new Date(date));
+  const d = new Date(date);
+  d.setFullYear(date.split(', ')[1]);
+  return new Intl.DateTimeFormat(language, { timeZone: 'UTC', dateStyle: 'medium' }).format(
+    new Date(d),
+  );
 };
 
 export const PureTaskCard = ({

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -33,10 +33,8 @@ export const taskStatusTranslateKey = {
 };
 
 const getDate = (date, language = 'en') => {
-  const d = new Date(date);
-  d.setFullYear(date.split(', ')[1]);
   return new Intl.DateTimeFormat(language, { timeZone: 'UTC', dateStyle: 'medium' }).format(
-    new Date(d),
+    new Date(date),
   );
 };
 

--- a/packages/webapp/src/util/moment.js
+++ b/packages/webapp/src/util/moment.js
@@ -65,7 +65,7 @@ export const getManagementPlanTileDate = (date) =>
   moment(date).locale(getLanguageFromLocalStorage()).format(`MMM DD,'YY`);
 
 export const getTaskCardDate = (date) =>
-  moment(date).locale(getLanguageFromLocalStorage()).format('MMM D, YYYY');
+  moment(date).locale(getLanguageFromLocalStorage()).format('YYYY-MM-DD');
 
 export const getNotificationCardDate = (date) =>
   moment(date).locale(getLanguageFromLocalStorage()).format('MM/DD/YY');


### PR DESCRIPTION
**Description**

When user entered due-date year that is smaller than 1970 the displaying date for the task is incorrect. 
Fixed with setting the year manually and with UTC timezone.

Jira link: https://lite-farm.atlassian.net/browse/LF-3506

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
