### PR TITLE
LF-3599: Fix total revenue calculation and general revenue values

### DIFF
--- a/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
+++ b/packages/webapp/src/containers/Finances/ActualRevenue/index.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { dateRangeSelector, salesSelector } from '../selectors';
+import { allRevenueTypesSelector } from '../../revenueTypeSlice';
 import WholeFarmRevenue from '../../../components/Finances/WholeFarmRevenue';
 import { AddLink, Semibold } from '../../../components/Typography';
 import DateRangePicker from '../../../components/Form/DateRangePicker';
@@ -13,6 +14,7 @@ import FinanceListHeader from '../../../components/Finances/FinanceListHeader';
 import { calcActualRevenue, filterSalesByDateRange } from '../util';
 import { setDateRange } from '../actions';
 import { setPersistedPaths } from '../../hooks/useHookFormPersist/hookFormPersistSlice';
+import { getRevenueTypes } from '../saga';
 
 export default function ActualRevenue({ history, match }) {
   const { t } = useTranslation();
@@ -25,6 +27,7 @@ export default function ActualRevenue({ history, match }) {
   // TODO: refactor sale data after finance reducer is remade
   const sales = useSelector(salesSelector);
   const dateRange = useSelector(dateRangeSelector);
+  const allRevenueTypes = useSelector(allRevenueTypesSelector);
 
   const year = new Date().getFullYear();
 
@@ -63,13 +66,19 @@ export default function ActualRevenue({ history, match }) {
   const toDate = watch('to_date');
 
   const revenueForWholeFarm = useMemo(
-    () => calcActualRevenue(sales, fromDate, toDate),
-    [sales, fromDate, toDate],
+    () => calcActualRevenue(sales, fromDate, toDate, allRevenueTypes),
+    [sales, fromDate, toDate, allRevenueTypes],
   );
   const filteredSales = useMemo(
     () => filterSalesByDateRange(sales, fromDate, toDate),
     [sales, fromDate, toDate],
   );
+
+  useEffect(() => {
+    if (!allRevenueTypes?.length) {
+      dispatch(getRevenueTypes());
+    }
+  }, []);
 
   useEffect(() => {
     dispatch(setDateRange({ startDate: fromDate, endDate: toDate }));

--- a/packages/webapp/src/containers/Finances/index.jsx
+++ b/packages/webapp/src/containers/Finances/index.jsx
@@ -19,6 +19,7 @@ import styles from './styles.module.scss';
 import DescriptiveButton from '../../components/Inputs/DescriptiveButton';
 import history from '../../history';
 import { dateRangeSelector, expenseSelector, salesSelector } from './selectors';
+import { allRevenueTypesSelector } from '../revenueTypeSlice';
 import {
   getFarmExpenseType,
   getExpense,
@@ -34,6 +35,7 @@ import InfoBoxComponent from '../../components/InfoBoxComponent';
 import { extendMoment } from 'moment-range';
 import { managementPlansSelector } from '../managementPlanSlice';
 import { getManagementPlansAndTasks } from '../saga';
+import { getRevenueTypes } from './saga';
 import Button from '../../components/Form/Button';
 import { Semibold, Title } from '../../components/Typography';
 import { useCurrencySymbol } from '../hooks/useCurrencySymbol';
@@ -52,6 +54,7 @@ const Finances = () => {
   const expenses = useSelector(expenseSelector);
   const managementPlans = useSelector(managementPlansSelector);
   const dateRange = useSelector(dateRangeSelector);
+  const allRevenueTypes = useSelector(allRevenueTypesSelector);
 
   const tasksByManagementPlanId = useSelector(taskEntitiesByManagementPlanIdSelector);
 
@@ -65,6 +68,7 @@ const Finances = () => {
     dispatch(getSales());
     dispatch(getExpense());
     dispatch(getFarmExpenseType());
+    dispatch(getRevenueTypes());
     dispatch(getManagementPlansAndTasks());
     dispatch(setSelectedExpenseTypes([]));
 
@@ -120,7 +124,7 @@ const Finances = () => {
     return parseFloat(totalRevenue).toFixed(2);
   };
 
-  const totalRevenue = calcActualRevenue(sales, startDate, endDate).toFixed(2);
+  const totalRevenue = calcActualRevenue(sales, startDate, endDate, allRevenueTypes).toFixed(2);
   const estimatedRevenue = getEstimatedRevenue(managementPlans);
   const labourExpense = roundToTwoDecimal(calcTotalLabour(tasks, startDate, endDate));
   const otherExpense = calcOtherExpense(expenses, startDate, endDate);

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -84,15 +84,28 @@ export function filterSalesByDateRange(sales, startDate, endDate) {
   return [];
 }
 
-export function calcActualRevenue(sales, startDate, endDate) {
+export function calcActualRevenue(sales, startDate, endDate, revenueTypes) {
   let total = 0.0;
+  const revenueTypesMap = {};
 
   if (sales && Array.isArray(sales)) {
     for (const s of sales) {
+      if (!revenueTypesMap[s.revenue_type_id]) {
+        revenueTypesMap[s.revenue_type_id] = revenueTypes.find(
+          ({ revenue_type_id }) => revenue_type_id === s.revenue_type_id,
+        );
+      }
+      const revenueType = revenueTypesMap[s.revenue_type_id];
+      const formType = getRevenueFormType(revenueType);
+
       const saleDate = moment(s.sale_date);
       if (saleDate.isSameOrAfter(startDate, 'day') && saleDate.isSameOrBefore(endDate, 'day')) {
-        for (const c of s.crop_variety_sale) {
-          total = roundToTwoDecimal(roundToTwoDecimal(total) + roundToTwoDecimal(c.sale_value));
+        if (formType === revenueFormTypes.CROP_SALE) {
+          for (const c of s.crop_variety_sale) {
+            total = roundToTwoDecimal(roundToTwoDecimal(total) + roundToTwoDecimal(c.sale_value));
+          }
+        } else if (formType === revenueFormTypes.GENERAL) {
+          total = roundToTwoDecimal(roundToTwoDecimal(total) + roundToTwoDecimal(s.value));
         }
       }
     }


### PR DESCRIPTION
**Description**

Fix the total revenue and general revenue values after logging out.
![Screenshot 2023-09-22 at 4 59 10 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/cfe2c809-af49-4e29-99b4-642d369bfa4d)
![Screenshot 2023-09-22 at 4 59 37 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/5c24ac13-44ca-4166-8c63-c599eae1a38e)


- revenue types are loaded in `Fnances` and `ActualRevenue` to:
   - show general revenue values correctly (types were loaded in the tile page, so once you logout and go to the actual revenue page directly, types were empty)
   - update `calcActualRevenue` function to include `value` for general type revenues.

Jira link: https://lite-farm.atlassian.net/browse/LF-3599

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
