### PR TITLE
LF-3744: Create new generic expandable item list component

### DIFF
--- a/packages/webapp/src/components/Expandable/ExpandableItem.jsx
+++ b/packages/webapp/src/components/Expandable/ExpandableItem.jsx
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { Collapse } from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import styles from './styles.module.scss';
+
+const icons = {
+  up: <KeyboardArrowUpIcon className={styles.icon} />,
+  down: <KeyboardArrowDownIcon className={styles.icon} />,
+};
+
+export default function ExpandableItem({
+  isExpanded,
+  onClick,
+  mainContent,
+  expandedContent,
+  iconClickOnly = true,
+  classes = {},
+}) {
+  const onElementClick = () => {
+    if (!iconClickOnly) {
+      onClick();
+    }
+  };
+
+  const onIconClick = () => {
+    if (iconClickOnly) {
+      onClick();
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={clsx(
+          styles.mainContentWithIcon,
+          !iconClickOnly && styles.clickable,
+          classes.mainContentWithIcon,
+        )}
+        onClick={onElementClick}
+      >
+        <div className={clsx(styles.mainContentWrapper, classes.mainContentWrapper)}>
+          {mainContent}
+        </div>
+        <div
+          onClick={onIconClick}
+          className={clsx(iconClickOnly && styles.clickable, classes.icon)}
+        >
+          {icons[isExpanded ? 'up' : 'down']}
+        </div>
+      </div>
+      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+        {expandedContent}
+      </Collapse>
+    </>
+  );
+}
+
+ExpandableItem.propTypes = {
+  isExpanded: PropTypes.bool,
+  onClick: PropTypes.func,
+  mainContent: PropTypes.node,
+  expandedContent: PropTypes.node,
+  iconClickOnly: PropTypes.bool,
+  classes: PropTypes.shape({
+    mainContentWithIcon: PropTypes.string,
+    icon: PropTypes.string,
+  }),
+};

--- a/packages/webapp/src/components/Expandable/styles.module.scss
+++ b/packages/webapp/src/components/Expandable/styles.module.scss
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+ 
+ .mainContentWithIcon {
+  display: flex;
+}
+
+.mainContentWrapper {
+  flex: 1;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.icon {
+  color: var(--grey500);
+}

--- a/packages/webapp/src/components/Expandable/useExpandableItem.js
+++ b/packages/webapp/src/components/Expandable/useExpandableItem.js
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+export default function useExpandable({ defaultExpandedIds = [], isSingleExpandable }) {
+  const [expandedIds, setExpandedIds] = useState(defaultExpandedIds);
+
+  const expand = (id) => {
+    if (expandedIds.includes(id)) {
+      return;
+    }
+    const newIds = isSingleExpandable ? [id] : [...expandedIds, id];
+    setExpandedIds(newIds);
+  };
+
+  const unExpand = (id) => {
+    if (!expandedIds.includes(id)) {
+      return;
+    }
+    const newIds = isSingleExpandable ? [] : expandedIds.filter((expandedId) => id !== expandedId);
+    setExpandedIds(newIds);
+  };
+
+  const toggleExpanded = (id) => {
+    expandedIds.includes(id) ? unExpand(id) : expand(id);
+  };
+
+  return { expandedIds, expand, unExpand, toggleExpanded };
+}
+
+useExpandable.propTypes = {
+  defaultExpandedIds: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  isSingleExpandable: PropTypes.bool,
+};

--- a/packages/webapp/src/stories/ExpandableItem/ExpandableItem.stories.jsx
+++ b/packages/webapp/src/stories/ExpandableItem/ExpandableItem.stories.jsx
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import clsx from 'clsx';
+import { expect } from '@storybook/jest';
+import { within, userEvent, waitForElementToBeRemoved } from '@storybook/testing-library';
+import Expandable from '../../components/Expandable/ExpandableItem';
+import useExpandable from '../../components/Expandable/useExpandableItem';
+import { componentDecorators } from '../Pages/config/Decorators';
+import { ReactComponent as SoilAmendment } from '../../assets/images/task/SoilAmendment.svg';
+import styles from './styles.module.scss';
+
+export default {
+  title: 'Components/Expandable',
+  component: Expandable,
+  decorators: componentDecorators,
+};
+
+const data = [
+  {
+    transaction: 'Summer Harvest',
+    type: 'Crop sales',
+    amount: '+ €17551.50',
+    expandedContent: 'Expanded content 1',
+    icon: <SoilAmendment />,
+  },
+  {
+    transaction: 'Gas refill',
+    type: 'Fuel',
+    amount: '- €873.00',
+    expandedContent: 'Expanded content 2',
+    icon: <SoilAmendment />,
+  },
+  {
+    transaction: 'Pesticide and traps',
+    type: 'Pest control',
+    amount: '- €873.00',
+    expandedContent: 'Expanded content 3',
+    icon: <SoilAmendment />,
+  },
+];
+
+const MainContent = ({ transaction, type, amount, icon }) => {
+  return (
+    <div className={styles.mainContent}>
+      <div className={styles.mainContentLeft}>
+        <div>{icon}</div>
+        <div>
+          <div className={styles.mainContentTitle}>{transaction}</div>
+          <div className={styles.mainContentInfo}>{type}</div>
+        </div>
+      </div>
+      <div>{amount}</div>
+    </div>
+  );
+};
+
+const Test = ({ defaultExpandedIds = [], isSingleExpandable, iconClickOnly }) => {
+  const { expandedIds, toggleExpanded } = useExpandable({ defaultExpandedIds, isSingleExpandable });
+
+  return data.map((values, index) => {
+    const isExpanded = expandedIds.includes(index);
+    return (
+      <div key={index} className={clsx(styles.item, isExpanded && styles.expanded)}>
+        <Expandable
+          isExpanded={isExpanded}
+          onClick={() => toggleExpanded(index)}
+          mainContent={<MainContent {...values} />}
+          expandedContent={<div className={styles.expandedContent}>{values.expandedContent}</div>}
+          iconClickOnly={iconClickOnly}
+          classes={{ mainContentWithIcon: styles.mainContentWithIcon, icon: styles.icon }}
+        />
+      </div>
+    );
+  });
+};
+
+export const SingleExpandableItem = {
+  render: () => <Test isSingleExpandable={true} iconClickOnly={false} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const row0 = canvas.getByText(data[0].transaction);
+    await userEvent.click(row0);
+    const expandedContent0 = await canvas.findByText(data[0].expandedContent);
+    expect(expandedContent0).toBeInTheDocument();
+
+    await userEvent.click(row0);
+    await waitForElementToBeRemoved(() => canvas.queryByText(data[0].expandedContent));
+    expect(expandedContent0).not.toBeInTheDocument();
+
+    const row1 = canvas.getByText(data[1].transaction);
+    await userEvent.click(row1);
+    const expandedContent1 = await canvas.findByText(data[1].expandedContent);
+    expect(expandedContent1).toBeInTheDocument();
+    expect(expandedContent0).not.toBeInTheDocument();
+    let expandedContent2 = await canvas.queryByText(data[2].expandedContent);
+    expect(expandedContent2).not.toBeInTheDocument();
+
+    const row2 = canvas.getByText(data[2].transaction);
+    await userEvent.click(row2);
+    expandedContent2 = await canvas.findByText(data[2].expandedContent);
+    expect(expandedContent2).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => canvas.queryByText(data[1].expandedContent));
+    expect(expandedContent1).not.toBeInTheDocument();
+    expect(expandedContent0).not.toBeInTheDocument();
+  },
+};
+
+export const MultipleExpandableItem = {
+  render: () => <Test isSingleExpandable={false} iconClickOnly={false} />,
+};
+
+export const IconClickOnlyExpandableItem = {
+  render: () => <Test isSingleExpandable={true} iconClickOnly={true} />,
+};
+
+export const ExpandableItemWithDefaultExpanded = {
+  render: () => <Test defaultExpandedIds={[1]} isSingleExpandable={true} iconClickOnly={false} />,
+};

