### PR TITLE
LF-3559 add manage custom expense type spotlight

### DIFF
--- a/packages/api/db/migration/20230817142109_add_custom_expense_types_spotlight.js
+++ b/packages/api/db/migration/20230817142109_add_custom_expense_types_spotlight.js
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex.schema.alterTable('showedSpotlight', (t) => {
+    t.boolean('manage_custom_expense_type').defaultTo(false);
+    t.timestamp('manage_custom_expense_type_end').nullable().defaultTo(null);
+  });
+};
+
+export const down = async function (knex) {
+  await knex.schema.alterTable('showedSpotlight', (t) => {
+    t.dropColumn('manage_custom_expense_type');
+    t.dropColumn('manage_custom_expense_type_end');
+  });
+};

--- a/packages/api/src/controllers/showedSpotlightController.js
+++ b/packages/api/src/controllers/showedSpotlightController.js
@@ -41,6 +41,7 @@ const showedSpotlightController = {
             'management_plan_creation',
             'sensor_reading_chart',
             'repeat_management_plan_creation',
+            'manage_custom_expense_type',
           )
           .findById(user_id);
         res.status(200).send(data);

--- a/packages/api/src/models/showedSpotlightModel.js
+++ b/packages/api/src/models/showedSpotlightModel.js
@@ -70,6 +70,7 @@ class ShowedSpotlight extends Model {
         sensor_reading_chart_end: { type: ['string', 'null'] },
         repeat_management_plan_creation: { type: 'boolean' },
         repeat_management_plan_creation_end: { type: ['string', 'null'] },
+        manage_custom_expense_type: { type: ['string', 'null'] },
       },
     };
   }

--- a/packages/api/src/models/showedSpotlightModel.js
+++ b/packages/api/src/models/showedSpotlightModel.js
@@ -70,7 +70,8 @@ class ShowedSpotlight extends Model {
         sensor_reading_chart_end: { type: ['string', 'null'] },
         repeat_management_plan_creation: { type: 'boolean' },
         repeat_management_plan_creation_end: { type: ['string', 'null'] },
-        manage_custom_expense_type: { type: ['string', 'null'] },
+        manage_custom_expense_type: { type: 'boolean' },
+        manage_custom_expense_type_end: { type: ['string', 'null'] },
       },
     };
   }

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1475,6 +1475,11 @@
       "EXPENSES": "Expenses",
       "FINANCE_HELP": "Finance Help",
       "LABOUR_LABEL": "Labour",
+      "MANAGE_CUSTOM_EXPENSE_TYPES_SPOTLIGHT": {
+        "TITLE": "Manage custom expense types",
+        "BODY": "Here you can add, modify, or retire expense types personalized to your farm."
+      },
+      "MANAGE_CUSTOM_EXPENSE_TYPE": "Manage custom type",
       "OTHER_EXPENSES_LABEL": "Other Expenses",
       "REVENUE": "Revenue",
       "TITLE": "Finances",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1476,6 +1476,11 @@
       "EXPENSES": "Gastos",
       "FINANCE_HELP": "Ayuda financiera",
       "LABOUR_LABEL": "Trabajo",
+      "MANAGE_CUSTOM_EXPENSE_TYPES_SPOTLIGHT": {
+        "TITLE": "Administrar tipos de gasto personalizados",
+        "BODY": "Aquí puede agregar, modificar o eliminar tipos de gasto personalizados para su granja."
+      },
+      "MANAGE_CUSTOM_EXPENSE_TYPE": "Administrar tipos personalizados",
       "OTHER_EXPENSES_LABEL": "Otros gastos",
       "REVENUE": "Ingresos",
       "TITLE": "Finanzas",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1477,6 +1477,11 @@
       "EXPENSES": "Dépenses",
       "FINANCE_HELP": "Aide Financière",
       "LABOUR_LABEL": "Coûts de main-d'œuvre",
+      "MANAGE_CUSTOM_EXPENSE_TYPES_SPOTLIGHT": {
+        "TITLE": "MISSING",
+        "BODY": "MISSING"
+      },
+      "MANAGE_CUSTOM_EXPENSE_TYPE": "MISSING",
       "OTHER_EXPENSES_LABEL": "Autres dépenses",
       "REVENUE": "Revenu",
       "TITLE": "Finances",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1477,6 +1477,11 @@
       "EXPENSES": "Despesas",
       "FINANCE_HELP": "Ajuda Financeira",
       "LABOUR_LABEL": "Trabalho",
+      "MANAGE_CUSTOM_EXPENSE_TYPES_SPOTLIGHT": {
+        "TITLE": "MISSING",
+        "BODY": "MISSING"
+      },
+      "MANAGE_CUSTOM_EXPENSE_TYPE": "MISSING",
       "OTHER_EXPENSES_LABEL": "Outras despesas",
       "REVENUE": "Receita",
       "TITLE": "Finanças",

