### PR TITLE
LF-3779 The field "Language preference" is missing when the user is creating the account using SSO method

### DIFF
--- a/packages/webapp/src/components/CreateUserAccount/index.jsx
+++ b/packages/webapp/src/components/CreateUserAccount/index.jsx
@@ -11,7 +11,7 @@ import ReactSelect from '../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../locales/i18n';
 
-export default function PureCreateUserAccount({ onSignUp, email, onGoBack }) {
+export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNotSSO }) {
   const {
     register,
     handleSubmit,
@@ -72,7 +72,7 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack }) {
     localStorage.setItem('litefarm_lang', language);
   }, [language]);
 
-  const disabled = !isDirty || !isValid || !isPasswordValid;
+  const disabled = !isDirty || !isValid || (isNotSSO && !isPasswordValid);
 
   const onSubmit = (data) => {
     data[GENDER] = data?.[GENDER]?.value || 'PREFER_NOT_TO_SAY';
@@ -86,9 +86,11 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack }) {
       onSubmit={handleSubmit(onSubmit, onError)}
       buttonGroup={
         <>
-          <Button onClick={onGoBack} color={'secondary'} type={'button'} fullLength>
-            {t('common:BACK')}
-          </Button>
+          {isNotSSO && ( // TODO LF-3798: Back button doesn't work in SSO as it will direct to Welcome Screen
+            <Button onClick={onGoBack} color={'secondary'} type={'button'} fullLength>
+              {t('common:BACK')}
+            </Button>
+          )}
           <Button data-cy="createUser-create" disabled={disabled} type={'submit'} fullLength>
             {t('CREATE_USER.CREATE_BUTTON')}
           </Button>
@@ -166,23 +168,34 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack }) {
         }
         optional
       />
-      <Input
-        data-cy="createUser-password"
-        style={{ marginBottom: '28px' }}
-        label={t('CREATE_USER.PASSWORD')}
-        type={PASSWORD}
-        hookFormRegister={register(PASSWORD)}
-      />
-      <PasswordError
-        hasNoDigit={hasNoDigit}
-        hasNoSymbol={hasNoSymbol}
-        hasNoUpperCase={hasNoUpperCase}
-        isTooShort={isTooShort}
-      />
+      {isNotSSO && (
+        <>
+          <Input
+            data-cy="createUser-password"
+            style={{ marginBottom: '28px' }}
+            label={t('CREATE_USER.PASSWORD')}
+            type={PASSWORD}
+            hookFormRegister={register(PASSWORD)}
+          />
+          <PasswordError
+            hasNoDigit={hasNoDigit}
+            hasNoSymbol={hasNoSymbol}
+            hasNoUpperCase={hasNoUpperCase}
+            isTooShort={isTooShort}
+          />
+        </>
+      )}
     </Form>
   );
 }
 
-PureCreateUserAccount.prototype = {
-  onLogin: PropTypes.func,
+PureCreateUserAccount.propTypes = {
+  onSignUp: PropTypes.func.isRequired,
+  onGoBack: PropTypes.func.isRequired,
+  email: PropTypes.string.isRequired,
+  isNotSSO: PropTypes.bool,
+};
+
+PureCreateUserAccount.defaultProps = {
+  isNotSSO: true,
 };

--- a/packages/webapp/src/components/CreateUserAccount/index.jsx
+++ b/packages/webapp/src/components/CreateUserAccount/index.jsx
@@ -1,7 +1,7 @@
 import Form from '../Form';
 import Button from '../Form/Button';
 import Input, { integerOnKeyDown } from '../Form/Input';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Title } from '../Typography';
 import PropTypes from 'prop-types';
 import { Controller, useForm } from 'react-hook-form';
@@ -17,8 +17,6 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNot
     handleSubmit,
     watch,
     control,
-    setValue,
-
     formState: { isDirty, isValid, errors },
   } = useForm({
     mode: 'onTouched',
@@ -115,7 +113,7 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNot
       <Controller
         control={control}
         name={GENDER}
-        render={({ field: { onChange, onBlur, value } }) => (
+        render={({ field: { onChange, value } }) => (
           <ReactSelect
             data-cy="createUser-gender"
             label={t('CREATE_USER.GENDER')}
@@ -132,21 +130,21 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNot
         data-cy="createUser-language"
         control={control}
         name={LANGUAGE}
-        render={({ field: { onChange, onBlur, value } }) => (
-          value && setLanguage(value.value),
-          (
-            <ReactSelect
-              label={t('CREATE_USER.LANGUAGE_PREFERENCE')}
-              options={languageOptions}
-              onChange={onChange}
-              value={languageOptions[languageOption]}
-              style={{ marginBottom: '28px' }}
-              defaultValue={{
-                value: t('CREATE_USER.DEFAULT_LANGUAGE_VALUE'),
-                label: t('CREATE_USER.DEFAULT_LANGUAGE'),
-              }}
-            />
-          )
+        render={({ field: { onChange } }) => (
+          <ReactSelect
+            label={t('CREATE_USER.LANGUAGE_PREFERENCE')}
+            options={languageOptions}
+            onChange={(selectedOption) => {
+              setLanguage(selectedOption.value);
+              onChange(selectedOption);
+            }}
+            value={languageOptions[languageOption]}
+            style={{ marginBottom: '28px' }}
+            defaultValue={{
+              value: t('CREATE_USER.DEFAULT_LANGUAGE_VALUE'),
+              label: t('CREATE_USER.DEFAULT_LANGUAGE'),
+            }}
+          />
         )}
       />
       <Input

--- a/packages/webapp/src/containers/SSOUserCreateAccountInfo/index.jsx
+++ b/packages/webapp/src/containers/SSOUserCreateAccountInfo/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import PureInvitedUserCreateAccountPage from '../../components/InvitedUserCreateAccount';
+import PureCreateUserAccount from '../../components/CreateUserAccount';
 
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -11,16 +11,26 @@ export default function SSOUserCreateAccountInfo({ history }) {
   const { user } = history.location.state;
   const { email, full_name: name } = user;
   const dispatch = useDispatch();
-  const onSubmit = (data) => {
-    dispatch(patchSSOUserInfo({ user: { ...data, email } }));
+
+  const onSignUp = ({ language, ...otherFormData }) => {
+    dispatch(
+      patchSSOUserInfo({ user: { ...otherFormData, language_preference: language, email } }),
+    );
   };
+
+  const onGoBack = () => {
+    //  TODO LF-3798: Going back (including with browser back button) will not work in this flow as the SSO user account was already created at the point of interacting with the Google Login button
+  };
+
   return (
-    <PureInvitedUserCreateAccountPage
-      onSubmit={onSubmit}
+    <PureCreateUserAccount
+      onSignUp={onSignUp}
       email={email}
       name={name}
       title={t('INVITATION.YOUR_INFORMATION')}
       buttonText={t('common:SAVE')}
+      isNotSSO={false}
+      onGoBack={onGoBack}
     />
   );
 }


### PR DESCRIPTION
**Description**

This PR moves the `<SSOUserCreateAccountInfo />` container off of the `<PureInvitedUserCreateAccountPage />` component (which has no language field) to the `<PureCreateUserAccount />` component (which does).

Jira link: https://lite-farm.atlassian.net/browse/LF-3779

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

The `language_preferences` field of the `users` table was previously always taking the field default value of `'en'` and should now store what was selected during account creation

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
