### PR TITLE
LF-3568: edit varietal history stack issue

### DIFF
--- a/packages/webapp/src/containers/AddCropVariety/saga.js
+++ b/packages/webapp/src/containers/AddCropVariety/saga.js
@@ -117,7 +117,8 @@ export function* patchVarietalSaga({ payload: { variety_id, crop_id, data } }) {
       header,
     );
     yield put(putCropVarietySuccess({ crop_variety_id: variety_id, ...data }));
-    history.push(`/crop/${variety_id}/detail`);
+    history.back();
+    history.replace(`/crop/${variety_id}/detail`);
     yield put(enqueueSuccessSnackbar(i18n.t('message:CROP_VARIETY.SUCCESS.UPDATE')));
   } catch (e) {
     if (

--- a/packages/webapp/src/containers/EditCropVariety/index.jsx
+++ b/packages/webapp/src/containers/EditCropVariety/index.jsx
@@ -33,25 +33,19 @@ function EditCropVarietyForm({ history, match }) {
     dispatch(patchVarietal({ variety_id, crop_id: cropVariety.crop_id, data: varietyData }));
   };
 
-  // TODO - Add persisted path (LF-1430)
-  const persistedPath = [];
-
   return (
-    <HookFormPersistProvider>
-      <PureEditCropVariety
-        onSubmit={onSubmit}
-        onError={onError}
-        isSeekingCert={interested}
-        imageUploader={
-          <ImagePickerWrapper>
-            <AddLink>{t('CROP.ADD_IMAGE')}</AddLink>
-          </ImagePickerWrapper>
-        }
-        handleGoBack={() => history.back()}
-        cropVariety={cropVariety}
-        persistedPath={persistedPath}
-      />
-    </HookFormPersistProvider>
+    <PureEditCropVariety
+      onSubmit={onSubmit}
+      onError={onError}
+      isSeekingCert={interested}
+      imageUploader={
+        <ImagePickerWrapper>
+          <AddLink>{t('CROP.ADD_IMAGE')}</AddLink>
+        </ImagePickerWrapper>
+      }
+      handleGoBack={() => history.back()}
+      cropVariety={cropVariety}
+    />
   );
 }
 


### PR DESCRIPTION
**Description**

After editing crop varietal, go back to the previous page. If the previous page is not crop detail page, replace current url with crop detail page so that history.back will leads to the page before crop detail page

Jira link:
https://lite-farm.atlassian.net/browse/LF-3568
**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Tested 
crop_varieties/crop/168
crop/02fc91b2-9f5b-11ed-ab82-01644e28fa9e/management
crop/02fc91b2-9f5b-11ed-ab82-01644e28fa9e/detail
crop/02fc91b2-9f5b-11ed-ab82-01644e28fa9e/edit_crop_variety
submit -> back
crop/02fc91b2-9f5b-11ed-ab82-01644e28fa9e/management

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
