### PR TITLE
LF-3616: Create reusable summary tile component

### DIFF
--- a/packages/webapp/src/assets/colors.scss
+++ b/packages/webapp/src/assets/colors.scss
@@ -4,6 +4,7 @@
   --teal600: #3ea992;
   --teal500: #89d1c7;
   --teal100: #f1fbf9;
+  --green800: #048211;
   --green700: #78c99e;
   --green400: #a8e6bd;
   --green200: #c7efd3;

--- a/packages/webapp/src/components/Card/SummaryCard/index.jsx
+++ b/packages/webapp/src/components/Card/SummaryCard/index.jsx
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { Info, Semibold } from '../../Typography';
+import Card from '../index';
+import styles from '../card.module.scss';
+
+export default function SummaryCard({ label, data, color, size, classes = {} }) {
+  return (
+    <Card color={'secondary'} className={clsx(styles[color], styles.summaryCard, classes.card)}>
+      <Info
+        className={clsx(
+          styles.summaryInfo,
+          styles[color],
+          styles[`${size}SummaryLabel`],
+          classes.info,
+        )}
+      >
+        {label}
+      </Info>
+      <Semibold className={clsx(styles[color], styles[`${size}SummaryData`], classes.data)}>
+        {data}
+      </Semibold>
+    </Card>
+  );
+}
+
+SummaryCard.propTypes = {
+  label: PropTypes.string,
+  data: PropTypes.string,
+  color: PropTypes.oneOf(['positive', 'negative']),
+  size: PropTypes.oneOf(['lg']),
+  classes: PropTypes.shape({
+    card: PropTypes.object,
+    info: PropTypes.object,
+    data: PropTypes.object,
+  }),
+};

--- a/packages/webapp/src/components/Card/card.module.scss
+++ b/packages/webapp/src/components/Card/card.module.scss
@@ -107,6 +107,7 @@
 p.summaryInfo {
   margin-top: 0;
   background-color: var(--white, #fff);
+  font-size: 11px;
 }
 
 p.lgSummaryLabel {

--- a/packages/webapp/src/components/Card/card.module.scss
+++ b/packages/webapp/src/components/Card/card.module.scss
@@ -97,3 +97,36 @@
 .notificationRead {
   background-color:  var(--grey200);
 }
+
+// SummaryCard
+.summaryCard {
+  padding: 20px;
+  background: var(--white, #fff);
+}
+
+p.summaryInfo {
+  margin-top: 0;
+  background-color: var(--white, #fff);
+}
+
+p.lgSummaryLabel {
+  font-size: 16px;
+}
+
+h4.lgSummaryData {
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 40px;
+}
+
+.negative {
+  h4, p {
+    color: var(--red700);
+  }
+}
+
+.positive {
+  h4, p {
+    color: var(--green800);
+  }
+}

--- a/packages/webapp/src/stories/Card/SummaryCard.stories.jsx
+++ b/packages/webapp/src/stories/Card/SummaryCard.stories.jsx
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import SummaryCard from '../../components/Card/SummaryCard';
+import { componentDecorators } from '../Pages/config/Decorators';
+
+export default {
+  title: 'Components/SummaryCard',
+  component: SummaryCard,
+  decorators: componentDecorators,
+};
+
+export const Large = {
+  args: {
+    label: 'My balance',
+    data: '$40,500.50',
+    size: 'lg',
+  },
+};
+
+export const Negative = {
+  args: {
+    color: 'negative',
+    label: 'Total expense',
+    data: '$40,500.50',
+  },
+};
+
+export const Positive = {
+  args: {
+    color: 'positive',
+    label: 'Total revenue',
+    data: '$40,500.50',
+  },
+};
+
+export const FinanceSummary = {
+  render: () => {
+    return (
+      <div style={{ maxWidth: 312, display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <SummaryCard label="My balance" data="$100,000.00" size="lg" />
+        <div style={{ display: 'flex', gap: 16 }}>
+          <SummaryCard color="negative" label="Total expense" data="$40,500.50" />
+          <SummaryCard color="positive" label="Total revenue" data="$140,500.50" />
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
**Description**

- add a new green colour (it's `Green-700` in [figma](https://www.figma.com/file/96NZ02oYe3jpet1roUp0s0/Mockups?type=design&node-id=3228-9302&mode=design&t=HYTw3PqVv7vmy3GT-0), but it already exists, so I changed it to `green800`...)
- create SummaryCard component
- create [stories](http://localhost:6006/?path=/docs/components-summarycard--docs)

Jira link: https://lite-farm.atlassian.net/browse/LF-3616

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
