### PR TITLE
LF-3574 outro back button link bug

### DIFF
--- a/packages/webapp/src/containers/Outro/index.jsx
+++ b/packages/webapp/src/containers/Outro/index.jsx
@@ -5,21 +5,15 @@ import PureOutroSplash from '../../components/Outro';
 import { certifierSurveySelector } from '../OrganicCertifierSurvey/slice';
 import { patchOutroStep } from './saga';
 import { showedSpotlightSelector } from '../showedSpotlightSlice';
-import { useCertifierName } from '../OrganicCertifierSurvey/useCertifierName';
 
 function Outro() {
   const dispatch = useDispatch();
   const survey = useSelector(certifierSurveySelector);
-  const { isRequestedCertifier } = useCertifierName();
   const { navigation } = useSelector(showedSpotlightSelector);
   const toShowSpotlight = !navigation;
   const onGoBack = () => {
     history.push(
-      !survey.interested
-        ? '/certification/interested_in_organic'
-        : isRequestedCertifier
-        ? '/certification/certifier/request'
-        : '/certification/certifier/selection',
+      !survey.interested ? '/certification/interested_in_organic' : 'certification/summary',
     );
   };
   const onContinue = () => {


### PR DESCRIPTION
**Description**

LF-3516 link outro back button to certification summary page if user pursues certification

Jira link:
https://lite-farm.atlassian.net/browse/LF-3516

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

select different types of certification, go to outro, back should lead to summary page


- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
