### PR TITLE
LF-3662: "< " Back arrow redirectes to the wrong page when the user saves the "Custom Revenue Type" 

### DIFF
--- a/packages/webapp/src/containers/Finances/CustomRevenueType/AddCustomRevenue.jsx
+++ b/packages/webapp/src/containers/Finances/CustomRevenueType/AddCustomRevenue.jsx
@@ -19,6 +19,7 @@ import { addCustomRevenueType } from '../saga';
 import { revenueTypesSelector } from '../../revenueTypeSlice';
 import { CUSTOM_REVENUE_NAME } from './constants';
 import { hookFormUniquePropertyValidation } from '../../../components/Form/hookformValidationUtils';
+import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 
 function AddCustomRevenue({ history }) {
   const { t } = useTranslation();
@@ -34,20 +35,22 @@ function AddCustomRevenue({ history }) {
   };
 
   return (
-    <PureSimpleCustomType
-      handleGoBack={handleGoBack}
-      onSubmit={onSubmit}
-      view="add"
-      buttonText={t('common:SAVE')}
-      pageTitle={t('REVENUE.ADD_REVENUE.ADD_CUSTOM_REVENUE')}
-      inputLabel={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_NAME')}
-      customTypeRegister={CUSTOM_REVENUE_NAME}
-      validateInput={hookFormUniquePropertyValidation(
-        revenueTypes,
-        'revenue_name',
-        t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
-      )}
-    />
+    <HookFormPersistProvider>
+      <PureSimpleCustomType
+        handleGoBack={handleGoBack}
+        onSubmit={onSubmit}
+        view="add"
+        buttonText={t('common:SAVE')}
+        pageTitle={t('REVENUE.ADD_REVENUE.ADD_CUSTOM_REVENUE')}
+        inputLabel={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_NAME')}
+        customTypeRegister={CUSTOM_REVENUE_NAME}
+        validateInput={hookFormUniquePropertyValidation(
+          revenueTypes,
+          'revenue_name',
+          t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
+        )}
+      />
+    </HookFormPersistProvider>
   );
 }
 

--- a/packages/webapp/src/containers/Finances/CustomRevenueType/EditCustomRevenue.jsx
+++ b/packages/webapp/src/containers/Finances/CustomRevenueType/EditCustomRevenue.jsx
@@ -19,6 +19,7 @@ import { updateCustomRevenueType } from '../saga';
 import { revenueTypeSelector, revenueTypesSelector } from '../../revenueTypeSlice';
 import { CUSTOM_REVENUE_NAME } from './constants';
 import { hookFormUniquePropertyValidation } from '../../../components/Form/hookformValidationUtils';
+import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 
 function EditCustomExpense({ history, match }) {
   const { revenue_type_id } = match.params;
@@ -37,21 +38,23 @@ function EditCustomExpense({ history, match }) {
   };
 
   return (
-    <PureSimpleCustomType
-      handleGoBack={handleGoBack}
-      onSubmit={onSubmit}
-      view="edit"
-      buttonText={t('common:SAVE')}
-      pageTitle={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_TYPE')}
-      inputLabel={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_NAME')}
-      customTypeRegister={CUSTOM_REVENUE_NAME}
-      defaultValue={revenue_name}
-      validateInput={hookFormUniquePropertyValidation(
-        revenueTypes,
-        'revenue_name',
-        t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
-      )}
-    />
+    <HookFormPersistProvider>
+      <PureSimpleCustomType
+        handleGoBack={handleGoBack}
+        onSubmit={onSubmit}
+        view="edit"
+        buttonText={t('common:SAVE')}
+        pageTitle={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_TYPE')}
+        inputLabel={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_NAME')}
+        customTypeRegister={CUSTOM_REVENUE_NAME}
+        defaultValue={revenue_name}
+        validateInput={hookFormUniquePropertyValidation(
+          revenueTypes,
+          'revenue_name',
+          t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
+        )}
+      />
+    </HookFormPersistProvider>
   );
 }
 

--- a/packages/webapp/src/containers/Finances/CustomRevenueType/ReadOnlyCustomRevenue.jsx
+++ b/packages/webapp/src/containers/Finances/CustomRevenueType/ReadOnlyCustomRevenue.jsx
@@ -19,6 +19,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { deleteRevenueType } from '../saga';
 import { revenueTypeSelector } from '../../revenueTypeSlice';
 import { CUSTOM_REVENUE_NAME } from './constants';
+import { HookFormPersistProvider } from '../../hooks/useHookFormPersist/HookFormPersistProvider';
 
 function ReadOnlyCustomRevenue({ history, match }) {
   const { revenue_type_id } = match.params;
@@ -40,20 +41,22 @@ function ReadOnlyCustomRevenue({ history, match }) {
   };
 
   return (
-    <PureSimpleCustomType
-      handleGoBack={handleGoBack}
-      onClick={handleEdit}
-      view="read-only"
-      buttonText={t('common:EDIT')}
-      pageTitle={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_TYPE')}
-      inputLabel={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_NAME')}
-      customTypeRegister={CUSTOM_REVENUE_NAME}
-      defaultValue={revenue_name}
-      onRetire={onRetire}
-      retireLinkText={t('REVENUE.EDIT_REVENUE.RETIRE_REVENUE_TYPE')}
-      retireHeader={t('REVENUE.EDIT_REVENUE.RETIRE_REVENUE_TYPE')}
-      retireMessage={t('REVENUE.EDIT_REVENUE.RETIRE_REVENUE_MESSAGE')}
-    />
+    <HookFormPersistProvider>
+      <PureSimpleCustomType
+        handleGoBack={handleGoBack}
+        onClick={handleEdit}
+        view="read-only"
+        buttonText={t('common:EDIT')}
+        pageTitle={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_TYPE')}
+        inputLabel={t('REVENUE.ADD_REVENUE.CUSTOM_REVENUE_NAME')}
+        customTypeRegister={CUSTOM_REVENUE_NAME}
+        defaultValue={revenue_name}
+        onRetire={onRetire}
+        retireLinkText={t('REVENUE.EDIT_REVENUE.RETIRE_REVENUE_TYPE')}
+        retireHeader={t('REVENUE.EDIT_REVENUE.RETIRE_REVENUE_TYPE')}
+        retireMessage={t('REVENUE.EDIT_REVENUE.RETIRE_REVENUE_MESSAGE')}
+      />
+    </HookFormPersistProvider>
   );
 }
 

--- a/packages/webapp/src/containers/Finances/ManageCustomRevenueTypes/index.jsx
+++ b/packages/webapp/src/containers/Finances/ManageCustomRevenueTypes/index.jsx
@@ -53,7 +53,7 @@ export default function ManageRevenueTypes({ history }) {
         // unlisten when the user gets out of the page without going back to '/Finances'.
         // pathname: "/manage_custom_revenue" happens when the user lands on this page.
         !(
-          history.location.pathname === `/manage_custom_revenue` ||
+          history.location.pathname === `/manage_custom_revenues` ||
           (history.action === 'POP' && history.location.pathname === '/Finances')
         )
       ) {


### PR DESCRIPTION
**Description**

- Wrap PureSimpleCustomType in revenue views to trigger page navigation.
- Fix ManageRevenueTypes path in useEffect.

Jira link: https://lite-farm.atlassian.net/browse/LF-3662

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
