### PR TITLE
LF-3651 Revenue type table unique violation error on auto-incrementing primary key

### DIFF
--- a/packages/api/db/migration/20230831015743_create_revenue_type_table.js
+++ b/packages/api/db/migration/20230831015743_create_revenue_type_table.js
@@ -31,20 +31,21 @@ export const up = async function (knex) {
   });
 
   // Prepopulate with one revenue type (crop_sale)
-  await knex('revenue_type').insert({
-    revenue_type_id: 1,
-    revenue_name: 'Crop Sale',
-    farm_id: null,
-    deleted: false,
-    created_by_user_id: '1',
-    updated_by_user_id: '1',
-    created_at: new Date('2000/1/1').toISOString(),
-    updated_at: new Date('2000/1/1').toISOString(),
-    revenue_translation_key: 'CROP_SALE',
-  });
+  const [cropSale] = await knex('revenue_type')
+    .insert({
+      revenue_name: 'Crop Sale',
+      farm_id: null,
+      deleted: false,
+      created_by_user_id: '1',
+      updated_by_user_id: '1',
+      created_at: new Date('2000/1/1').toISOString(),
+      updated_at: new Date('2000/1/1').toISOString(),
+      revenue_translation_key: 'CROP_SALE',
+    })
+    .returning('revenue_type_id');
 
   // Reference crop_sale type for all existing records
-  await knex('sale').update({ revenue_type_id: 1 });
+  await knex('sale').update({ revenue_type_id: cropSale.revenue_type_id });
 
   // Add  permissions
   await knex('permissions').insert([

--- a/packages/api/src/middleware/validation/sale.js
+++ b/packages/api/src/middleware/validation/sale.js
@@ -12,12 +12,16 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
+import RevenueTypeModel from '../../models/revenueTypeModel.js';
 
 async function validateSale(req, res, next) {
   // TODO replace upsertGraph
   const { crop_variety_sale, revenue_type_id } = req.body;
   // TODO: implement properly once LF-3595 is complete
-  const isCropRevenue = revenue_type_id === 1;
+  const cropSaleRevenueType = await RevenueTypeModel.query()
+    .where('revenue_name', 'Crop Sale')
+    .first();
+  const isCropRevenue = revenue_type_id === cropSaleRevenueType.revenue_type_id;
   if (isCropRevenue && !(crop_variety_sale && crop_variety_sale[0])) {
     return res.status(400).send('crop_variety_sale is required');
   }

--- a/packages/api/tests/sale.test.js
+++ b/packages/api/tests/sale.test.js
@@ -31,6 +31,7 @@ jest.mock('../src/middleware/acl/checkJwt.js', () =>
 import mocks from './mock.factories.js';
 import saleModel from '../src/models/saleModel.js';
 import cropVarietySaleModel from '../src/models/cropVarietySaleModel.js';
+import revenueTypeModel from '../src/models/revenueTypeModel.js';
 
 describe('Sale Tests', () => {
   let token;
@@ -374,11 +375,18 @@ describe('Sale Tests', () => {
     let cropVariety2;
     let someoneElsecrop;
     let someoneElseVariety;
+    let cropSaleRevenueType;
     beforeEach(async () => {
       [crop2] = await mocks.cropFactory({ promisedFarm: [farm] });
       [cropVariety2] = await mocks.crop_varietyFactory({ promisedCrop: [crop2] });
       [someoneElsecrop] = await mocks.cropFactory();
       [someoneElseVariety] = await mocks.crop_varietyFactory({ promisedCrop: [someoneElsecrop] });
+
+      cropSaleRevenueType = await revenueTypeModel
+        .query()
+        .where('revenue_name', 'Crop Sale')
+        .first();
+
       sampleReqBody = {
         ...mocks.fakeSale(),
         farm_id: farm.farm_id,
@@ -392,7 +400,7 @@ describe('Sale Tests', () => {
             crop_variety_id: cropVariety2.crop_variety_id,
           },
         ],
-        revenue_type_id: 1,
+        revenue_type_id: cropSaleRevenueType.revenue_type_id,
       };
     });
 


### PR DESCRIPTION
**Description**

This fixes the database error seen on first insert(s) into the new `revenue_type` table due to the auto-incrementing primary key which was ignored in favour of insertion.

This PR **amends the migration file**. Affected databases (beta, developer local environments) should be rolled back to before when this migration was run (likely 1 or two 2 batches -- please see your own database's `knex_migrations` table) and then run again once this PR is merged. You will lose your existing custom revenue types (on beta none exist yet as the API to create them has not been merged).

Jira link: https://lite-farm.atlassian.net/browse/LF-3651

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Was written and tested on local database with all authors @Duncan-Brain and @SayakaOno and @kathyavini 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
