### PR TITLE
LF-3797: Finance custom date range dropdown is shown under CardsCarrousel

### DIFF
--- a/packages/webapp/src/components/DateRangeSelector/styles.module.scss
+++ b/packages/webapp/src/components/DateRangeSelector/styles.module.scss
@@ -58,7 +58,7 @@
   background: var(--white, #fff);
   border-radius: 4px;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-  z-index: 11; // should not be under react-table (z-index: 10) in OtherExpense
+  z-index: 1000; // should be over the carrousel in Finances
 }
 
 .buttons {


### PR DESCRIPTION
**Description**

<img width="350" alt="Screenshot 2023-11-07 at 11 55 36 AM" src="https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/f6af45b1-8fde-4875-a9c2-e9fb1c67d186">

Update customDateRangeSelector's z-index so that the component is displayed over the carrousel.

Jira link: https://lite-farm.atlassian.net/browse/LF-3797

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