--- a/packages/webapp/src/components/Typography/index.tsx
+++ b/packages/webapp/src/components/Typography/index.tsx
@@ -31,6 +31,7 @@ export const Underlined = ({
 type IconLinkProps = TypographyProps & {
   icon?: ReactNode;
   isIconClickable?: boolean;
+  underlined?: boolean;
 };
 export const IconLink = ({
   children = 'IconLink',
@@ -39,6 +40,7 @@ export const IconLink = ({
   onClick,
   icon,
   isIconClickable = false,
+  underlined = true,
   ...props
 }: IconLinkProps) => {
   return (
@@ -50,7 +52,7 @@ export const IconLink = ({
     >
       {icon}{' '}
       <span
-        className={clsx(styles.underlined, styles.iconLinkText)}
+        className={clsx(underlined && styles.underlined, styles.iconLinkText)}
         onClick={isIconClickable ? undefined : onClick}
       >
         {children}

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PageTitle from '../../../../components/PageTitle';
+import Button from '../../../../components/Form/Button';
 import connect from 'react-redux/es/connect/connect';
 import defaultStyles from '../../styles.module.scss';
 import styles from './styles.module.scss';
@@ -13,10 +14,13 @@ import SeedImg from '../../../../assets/images/log/seeding.svg';
 import OtherImg from '../../../../assets/images/log/other.svg';
 import LandImg from '../../../../assets/images/log/land.svg';
 import { setSelectedExpenseTypes } from '../../actions';
+import { IconLink } from '../../../../components/Typography';
 import history from '../../../../history';
 import { withTranslation } from 'react-i18next';
 import { Grid } from '@mui/material';
 import PropTypes from 'prop-types';
+import { BsGear } from 'react-icons/bs';
+import ManageCustomExpenseTypesSpotlight from '../ManageCustomExpenseTypesSpotlight';
 
 const iconMap = {
   EQUIPMENT: EquipImg,
@@ -78,68 +82,89 @@ class ExpenseCategories extends Component {
     const { expenseTypes } = this.props;
     const { selectedStyle, unSelectedStyle, selectedTypes } = this.state;
     return (
-      <div className={defaultStyles.financesContainer}>
-        <PageTitle backUrl="/Finances" title={this.props.t('EXPENSE.ADD_EXPENSE.TITLE_1')} />
-        <Grid
-          container
-          spacing={3}
-          style={{
-            marginLeft: 0,
-            marginRight: 0,
-            marginTop: '24px',
-            width: '100%',
-          }}
-        >
-          {expenseTypes
-            ?.sort((firstExpenseType, secondExpenseType) => {
-              if (firstExpenseType.expense_translation_key === 'OTHER') return 1;
-              if (secondExpenseType.expense_translation_key === 'OTHER') return -1;
-              return this.props
-                .t(`expense:${firstExpenseType.expense_translation_key}`)
-                .localeCompare(
-                  this.props.t(`expense:${secondExpenseType.expense_translation_key}`),
-                );
-            })
-            .map((type) => {
-              return (
-                <Grid
-                  item
-                  xs={4}
-                  md={3}
-                  lg={2}
-                  key={type.expense_type_id}
-                  style={{ marginBottom: '12px' }}
-                >
-                  <div>
-                    <div
-                      style={
-                        selectedTypes.includes(type.expense_type_id)
-                          ? selectedStyle
-                          : unSelectedStyle
-                      }
-                      onClick={() => this.addRemoveType(type.expense_type_id)}
-                      className={styles.greenCircle}
+      <ManageCustomExpenseTypesSpotlight>
+        <div className={defaultStyles.financesContainer}>
+          <div>
+            <PageTitle backUrl="/Finances" title={this.props.t('EXPENSE.ADD_EXPENSE.TITLE_1')} />
+            <Grid
+              container
+              spacing={3}
+              style={{
+                marginLeft: 0,
+                marginRight: 0,
+                marginTop: '24px',
+                width: '100%',
+              }}
+            >
+              {expenseTypes
+                ?.sort((firstExpenseType, secondExpenseType) => {
+                  if (firstExpenseType.expense_translation_key === 'OTHER') return 1;
+                  if (secondExpenseType.expense_translation_key === 'OTHER') return -1;
+                  return this.props
+                    .t(`expense:${firstExpenseType.expense_translation_key}`)
+                    .localeCompare(
+                      this.props.t(`expense:${secondExpenseType.expense_translation_key}`),
+                    );
+                })
+                .map((type) => {
+                  return (
+                    <Grid
+                      item
+                      xs={4}
+                      md={3}
+                      lg={2}
+                      key={type.expense_type_id}
+                      style={{ marginBottom: '12px' }}
                     >
-                      <img
-                        src={iconMap[type.expense_translation_key]}
-                        alt=""
-                        className={styles.circleImg}
-                      />
-                    </div>
-                    <div className={styles.typeName}>
-                      {this.props.t(`expense:${type.expense_translation_key}`)}
-                    </div>
-                  </div>
-                </Grid>
-              );
-            })}
-        </Grid>
-        <div className={styles.bottomContainer}>
-          <button className="btn btn-primary" onClick={() => this.nextPage()}>
-            {this.props.t('common:NEXT')}
-          </button>
+                      <div>
+                        <div
+                          style={
+                            selectedTypes.includes(type.expense_type_id)
+                              ? selectedStyle
+                              : unSelectedStyle
+                          }
+                          onClick={() => this.addRemoveType(type.expense_type_id)}
+                          className={styles.greenCircle}
+                        >
+                          <img
+                            src={iconMap[type.expense_translation_key]}
+                            alt=""
+                            className={styles.circleImg}
+                          />
+                        </div>
+                        <div className={styles.typeName}>
+                          {this.props.t(`expense:${type.expense_translation_key}`)}
+                        </div>
+                      </div>
+                    </Grid>
+                  );
+                })}
+            </Grid>
+          </div>
+          <div>
+            <div className={styles.manageCustomTypeLinkContainer}>
+              <IconLink
+                id="manageCustomExpenseType"
+                className={styles.manageCustomTypeLink}
+                icon={<BsGear className={styles.manageCustomTypeIcon} />}
+                isIconClickable
+                underlined={false}
+              >
+                {this.props.t('SALE.FINANCES.MANAGE_CUSTOM_EXPENSE_TYPE')}
+              </IconLink>
+            </div>
+            <Button
+              color={'primary'}
+              fullLength
+              onClick={() => this.nextPage()}
+              disabled={!selectedTypes.length}
+              className={styles.continueButton}
+            >
+              {this.props.t('common:CONTINUE')}
+            </Button>
+          </div>
         </div>
-      </div>
+      </ManageCustomExpenseTypesSpotlight>
     );
   }
 }

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/styles.module.scss
@@ -34,3 +34,21 @@
   display: flex;
   align-items: center;
 }
+
+.manageCustomTypeIcon {
+  margin-right: 4px;
+}
+
+.manageCustomTypeLinkContainer {
+  display: inline-block;
+}
+
+.manageCustomTypeLink {
+  display: flex;
+  color: var(--grey600);
+  margin: auto;
+}
+
+.continueButton {
+  margin-top: 10px;
+}

--- a/packages/webapp/src/containers/Finances/NewExpense/ManageCustomExpenseTypesSpotlight/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ManageCustomExpenseTypesSpotlight/index.jsx
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { showedSpotlightSelector } from '../../../showedSpotlightSlice';
+import { setSpotlightToShown } from '../../../Map/saga';
+import { TourProviderWrapper } from '../../../../components/TourProviderWrapper/TourProviderWrapper';
+
+export default function ManageCustomExpenseTypesSpotlight({ children }) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { manage_custom_expense_type } = useSelector(showedSpotlightSelector);
+  const onFinish = () => dispatch(setSpotlightToShown('manage_custom_expense_type'));
+
+  return (
+    <TourProviderWrapper
+      open={!manage_custom_expense_type}
+      steps={[
+        {
+          title: t('SALE.FINANCES.MANAGE_CUSTOM_EXPENSE_TYPES_SPOTLIGHT.TITLE'),
+          contents: [t('SALE.FINANCES.MANAGE_CUSTOM_EXPENSE_TYPES_SPOTLIGHT.BODY')],
+          selector: `#manageCustomExpenseType`,
+          position: 'center',
+        },
+      ]}
+      onFinish={onFinish}
+    >
+      {children}
+    </TourProviderWrapper>
+  );
+}

--- a/packages/webapp/src/containers/Finances/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/styles.module.scss
@@ -16,11 +16,12 @@
 .financesContainer {
   width: 100%;
   max-width: 1024px;
-  min-height: 100vh;
+  min-height: 100%;
   height: auto;
   padding: 24px 24px 50px 24px;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 }
 
 .topContainer {
@@ -147,15 +148,6 @@
 .rightDiv {
   display: inline;
   float: right;
-}
-
-.expenseContainer {
-}
-
-.salesContainer {
-}
-
-.balanceContainer {
 }
 
 .table {

--- a/packages/webapp/src/containers/showedSpotlightSlice.js
+++ b/packages/webapp/src/containers/showedSpotlightSlice.js
@@ -20,6 +20,7 @@ const initialState = {
   planting_task: false,
   sensor_reading_chart: false,
   repeat_management_plan_creation: false,
+  manage_custom_expense_type: false,
 };
 
 const showedSpotlightSlice = createSlice({


### PR DESCRIPTION
**Description**

- Added "Manage custom type" icon link at the end of the Add Expense page.
- Added spotlight to highlight this icon link.

Jira link:
https://lite-farm.atlassian.net/browse/LF-3559

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Tested locally by going to Add expense page and checking that the new icon link renders at the end of the page correctly, the spotlight is shown the first time, and once it's dismissed it doesn't display again when reloading the page.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
