### PR TITLE
LF-3586 make the revenue type slice and add the revenue types selector and sagas

### DIFF
--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -133,6 +133,18 @@
       "EDIT": "Revenue successfully updated"
     }
   },
+  "REVENUE_TYPE": {
+    "ERROR": {
+      "ADD": "Failed to add revenue type",
+      "DELETE": "Failed to retire revenue type",
+      "UPDATE": "Failed to update revenue type"
+    },
+    "SUCCESS": {
+      "ADD": "Successfully added revenue type",
+      "DELETE": "Successfully retired revenue type",
+      "UPDATE": "Successfully updated revenue type"
+    }
+  },
   "SALE": {
     "ERROR": {
       "ADD": "Failed to add sale",

--- a/packages/webapp/public/locales/es/message.json
+++ b/packages/webapp/public/locales/es/message.json
@@ -133,6 +133,18 @@
       "EDIT": "Ingresos actualizados correctamente"
     }
   },
+  "REVENUE_TYPE": {
+    "ERROR": {
+      "ADD": "MISSING",
+      "DELETE": "MISSING",
+      "UPDATE": "MISSING"
+    },
+    "SUCCESS": {
+      "ADD": "MISSING",
+      "DELETE": "MISSING",
+      "UPDATE": "MISSING"
+    }
+  },
   "SALE": {
     "ERROR": {
       "ADD": "No se pudo agregar venta",

--- a/packages/webapp/public/locales/fr/message.json
+++ b/packages/webapp/public/locales/fr/message.json
@@ -133,6 +133,18 @@
       "EDIT": "Chiffre d'affaires mis à jour avec succès"
     }
   },
+  "REVENUE_TYPE": {
+    "ERROR": {
+      "ADD": "MISSING",
+      "DELETE": "MISSING",
+      "UPDATE": "MISSING"
+    },
+    "SUCCESS": {
+      "ADD": "MISSING",
+      "DELETE": "MISSING",
+      "UPDATE": "MISSING"
+    }
+  },
   "SALE": {
     "ERROR": {
       "ADD": "Impossible d'ajouter la vente",

--- a/packages/webapp/public/locales/pt/message.json
+++ b/packages/webapp/public/locales/pt/message.json
@@ -133,6 +133,18 @@
       "EDIT": "Receita atualizada com sucesso"
     }
   },
