### PR TITLE
LF-3558 Retire custom expense type UI

### DIFF
--- a/packages/webapp/src/components/Forms/SimpleCustomType/index.jsx
+++ b/packages/webapp/src/components/Forms/SimpleCustomType/index.jsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import Form from '../../Form';
@@ -21,6 +21,9 @@ import PageTitle from '../../PageTitle/v2';
 import Input, { getInputErrors } from '../../Form/Input';
 import Button from '../../Form/Button';
 import PropTypes from 'prop-types';
+import { IconLink } from '../../Typography';
+import { MdOutlineInventory2 } from 'react-icons/md';
+import DeleteBox from '../../Task/TaskReadOnly/DeleteBox';
 
 // onSubmit: should be used in Add, Edit view
 // onClick: should be used in Read-only view
@@ -35,8 +38,13 @@ const PureSimpleCustomType = ({
   inputLabel,
   customTypeRegister,
   defaultValue,
+  onRetire = () => {},
+  retireLinkText,
+  retireHeader,
+  retireMessage,
 }) => {
   const { t } = useTranslation();
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const {
     handleSubmit,
@@ -80,6 +88,39 @@ const PureSimpleCustomType = ({
         optional={false}
         disabled={disabledInput}
       />
+      <div style={{ marginTop: 'auto' }}>
+        {readonly && !isDeleting && (
+          <IconLink
+            style={{ color: 'var(--grey600)' }}
+            icon={
+              <MdOutlineInventory2
+                style={{
+                  fontSize: '16px',
+                  transform: 'translateY(3px)',
+                }}
+              />
+            }
+            onClick={() => setIsDeleting(true)}
+            isIconClickable
+          >
+            {retireLinkText}
+          </IconLink>
+        )}
+
+        {isDeleting && (
+          <DeleteBox
+            color="warning"
+            onOk={onRetire}
+            onCancel={() => setIsDeleting(false)}
+            header={retireHeader}
+            headerIcon={
+              <MdOutlineInventory2 style={{ fontSize: '24px', transform: 'translateY(5px)' }} />
+            }
+            message={retireMessage}
+            primaryButtonLabel={t('common:CONFIRM')}
+          />
+        )}
+      </div>
     </Form>
   );
 };
@@ -94,6 +135,10 @@ PureSimpleCustomType.propTypes = {
   inputLabel: PropTypes.string,
   customTypeRegister: PropTypes.string,
   defaultValue: PropTypes.string,
+  onRetire: PropTypes.func,
+  retireLinkText: PropTypes.string,
+  retireHeader: PropTypes.string,
+  retireMessage: PropTypes.string,
 };
 
 export default PureSimpleCustomType;

--- a/packages/webapp/src/stories/Pages/Forms/SimpleCustomType.stories.jsx
+++ b/packages/webapp/src/stories/Pages/Forms/SimpleCustomType.stories.jsx
@@ -53,6 +53,10 @@ ReadOnlyCustomType.args = {
   onClick: () => {
     console.log('Moving to edit mode');
   },
+  retireLinkText: 'Retire expense type',
+  retireHeader: 'Retire expense type',
+  retireMessage:
+    'Retiring this expense type will remove it as a possible choice for future expenses. You can still search and filter for historical instances of this expense type on the Finances tab.',
   ...args,
 };
 


### PR DESCRIPTION
**Description**

This adds the retire UI (link and DeleteBox) to SimpleCustomTypes. Since that is a flexible component meant to be used in more than one context, the text is taken in as props.

For Storybook I have used the text associated with custom expenses as those props:
http://localhost:6006/?path=/story/form-simplecustomtype--read-only-custom-type

Jira link: https://lite-farm.atlassian.net/browse/LF-3558

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Viewed in Storybook as this component is not yet in app (containers are currently being built).

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
