### PR TITLE
LF-3601: The user is not able to change the unit of measurement after he adds another harvest use during the completion of the harvest task

### DIFF
--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -173,6 +173,7 @@ const Unit = ({
                 isSearchable={false}
                 options={options}
                 isDisabled={isSelectDisabled}
+                menuPortalTarget={document.body}
               />
             )}
           />


### PR DESCRIPTION
**Description**

![Screenshot 2023-11-08 at 11 38 40 AM](https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/352cc15d-6465-42c0-a884-1d83afdc7515)

Fix the unit dropdown that is shown under "Continue" button by portaling the select menu to the document.body level of the DOM.

References:
- https://stackoverflow.com/questions/55830799/how-to-change-zindex-in-react-select-drowpdown
- https://react-select.com/advanced#portaling

Jira link: https://lite-farm.atlassian.net/browse/LF-3601

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
