### PR TITLE
LF-3761: Implement crop sales expandable content

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -848,6 +848,8 @@
       "REVENUE_TYPES": "Search revenue type"
     },
     "TRANSACTION": {
+      "CROPS": "Crops",
+      "DAILY_TOTAL": "DAILY TOTAL",
       "LABOUR_EXPENSE": "Labour expense",
       "VIEW_AND_EDIT": "View & edit",
       "VIEW_DETAILS": "View details"

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -847,6 +847,8 @@
       "REVENUE_TYPES": "MISSING"
     },
     "TRANSACTION": {
+      "CROPS": "MISSING",
+      "DAILY_TOTAL": "MISSING",
       "LABOUR_EXPENSE": "MISSING",
       "VIEW_AND_EDIT": "MISSING",
       "VIEW_DETAILS": "MISSING"

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -848,6 +848,8 @@
       "REVENUE_TYPES": "MISSING"
     },
     "TRANSACTION": {
+      "CROPS": "MISSING",
+      "DAILY_TOTAL": "MISSING",
       "LABOUR_EXPENSE": "MISSING",
       "VIEW_AND_EDIT": "MISSING",
       "VIEW_DETAILS": "MISSING"

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -847,6 +847,8 @@
       "REVENUE_TYPES": "MISSING"
     },
     "TRANSACTION": {
+      "CROPS": "MISSING",
+      "DAILY_TOTAL": "MISSING",
       "LABOUR_EXPENSE": "MISSING",
       "VIEW_AND_EDIT": "MISSING",
       "VIEW_DETAILS": "MISSING"

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/CropSaleTable.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/CropSaleTable.jsx
@@ -52,9 +52,9 @@ const getColumns = (t, mobileView, totalAmount, quantityTotal, currencySymbol) =
     id: 'amount',
     label: t('FINANCES.REVENUE'),
     align: 'right',
-    format: (d) => `${currencySymbol} ${Math.abs(d.amount).toFixed(2)}`,
+    format: (d) => `${currencySymbol}${Math.abs(d.amount).toFixed(2)}`,
     columnProps: {
-      style: { width: '250px', paddingRight: `${mobileView ? 9 : 75}px` },
+      style: { width: '100px', paddingRight: `${mobileView ? 9 : 75}px` },
     },
     Footer: mobileView ? null : <div className={styles.bold}>{totalAmount}</div>,
   },
