### PR TITLE
Lf 3551 create api's for custom expense types

### DIFF
--- a/packages/api/src/controllers/baseController.js
+++ b/packages/api/src/controllers/baseController.js
@@ -108,6 +108,17 @@ export default {
       .returning('*');
   },
 
+  async patch(model, id, data, req, { trx = null, context = {} } = {}) {
+    const resource = removeAdditionalProperties(model, data);
+    const table_id = model.idColumn;
+
+    return await model
+      .query(trx)
+      .context({ user_id: req?.auth?.user_id, ...context })
+      .where(table_id, id)
+      .patch(resource);
+  },
+
   async delete(model, id, req, { trx = null, context = {} } = {}) {
     const table_id = model.idColumn;
     return await model

--- a/packages/api/src/controllers/baseController.js
+++ b/packages/api/src/controllers/baseController.js
@@ -170,5 +170,14 @@ export default {
   async eager(model, subModel, trx) {
     return await model.query(trx).eager(subModel);
   },
+
+  /**
+   * Format transaltion key
+   * @param {String} key
+   * @returns {String} - Formatted key
+   */
+  formatTranslationKey(key) {
+    return key.toUpperCase().trim().replaceAll(' ', '_');
+  },
 };
 //export trx;

--- a/packages/api/src/controllers/farmExpenseTypeController.js
+++ b/packages/api/src/controllers/farmExpenseTypeController.js
@@ -127,6 +127,7 @@ const farmExpenseTypeController = {
       const { expense_type_id } = req.params;
       const farm_id = req.headers.farm_id;
       const data = req.body;
+      data.farm_id = farm_id;
 
       try {
         // if record exists throw Conflict error

--- a/packages/api/src/models/expenseTypeModel.js
+++ b/packages/api/src/models/expenseTypeModel.js
@@ -42,28 +42,6 @@ class ExpenseType extends baseModel {
       additionalProperties: false,
     };
   }
-
-  /**
-   * Check if records exists in DB
-   * @param {number} farm_id
-   * @param {String} expense_name
-   * @param {number} expense_type_id - Expesnse type id to be excluded while checking records
-   * @static
-   * @async
-   * @returns {String} - Object DB record
-   */
-  static async existsInFarm(farm_id, expense_name, expense_type_id = '') {
-    let query = this.query().context({ showHidden: true }).where({
-      expense_name,
-      farm_id,
-    });
-
-    if (expense_type_id) {
-      query = query.whereNot({ expense_type_id });
-    }
-
-    return query.first();
-  }
 }
 
 export default ExpenseType;

--- a/packages/api/src/models/expenseTypeModel.js
+++ b/packages/api/src/models/expenseTypeModel.js
@@ -42,6 +42,28 @@ class ExpenseType extends baseModel {
       additionalProperties: false,
     };
   }
+
+  /**
+   * Check if records exists in DB
+   * @param {number} farm_id
+   * @param {String} expense_name
+   * @param {number} expense_type_id - Expesnse type id to be excluded while checking records
+   * @static
+   * @async
+   * @returns {String} - Object DB record
+   */
+  static async existsInFarm(farm_id, expense_name, expense_type_id = '') {
+    let query = this.query().context({ showHidden: true }).where({
+      expense_name,
+      farm_id,
+    });
+
+    if (expense_type_id) {
+      query = query.whereNot({ expense_type_id });
+    }
+
+    return query.first();
+  }
 }
 
 export default ExpenseType;

--- a/packages/api/src/routes/farmExpenseTypeRoute.js
+++ b/packages/api/src/routes/farmExpenseTypeRoute.js
@@ -43,4 +43,11 @@ router.delete(
   farmExpenseTypeController.delFarmExpenseType(),
 );
 
+router.put(
+  '/:expense_type_id',
+  hasFarmAccess({ params: 'expense_type_id' }),
+  checkScope(['add:expense_types']),
+  farmExpenseTypeController.updateFarmExpenseType(),
+);
+
 export default router;

--- a/packages/api/src/routes/farmExpenseTypeRoute.js
+++ b/packages/api/src/routes/farmExpenseTypeRoute.js
@@ -43,10 +43,10 @@ router.delete(
   farmExpenseTypeController.delFarmExpenseType(),
 );
 
