### PR TITLE
LF-3626: Persist data in expense form

### DIFF
--- a/packages/webapp/src/components/Finances/AddExpense/ExpenseItemsForType.jsx
+++ b/packages/webapp/src/components/Finances/AddExpense/ExpenseItemsForType.jsx
@@ -37,10 +37,10 @@ export default function ExpenseItemsForType({ type, register, control, getValues
 
   // Unselect the type when all items are removed, select the type when the first item is added.
   // If the user removes items for the type, it will be unselected in the previous page when going back.
-  const handleSelectedExpenseTypes = (actionType) => {
+  const handleSelectedExpenseTypes = (operationType) => {
     const itemsLength = getValues(`${EXPENSE_DETAIL}.${type.id}`).length;
     const allItemsRemoved = itemsLength === 0;
-    const firstItemAdded = actionType === 'add' && itemsLength === 1;
+    const firstItemAdded = operationType === 'add' && itemsLength === 1;
 
     if (allItemsRemoved) {
       dispatch(setSelectedExpenseTypes(selectedExpense.filter((id) => id !== type.id)));

--- a/packages/webapp/src/components/Finances/AddExpense/index.jsx
+++ b/packages/webapp/src/components/Finances/AddExpense/index.jsx
@@ -81,7 +81,7 @@ export default function PureAddExpense({
     register,
     control,
     watch,
-    setValue,
+    getValues,
     formState: { isValid, errors },
     handleSubmit,
   } = useForm({
@@ -132,7 +132,7 @@ export default function PureAddExpense({
             type={type}
             register={register}
             control={control}
-            setValue={setValue}
+            getValues={getValues}
             errors={errors}
           />
         );

--- a/packages/webapp/src/components/Finances/AddExpense/index.jsx
+++ b/packages/webapp/src/components/Finances/AddExpense/index.jsx
@@ -75,7 +75,6 @@ export default function PureAddExpense({
   persistedFormData,
 }) {
   const { t } = useTranslation();
-  const { historyCancel } = useHookFormPersist();
 
   const {
     register,
@@ -91,6 +90,8 @@ export default function PureAddExpense({
       [EXPENSE_DETAIL]: getDefaultExpenseDetail(types, persistedFormData?.[EXPENSE_DETAIL]),
     },
   });
+
+  const { historyCancel } = useHookFormPersist(getValues);
 
   const expenseDetail = watch(EXPENSE_DETAIL);
 

--- a/packages/webapp/src/components/Finances/AddExpense/index.jsx
+++ b/packages/webapp/src/components/Finances/AddExpense/index.jsx
@@ -23,16 +23,57 @@ import Button from '../../Form/Button';
 import { NOTE, VALUE, DATE, EXPENSE_DETAIL } from './constants';
 import { getLocalDateInYYYYDDMM } from '../../../util/date';
 
-const getDefaultExpenseDetail = (types) => {
+/**
+ * Function that generates defaultValues for a type.
+ * Return persisted data if exists, otherwise, return [{ [NOTE]: '', [VALUE]: null }].
+ *
+ * @typedef ExpenseItemValues
+ * @type {object}
+ * @property {string} note - note
+ * @property {number} value - value
+ *
+ * @param {Array<ExpenseItemValues>} persistedFormDataForType Data user entered. It could be [], [{}] or undefined.
+ * @returns {Array<ExpenseItemValues>}
+ */
+const getDefaultValuesForType = (persistedFormDataForType) => {
+  if (persistedFormDataForType?.length && Object.keys(persistedFormDataForType[0]).length) {
+    return persistedFormDataForType;
+  }
+  return [{ [NOTE]: '', [VALUE]: null }];
+};
+
+/**
+ * Function that generates default expenseDetail.
+ *
+ * @typedef ExpenseType
+ * @type {Object}
+ * @property {string} name - name of the type
+ * @property {string} id - id of the type
+ *
+ * @typedef ExpenseDetailData
+ * @type {Object}
+ * @property {Object} - key: typeId of string, value: array of { [NOTE]: <note>, [VALUE]: <value> }
+ *
+ * @param {Array<ExpenseType>} types Types that the user selected in the previous page.
+ * @param {ExpenseDetailData} persistedExpenseDetailData Data user entered. It could be undefined.
+ * @returns {ExpenseDetailData}
+ */
+const getDefaultExpenseDetail = (types, persistedExpenseDetailData) => {
   return types.reduce((expenseDetail, { id }) => {
     return {
       ...expenseDetail,
-      [id]: [{ [NOTE]: '', [VALUE]: null }],
+      [id]: getDefaultValuesForType(persistedExpenseDetailData?.[id]),
     };
   }, {});
 };
 
-export default function PureAddExpense({ types, onGoBack, onSubmit, useHookFormPersist }) {
+export default function PureAddExpense({
+  types,
+  onGoBack,
+  onSubmit,
+  useHookFormPersist,
+  persistedFormData,
+}) {
   const { t } = useTranslation();
   const { historyCancel } = useHookFormPersist();
 
@@ -47,7 +88,7 @@ export default function PureAddExpense({ types, onGoBack, onSubmit, useHookFormP
     mode: 'onBlur',
     defaultValues: {
       [DATE]: getLocalDateInYYYYDDMM(),
-      [EXPENSE_DETAIL]: getDefaultExpenseDetail(types),
+      [EXPENSE_DETAIL]: getDefaultExpenseDetail(types, persistedFormData?.[EXPENSE_DETAIL]),
     },
   });
 

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
@@ -17,7 +17,6 @@ import PropTypes from 'prop-types';
 import ManageCustomExpenseTypesSpotlight from '../ManageCustomExpenseTypesSpotlight';
 import PureFinanceTypeSelection from '../../../../components/Finances/PureFinanceTypeSelection';
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
-import { hookFormPersistSelector } from '../../../hooks/useHookFormPersist/hookFormPersistSlice';
 import labelIconStyles from '../../../../components/Tile/styles.module.scss';
 
 export const icons = {
@@ -52,18 +51,6 @@ class ExpenseCategories extends Component {
 
     this.addRemoveType = this.addRemoveType.bind(this);
     this.nextPage = this.nextPage.bind(this);
-  }
-
-  componentDidUpdate(prevProps) {
-    // "this.props.selectedExpense" is updated in useEffect cleanup function in ExpenseItemsForType,
-    // which happens after the constructor is called. This is to sync state's selectedExpense and props's selectedExpense
-    if (this.props.selectedExpense.length !== prevProps.selectedExpense.length) {
-      this.setState({
-        selectedTypes: this.props.selectedExpense.filter((typeId) => {
-          return this.props.expenseTypes.some(({ expense_type_id }) => expense_type_id === typeId);
-        }),
-      });
-    }
   }
 
   nextPage(event) {
@@ -130,7 +117,6 @@ const mapStateToProps = (state) => {
   return {
     expenseTypes: expenseTypeTileContentsSelector(state),
     selectedExpense: selectedExpenseSelector(state),
-    persistedFormData: hookFormPersistSelector(state),
   };
 };
 

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
@@ -17,6 +17,7 @@ import PropTypes from 'prop-types';
 import ManageCustomExpenseTypesSpotlight from '../ManageCustomExpenseTypesSpotlight';
 import PureFinanceTypeSelection from '../../../../components/Finances/PureFinanceTypeSelection';
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
+import { hookFormPersistSelector } from '../../../hooks/useHookFormPersist/hookFormPersistSlice';
 import labelIconStyles from '../../../../components/Tile/styles.module.scss';
 
 export const icons = {
@@ -51,6 +52,18 @@ class ExpenseCategories extends Component {
 
     this.addRemoveType = this.addRemoveType.bind(this);
     this.nextPage = this.nextPage.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    // "this.props.selectedExpense" is updated in useEffect cleanup function in ExpenseItemsForType,
+    // which happens after the constructor is called. This is to sync state's selectedExpense and props's selectedExpense
+    if (this.props.selectedExpense.length !== prevProps.selectedExpense.length) {
+      this.setState({
+        selectedTypes: this.props.selectedExpense.filter((typeId) => {
+          return this.props.expenseTypes.some(({ expense_type_id }) => expense_type_id === typeId);
+        }),
+      });
+    }
   }
 
   nextPage(event) {
@@ -117,6 +130,7 @@ const mapStateToProps = (state) => {
   return {
     expenseTypes: expenseTypeTileContentsSelector(state),
     selectedExpense: selectedExpenseSelector(state),
+    persistedFormData: hookFormPersistSelector(state),
   };
 };
 


### PR DESCRIPTION
**Description**

- show data the user entered in `AddExpense` when he/she goes back to the expense type selection view and to the form again. (the function to generate default values is updated to use persistedFormData)
- if the user removes all items for the type (please refer the screenshot below), when he/she goes back to the type selection view, the type should be unselected.
   - when all items are removed, remove the type from `selectedExpense`
   - when the first item is added, add the type back to `selectedExpense`.
![Screenshot 2023-09-22 at 3 25 41 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/d6b68171-144c-4264-9abc-f05d0960a144)

Jira link: https://lite-farm.atlassian.net/browse/LF-3626

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
