### PR TITLE
LF-3770 Move finance type tiles to new List component

### DIFF
--- a/packages/webapp/src/components/Finances/PureFinanceTypeSelection/index.jsx
+++ b/packages/webapp/src/components/Finances/PureFinanceTypeSelection/index.jsx
@@ -20,8 +20,7 @@ import MultiStepPageTitle from '../../PageTitle/MultiStepPageTitle';
 import { Main } from '../../Typography';
 import Form from '../../Form';
 import Button from '../../Form/Button';
-import Tiles from '../../Tile/Tiles';
-import { tileTypes } from '../../Tile/constants';
+import List from '../../List';
 import styles from './styles.module.scss';
 import { CantFindCustomType } from './CantFindCustomType';
 
@@ -38,6 +37,7 @@ export default function PureFinanceTypeSelection({
   isTypeSelected,
   formatTileData,
   getFormatTileDataFunc,
+  listItemType,
   progressValue,
   useHookFormPersist,
   persistedFormData = {},
@@ -70,10 +70,12 @@ export default function PureFinanceTypeSelection({
           style={{ marginBottom: '24px' }}
         />
         <Main className={styles.leadText}>{leadText}</Main>
-        <Tiles
-          tileType={tileTypes.ICON_LABEL}
-          tileData={types}
-          formatTileData={getFormatTileDataFunc ? getFormatTileDataFunc(setValue) : formatTileData}
+        <List
+          listItemType={listItemType}
+          listItemData={types}
+          formatListItemData={
+            getFormatTileDataFunc ? getFormatTileDataFunc(setValue) : formatTileData
+          }
         />
         <div className={styles.cantFindWrapper}>
           <CantFindCustomType

--- a/packages/webapp/src/components/Forms/ManageCustomTypes/index.jsx
+++ b/packages/webapp/src/components/Forms/ManageCustomTypes/index.jsx
@@ -16,9 +16,8 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { AddLink } from '../../Typography';
 import PageTitle from '../../PageTitle/v2';
-import Tiles from '../../Tile/Tiles';
-import IconLabelTile from '../../Tile/IconLabelTile';
-import { tileTypes } from '../../Tile/constants';
+import List from '../../List';
+import { listItemTypes } from '../../List/constants';
 
 export default function ManageCustomTypes({
   title,
@@ -27,7 +26,6 @@ export default function ManageCustomTypes({
   onAddType,
   tileData,
   formatTileData,
-  onTileClick,
 }) {
   return (
     <div style={{ padding: '24px' }}>
@@ -35,16 +33,11 @@ export default function ManageCustomTypes({
       <AddLink style={{ paddingBottom: '24px' }} onClick={onAddType}>
         {addLinkText}
       </AddLink>
-      <Tiles tileType={tileTypes.ICON_LABEL} tileData={tileData} formatTileData={formatTileData}>
-        {tileData.map((data) => {
-          const tileProps = formatTileData(data);
-          const { tileKey } = tileProps;
-
-          return (
-            <IconLabelTile {...tileProps} key={tileKey} onClick={() => onTileClick(tileKey)} />
-          );
-        })}
-      </Tiles>
+      <List
+        listItemType={listItemTypes.ICON_DESCRIPTION_CHEVRON}
+        listItemData={tileData}
+        formatListItemData={formatTileData}
+      />
     </div>
   );
 }

--- a/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/index.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/index.jsx
@@ -22,6 +22,7 @@ import { ReactComponent as CustomTypeIcon } from '../../../../assets/images/fina
 import PureFinanceTypeSelection from '../../../../components/Finances/PureFinanceTypeSelection';
 import useSortedRevenueTypes from './useSortedRevenueTypes';
 import labelIconStyles from '../../../../components/Tile/styles.module.scss';
+import { listItemTypes } from '../../../../components/List/constants';
 
 export const icons = {
   CROP_SALE: <CropSaleIcon />,
@@ -42,7 +43,13 @@ export default function RevenueTypes({ useHookFormPersist, history }) {
 
   const getFormatTileDataFunc = (setValue) => {
     return (data) => {
-      const { farm_id, revenue_translation_key, revenue_type_id, revenue_name } = data;
+      const {
+        farm_id,
+        revenue_translation_key,
+        revenue_type_id,
+        revenue_name,
+        custom_description,
+      } = data;
 
       return {
         key: revenue_type_id,
@@ -52,6 +59,9 @@ export default function RevenueTypes({ useHookFormPersist, history }) {
         onClick: () => getOnTileClickFunc(setValue)(revenue_type_id),
         className: labelIconStyles.boldLabelIcon,
         selected: persistedFormData?.revenue_type_id === revenue_type_id,
+        description: farm_id
+          ? custom_description
+          : t(`revenue:${revenue_translation_key}.CUSTOM_DESCRIPTION`),
       };
     };
   };
@@ -67,6 +77,7 @@ export default function RevenueTypes({ useHookFormPersist, history }) {
         progressValue={33}
         onGoToManageCustomType={() => history.push('/manage_custom_revenues')}
         getFormatTileDataFunc={getFormatTileDataFunc}
+        listItemType={listItemTypes.ICON_DESCRIPTION}
         useHookFormPersist={useHookFormPersist}
         customTypeMessages={{
           info: t('FINANCES.CANT_FIND.INFO_REVENUE'),

--- a/packages/webapp/src/containers/Finances/ManageCustomExpenseTypes/index.jsx
+++ b/packages/webapp/src/containers/Finances/ManageCustomExpenseTypes/index.jsx
@@ -74,9 +74,14 @@ export default function ManageExpenseTypes({ history }) {
       addLinkText={t('EXPENSE.ADD_EXPENSE.ADD_CUSTOM_EXPENSE_TYPE')}
       onAddType={onAddType}
       tileData={customTypes}
-      onTileClick={onTileClick}
       formatTileData={(data) => {
-        const { farm_id, expense_translation_key, expense_name, expense_type_id } = data;
+        const {
+          farm_id,
+          expense_translation_key,
+          expense_name,
+          expense_type_id,
+          custom_description,
+        } = data;
 
         return {
           key: expense_type_id,
@@ -84,6 +89,10 @@ export default function ManageExpenseTypes({ history }) {
           icon: icons[farm_id ? 'OTHER' : expense_translation_key],
           label: farm_id ? expense_name : t(`expense:${expense_translation_key}.EXPENSE_NAME`),
           className: labelIconStyles.boldLabelIcon,
+          description: farm_id
+            ? custom_description
+            : t(`expense:${expense_translation_key}.CUSTOM_DESCRIPTION`),
+          onClick: () => onTileClick(expense_type_id),
         };
       }}
     />

--- a/packages/webapp/src/containers/Finances/ManageCustomRevenueTypes/index.jsx
+++ b/packages/webapp/src/containers/Finances/ManageCustomRevenueTypes/index.jsx
@@ -74,9 +74,14 @@ export default function ManageRevenueTypes({ history }) {
       addLinkText={t('SALE.ADD_SALE.ADD_CUSTOM_REVENUE_TYPE')}
       onAddType={onAddType}
       tileData={customTypes}
-      onTileClick={onTileClick}
       formatTileData={(data) => {
-        const { farm_id, revenue_translation_key, revenue_name, revenue_type_id } = data;
+        const {
+          farm_id,
+          revenue_translation_key,
+          revenue_name,
+          revenue_type_id,
+          custom_description,
+        } = data;
 
         return {
           key: revenue_type_id,
@@ -84,6 +89,10 @@ export default function ManageRevenueTypes({ history }) {
           icon: icons[farm_id ? 'CUSTOM' : revenue_translation_key],
           label: farm_id ? revenue_name : t(`revenue:${revenue_translation_key}.REVENUE_NAME`),
           className: labelIconStyles.boldLabelIcon,
+          description: farm_id
+            ? custom_description
+            : t(`revenue:${revenue_translation_key}.REVENUE_NAME`),
+          onClick: () => onTileClick(revenue_type_id),
         };
       }}
     />

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
@@ -23,6 +23,7 @@ import ManageCustomExpenseTypesSpotlight from '../ManageCustomExpenseTypesSpotli
 import PureFinanceTypeSelection from '../../../../components/Finances/PureFinanceTypeSelection';
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
 import labelIconStyles from '../../../../components/Tile/styles.module.scss';
+import { listItemTypes } from '../../../../components/List/constants';
 
 export const icons = {
   EQUIPMENT: <EquipIcon />,
@@ -99,7 +100,13 @@ class ExpenseCategories extends Component {
           onGoToManageCustomType={() => history.push('/manage_custom_expenses')}
           isTypeSelected={!!this.state.selectedTypes.length}
           formatTileData={(data) => {
-            const { farm_id, expense_translation_key, expense_type_id, expense_name } = data;
+            const {
+              farm_id,
+              expense_translation_key,
+              expense_type_id,
+              expense_name,
+              custom_description,
+            } = data;
 
             return {
               key: expense_type_id,
@@ -111,8 +118,12 @@ class ExpenseCategories extends Component {
               onClick: () => this.addRemoveType(expense_type_id),
               selected: this.state.selectedTypes.includes(expense_type_id),
               className: labelIconStyles.boldLabelIcon,
+              description: farm_id
+                ? custom_description
+                : this.props.t(`expense:${expense_translation_key}.CUSTOM_DESCRIPTION`),
             };
           }}
+          listItemType={listItemTypes.ICON_DESCRIPTION_CHECKBOX}
           useHookFormPersist={this.props.useHookFormPersist}
           iconLinkId={'manageCustomExpenseType'}
           Wrapper={ManageCustomExpenseTypesSpotlight}

--- a/packages/webapp/src/containers/revenueTypeSlice.js
+++ b/packages/webapp/src/containers/revenueTypeSlice.js
@@ -27,6 +27,7 @@ export const getRevenueType = (obj) => {
     'deleted',
     'agriculture_associated',
     'crop_generated',
+    'custom_description',
   ]);
 };
 

--- a/packages/webapp/src/stories/Pages/Finance/PureFinanceTypeSelection.stories.jsx
+++ b/packages/webapp/src/stories/Pages/Finance/PureFinanceTypeSelection.stories.jsx
@@ -17,6 +17,7 @@ import { chromaticSmallScreen } from '../config/chromatic';
 import PureFinanceTypeSelection from '../../../components/Finances/PureFinanceTypeSelection';
 import { icons } from '../../../containers/Finances/NewExpense/ExpenseCategories';
 import { icons as revenueTypeIcons } from '../../../containers/Finances/AddSale/RevenueTypes';
+import { listItemTypes } from '../../../components/List/constants';
 
 export default {
   title: 'Page/Finance/PureFinanceTypeSelection',
@@ -152,7 +153,7 @@ export const Expense = {
     onGoToManageCustomType: () => console.log('Go to Management Custom Type'),
     isTypeSelected: false,
     formatTileData: (data) => {
-      const { farm_id, expense_translation_key, expense_name } = data;
+      const { farm_id, expense_translation_key, expense_name, custom_description } = data;
 
       return {
         key: expense_translation_key,
@@ -160,8 +161,10 @@ export const Expense = {
         icon: icons[farm_id ? 'OTHER' : expense_translation_key],
         label: expense_name,
         onClick: () => console.log(`${expense_name} clicked!`),
+        description: custom_description,
       };
     },
+    listItemType: listItemTypes.ICON_DESCRIPTION_CHECKBOX,
     useHookFormPersist: () => ({ historyCancel: () => ({}) }),
     customTypeMessages: {
       info: 'You can also create your own custom expense types!',
@@ -207,7 +210,7 @@ export const Revenue = {
     onGoToManageCustomType: () => console.log('Go to Management Custom Type'),
     isTypeSelected: false,
     formatTileData: (data) => {
-      const { farm_id, revenue_translation_key, revenue_name } = data;
+      const { farm_id, revenue_translation_key, revenue_name, custom_description } = data;
 
       return {
         key: revenue_translation_key,
@@ -215,8 +218,10 @@ export const Revenue = {
         icon: farm_id ? revenueTypeIcons['CUSTOM'] : revenueTypeIcons['CROP_SALE'],
         label: revenue_name,
         onClick: () => console.log(`${revenue_name} clicked!`),
+        description: custom_description,
       };
     },
+    listItemType: listItemTypes.ICON_DESCRIPTION,
     useHookFormPersist: () => ({ historyCancel: () => ({}) }),
     customTypeMessages: {
       info: 'You can also create your own custom revenue types!',

--- a/packages/webapp/src/stories/Pages/Forms/ManageCustomTypes.stories.jsx
+++ b/packages/webapp/src/stories/Pages/Forms/ManageCustomTypes.stories.jsx
@@ -15,7 +15,7 @@
 import decorators from '../config/Decorators';
 import { chromaticSmallScreen } from '../config/chromatic';
 import ManageCustomTypes from '../../../components/Forms/ManageCustomTypes';
-import { ReactComponent as OtherIcon } from '../../../assets/images/log/other.svg';
+import { ReactComponent as OtherIcon } from '../../../assets/images/finance/Custom-expense.svg';
 
 export default {
   title: 'Form/ManageCustomTypes',
@@ -30,6 +30,7 @@ const customTypes = [
     expense_type_id: '461d2e5e-3d4c-11ee-ba15-e66db4bef552',
     deleted: false,
     expense_translation_key: 'CUSTOM',
+    custom_description: 'A user-provided description of this type',
   },
   {
     expense_name: 'Custom type 2',
@@ -37,6 +38,7 @@ const customTypes = [
     expense_type_id: '461d2e5e-3d4c-11ee-ba15-e66db4bef553',
     deleted: false,
     expense_translation_key: 'CUSTOM_2',
+    custom_description: 'A user-provided description of this type',
   },
 ];
 
@@ -50,13 +52,14 @@ export const Expense = {
     onTileClick: (key) => console.log(`${key} clicked!`),
     customTypeFieldName: 'expense_type_id',
     formatTileData: (data) => {
-      const { expense_name, expense_type_id } = data;
+      const { expense_name, expense_type_id, custom_description } = data;
 
       return {
         key: expense_type_id,
         tileKey: expense_type_id,
         icon: <OtherIcon />,
         label: expense_name,
+        description: custom_description,
       };
     },
     useHookFormPersist: () => ({}),


### PR DESCRIPTION
**Description**

This takes the new `<List />` component from this PR:
- https://github.com/LiteFarmOrg/LiteFarm/pull/2925

And uses it to replace the four "type" tile views (expense, revenue, custom expense, custom revenue). Also updates the two Storybook stories for the two Pure components (PureFinanceTypeSelection + ManageCustomTypes).

Jira link: https://lite-farm.atlassian.net/browse/LF-3770

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