@@ -74,7 +74,7 @@ export default function CropSaleTable({ data, currencySymbol, mobileView }) {
   const quantityUnit = items?.[0]?.quantityUnit;
   const quantityTotal = items.reduce((total, { quantity }) => total + quantity, 0);
   const quantityWithUnit = `${quantityTotal} ${quantityUnit}`;
-  const totalAmount = `${currencySymbol} ${amount.toFixed(2)}`;
+  const totalAmount = `${currencySymbol}${amount.toFixed(2)}`;
 
   if (!items?.length) {
     return null;

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/CropSaleTable.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/CropSaleTable.jsx
@@ -72,8 +72,8 @@ export default function CropSaleTable({ data, currencySymbol, mobileView }) {
   const { t } = useTranslation();
   const { items, amount, relatedId } = data;
   const quantityUnit = items?.[0]?.quantityUnit;
-  let quantityTotal = items.reduce((total, { quantity }) => total + quantity, 0);
-  quantityTotal += ` ${quantityUnit}`;
+  const quantityTotal = items.reduce((total, { quantity }) => total + quantity, 0);
+  const quantityWithUnit = `${quantityTotal} ${quantityUnit}`;
   const totalAmount = `${currencySymbol} ${amount.toFixed(2)}`;
 
   if (!items?.length) {
@@ -82,13 +82,13 @@ export default function CropSaleTable({ data, currencySymbol, mobileView }) {
 
   return (
     <Table
-      columns={getColumns(t, mobileView, totalAmount, quantityTotal, currencySymbol)}
+      columns={getColumns(t, mobileView, totalAmount, quantityWithUnit, currencySymbol)}
       data={items}
       minRows={10}
       shouldFixTableLayout={true}
       FooterCell={
         mobileView
-          ? () => <FooterCell t={t} totalAmount={totalAmount} quantityTotal={quantityTotal} />
+          ? () => <FooterCell t={t} totalAmount={totalAmount} quantityTotal={quantityWithUnit} />
           : null
       }
       onClickMore={() => history.push(`/revenue/${relatedId}`)}

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/CropSaleTable.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/CropSaleTable.jsx
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Table from '../../../Table/v2';
+import history from '../../../../history';
+import styles from './styles.module.scss';
+
+const getColumns = (t, mobileView, totalAmount, quantityTotal, currencySymbol) => [
+  {
+    id: 'title',
+    label: t('FINANCES.TRANSACTION.CROPS'),
+    format: (d) =>
+      mobileView ? (
+        <div className={styles.mobileCrops}>
+          <div className={styles.mobileCropsTitle}>{d.title}</div>
+          <div className={styles.mobileCropsQuantity}>
+            {d.quantity} {d.quantityUnit}
+          </div>
+        </div>
+      ) : (
+        d.title
+      ),
+    columnProps: {
+      style: { padding: `0 ${mobileView ? 8 : 12}px` },
+    },
+    Footer: mobileView ? null : t('FINANCES.TRANSACTION.DAILY_TOTAL'),
+  },
+  {
+    id: mobileView ? null : 'quantity',
+    label: mobileView ? null : t('common:QUANTITY'),
+    align: 'right',
+    format: (d) => `${d.quantity} ${d.quantityUnit}`,
+    columnProps: {
+      style: { width: '100px' },
+    },
+    Footer: mobileView ? null : <div className={styles.bold}>{quantityTotal}</div>,
+  },
+  {
+    id: 'amount',
+    label: t('FINANCES.REVENUE'),
+    align: 'right',
+    format: (d) => `${currencySymbol} ${Math.abs(d.amount).toFixed(2)}`,
+    columnProps: {
+      style: { width: '250px', paddingRight: `${mobileView ? 9 : 75}px` },
+    },
+    Footer: mobileView ? null : <div className={styles.bold}>{totalAmount}</div>,
+  },
+];
+
+const FooterCell = ({ t, quantityTotal, totalAmount }) => (
+  <div className={styles.mobileCropSaleFooterCell}>
+    <div>{t('FINANCES.TRANSACTION.DAILY_TOTAL')}</div>
+    <div className={styles.bold}>{quantityTotal}</div>
+    <div className={styles.bold}>{totalAmount}</div>
+  </div>
+);
+
+export default function CropSaleTable({ data, currencySymbol, mobileView }) {
+  const { t } = useTranslation();
+  const { items, amount, relatedId } = data;
+  const quantityUnit = items?.[0]?.quantityUnit;
+  let quantityTotal = items.reduce((total, { quantity }) => total + quantity, 0);
+  quantityTotal += ` ${quantityUnit}`;
+  const totalAmount = `${currencySymbol} ${amount.toFixed(2)}`;
+
+  if (!items?.length) {
+    return null;
+  }
+
+  return (
+    <Table
+      columns={getColumns(t, mobileView, totalAmount, quantityTotal, currencySymbol)}
+      data={items}
+      minRows={10}
+      shouldFixTableLayout={true}
+      FooterCell={
+        mobileView
+          ? () => <FooterCell t={t} totalAmount={totalAmount} quantityTotal={quantityTotal} />
+          : null
+      }
+      onClickMore={() => history.push(`/revenue/${relatedId}`)}
+    />
+  );
+}

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/index.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/index.jsx
@@ -18,14 +18,15 @@ import { BsChevronRight } from 'react-icons/bs';
 import TextButton from '../../../Form/Button/TextButton';
 import history from '../../../../history';
 import { transactionTypeEnum } from '../../../../containers/Finances/useTransactions';
+import CropSaleTable from './CropSaleTable';
 import styles from './styles.module.scss';
 
-// TODO LF-3748, 3749, 3761
+// TODO LF-3748, 3749
 const components = {
   EXPENSE: (props) => <div>expense placeholder</div>,
   REVENUE: (props) => <div>revenue placeholder</div>,
   LABOUR_EXPENSE: (props) => <div>labour placeholder</div>,
-  CROP_SALE: (props) => <div>crop sale placeholder</div>,
+  CROP_SALE: (props) => <CropSaleTable {...props} />,
 };
 
 const getDetailPageLink = ({ transactionType, relatedId }) => {

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/index.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/index.jsx
@@ -36,7 +36,7 @@ const getDetailPageLink = ({ transactionType, relatedId }) => {
   }[transactionType];
 };
 
-export default function ExpandedContent({ data }) {
+export default function ExpandedContent({ data, currencySymbol, mobileView }) {
   const { typeLabel, transactionType } = data;
 
   const { t } = useTranslation();
@@ -55,7 +55,7 @@ export default function ExpandedContent({ data }) {
         {toDetailText}
         <BsChevronRight />
       </TextButton>
-      <Component data={data} />
+      <Component data={data} currencySymbol={currencySymbol} mobileView={mobileView} />
     </div>
   );
 }

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/index.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/index.jsx
@@ -38,7 +38,7 @@ const getDetailPageLink = ({ transactionType, relatedId }) => {
 };
 
 export default function ExpandedContent({ data, currencySymbol, mobileView }) {
-  const { typeLabel, transactionType } = data;
+  const { transactionType, cropGenerated } = data;
 
   const { t } = useTranslation();
 
@@ -47,7 +47,7 @@ export default function ExpandedContent({ data, currencySymbol, mobileView }) {
       ? t('FINANCES.TRANSACTION.VIEW_DETAILS')
       : t('FINANCES.TRANSACTION.VIEW_AND_EDIT');
 
-  const componentKey = typeLabel === 'Crop Sale' ? 'CROP_SALE' : transactionType;
+  const componentKey = cropGenerated ? 'CROP_SALE' : transactionType;
   const Component = components[componentKey];
 
   return (

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/styles.module.scss
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/styles.module.scss
@@ -38,3 +38,42 @@ button.toDetail {
     margin-left: 8px;
   }
 }
+
+.bold {
+  font-weight: bold;
+}
+
+// Crop sales
+.mobileCrops {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.mobileCropsTitle {
+  font-weight: 600;
+}
+
+.mobileCropsQuantity {
+  color: var(--grey500);
+  font-size: 12px;
+}
+
+.mobileCropSaleFooterCell { 
+  width: 100%;
+  background-color:var(--grey200);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 40px;
+  padding-left: 8px;
+  padding-right: 9px;
+
+  > div {
+    padding: 0 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/styles.module.scss
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/styles.module.scss
@@ -71,7 +71,6 @@ button.toDetail {
   padding-right: 9px;
 
   > div {
-    padding: 0 4px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/webapp/src/components/Finances/Transaction/Mobile/List.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/Mobile/List.jsx
@@ -37,7 +37,7 @@ export const MainContent = ({ t, note, typeLabel, amount, icon, currencySymbol }
   );
 };
 
-const Rows = ({ t, data, currencySymbol }) => {
+const Rows = ({ t, data, currencySymbol, mobileView }) => {
   const { expandedIds, toggleExpanded } = useExpandable({ isSingleExpandable: true });
   const rows = [];
   let groupDate = null;
@@ -65,7 +65,13 @@ const Rows = ({ t, data, currencySymbol }) => {
           isExpanded={isExpanded}
           onClick={() => toggleExpanded(index)}
           mainContent={<MainContent t={t} {...values} currencySymbol={currencySymbol} />}
-          expandedContent={<ExpandedContent data={values} />}
+          expandedContent={
+            <ExpandedContent
+              data={values}
+              currencySymbol={currencySymbol}
+              mobileView={mobileView}
+            />
+          }
           iconClickOnly={false}
           classes={{ mainContentWithIcon: styles.expandableItem }}
           itemKey={`transaction-${index}`}
@@ -76,7 +82,7 @@ const Rows = ({ t, data, currencySymbol }) => {
   return <div>{rows}</div>;
 };
 
-export default function TransactionList({ data, minRows = 10 }) {
+export default function TransactionList({ data, minRows = 10, mobileView }) {
   const [visibleRows, setVisibleRows] = useState(minRows);
 
   const { t } = useTranslation(['translation', 'expense', 'revenue']);
@@ -88,7 +94,12 @@ export default function TransactionList({ data, minRows = 10 }) {
 
   return (
     <div className={styles.transactionList}>
-      <Rows t={t} data={data.slice(0, visibleRows)} currencySymbol={currencySymbol} />
+      <Rows
+        t={t}
+        data={data.slice(0, visibleRows)}
+        currencySymbol={currencySymbol}
+        mobileView={mobileView}
+      />
       {data.length > visibleRows && (
         <div className={styles.buttonWrapper}>
           <Button

--- a/packages/webapp/src/components/Finances/Transaction/Mobile/List.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/Mobile/List.jsx
@@ -48,9 +48,9 @@ const Rows = ({ t, data, currencySymbol, mobileView }) => {
     if (!isSameDay(groupDate, itemDate)) {
       groupDate = itemDate;
       rows.push(
-        <div key={values.date} className={styles.transactionDate}>
+        <h4 key={values.date} className={styles.transactionDate}>
           {formatTransactionDate(itemDate)}
-        </div>,
+        </h4>,
       );
     }
 

--- a/packages/webapp/src/components/Finances/Transaction/Mobile/List.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/Mobile/List.jsx
@@ -42,7 +42,7 @@ const Rows = ({ t, data, currencySymbol, mobileView }) => {
   const rows = [];
   let groupDate = null;
 
-  data.forEach((values, index) => {
+  data.forEach((values) => {
     const itemDate = new Date(values.date);
 
     if (!isSameDay(groupDate, itemDate)) {
@@ -54,16 +54,15 @@ const Rows = ({ t, data, currencySymbol, mobileView }) => {
       );
     }
 
-    const isExpanded = expandedIds.includes(index);
+    const { transactionType, relatedId, date } = values;
+    const key = `${transactionType}+${relatedId || date}`;
+    const isExpanded = expandedIds.includes(key);
 
     rows.push(
-      <div
-        key={index}
-        className={clsx(styles.expandableItemWrapper, isExpanded && styles.expanded)}
-      >
+      <div key={key} className={clsx(styles.expandableItemWrapper, isExpanded && styles.expanded)}>
         <ExpandableItem
           isExpanded={isExpanded}
-          onClick={() => toggleExpanded(index)}
+          onClick={() => toggleExpanded(key)}
           mainContent={<MainContent t={t} {...values} currencySymbol={currencySymbol} />}
           expandedContent={
             <ExpandedContent
@@ -74,7 +73,7 @@ const Rows = ({ t, data, currencySymbol, mobileView }) => {
           }
           iconClickOnly={false}
           classes={{ mainContentWithIcon: styles.expandableItem }}
-          itemKey={`transaction-${index}`}
+          itemKey={`transaction-${key}`}
         />
       </div>,
     );

--- a/packages/webapp/src/components/Finances/Transaction/Mobile/styles.module.scss
+++ b/packages/webapp/src/components/Finances/Transaction/Mobile/styles.module.scss
@@ -19,6 +19,7 @@
 }
 
 .transactionDate {
+  font-weight: normal;
   font-size: 12px;
   line-height: 16px;
   padding-top: 16px;

--- a/packages/webapp/src/components/Finances/Transaction/Mobile/styles.module.scss
+++ b/packages/webapp/src/components/Finances/Transaction/Mobile/styles.module.scss
@@ -69,7 +69,7 @@
 .mainContentLeft {
   display: flex;
   gap: 4px;
-  width: calc(100% - 80px);
+  width: calc(100% - 100px);
 }
 
 .mainContentText {

--- a/packages/webapp/src/components/Finances/Transaction/Mobile/styles.module.scss
+++ b/packages/webapp/src/components/Finances/Transaction/Mobile/styles.module.scss
@@ -42,7 +42,7 @@
     border-radius: 1px;
   }
 
-  &:hover {
+  &:hover:not(.expanded) {
     background-color: var(--grey200);
   }
 }

--- a/packages/webapp/src/components/Table/v2/index.jsx
+++ b/packages/webapp/src/components/Table/v2/index.jsx
@@ -160,14 +160,10 @@ export default function EnhancedTable(props) {
                   onClick={(event) => handleRowClick(event, row)}
                   className={clsx(styles.tableRow, onRowClick && styles.clickable)}
                 >
-                  {columns.map(({ id, format, accessor, align, columnProps }) => {
+                  {columns.map(({ id, format, align, columnProps }) => {
                     if (!id) {
                       return null;
                     }
-
-                    const dataGetter = accessor || id;
-                    const data =
-                      typeof dataGetter === 'function' ? dataGetter(row) : row[dataGetter];
 
                     return (
                       <TableCell
@@ -176,7 +172,7 @@ export default function EnhancedTable(props) {
                         align={align || 'left'}
                         {...columnProps}
                       >
-                        {format ? format(row) : data}
+                        {format ? format(row) : row[id]}
                       </TableCell>
                     );
                   })}
@@ -247,7 +243,6 @@ EnhancedTable.propTypes = {
     PropTypes.shape({
       id: PropTypes.string,
       format: PropTypes.func,
-      accessor: PropTypes.func,
       align: PropTypes.oneOf(['left', 'right']),
       Footer: PropTypes.node,
       columnProps: PropTypes.object,

--- a/packages/webapp/src/containers/Finances/TransactionList/index.jsx
+++ b/packages/webapp/src/containers/Finances/TransactionList/index.jsx
@@ -16,6 +16,8 @@ import PureTransactionList from '../../../components/Finances/Transaction/Mobile
 import useTransactions from '../useTransactions';
 
 export default function TransactionList({ startDate, endDate }) {
+  const mobileView = true;
+
   const dateFilter = { startDate, endDate };
   // TODO: LF-3752
   const expenseTypeFilter = null;
@@ -23,5 +25,5 @@ export default function TransactionList({ startDate, endDate }) {
 
   const transactions = useTransactions({ dateFilter, expenseTypeFilter, revenueTypeFilter });
 
-  return <PureTransactionList data={transactions} />;
+  return <PureTransactionList data={transactions} mobileView={mobileView} />;
 }

--- a/packages/webapp/src/containers/Finances/useTransactions.js
+++ b/packages/webapp/src/containers/Finances/useTransactions.js
@@ -139,6 +139,7 @@ const buildRevenueTransactions = ({
       note: item.sale.customer_name,
       items: item.financeItemsProps,
       relatedId: item.sale.sale_id,
+      cropGenerated: item.cropGenerated || false,
     };
   });
 };

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -223,6 +223,7 @@ export const mapSalesToRevenueItems = (sales, revenueTypes, cropVarieties) => {
             amount: cvs.sale_value,
           };
         }),
+        cropGenerated: true,
       };
     } else {
       return {

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -288,7 +288,7 @@ export function mapRevenueFormDataToApiCallFormat(data, revenueTypes, sale_id, f
 
 export const formatAmount = (amount, symbol) => {
   const sign = amount > 0 ? '+ ' : '- ';
-  return `${amount ? sign : ''}${symbol}${Math.abs(amount)}`;
+  return `${amount ? sign : ''}${symbol}${Math.abs(amount).toFixed(2)}`;
 };
 
 export const formatTransactionDate = (date, language = getLanguageFromLocalStorage()) => {

--- a/packages/webapp/src/stories/Table/TableV2.stories.jsx
+++ b/packages/webapp/src/stories/Table/TableV2.stories.jsx
@@ -26,8 +26,6 @@ const getCropSalesColumns = (mobileView = true) => {
   return [
     {
       id: 'crop',
-      numeric: false,
-      disablePadding: true,
       label: 'Crops',
       Footer: mobileView ? null : 'DAILY TOTAL',
       format: (d) =>
@@ -44,8 +42,6 @@ const getCropSalesColumns = (mobileView = true) => {
     },
     {
       id: mobileView ? null : 'quantity',
-      numeric: true,
-      disablePadding: true,
       label: mobileView ? null : 'Quantity',
       format: (d) => (mobileView ? null : `${Math.abs(d.quantity).toFixed(2)} kg`),
       align: 'right',
@@ -56,8 +52,6 @@ const getCropSalesColumns = (mobileView = true) => {
     },
     {
       id: 'revenue',
-      numeric: true,
-      disablePadding: true,
       label: 'Revenue',
       format: (d) => {
         const sign = '$';
@@ -138,15 +132,11 @@ const getEmployeesLabourColumns = () => {
   return [
     {
       id: 'employee',
-      numeric: false,
-      disablePadding: true,
       label: 'Employee',
       Footer: 'DAILY TOTAL',
     },
     {
       id: 'time',
-      numeric: true,
-      disablePadding: true,
       label: 'Time',
       format: (d) => `${d.time} h`,
       align: 'right',
@@ -154,8 +144,6 @@ const getEmployeesLabourColumns = () => {
     },
     {
       id: 'labourCost',
-      numeric: true,
-      disablePadding: true,
       label: 'Labour cost',
       format: (d) => {
         const sign = '$';
@@ -194,8 +182,6 @@ const getTasksLabourColumns = () => {
   return [
     {
       id: 'task',
-      numeric: false,
-      disablePadding: true,
       label: 'Tasks',
       Footer: 'DAILY TOTAL',
       component: 'th',
@@ -205,8 +191,6 @@ const getTasksLabourColumns = () => {
     },
     {
       id: 'time',
-      numeric: true,
-      disablePadding: true,
       label: 'Time',
       format: (d) => `${d.time} h`,
       align: 'right',
@@ -217,8 +201,6 @@ const getTasksLabourColumns = () => {
     },
     {
       id: 'labourCost',
-      numeric: true,
-      disablePadding: true,
       label: 'Labour cost',
       format: (d) => {
         const sign = '$';

--- a/packages/webapp/src/tests/buildTransactions.test.jsx
+++ b/packages/webapp/src/tests/buildTransactions.test.jsx
@@ -297,6 +297,7 @@ const allResults = [
       },
     ],
     relatedId: 16,
+    cropGenerated: true,
   },
   {
     icon: 'CUSTOM',
@@ -307,6 +308,7 @@ const allResults = [
     note: 'Customer 3',
     items: [{ key: 18, title: 'Custom type', amount: 200 }],
     relatedId: 18,
+    cropGenerated: false,
   },
   {
     date: '2023-10-14T00:00:00.000',
@@ -344,6 +346,7 @@ const allResults = [
       },
     ],
     relatedId: 9,
+    cropGenerated: true,
   },
 ];
 


### PR DESCRIPTION
**Description**

- create `CropSale` transaction table
- pass `mobileView` `currencySymbol` to `ExpandedContent` (`mobileView` is for the future, and the style for the desktop view will not be shown and has not been finalized)

Some other improvements
- remove unused properties in TableV2 stories
- remove accessor prop that is incompatible with sorting from V2 table
- fix `ExpandableItem`'s `key`. (`index` was being used, and it was expanding a different transaction after the date range is updated)
- remove hovered colour of the expandable item when expanding
- update transactionDate's tag to `h4` (the title of the page "Finances" is `h3` so I chose `h4`)

Jira link: https://lite-farm.atlassian.net/browse/LF-3761

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