+  "REVENUE_TYPE": {
+    "ERROR": {
+      "ADD": "MISSING",
+      "DELETE": "MISSING",
+      "UPDATE": "MISSING"
+    },
+    "SUCCESS": {
+      "ADD": "MISSING",
+      "DELETE": "MISSING",
+      "UPDATE": "MISSING"
+    }
+  },
   "SALE": {
     "ERROR": {
       "ADD": "Falha ao adicionar venda",

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -55,6 +55,7 @@ export const salesURL = URI + '/sale';
 //export const cropSalesURL = URI + '/crop_sale';
 export const expenseUrl = URI + '/expense';
 export const expenseTypeDefaultUrl = URI + '/expense_type';
+export const revenueTypeUrl = URI + '/revenue_type';
 //export const contactURL = URI + '/contact';
 //export const farmDataUrl = URI + '/farmdata';
 export const userFarmUrl = `${URI}/user_farm`;
@@ -96,6 +97,7 @@ export default {
   //cropSalesURL,
   expenseUrl,
   expenseTypeDefaultUrl,
+  revenueTypeUrl,
   //contactURL,
   //farmDataUrl,
   userFarmUrl,

--- a/packages/webapp/src/containers/Finances/saga.js
+++ b/packages/webapp/src/containers/Finances/saga.js
@@ -35,6 +35,7 @@ import i18n from '../../locales/i18n';
 import history from '../../history';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
 import { createAction } from '@reduxjs/toolkit';
+import { getRevenueTypesSuccess } from '../revenueTypeSlice';
 
 export function* getSales() {
   const { salesURL } = apiConfig;
@@ -240,6 +241,23 @@ export function* tempEditExpenseSaga(action) {
   }
 }
 
+export const getRevenueTypes = createAction('getRevenueTypesSaga');
+
+export function* getRevenueTypesSaga() {
+  const { revenueTypeUrl } = apiConfig;
+  let { user_id, farm_id } = yield select(loginSelector);
+  const header = getHeader(user_id, farm_id);
+
+  try {
+    const result = yield call(axios.get, `${revenueTypeUrl}/farm/${farm_id}`, header);
+    if (result) {
+      yield put(getRevenueTypesSuccess(result.data));
+    }
+  } catch (e) {
+    console.log('failed to fetch revenue types from database');
+  }
+}
+
 export const patchEstimatedCropRevenue = createAction(`patchEstimatedCropRevenueSaga`);
 export function* patchEstimatedCropRevenueSaga({ payload: managementPlan }) {
   const { managementPlanURL } = apiConfig;
@@ -267,6 +285,7 @@ export default function* financeSaga() {
   yield takeLeading(ADD_OR_UPDATE_SALE, addSale);
   yield takeLatest(GET_EXPENSE, getExpenseSaga);
   yield takeLatest(GET_FARM_EXPENSE_TYPE, getFarmExpenseTypeSaga);
+  yield takeLatest(getRevenueTypes.type, getRevenueTypesSaga);
   yield takeLeading(ADD_EXPENSES, addExpensesSaga);
   yield takeLeading(DELETE_SALE, deleteSale);
   yield takeLeading(DELETE_EXPENSES, deleteExpensesSaga);

--- a/packages/webapp/src/containers/Finances/saga.js
+++ b/packages/webapp/src/containers/Finances/saga.js
@@ -35,7 +35,7 @@ import i18n from '../../locales/i18n';
 import history from '../../history';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
 import { createAction } from '@reduxjs/toolkit';
-import { getRevenueTypesSuccess } from '../revenueTypeSlice';
+import { getRevenueTypesSuccess, deleteRevenueTypeSuccess } from '../revenueTypeSlice';
 
 export function* getSales() {
   const { salesURL } = apiConfig;
@@ -258,6 +258,25 @@ export function* getRevenueTypesSaga() {
   }
 }
 
+export const deleteRevenueType = createAction('deleteRevenueTypeSaga');
+
+export function* deleteRevenueTypeSaga({ payload: id }) {
+  const { revenueTypeUrl } = apiConfig;
+  let { user_id, farm_id } = yield select(loginSelector);
+  const header = getHeader(user_id, farm_id);
+  try {
+    const result = yield call(axios.delete, `${revenueTypeUrl}/${id}`, header);
+
+    if (result) {
+      yield put(deleteRevenueTypeSuccess(id));
+      yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.DELETE')));
+      history.back();
+    }
+  } catch (e) {
+    yield put(enqueueErrorSnackbar(i18n.t('message:REVENUE_TYPE.ERROR.DELETE')));
+  }
+}
+
 export const patchEstimatedCropRevenue = createAction(`patchEstimatedCropRevenueSaga`);
 export function* patchEstimatedCropRevenueSaga({ payload: managementPlan }) {
   const { managementPlanURL } = apiConfig;
@@ -286,6 +305,7 @@ export default function* financeSaga() {
   yield takeLatest(GET_EXPENSE, getExpenseSaga);
   yield takeLatest(GET_FARM_EXPENSE_TYPE, getFarmExpenseTypeSaga);
   yield takeLatest(getRevenueTypes.type, getRevenueTypesSaga);
+  yield takeLatest(deleteRevenueType.type, deleteRevenueTypeSaga);
   yield takeLeading(ADD_EXPENSES, addExpensesSaga);
   yield takeLeading(DELETE_SALE, deleteSale);
   yield takeLeading(DELETE_EXPENSES, deleteExpensesSaga);

--- a/packages/webapp/src/containers/Finances/saga.js
+++ b/packages/webapp/src/containers/Finances/saga.js
@@ -255,9 +255,8 @@ export function* getRevenueTypesSaga() {
 
   try {
     const result = yield call(axios.get, `${revenueTypeUrl}/farm/${farm_id}`, header);
-    if (result) {
-      yield put(getRevenueTypesSuccess(result.data));
-    }
+
+    yield put(getRevenueTypesSuccess(result.data));
   } catch (e) {
     console.log('failed to fetch revenue types from database');
   }
@@ -270,13 +269,10 @@ export function* deleteRevenueTypeSaga({ payload: id }) {
   let { user_id, farm_id } = yield select(loginSelector);
   const header = getHeader(user_id, farm_id);
   try {
-    const result = yield call(axios.delete, `${revenueTypeUrl}/${id}`, header);
+    yield call(axios.delete, `${revenueTypeUrl}/${id}`, header);
 
-    if (result) {
-      yield put(deleteRevenueTypeSuccess(id));
-      yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.DELETE')));
-      history.back();
-    }
+    yield put(deleteRevenueTypeSuccess(id));
+    yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.DELETE')));
   } catch (e) {
     yield put(enqueueErrorSnackbar(i18n.t('message:REVENUE_TYPE.ERROR.DELETE')));
   }
@@ -284,12 +280,11 @@ export function* deleteRevenueTypeSaga({ payload: id }) {
 
 export const addCustomRevenueType = createAction('addRevenueTypeSaga');
 
-export function* addRevenueTypeSaga({ payload: data }) {
+export function* addRevenueTypeSaga({ payload: { revenue_name } }) {
   const { revenueTypeUrl } = apiConfig;
   let { user_id, farm_id } = yield select(loginSelector);
   const header = getHeader(user_id, farm_id);
 
-  let { revenue_name } = data;
   const body = {
     revenue_name,
     farm_id: farm_id,
@@ -297,10 +292,9 @@ export function* addRevenueTypeSaga({ payload: data }) {
 
   try {
     const result = yield call(axios.post, revenueTypeUrl, body, header);
-    if (result) {
-      yield put(postRevenueTypeSuccess(result.data));
-      yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.ADD')));
-    }
+
+    yield put(postRevenueTypeSuccess(result.data));
+    yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.ADD')));
   } catch (e) {
     yield put(enqueueErrorSnackbar(i18n.t('message:REVENUE_TYPE.ERROR.ADD')));
   }
@@ -314,16 +308,15 @@ export function* updateRevenueTypeSaga({ payload: { revenue_type_id, revenue_nam
   const header = getHeader(user_id, farm_id);
 
   try {
-    const result = yield call(
+    yield call(
       axios.patch,
       `${revenueTypeUrl}/${revenue_type_id}`,
       { revenue_name, farm_id },
       header,
     );
-    if (result) {
-      yield put(putRevenueTypeSuccess({ revenue_type_id, revenue_name }));
-      yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.UPDATE')));
-    }
+
+    yield put(putRevenueTypeSuccess({ revenue_type_id, revenue_name }));
+    yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.UPDATE')));
   } catch (e) {
     yield put(enqueueErrorSnackbar(i18n.t('message:REVENUE_TYPE.ERROR.UPDATE')));
   }

--- a/packages/webapp/src/containers/revenueTypeSlice.js
+++ b/packages/webapp/src/containers/revenueTypeSlice.js
@@ -45,10 +45,18 @@ const softDeleteRevenueType = (state, { payload: revenue_type_id }) => {
   revenueTypeAdapter.updateOne(state, { id: revenue_type_id, changes: { deleted: true } });
 };
 
-const updateOneRevenueType = (state, { payload: revenueType }) => {
+const addOneRevenueType = (state, { payload }) => {
+  state.loading = false;
+  state.error = null;
+  revenueTypeAdapter.upsertOne(state, getRevenueType(payload));
+};
+
+const updateOneRevenueType = (state, { payload: { revenue_type_id, revenue_name } }) => {
+  state.loading = false;
+  state.error = null;
   revenueTypeAdapter.updateOne(state, {
-    changes: revenueType,
-    id: revenueType.revenue_type_id,
+    id: revenue_type_id,
+    changes: { revenue_name },
   });
 };
 
@@ -68,6 +76,7 @@ const revenueTypeSlice = createSlice({
     onLoadingRevenueTypeFail: onLoadingFail,
     getRevenueTypesSuccess: addManyRevenueTypes,
     deleteRevenueTypeSuccess: softDeleteRevenueType,
+    postRevenueTypeSuccess: addOneRevenueType,
     putRevenueTypeSuccess: updateOneRevenueType,
   },
 });
@@ -76,6 +85,7 @@ export const {
   onLoadingRevenueTypeFail,
   getRevenueTypesSuccess,
   deleteRevenueTypeSuccess,
+  postRevenueTypeSuccess,
   putRevenueTypeSuccess,
 } = revenueTypeSlice.actions;
 

--- a/packages/webapp/src/containers/revenueTypeSlice.js
+++ b/packages/webapp/src/containers/revenueTypeSlice.js
@@ -93,7 +93,7 @@ export const revenueTypesSelector = createSelector(
   [revenueTypeSelectors.selectAll, loginSelector],
   (revenueTypes, { farm_id, deleted }) => {
     return revenueTypes.filter(
-      (revenue) => (revenue.farm_id === farm_id || !revenue.farm_id) && !deleted,
+      (revenue) => (revenue.farm_id === farm_id || !revenue.farm_id) && !revenue.deleted,
     );
   },
 );

--- a/packages/webapp/src/containers/revenueTypeSlice.js
+++ b/packages/webapp/src/containers/revenueTypeSlice.js
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import { loginSelector, onLoadingFail, onLoadingStart } from './userFarmSlice';
+import { pick } from '../util/pick';
+import { createSelector } from 'reselect';
+
+export const getRevenueType = (obj) => {
+  return pick(obj, [
+    'revenue_type_id',
+    'revenue_name',
+    'revenue_translation_key',
+    'farm_id',
+    'deleted',
+  ]);
+};
+
+const addManyRevenueTypes = (state, { payload: revenueTypes }) => {
+  state.loading = false;
+  state.error = null;
+  state.loaded = true;
+  revenueTypeAdapter.upsertMany(
+    state,
+    revenueTypes.map((types) => getRevenueType(types)),
+  );
+};
+
+const softDeleteRevenueType = (state, { payload: revenue_type_id }) => {
+  state.loading = false;
+  state.error = null;
+  state.loaded = true;
+  revenueTypeAdapter.updateOne(state, { id: revenue_type_id, changes: { deleted: true } });
+};
+
+const updateOneRevenueType = (state, { payload: revenueType }) => {
+  revenueTypeAdapter.updateOne(state, {
+    changes: revenueType,
+    id: revenueType.revenue_type_id,
+  });
+};
+
+const revenueTypeAdapter = createEntityAdapter({
+  selectId: (revenueType) => revenueType.revenue_type_id,
+});
+
+const revenueTypeSlice = createSlice({
+  name: 'revenueTypeReducer',
+  initialState: revenueTypeAdapter.getInitialState({
+    loading: false,
+    error: undefined,
+    loaded: false,
+  }),
+  reducers: {
+    onLoadingRevenueTypeStart: onLoadingStart,
+    onLoadingRevenueTypeFail: onLoadingFail,
+    getRevenueTypesSuccess: addManyRevenueTypes,
+    deleteRevenueTypeSuccess: softDeleteRevenueType,
+    putRevenueTypeSuccess: updateOneRevenueType,
+  },
+});
+export const {
+  onLoadingRevenueTypeStart,
+  onLoadingRevenueTypeFail,
+  getRevenueTypesSuccess,
+  deleteRevenueTypeSuccess,
+  putRevenueTypeSuccess,
+} = revenueTypeSlice.actions;
+
+export default revenueTypeSlice.reducer;
+
+export const revenueTypeReducerSelector = (state) => state.entitiesReducer[revenueTypeSlice.name];
+
+const revenueTypeSelectors = revenueTypeAdapter.getSelectors(
+  (state) => state.entitiesReducer[revenueTypeSlice.name],
+);
+
+export const revenueTypeEntitiesSelector = revenueTypeSelectors.selectEntities;
+
+export const revenueTypesSelector = createSelector(
+  [revenueTypeSelectors.selectAll, loginSelector],
+  (revenueTypes, { farm_id, deleted }) => {
+    return revenueTypes.filter(
+      (revenue) => (revenue.farm_id === farm_id || !revenue.farm_id) && !deleted,
+    );
+  },
+);
+
+export const allRevenueTypesSelector = createSelector(
+  [revenueTypeSelectors.selectAll, loginSelector],
+  (revenueTypes, { farm_id }) => {
+    return revenueTypes.filter((revenue) => revenue.farm_id === farm_id || !revenue.farm_id);
+  },
+);
+
+export const revenueTypeSelector = (revenue_type_id) => (state) =>
+  revenueTypeSelectors.selectById(state, revenue_type_id);

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -86,6 +86,7 @@ import customSignUpReducer from '../containers/customSignUpSlice';
 import fieldWorkReducer from '../containers/fieldWorkSlice';
 import irrigationTaskReducer from '../containers/slice/taskSlice/irrigationTaskSlice';
 import irrigationTaskTypesReducer from '../containers/irrigationTaskTypesSlice';
+import revenueTypeReducer from '../containers/revenueTypeSlice';
 
 import { ActionTypes } from './actionTypes';
 // all the initial state for the forms
@@ -208,6 +209,7 @@ const entitiesReducer = combineReducers({
   fieldWorkReducer,
   irrigationTaskReducer,
   irrigationTaskTypesReducer,
+  revenueTypeReducer,
 });
 
 const farmStateReducer = combineReducers({


### PR DESCRIPTION
**Description**

This PR creates the new Redux Toolkit (RTK) slice and the saga functions for revenue types, corresponding to the db table created in PR #2857.

I took the custom expense type API PR (#2849) by @gursimran-singh as the model for how I expect the new API endpoints to look.

Jira link: https://lite-farm.atlassian.net/browse/LF-3586

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I tested these rendering by the selectors in the client (with some dummy JSX) and some temporary API routes on the backend -- please ping on Slack if you would like the dummy code for frontend or backend. Ideally these should be tested with the actual controllers and API 🙂 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
