### PR TITLE
LF-3591 Create the revenueType backend api (route and controller) and the get all types function

### DIFF
--- a/packages/api/src/controllers/baseController.js
+++ b/packages/api/src/controllers/baseController.js
@@ -193,14 +193,15 @@ export default {
 
   /**
    * To check if record is deleted or not
+   * @param {Object} trx - Transaction object
    * @param {Object} model - Database model instance
    * @param {object} where - 'Where' condition to fetch record
    * @async
    * @returns {Boolean} - true or false
    */
-  async isDeleted(model, where) {
+  async isDeleted(trx, model, where) {
     const record = await model
-      .query()
+      .query(trx)
       .context({ showHidden: true })
       .where(where)
       .select('deleted')
@@ -211,13 +212,14 @@ export default {
 
   /**
    * Check if records exists in table
+   * @param {object} trx - Transaction object
    * @param {object} model - Database model instance
    * @param {object} where - 'Where' condition to fetch record
    * @param {object} whereNot - 'WhereNot' condition to fetch record
    * @returns {Promise} - Object DB record promise
    */
-  existsInTable(model, where, whereNot = {}) {
-    let query = model.query().context({ showHidden: true }).where(where);
+  existsInTable(trx, model, where, whereNot = {}) {
+    let query = model.query(trx).context({ showHidden: true }).where(where);
 
     if (Object.keys(whereNot).length > 0) {
       query = query.whereNot(whereNot);

--- a/packages/api/src/controllers/revenueTypeController.js
+++ b/packages/api/src/controllers/revenueTypeController.js
@@ -27,7 +27,7 @@ const revenueTypeController = {
         const data = req.body;
         data.revenue_translation_key = baseController.formatTranslationKey(data.revenue_name);
 
-        const record = await baseController.existsInTable(RevenueTypeModel, {
+        const record = await baseController.existsInTable(trx, RevenueTypeModel, {
           revenue_name: data.revenue_name,
           farm_id,
         });
@@ -113,7 +113,7 @@ const revenueTypeController = {
       try {
         // do not allow operations to deleted records
         if (
-          await baseController.isDeleted(RevenueTypeModel, {
+          await baseController.isDeleted(trx, RevenueTypeModel, {
             revenue_type_id: req.params.revenue_type_id,
           })
         ) {
@@ -152,7 +152,7 @@ const revenueTypeController = {
 
       try {
         // do not allow update to deleted records
-        if (await baseController.isDeleted(RevenueTypeModel, { revenue_type_id })) {
+        if (await baseController.isDeleted(trx, RevenueTypeModel, { revenue_type_id })) {
           await trx.rollback();
           return res.status(404).send();
         }
@@ -160,6 +160,7 @@ const revenueTypeController = {
         // if record exists then throw Conflict error
         if (
           await baseController.existsInTable(
+            trx,
             RevenueTypeModel,
             {
               revenue_name: data.revenue_name,

--- a/packages/api/src/controllers/revenueTypeController.js
+++ b/packages/api/src/controllers/revenueTypeController.js
@@ -68,7 +68,7 @@ const revenueTypeController = {
     };
   },
 
-  getAllTypes() {
+  getFarmRevenueType() {
     return async (req, res) => {
       try {
         const farm_id = req.headers.farm_id;

--- a/packages/api/src/routes/revenueTypeRoute.js
+++ b/packages/api/src/routes/revenueTypeRoute.js
@@ -26,7 +26,12 @@ router.post(
   checkScope(['add:revenue_types']),
   RevenueTypeController.addType(),
 );
-router.get('/', checkScope(['get:revenue_types']), RevenueTypeController.getAllTypes());
+router.get(
+  '/farm/:farm_id',
+  hasFarmAccess({ params: 'farm_id' }),
+  checkScope(['get:revenue_types']),
+  RevenueTypeController.getFarmRevenueType(),
+);
 router.get(
   '/:revenue_type_id',
   hasFarmAccess({ params: 'revenue_type_id' }),

--- a/packages/api/tests/revenue_type.test.js
+++ b/packages/api/tests/revenue_type.test.js
@@ -84,7 +84,7 @@ describe('Revenue Type Tests', () => {
   function getRequest({ user_id = newOwner.user_id, farm_id = farm.farm_id }, callback) {
     chai
       .request(server)
-      .get(`/revenue_type`)
+      .get(`/revenue_type/farm/${farm_id}`)
       .set('user_id', user_id)
       .set('farm_id', farm_id)
       .end(callback);


### PR DESCRIPTION
**Description**

A working GET Revenue Type API was already created alongside the other CRUD methods for Revenue Type.

This PR only updates the GET route path and the name of the controller, to:

- match custom expense type
- be more explicit that the types are fetched on a per-farm basis (as was already the case)
- connect to the existing saga which expects this route

EDIT: After @Duncan-Brain pointed out we were clogging up the transaction pool by running queries outside of the existing established transaction, see thread [here](https://github.com/LiteFarmOrg/LiteFarm/pull/2877/files#r1333494616), I have passed the transaction object to the baseController methods for these controllers as well.

Jira link: https://lite-farm.atlassian.net/browse/LF-3591

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
