### PR TITLE
Remove permission for worker role to edit expense types

### DIFF
--- a/packages/api/db/migration/20230829200916_remove_permission_to_edit_custom_expense_type_for_worker_role.js
+++ b/packages/api/db/migration/20230829200916_remove_permission_to_edit_custom_expense_type_for_worker_role.js
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex('rolePermissions')
+    .where({
+      role_id: 3,
+      permission_id: 45,
+    })
+    .del();
+};
+export const down = async function (knex) {
+  await knex('rolePermissions').insert({
+    role_id: 3,
+    permission_id: 45,
+  });
+};


### PR DESCRIPTION
**Description**

This PR removes the permission for the 'Worker' role to edit the expense types. 

Jira link:https://lite-farm.atlassian.net/browse/LF-3580

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Run migration by executing command `npm run migrate:dev:db`. This will remove the entry from the DB.

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
