### PR TITLE
LF-3660 Add optional port variable to test config

### DIFF
--- a/packages/api/.env.default
+++ b/packages/api/.env.default
@@ -15,6 +15,7 @@ TEST_DATABASE_HOST=localhost
 TEST_DATABASE=test_farm
 TEST_DATABASE_USER=postgres
 TEST_DATABASE_PASSWORD=postgres
+TEST_DATABASE_PORT=5433 # 5432 is default if running natively; use 5433 for the Dockerized database
 
 JWT_SECRET=This_will_(really)_work
 JWT_INVITE_SECRET=Any_arbitrary_string_will_do

--- a/packages/api/.knex/knexfile.js
+++ b/packages/api/.knex/knexfile.js
@@ -95,6 +95,7 @@ module.exports = {
       database: process.env.TEST_DATABASE,
       user: process.env.TEST_DATABASE_USER,
       password: process.env.TEST_DATABASE_PASSWORD,
+      port: process.env.TEST_DATABASE_PORT || 5432,
     },
     pool: { min: 0, max: 100 },
     migrations: {


### PR DESCRIPTION
**Description**

Context: I was having to make this change manually each time I worked wth `npm test` locally and it was driving me nuts!

When we updated our readme instructions to recommend using a Dockerized Postgres, we needed to change our local dev configuration to allow connecting to that database, which was done in this PR:
- https://github.com/LiteFarmOrg/LiteFarm/pull/2737

What should also have been done at that time was applying the same to the test database, as used in `migrate:testing:db` and `npm test`. Otherwise `test_farm` can only be populated on a native installation Postgres which, if the readme instructions were followed exactly, might not even exist.

Note that this **refers to local testing** -- the pipeline (CI tests) has its own knex config.

As before it's an entirely optional variable. Not adding it will not change how `npm test` behaves for you if you are using the default port.

Jira link: https://lite-farm.atlassian.net/browse/LF-3660

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

`.env.default` has been updated in the PR

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested locally with `npm run test` with my native Postgres stopped (only Dockerized db running).

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
