### PR TITLE
LF-3411-One-of-the-area-becomes-unselected-once-the-user-goes-back-during-the-creation-of-the-new-task-directly-through-an-active-crop-plan

### DIFF
--- a/packages/webapp/src/components/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/components/Task/TaskLocations/index.jsx
@@ -72,7 +72,8 @@ export default function PureTaskLocations({
   };
 
   useEffect(() => {
-    defaultLocation &&
+    !selectedLocations?.length &&
+      defaultLocation &&
       locations.some((location) => location.location_id === defaultLocation.location_id) &&
       onSelectLocation(defaultLocation.location_id);
   }, [defaultLocation]);


### PR DESCRIPTION
**Description**

There was a problem with creating tasks from a crop plan. When you picked more than one location and moved forward, then went back to select the field, only one location was getting selected.

The issue was in how the component handled the default location. It would automatically select a location when the component loaded or when the default location changed. However, it didn't check if there were already locations selected.

To fix this, I added a check to see if any locations were already selected. This way, the default location wouldn't override any existing selections.

Jira link: https://lite-farm.atlassian.net/browse/LF-3411?atlOrigin=eyJpIjoiYTFmZWJhOTE5MjBiNDMxYjhjNDVmNmU3N2JjOTY1YzAiLCJwIjoiaiJ9

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

I have tested all the tasks types for a crop plan, and also checked that there weren't errors when creating a task not related to a crop plan.

I have also checked on a farm where there were only one field.

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
