### PR TITLE
LF-3651_2 Fix tests and validateSale middleware for sale tests to pass

### DIFF
--- a/packages/api/src/middleware/validation/sale.js
+++ b/packages/api/src/middleware/validation/sale.js
@@ -12,12 +12,16 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
+import RevenueTypeModel from '../../models/revenueTypeModel.js';
 
 async function validateSale(req, res, next) {
   // TODO replace upsertGraph
   const { crop_variety_sale, revenue_type_id } = req.body;
   // TODO: implement properly once LF-3595 is complete
-  const isCropRevenue = revenue_type_id === 1;
+  const cropSaleRevenueType = await RevenueTypeModel.query()
+    .where('revenue_name', 'Crop Sale')
+    .first();
+  const isCropRevenue = revenue_type_id === cropSaleRevenueType.revenue_type_id;
   if (isCropRevenue && !(crop_variety_sale && crop_variety_sale[0])) {
     return res.status(400).send('crop_variety_sale is required');
   }

--- a/packages/api/tests/sale.test.js
+++ b/packages/api/tests/sale.test.js
@@ -31,6 +31,7 @@ jest.mock('../src/middleware/acl/checkJwt.js', () =>
 import mocks from './mock.factories.js';
 import saleModel from '../src/models/saleModel.js';
 import cropVarietySaleModel from '../src/models/cropVarietySaleModel.js';
+import revenueTypeModel from '../src/models/revenueTypeModel.js';
 
 describe('Sale Tests', () => {
   let token;
@@ -374,11 +375,18 @@ describe('Sale Tests', () => {
     let cropVariety2;
     let someoneElsecrop;
     let someoneElseVariety;
+    let cropSaleRevenueType;
     beforeEach(async () => {
       [crop2] = await mocks.cropFactory({ promisedFarm: [farm] });
       [cropVariety2] = await mocks.crop_varietyFactory({ promisedCrop: [crop2] });
       [someoneElsecrop] = await mocks.cropFactory();
       [someoneElseVariety] = await mocks.crop_varietyFactory({ promisedCrop: [someoneElsecrop] });
+
+      cropSaleRevenueType = await revenueTypeModel
+        .query()
+        .where('revenue_name', 'Crop Sale')
+        .first();
+
       sampleReqBody = {
         ...mocks.fakeSale(),
         farm_id: farm.farm_id,
@@ -392,7 +400,7 @@ describe('Sale Tests', () => {
             crop_variety_id: cropVariety2.crop_variety_id,
           },
         ],
-        revenue_type_id: 1,
+        revenue_type_id: cropSaleRevenueType.revenue_type_id,
       };
     });
 


### PR DESCRIPTION
**Description**

- In tests, create sales with `revenue_type_id` for "Crop Sale" gotten from the DB, not hard-coded "1".
- update `validateSale` middleware to get `revenue_type_id` for Crop Sale from the DB.