### PR TITLE
LF-3575: add custom task navigation bugs

### DIFF
--- a/packages/webapp/src/components/Task/PureAddCustomTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureAddCustomTask/index.jsx
@@ -6,28 +6,18 @@ import PageTitle from '../../PageTitle/v2';
 import Input, { getInputErrors } from '../../Form/Input';
 import Button from '../../Form/Button';
 
-const PureAddCustomTask = ({
-  handleGoBack,
-  history,
-  useHookFormPersist,
-
-  persistedFormData,
-  onSave,
-}) => {
+const PureAddCustomTask = ({ handleGoBack, useHookFormPersist, onSave }) => {
   const { t } = useTranslation();
 
   const {
     handleSubmit,
-    getValues,
-    watch,
-    control,
     setValue,
     register,
     formState: { errors, isValid },
   } = useForm({
     mode: 'onChange',
   });
-
+  useHookFormPersist();
   const CUSTOM_TASK_TYPE = 'task_name';
 
   return (

--- a/packages/webapp/src/components/Task/PureEditCustomTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureEditCustomTask/index.jsx
@@ -7,13 +7,7 @@ import Layout from '../../Layout';
 import { useForm } from 'react-hook-form';
 import Input from '../../Form/Input';
 
-const PureEditCustomTask = ({
-  handleGoBack,
-  handleEdit,
-  handleRetire,
-  selectedType,
-  useHookFormPersist,
-}) => {
+const PureEditCustomTask = ({ handleGoBack, handleEdit, handleRetire, selectedType }) => {
   const { t } = useTranslation();
   const {
     register,
@@ -22,7 +16,6 @@ const PureEditCustomTask = ({
     mode: 'onChange',
     defaultValues: { task_name: selectedType?.task_name },
   });
-  useHookFormPersist();
   const TASK_NAME = 'task_name';
   const [showRetire, setShowRetire] = useState(false);
   return (

--- a/packages/webapp/src/components/Task/PureEditCustomTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureEditCustomTask/index.jsx
@@ -7,16 +7,22 @@ import Layout from '../../Layout';
 import { useForm } from 'react-hook-form';
 import Input from '../../Form/Input';
 
-const PureEditCustomTask = ({ handleGoBack, handleEdit, handleRetire, selectedType }) => {
+const PureEditCustomTask = ({
+  handleGoBack,
+  handleEdit,
+  handleRetire,
+  selectedType,
+  useHookFormPersist,
+}) => {
   const { t } = useTranslation();
   const {
-    handleSubmit,
     register,
     formState: { errors, isValid },
   } = useForm({
     mode: 'onChange',
     defaultValues: { task_name: selectedType?.task_name },
   });
+  useHookFormPersist();
   const TASK_NAME = 'task_name';
   const [showRetire, setShowRetire] = useState(false);
   return (


### PR DESCRIPTION
**Description**

Add missing useHookFormPersist to add custom task page and edit custom task page so that when history.back is called, the last url will be removed from hookFormPersistReducer.historyStack

Jira link:
https://lite-farm.atlassian.net/browse/LF-3575

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

create a custom task -> back arrow -> cancel button -> task page
retire a custom task -> back arrow -> cancel button -> task page


- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
