### PR TITLE
LF-3190-change-too-many-password-resets-to-be-in-line-error-rather-than-snack-bar

### DIFF
--- a/packages/webapp/src/components/Modals/ModalComponent/v1/index.jsx
+++ b/packages/webapp/src/components/Modals/ModalComponent/v1/index.jsx
@@ -1,7 +1,7 @@
 import styles from './styles.module.scss';
 import Button from '../../../Form/Button';
 import React from 'react';
-import { Title } from '../../../Typography';
+import { Error, Title } from '../../../Typography';
 import PropTypes from 'prop-types';
 
 export default function ModalComponent({
@@ -40,7 +40,7 @@ export default function ModalComponent({
       >
         {buttonLabel}
       </Button>
-      {error && <span className={styles.error}>{error}</span>}
+      {error && <Error className={styles.error}>{error}</Error>}
     </div>
   );
 }

--- a/packages/webapp/src/components/Modals/ModalComponent/v1/index.jsx
+++ b/packages/webapp/src/components/Modals/ModalComponent/v1/index.jsx
@@ -12,6 +12,7 @@ export default function ModalComponent({
   descriptions,
   buttonLabel,
   buttonColor,
+  error,
 }) {
   const buttonStyles = {
     letterSpacing: '0.4005px',
@@ -26,7 +27,9 @@ export default function ModalComponent({
         {title}
       </Title>
       {descriptions.map((description) => (
-        <Title style={{ marginBottom: 0, textAlign: 'center' }}>{description}</Title>
+        <Title key={description} style={{ marginBottom: 0, textAlign: 'center' }}>
+          {description}
+        </Title>
       ))}
       <Button
         fullLength
@@ -37,6 +40,7 @@ export default function ModalComponent({
       >
         {buttonLabel}
       </Button>
+      {error && <span className={styles.error}>{error}</span>}
     </div>
   );
 }

--- a/packages/webapp/src/components/Modals/ModalComponent/v1/styles.module.scss
+++ b/packages/webapp/src/components/Modals/ModalComponent/v1/styles.module.scss
@@ -9,3 +9,8 @@
   position: relative;
   padding: 28px 24px 30px 24px;
 }
+
+.error {
+  color: red;
+  margin: 1rem;
+}

--- a/packages/webapp/src/components/Modals/ModalComponent/v1/styles.module.scss
+++ b/packages/webapp/src/components/Modals/ModalComponent/v1/styles.module.scss
@@ -11,6 +11,5 @@
 }
 
 .error {
-  color: red;
   margin: 1rem;
 }

--- a/packages/webapp/src/components/Modals/ResetPassword/index.jsx
+++ b/packages/webapp/src/components/Modals/ResetPassword/index.jsx
@@ -16,7 +16,7 @@ export function PureResetPasswordComponent({ onClick, changeText, passwordResetE
       title={title}
       descriptions={[descriptionTop, descriptionBottom]}
       buttonLabel={buttonLabel}
-      disabled={changeText}
+      disabled={!!passwordResetError || changeText}
       icon={<MailIconImg />}
       error={passwordResetError}
     />

--- a/packages/webapp/src/components/Modals/ResetPassword/index.jsx
+++ b/packages/webapp/src/components/Modals/ResetPassword/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal, ModalComponent } from '../';
 
-export function PureResetPasswordComponent({ onClick, changeText }) {
+export function PureResetPasswordComponent({ onClick, changeText, passwordResetError }) {
   const { t } = useTranslation();
   const title = t('PASSWORD_RESET.TITLE');
   const descriptionTop = t('PASSWORD_RESET.DESCRIPTION_TOP');
@@ -18,14 +18,24 @@ export function PureResetPasswordComponent({ onClick, changeText }) {
       buttonLabel={buttonLabel}
       disabled={changeText}
       icon={<MailIconImg />}
+      error={passwordResetError}
     />
   );
 }
 
-export default function ResetPasswordModal({ onClick, dismissModal, changeText }) {
+export default function ResetPasswordModal({
+  onClick,
+  dismissModal,
+  changeText,
+  passwordResetError,
+}) {
   return (
     <Modal dismissModal={dismissModal}>
-      <PureResetPasswordComponent onClick={onClick} changeText={changeText} />
+      <PureResetPasswordComponent
+        onClick={onClick}
+        changeText={changeText}
+        passwordResetError={passwordResetError}
+      />
     </Modal>
   );
 }

--- a/packages/webapp/src/containers/CustomSignUp/saga.js
+++ b/packages/webapp/src/containers/CustomSignUp/saga.js
@@ -24,7 +24,7 @@ import { getFirstNameLastName } from '../../util';
 import { axios } from '../saga';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
-import { setCustomSignUpErrorKey } from '../customSignUpSlice';
+import { setCustomSignUpErrorKey, setPasswordResetError } from '../customSignUpSlice';
 
 const loginUrl = (email) => `${url}/login/user/${email}`;
 const loginWithPasswordUrl = () => `${url}/login`;
@@ -151,7 +151,7 @@ export function* sendResetPasswordEmailSaga({ payload: email }) {
     const result = yield call(axios.post, resetPasswordUrl(), { email });
   } catch (e) {
     if (e.response.data === 'Reached maximum number of available reset tokens') {
-      yield put(enqueueErrorSnackbar(i18n.t('message:USER.ERROR.MAX_RESET_EMAILS')));
+      yield put(setPasswordResetError(i18n.t('message:USER.ERROR.MAX_RESET_EMAILS')));
     } else {
       yield put(enqueueErrorSnackbar(i18n.t('message:USER.ERROR.RESET_PASSWORD')));
     }

--- a/packages/webapp/src/containers/ResetPassword/index.jsx
+++ b/packages/webapp/src/containers/ResetPassword/index.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import ResetPasswordModal from '../../components/Modals/ResetPassword';
 import { sendResetPasswordEmail } from '../CustomSignUp/saga';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { passwordResetErrorSelector } from '../customSignUpSlice';
 
 export default function ResetPassword({ email, dismissModal }) {
   const [changeText, setChangeText] = useState(false);
-
+  const passwordResetError = useSelector(passwordResetErrorSelector);
   const dispatch = useDispatch();
 
   const resendLink = () => {
@@ -17,6 +18,11 @@ export default function ResetPassword({ email, dismissModal }) {
   };
 
   return (
-    <ResetPasswordModal onClick={resendLink} changeText={changeText} dismissModal={dismissModal} />
+    <ResetPasswordModal
+      onClick={resendLink}
+      changeText={changeText}
+      dismissModal={dismissModal}
+      passwordResetError={passwordResetError}
+    />
   );
 }

--- a/packages/webapp/src/containers/customSignUpSlice.js
+++ b/packages/webapp/src/containers/customSignUpSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   customSignUpErrorKey: null,
+  passwordResetError: null,
 };
 
 const customSignUpSlice = createSlice({
@@ -11,12 +12,18 @@ const customSignUpSlice = createSlice({
     setCustomSignUpErrorKey: (state, { payload: { key } }) => {
       state.customSignUpErrorKey = key;
     },
+    setPasswordResetError: (state, { payload: error }) => {
+      state.passwordResetError = error;
+    },
   },
 });
 
-export const { setCustomSignUpErrorKey } = customSignUpSlice.actions;
+export const { setCustomSignUpErrorKey, setPasswordResetError } = customSignUpSlice.actions;
 
 export const customSignUpErrorKeySelector = (state) =>
   state.tempStateReducer[customSignUpSlice.name]?.customSignUpErrorKey;
+
+export const passwordResetErrorSelector = (state) =>
+  state.tempStateReducer[customSignUpSlice.name]?.passwordResetError;
 
 export default customSignUpSlice.reducer;


### PR DESCRIPTION
**Description**

Replaced the error snackbar with an inline error message by creating a new state variable in redux to hold the error message. 

Modified modal component to accept an error prop to be rendered underneath the button.

Jira link: https://lite-farm.atlassian.net/browse/LF-3190

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