--- a/packages/webapp/src/stories/ExpandableItem/styles.module.scss
+++ b/packages/webapp/src/stories/ExpandableItem/styles.module.scss
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+ 
+ .mainContentWithIcon {
+  padding: 12px;
+  align-items: center;
+}
+
+.item {
+  border: solid 1px transparent;
+  border-bottom: solid 1px var(--grey200);
+
+  &.expanded {
+    background-color: #F6FBFA;
+    border: solid 1px var(--grey400);
+  }
+}
+
+.icon {
+  margin-top: 5px;
+}
+
+.mainContent {
+ display: flex;
+ justify-content: space-between;
+ align-items: center;
+}
+
+.mainContentLeft {
+  display: flex;
+
+  svg {
+    width: 28px;
+    height: 28px;
+    margin-top: 5px;
+    margin-right: 4px;
+  }
+}
+
+.mainContentTitle {
+  font-weight: 700;
+}
+
+.mainContentInfo {
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.expandedContent {
+  background-color: #fff;
+  width: 96%;
+  margin: 2%;
+  margin-top: 0 
+}


### PR DESCRIPTION
**Description**

- create `ExpandableItem` component that takes `mainContent` and `expandedContent` etc. and displays them with a chevron icon
   <img width="622" alt="Screenshot 2023-10-17 at 11 12 54 AM" src="https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/e96c0f01-6bfa-4b51-8fb3-946580793a4b">
- create `useExpandable` hook that takes care of `expanded` state and provides expand/unexpand/toggle functions
- write [stories](http://localhost:6006/?path=/docs/components-expandable--docs) and tests

Jira link: https://lite-farm.atlassian.net/browse/LF-3744

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

```
pnpm test-storybook ExpandableItem
```

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
