### PR TITLE
LF-3663 The white screen will be displayed once the user will create the revenue type with an exact name that he has previously deleted

### DIFF
--- a/packages/api/src/controllers/revenueTypeController.js
+++ b/packages/api/src/controllers/revenueTypeController.js
@@ -46,7 +46,7 @@ const revenueTypeController = {
               trx,
             });
             await trx.commit();
-            res.status(204).send(record);
+            res.status(200).send(record);
           }
         } else {
           const result = await baseController.postWithResponse(


### PR DESCRIPTION
**Description**

THIS IS A FUN ONE! 😁 

Express won't send any content regardless of what was supplied in `res.send()` if the status code is 204 No Content 🙂 

When "adding" (un-retiring) a deleted record, the POST controller was sending back `res.status(204).send(record)` and the saga was getting merely empty data with message 'No Content'.

Blog post on it: [Express response.status(204) Won’t Return Content](https://bambielli.com/til/2017-03-26-express-res-204/)
MDN Docs: [204 No Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204)

Jira link: https://lite-farm.atlassian.net/browse/LF-3663

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Issue is easily seen with a debugger in the POST saga after the result is returned from the API.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