-router.put(
+router.patch(
   '/:expense_type_id',
   hasFarmAccess({ params: 'expense_type_id' }),
-  checkScope(['add:expense_types']),
+  checkScope(['edit:expense_types']),
   farmExpenseTypeController.updateFarmExpenseType(),
 );
 

--- a/packages/api/tests/expense_type.test.js
+++ b/packages/api/tests/expense_type.test.js
@@ -14,6 +14,7 @@
  */
 
 import chai from 'chai';
+import util from 'util';
 
 import chaiHttp from 'chai-http';
 chai.use(chaiHttp);
@@ -58,6 +59,7 @@ describe('Expense Type Tests', () => {
       .send(data)
       .end(callback);
   }
+  const postExpenseTypeRequestAsPromise = util.promisify(postExpenseTypeRequest);
 
   function patchExpenseTypeRequest(
     data,
@@ -73,6 +75,7 @@ describe('Expense Type Tests', () => {
       .send(data)
       .end(callback);
   }
+  const patchExpenseTypeRequestAsPromise = util.promisify(patchExpenseTypeRequest);
 
   function fakeUserFarm(role = 1) {
     return { ...mocks.fakeUserFarm(), role_id: role };
@@ -86,6 +89,7 @@ describe('Expense Type Tests', () => {
       .set('farm_id', farm_id)
       .end(callback);
   }
+  const getRequestAsPromise = util.promisify(getRequest);
 
   function getDefaultRequest({ user_id = newOwner.user_id, farm_id = farm1.farm_id }, callback) {
     chai
@@ -96,6 +100,7 @@ describe('Expense Type Tests', () => {
       // .send(farm_id)
       .end(callback);
   }
+  const getDefaultRequestAsPromise = util.promisify(getDefaultRequest);
 
   function deleteRequest(data, { user_id = newOwner.user_id, farm_id = farm.farm_id }, callback) {
     const { expense_type_id } = data;
@@ -106,6 +111,7 @@ describe('Expense Type Tests', () => {
       .set('farm_id', farm_id)
       .end(callback);
   }
+  const deleteRequestAsPromise = util.promisify(deleteRequest);
 
   async function returnUserFarms(role) {
     const [mainFarm] = await mocks.farmFactory();
@@ -150,364 +156,330 @@ describe('Expense Type Tests', () => {
   });
 
   // POST TESTS
-
   describe('Post expense type tests', () => {
-    test('Owner should post expense type', async (done) => {
+    test('Owner should post expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense_type = getFakeExpenseType(mainFarm.farm_id);
 
-      postExpenseTypeRequest(
-        expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(201);
-          const expense_types = await farmExpenseTypeModel
-            .query()
-            .context({ showHidden: true })
-            .where('farm_id', mainFarm.farm_id);
-          expect(expense_types.length).toBe(1);
-          expect(expense_types[0].value).toBe(expense_type.value);
-          done();
-        },
-      );
+      const res = await postExpenseTypeRequestAsPromise(expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(201);
+      const expense_types = await farmExpenseTypeModel
+        .query()
+        .context({ showHidden: true })
+        .where('farm_id', mainFarm.farm_id);
+      expect(expense_types.length).toBe(1);
+      expect(expense_types[0].value).toBe(expense_type.value);
     });
-    test('Manager should post expense type', async (done) => {
+
+    test('Manager should post expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense_type = getFakeExpenseType(mainFarm.farm_id);
 
-      postExpenseTypeRequest(
-        expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(201);
-          const expense_types = await farmExpenseTypeModel
-            .query()
-            .context({ showHidden: true })
-            .where('farm_id', mainFarm.farm_id);
-          expect(expense_types.length).toBe(1);
-          expect(expense_types[0].value).toBe(expense_type.value);
-          done();
-        },
-      );
+      const res = await postExpenseTypeRequestAsPromise(expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(201);
+      const expense_types = await farmExpenseTypeModel
+        .query()
+        .context({ showHidden: true })
+        .where('farm_id', mainFarm.farm_id);
+      expect(expense_types.length).toBe(1);
+      expect(expense_types[0].value).toBe(expense_type.value);
     });
-    test('Worker should get 403 if they try to post expense type', async (done) => {
+
+    test('Worker should get 403 if they try to post expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense_type = getFakeExpenseType(mainFarm.farm_id);
 
-      postExpenseTypeRequest(
-        expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(403);
-          expect(res.error.text).toBe(
-            'User does not have the following permission(s): add:expense_types',
-          );
-          done();
-        },
+      const res = await postExpenseTypeRequestAsPromise(expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): add:expense_types',
       );
     });
-    test('Unauthorized user should get 403 if they try to post expense type', async (done) => {
+
+    test('Unauthorized user should get 403 if they try to post expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense_type = getFakeExpenseType(mainFarm.farm_id);
       const [unAuthorizedUser] = await mocks.usersFactory();
 
-      postExpenseTypeRequest(
-        expense_type,
-        {
-          user_id: unAuthorizedUser.user_id,
-          farm_id: mainFarm.farm_id,
-        },
-        async (err, res) => {
-          expect(res.status).toBe(403);
-          expect(res.error.text).toBe(
-            'User does not have the following permission(s): add:expense_types',
-          );
-          done();
-        },
+      const res = await postExpenseTypeRequestAsPromise(expense_type, {
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): add:expense_types',
       );
     });
   });
 
   // GET TESTS
-
   describe('Get expense type tests', () => {
-    test('Owner should get expense type by farm id (or null)', async (done) => {
+    test('Owner should get expense type by farm id (or null)', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnExpenseType(mainFarm);
 
-      getRequest({ user_id: user.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(200);
-
-        expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
-        done();
-      });
+      const res = await getRequestAsPromise({ user_id: user.user_id, farm_id: mainFarm.farm_id });
+      expect(res.status).toBe(200);
+      expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
     });
-    test('manager should get expense type by farm id (or null)', async (done) => {
+
+    test('manager should get expense type by farm id (or null)', async () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense = await returnExpenseType(mainFarm);
 
-      getRequest({ user_id: user.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(200);
-
-        expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
-        done();
-      });
+      const res = await getRequestAsPromise({ user_id: user.user_id, farm_id: mainFarm.farm_id });
+      expect(res.status).toBe(200);
+      expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
     });
-    test('Worker should get expense type by farm id (or null)', async (done) => {
+
+    test('Worker should get expense type by farm id (or null)', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense = await returnExpenseType(mainFarm);
 
-      getRequest({ user_id: user.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(200);
-
-        expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
-        done();
-      });
+      const res = await getRequestAsPromise({ user_id: user.user_id, farm_id: mainFarm.farm_id });
+      expect(res.status).toBe(200);
+      expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
     });
-    test('Unauthorized user should get 403 if they try to get expense type by farm id (or null)', async (done) => {
+
+    test('Unauthorized user should get 403 if they try to get expense type by farm id (or null)', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnExpenseType(mainFarm);
       const [unAuthorizedUser] = await mocks.usersFactory();
 
-      getRequest({ user_id: unAuthorizedUser.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(403);
-        expect(res.error.text).toBe(
-          'User does not have the following permission(s): get:expense_types',
-        );
-        done();
+      const res = await getRequestAsPromise({
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
       });
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): get:expense_types',
+      );
     });
   });
 
   // GET DEFAULT TESTS
-
   describe('Get expense type default tests', () => {
-    test('Owner should get default expense type', async (done) => {
+    test('Owner should get default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnDefaultExpenseType();
 
-      getDefaultRequest({ user_id: user.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(200);
-        expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
-        done();
+      const res = await getDefaultRequestAsPromise({
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
       });
+      expect(res.status).toBe(200);
+      expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
     });
-    test('manager should get default expense type', async (done) => {
+
+    test('manager should get default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense = await returnDefaultExpenseType();
 
-      getDefaultRequest({ user_id: user.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(200);
-
-        expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
-        done();
+      const res = await getDefaultRequestAsPromise({
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
       });
+      expect(res.status).toBe(200);
+      expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
     });
-    test('worker should get default expense type', async (done) => {
+
+    test('worker should get default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense = await returnDefaultExpenseType();
 
-      getDefaultRequest({ user_id: user.user_id, farm_id: mainFarm.farm_id }, (err, res) => {
-        expect(res.status).toBe(200);
-
-        expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
-        done();
+      const res = await getDefaultRequestAsPromise({
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
       });
+      expect(res.status).toBe(200);
+      expect(res.body[0].farm_id).toBe(expense.expense_type.farm_id);
     });
   });
 
   // DELETE DEFAULT TEST
-
   describe('Delete expense type default tests', () => {
-    test('Owner should get 403 if they try to delete default expense type', async (done) => {
+    test('Owner should get 403 if they try to delete default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnDefaultExpenseType();
-      deleteRequest(expense.expense_type, { user_id: expense.user_id }, (err, res) => {
-        expect(res.status).toBe(403);
-        done();
-      });
+      const res = await deleteRequestAsPromise(expense.expense_type, { user_id: expense.user_id });
+      expect(res.status).toBe(403);
     });
-    test('manager should get 403 if they try to delete default expense type', async (done) => {
+
+    test('manager should get 403 if they try to delete default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense = await returnDefaultExpenseType();
 
-      deleteRequest(expense.expense_type, { user_id: user.user_id }, (err, res) => {
-        expect(res.status).toBe(403);
-        done();
-      });
+      const res = await deleteRequestAsPromise(expense.expense_type, { user_id: user.user_id });
+      expect(res.status).toBe(403);
     });
-    test('Worker should get 403 if they try to delete default expense type', async (done) => {
+
+    test('Worker should get 403 if they try to delete default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense = await returnDefaultExpenseType();
 
-      deleteRequest(expense.expense_type, { user_id: user.user_id }, (err, res) => {
-        expect(res.status).toBe(403);
-        done();
-      });
+      const res = await deleteRequestAsPromise(expense.expense_type, { user_id: user.user_id });
+      expect(res.status).toBe(403);
     });
-    test('unauthorized user should get 403 if they try to delete default expense type', async (done) => {
+
+    test('unauthorized user should get 403 if they try to delete default expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnDefaultExpenseType();
       const [unAuthorizedUser] = await mocks.usersFactory();
 
-      deleteRequest(expense.expense_type, { user_id: unAuthorizedUser.user_id }, (err, res) => {
-        expect(res.status).toBe(403);
-        done();
+      const res = await deleteRequestAsPromise(expense.expense_type, {
+        user_id: unAuthorizedUser.user_id,
       });
+      expect(res.status).toBe(403);
     });
   });
 
   // DELETE TESTS
-
   describe('Delete expense type tests', () => {
-    test('Owner should delete their expense type', async (done) => {
+    test('Owner should delete their expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnExpenseType(mainFarm);
 
-      deleteRequest(
-        expense.expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(200);
-          const [deletedField] = await farmExpenseTypeModel
-            .query()
-            .context({ showHidden: true })
-            .where('expense_type_id', expense.expense_type.expense_type_id);
-          expect(deletedField.deleted).toBe(true);
-          done();
-        },
-      );
+      const res = await deleteRequestAsPromise(expense.expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(200);
+      const [deletedField] = await farmExpenseTypeModel
+        .query()
+        .context({ showHidden: true })
+        .where('expense_type_id', expense.expense_type.expense_type_id);
+      expect(deletedField.deleted).toBe(true);
     });
-    test('manager should delete their expense type', async (done) => {
+
+    test('manager should delete their expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense = await returnExpenseType(mainFarm);
 
-      deleteRequest(
-        expense.expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(200);
-          const [deletedField] = await farmExpenseTypeModel
-            .query()
-            .context({ showHidden: true })
-            .where('expense_type_id', expense.expense_type.expense_type_id);
-          expect(deletedField.deleted).toBe(true);
-          done();
-        },
-      );
+      const res = await deleteRequestAsPromise(expense.expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(200);
+      const [deletedField] = await farmExpenseTypeModel
+        .query()
+        .context({ showHidden: true })
+        .where('expense_type_id', expense.expense_type.expense_type_id);
+      expect(deletedField.deleted).toBe(true);
     });
-    test('worker should get 403 if they try to delete their expense type', async (done) => {
+
+    test('worker should get 403 if they try to delete their expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense = await returnExpenseType(mainFarm);
 
-      deleteRequest(
-        expense.expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(403);
-          expect(res.error.text).toBe(
-            'User does not have the following permission(s): delete:expense_types',
-          );
-          done();
-        },
+      const res = await deleteRequestAsPromise(expense.expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): delete:expense_types',
       );
     });
-    test('Unauthorized user should delete get 403 if they try to delete their expense type', async (done) => {
+
+    test('Unauthorized user should delete get 403 if they try to delete their expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const [unAuthorizedUser] = await mocks.usersFactory();
       const expense = await returnExpenseType(mainFarm);
 
-      deleteRequest(
-        expense.expense_type,
-        {
-          user_id: unAuthorizedUser.user_id,
-          farm_id: mainFarm.farm_id,
-        },
-        async (err, res) => {
-          expect(res.status).toBe(403);
-          expect(res.error.text).toBe(
-            'User does not have the following permission(s): delete:expense_types',
-          );
-          done();
-        },
+      const res = await deleteRequestAsPromise(expense.expense_type, {
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): delete:expense_types',
       );
     });
   });
 
   // Update expense type
   describe('Update expense type tests', () => {
-    test('Owner should update expense type', async (done) => {
+    test('Owner should update expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnExpenseType(mainFarm);
 
-      patchExpenseTypeRequest(
-        expense.expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(204);
-          const expense_types = await farmExpenseTypeModel
-            .query()
-            .context({ showHidden: true })
-            .where('farm_id', mainFarm.farm_id);
-          expect(expense_types.length).toBe(1);
-          expect(expense_types[0].value).toBe(expense.expense_type.value);
-          done();
-        },
-      );
+      const res = await patchExpenseTypeRequestAsPromise(expense.expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(204);
+      const expense_types = await farmExpenseTypeModel
+        .query()
+        .context({ showHidden: true })
+        .where('farm_id', mainFarm.farm_id);
+      expect(expense_types.length).toBe(1);
+      expect(expense_types[0].value).toBe(expense.expense_type.value);
     });
-    test('Manager should update expense type', async (done) => {
+
+    test('Manager should update expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense = await returnExpenseType(mainFarm);
 
-      patchExpenseTypeRequest(
-        expense.expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(204);
-          const expense_types = await farmExpenseTypeModel
-            .query()
-            .context({ showHidden: true })
-            .where('farm_id', mainFarm.farm_id);
-          expect(expense_types.length).toBe(1);
-          expect(expense_types[0].value).toBe(expense.expense_type.value);
-          done();
-        },
-      );
+      const res = await patchExpenseTypeRequestAsPromise(expense.expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(204);
+      const expense_types = await farmExpenseTypeModel
+        .query()
+        .context({ showHidden: true })
+        .where('farm_id', mainFarm.farm_id);
+      expect(expense_types.length).toBe(1);
+      expect(expense_types[0].value).toBe(expense.expense_type.value);
     });
-    test('Worker should get 403 if they try to update expense type', async (done) => {
+
+    test('Worker should get 403 if they try to update expense type', async () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense = await returnExpenseType(mainFarm);
 
-      patchExpenseTypeRequest(
-        expense.expense_type,
-        { user_id: user.user_id, farm_id: mainFarm.farm_id },
-        async (err, res) => {
-          expect(res.status).toBe(403);
-          expect(res.error.text).toBe(
-            'User does not have the following permission(s): edit:expense_types',
-          );
-          done();
-        },
+      const res = await patchExpenseTypeRequestAsPromise(expense.expense_type, {
+        user_id: user.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): edit:expense_types',
       );
     });
-    test('Unauthorized user should get 403 if they try to update expense type', async (done) => {
+
+    test('Unauthorized user should get 403 if they try to update expense type', async () => {
       const { mainFarm } = await returnUserFarms(3);
       const expense = await returnExpenseType(mainFarm);
       const [unAuthorizedUser] = await mocks.usersFactory();
 
-      patchExpenseTypeRequest(
-        expense.expense_type,
-        {
-          user_id: unAuthorizedUser.user_id,
-          farm_id: mainFarm.farm_id,
-        },
-        async (err, res) => {
-          expect(res.status).toBe(403);
-          expect(res.error.text).toBe(
-            'User does not have the following permission(s): edit:expense_types',
-          );
-          done();
-        },
+      const res = await patchExpenseTypeRequestAsPromise(expense.expense_type, {
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): edit:expense_types',
       );
     });
   });

--- a/packages/api/tests/expense_type.test.js
+++ b/packages/api/tests/expense_type.test.js
@@ -59,14 +59,14 @@ describe('Expense Type Tests', () => {
       .end(callback);
   }
 
-  function putExpenseTypeRequest(
+  function patchExpenseTypeRequest(
     data,
     { user_id = newOwner.user_id, farm_id = farm.farm_id },
     callback,
   ) {
     chai
       .request(server)
-      .put(`/expense_type/${data.expense_type_id}`)
+      .patch(`/expense_type/${data.expense_type_id}`)
       .set('Content-Type', 'application/json')
       .set('user_id', user_id)
       .set('farm_id', farm_id)
@@ -322,7 +322,6 @@ describe('Expense Type Tests', () => {
     test('Owner should get 403 if they try to delete default expense type', async (done) => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnDefaultExpenseType();
-      //console.log(expense);
       deleteRequest(expense.expense_type, { user_id: expense.user_id }, (err, res) => {
         expect(res.status).toBe(403);
         done();
@@ -441,7 +440,7 @@ describe('Expense Type Tests', () => {
       const { mainFarm, user } = await returnUserFarms(1);
       const expense = await returnExpenseType(mainFarm);
 
-      putExpenseTypeRequest(
+      patchExpenseTypeRequest(
         expense.expense_type,
         { user_id: user.user_id, farm_id: mainFarm.farm_id },
         async (err, res) => {
@@ -460,7 +459,7 @@ describe('Expense Type Tests', () => {
       const { mainFarm, user } = await returnUserFarms(2);
       const expense = await returnExpenseType(mainFarm);
 
-      putExpenseTypeRequest(
+      patchExpenseTypeRequest(
         expense.expense_type,
         { user_id: user.user_id, farm_id: mainFarm.farm_id },
         async (err, res) => {
@@ -479,13 +478,13 @@ describe('Expense Type Tests', () => {
       const { mainFarm, user } = await returnUserFarms(3);
       const expense = await returnExpenseType(mainFarm);
 
-      putExpenseTypeRequest(
+      patchExpenseTypeRequest(
         expense.expense_type,
         { user_id: user.user_id, farm_id: mainFarm.farm_id },
         async (err, res) => {
           expect(res.status).toBe(403);
           expect(res.error.text).toBe(
-            'User does not have the following permission(s): add:expense_types',
+            'User does not have the following permission(s): edit:expense_types',
           );
           done();
         },
@@ -496,7 +495,7 @@ describe('Expense Type Tests', () => {
       const expense = await returnExpenseType(mainFarm);
       const [unAuthorizedUser] = await mocks.usersFactory();
 
-      putExpenseTypeRequest(
+      patchExpenseTypeRequest(
         expense.expense_type,
         {
           user_id: unAuthorizedUser.user_id,
@@ -505,7 +504,7 @@ describe('Expense Type Tests', () => {
         async (err, res) => {
           expect(res.status).toBe(403);
           expect(res.error.text).toBe(
-            'User does not have the following permission(s): add:expense_types',
+            'User does not have the following permission(s): edit:expense_types',
           );
           done();
         },


### PR DESCRIPTION
**Description**

To create Api's to add, edit, delete custom expense types. Following are the response types of each endpoint

1. `POST /expense_type` to create new expense type

- If for combination of expense name and farm id exists but is either deleted or not, then no new record is created and deleted is set to false for the existing record. 204 status code is sent in this case.
- If for above combination, no record is present in DB, then new expense type is created and 201 status code is sent.

2. `PUT /expense_type/[expense_type_id]` to update expense type

- While editing, if we change custom expense type to which is already present for that particular farm, then 409 status code is sent.
- On successful update 204 status code is sent.

3. `DELETE /expense_type/[expense_type_id]` to delete expense type

- If delete is successful, then 200 status code is send.
- If expense_type_id is wrong, then 404 status code is sent.


Note: Farm workers(role 3) has permission to edit custom expense type which needs to be changed and is addressed in this ticket https://lite-farm.atlassian.net/browse/LF-3580

Jira link: https://lite-farm.atlassian.net/browse/LF-3551

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**How Has This Been Tested?**

Test cases written to support each case such as Owners, Managers can add, edit, delete expense type in their own farms and workers or unauthorized users cannot add, edit, delete expense type.

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
