### PR TITLE
changed symbol_native property for the right one

### DIFF
--- a/packages/webapp/src/containers/AddFarm/currency/commonCurrency.json
+++ b/packages/webapp/src/containers/AddFarm/currency/commonCurrency.json
@@ -434,7 +434,7 @@
   "INR": {
     "symbol": "Rs",
     "name": "Indian Rupee",
-    "symbol_native": "টকা",
+    "symbol_native": "₹",
     "decimal_digits": 2,
     "rounding": 0,
     "code": "INR",


### PR DESCRIPTION
**Description**

The issue: when a farm in India added an expense an incorrect symbol for the INR currency was being used.  The problem was traced to the json file with all currency symbols, where the one for INR was wrong.

The fix: the INR symbol was fixed on the json file that contains all the supported currency symbols.

Jira link: https://lite-farm.atlassian.net/browse/LF-3669?atlOrigin=eyJpIjoiNmNhMGQyOWM1MWJhNDczNWI2ZTY5OGU3YmJhMzFiZGYiLCJwIjoiaiJ9

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

The usage of the currency symbol was tested on all types of expenses

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
