### PR TITLE
LF-3788 The user is not able to type out a product name during the creation of the soil amendment task or clean task

### DIFF
--- a/packages/webapp/src/components/Form/ReactSelect/index.jsx
+++ b/packages/webapp/src/components/Form/ReactSelect/index.jsx
@@ -219,7 +219,7 @@ const ReactSelect = React.forwardRef(function ReactSelect(
             ),
             ...components,
           }}
-          isSearchable={isSearchable ?? options?.length > 8}
+          isSearchable={true} // CreatableSelects must be searchable to accept input
           ref={ref}
           defaultValue={defaultValue}
           isDisabled={isDisabled}


### PR DESCRIPTION
**Description**

This is a fun bug!!

This [commit](https://github.com/LiteFarmOrg/LiteFarm/pull/2913/files#diff-9b510ffac5e2f98e7a188cd29fe6409be58bfd51d9a33be2b4cec8aade222fb5) by @SayakaOno fixed the logic assigning `isSearchable` in the `<ReactSelect />`.

Currently we have only one "creatable" React Select in App (for Product). Here the `isSearchable` prop was never passed, but the faulty original logic:

`isSearchable={options?.length > 8 || isSearchable}`

meant that if there were fewer than 8 options, `isSearchable={undefined}` was passed, and the `<CreateableSelect />` took its default value of `isSearchable={true}`

Now that the logic has been fixed, `isSearchable` was false when the number of options was less than 8.

However a `<CreateableSelect />` needs to have `isSearchable={true}` in order to accept input (and it should not have anything to do with the number of options), so I am assigning `isSearchable={true}` and leaving a note about what the prop does.

Jira link: https://lite-farm.atlassian.net/browse/LF-3788

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
