### PR TITLE
LF-3803 show filters and report in drawer

### DIFF
--- a/packages/webapp/src/components/CardsCarrousel/index.jsx
+++ b/packages/webapp/src/components/CardsCarrousel/index.jsx
@@ -57,6 +57,7 @@ const CardsCarrousel = ({ cards }) => {
             </div>
           ) : (
             <div
+              key={card.id}
               className={clsx([styles.card, styles.inactiveCard])}
               style={{
                 marginTop: index * 8,
@@ -66,7 +67,6 @@ const CardsCarrousel = ({ cards }) => {
               }}
             >
               <TextButton
-                key={card.id}
                 aria-label={card.label}
                 onClick={() => onCardClick(card)}
                 className={styles.inactiveCardButton}

--- a/packages/webapp/src/components/CardsCarrousel/styles.module.scss
+++ b/packages/webapp/src/components/CardsCarrousel/styles.module.scss
@@ -43,7 +43,11 @@
   flex-grow: 1;
   z-index: 999;
   animation: card-swapping 300ms ease-out;
-  min-width: 294px;
+  width: 256px;
+
+  @media only screen and (min-width: 414px) {
+    width: 296px;
+  }
 
   @media only screen and (min-width: 768px) {
     min-width: 310px;

--- a/packages/webapp/src/components/CardsCarrousel/styles.module.scss
+++ b/packages/webapp/src/components/CardsCarrousel/styles.module.scss
@@ -12,7 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
- 
+
 .carrouselContainer {
   display: flex;
   height: 128px;
@@ -27,16 +27,6 @@
 .card {
   border-radius: 4px;
   box-shadow: 1px 0px 8px 0px rgba(0, 0, 0, 0.15);
-
-  &:first-child {
-    @media only screen and (max-width: 768px) {
-      max-width: 294px;
-    }
-
-    @media only screen and (min-width: 768px) {
-      min-width: 310px;
-    }
-  }
 }
 
 @keyframes card-swapping {
@@ -53,6 +43,11 @@
   flex-grow: 1;
   z-index: 999;
   animation: card-swapping 300ms ease-out;
+  min-width: 294px;
+
+  @media only screen and (min-width: 768px) {
+    min-width: 310px;
+  }
 }
 
 .inactiveCard {

--- a/packages/webapp/src/components/Drawer/index.jsx
+++ b/packages/webapp/src/components/Drawer/index.jsx
@@ -15,26 +15,13 @@
 
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
 import { BsX } from 'react-icons/bs';
+import useIsAboveBreakpoint from '../../hooks/useIsAboveBreakpoint';
 import ModalComponent from '../Modals/ModalComponent/v2';
 import styles from './style.module.scss';
 
 const Drawer = ({ title, isOpen, onClose, children, buttonGroup, className }) => {
-  const [isAboveBreakPoint, setIsAboveBreakPoint] = useState(null);
-
-  useEffect(() => {
-    const mqString = `(min-width: 768px)`;
-    const media = matchMedia(mqString);
-
-    setIsAboveBreakPoint(media.matches);
-
-    media.addEventListener('change', (e) => setIsAboveBreakPoint(e.matches));
-
-    return () => {
-      media.removeEventListener('change', setIsAboveBreakPoint);
-    };
-  }, []);
+  const isAboveBreakPoint = useIsAboveBreakpoint(`(min-width: 768px)`);
 
   return isAboveBreakPoint ? (
     isOpen && (

--- a/packages/webapp/src/components/Drawer/index.jsx
+++ b/packages/webapp/src/components/Drawer/index.jsx
@@ -13,15 +13,43 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import styles from './style.module.scss';
 import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
 import { BsX } from 'react-icons/bs';
+import ModalComponent from '../Modals/ModalComponent/v2';
+import styles from './style.module.scss';
 
-const Drawer = ({ title, isOpen, onClose, children }) => {
-  return (
-    <div>
+const Drawer = ({ title, isOpen, onClose, children, buttonGroup, className }) => {
+  const [isAboveBreakPoint, setIsAboveBreakPoint] = useState(null);
+
+  useEffect(() => {
+    const mqString = `(min-width: 768px)`;
+    const media = matchMedia(mqString);
+
+    setIsAboveBreakPoint(media.matches);
+
+    media.addEventListener('change', (e) => setIsAboveBreakPoint(e.matches));
+
+    return () => {
+      media.removeEventListener('change', setIsAboveBreakPoint);
+    };
+  }, []);
+
+  return isAboveBreakPoint ? (
+    isOpen && (
+      <ModalComponent
+        className={className}
+        title={title}
+        titleClassName={styles.title}
+        dismissModal={onClose}
+        buttonGroup={buttonGroup}
+      >
+        <div className={styles.modalContent}>{children}</div>
+      </ModalComponent>
+    )
+  ) : (
+    <div className={className}>
       <div
         className={clsx(styles.drawerBackdrop, isOpen ? styles.openC : '')}
         onClick={onClose}
@@ -33,7 +61,9 @@ const Drawer = ({ title, isOpen, onClose, children }) => {
             <BsX />
           </div>
         </div>
-        <div className={styles.content}>{children}</div>
+        <div className={styles.drawerContent}>
+          {children} {buttonGroup}
+        </div>
       </div>
     </div>
   );
@@ -44,6 +74,8 @@ Drawer.prototype = {
   isOpen: PropTypes.func,
   onClose: PropTypes.func,
   children: PropTypes.node,
+  className: PropTypes.string,
+  buttonGroup: PropTypes.node,
 };
 
 export default Drawer;

--- a/packages/webapp/src/components/Drawer/style.module.scss
+++ b/packages/webapp/src/components/Drawer/style.module.scss
@@ -40,7 +40,6 @@
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   padding: 16px;
-  max-width: 600px;
   margin: auto;
   z-index: 1110;
   &.openD {
@@ -57,11 +56,20 @@
 .title {
   font-size: 16px;
   font-weight: 600;
+  color: #000;
 }
 
-.content{
+.drawerContent {
   max-height: 60vh;
   overflow-y: auto;
+  margin: 0 -16px;
+  padding: 16px;
+}
+
+.modalContent {
+  overflow-y: auto;
+  margin: 0 -24px;
+  padding: 0 24px;
 }
 
 .close {

--- a/packages/webapp/src/components/Finances/AddTransactionButton/index.jsx
+++ b/packages/webapp/src/components/Finances/AddTransactionButton/index.jsx
@@ -13,14 +13,15 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { forwardRef, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import history from '../../../history';
-import DropdownButton from '../../Form/DropDownButton';
-import FloatingMenu from '../../Menu/FloatingButtonMenu/FloatingMenu';
-import FloatingButtonMenu from '../../Menu/FloatingButtonMenu';
+import { useDispatch } from 'react-redux';
 import { setPersistedPaths } from '../../../containers/hooks/useHookFormPersist/hookFormPersistSlice';
+import history from '../../../history';
+import useIsAboveBreakpoint from '../../../hooks/useIsAboveBreakpoint';
+import DropdownButton from '../../Form/DropDownButton';
+import FloatingButtonMenu from '../../Menu/FloatingButtonMenu';
+import FloatingMenu from '../../Menu/FloatingButtonMenu/FloatingMenu';
 import styles from './styles.module.scss';
 
 const Menu = forwardRef((props, ref) => {
@@ -52,23 +53,8 @@ const Menu = forwardRef((props, ref) => {
 Menu.displayName = 'Menu';
 
 export default function AddTransactionButton() {
-  // this will get a boolean value later, but initialize with null so that
-  // a wrong button will not be shown initially
-  const [isAboveBreakPoint, setIsAboveBreakPoint] = useState(null);
   const { t } = useTranslation();
-
-  useEffect(() => {
-    const mqString = `(min-width: 768px)`;
-    const media = matchMedia(mqString);
-
-    setIsAboveBreakPoint(media.matches);
-
-    media.addEventListener('change', (e) => setIsAboveBreakPoint(e.matches));
-
-    return () => {
-      media.removeEventListener('change', setIsAboveBreakPoint);
-    };
-  }, []);
+  const isAboveBreakPoint = useIsAboveBreakpoint(`(min-width: 768px)`);
 
   return (
     <>

--- a/packages/webapp/src/containers/Filter/Transactions/index.jsx
+++ b/packages/webapp/src/containers/Filter/Transactions/index.jsx
@@ -37,7 +37,7 @@ const TransactionFilterContent = ({
       subject: t('FINANCES.FILTER.EXPENSE_TYPE'),
       filterKey: EXPENSE_TYPE,
       options: [
-        ...expenseTypes.map((type) => ({
+        ...(expenseTypes || []).map((type) => ({
           value: type.expense_type_id,
           // This sets the initial state of the filter pill
           default: transactionsFilter[EXPENSE_TYPE]?.[type.expense_type_id]?.active ?? true,
@@ -57,7 +57,7 @@ const TransactionFilterContent = ({
     {
       subject: t('FINANCES.FILTER.REVENUE_TYPE'),
       filterKey: REVENUE_TYPE,
-      options: revenueTypes.map((type) => ({
+      options: (revenueTypes || []).map((type) => ({
         value: type.revenue_type_id,
         // This sets the initial state of the filter pill
         default: transactionsFilter[REVENUE_TYPE]?.[type.revenue_type_id]?.active ?? true,

--- a/packages/webapp/src/containers/Finances/Report/index.jsx
+++ b/packages/webapp/src/containers/Finances/Report/index.jsx
@@ -17,10 +17,10 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { ReactComponent as ReportIcon } from '../../../assets/images/finance/Report-icn.svg';
+import Drawer from '../../../components/Drawer';
 import FinanceDateRangeSelector from '../../../components/Finances/DateRangeSelector';
 import Button from '../../../components/Form/Button';
 import TextButton from '../../../components/Form/Button/TextButton';
-import ModalComponent from '../../../components/Modals/ModalComponent/v2';
 import { Semibold, Text } from '../../../components/Typography';
 import TransactionFilterContent from '../../Filter/Transactions';
 import { EXPENSE_TYPE, REVENUE_TYPE } from '../../Filter/constants';
@@ -62,7 +62,7 @@ const Report = () => {
     setIsButtonDisabled(!isValid);
   };
 
-  const dismissModal = () => {
+  const closeExportReport = () => {
     setIsExportReportOpen(false);
     setDateFilter(dashboardDateFilter);
     setTypesFilter(dashboardTypesFilter);
@@ -136,50 +136,48 @@ const Report = () => {
         },
       }),
     );
-    dismissModal();
+    closeExportReport();
   };
 
   return (
-    <>
+    <div>
       <TextButton onClick={() => setIsExportReportOpen(true)} className={styles.reportButton}>
         <ReportIcon />
         {t('SALE.FINANCES.REPORT')}
       </TextButton>
-      {isExportReportOpen && (
-        <ModalComponent
-          title={t('SALE.FINANCES.EXPORT_REPORT')}
-          titleClassName={styles.title}
-          dismissModal={dismissModal}
-          buttonGroup={
-            <Button fullLength onClick={handleExport} color={'primary'} disabled={isButtonDisabled}>
-              {t('common:EXPORT')}
-            </Button>
-          }
-        >
-          <div className={styles.exportContents}>
-            <Semibold className={styles.helpText}>{t('SALE.FINANCES.REPORT_HELP_TEXT')}</Semibold>
-            <div className={styles.dateFilterContainer}>
-              <Text>Date</Text>
-              <FinanceDateRangeSelector
-                value={dateFilter}
-                onChange={(dateRange) => {
-                  setDateFilter({ ...dateFilter, ...dateRange });
-                }}
-                onValidityChange={onValidityChange}
-              />
-            </div>
-            <TransactionFilterContent
-              transactionsFilter={dashboardTypesFilter}
-              filterRef={filterRef}
-              filterContainerClassName={styles.filterContainer}
-              onChange={(filterKey, filterState) =>
-                setTypesFilter({ ...typesFilter, [filterKey]: filterState })
-              }
+      <Drawer
+        isOpen={isExportReportOpen}
+        title={t('SALE.FINANCES.EXPORT_REPORT')}
+        onClose={closeExportReport}
+        buttonGroup={
+          <Button fullLength onClick={handleExport} color={'primary'} disabled={isButtonDisabled}>
+            {t('common:EXPORT')}
+          </Button>
+        }
+      >
+        <>
+          <Semibold className={styles.helpText}>{t('SALE.FINANCES.REPORT_HELP_TEXT')}</Semibold>
+          <div className={styles.dateFilterContainer}>
+            <Text>Date</Text>
+            <FinanceDateRangeSelector
+              value={dateFilter}
+              onChange={(dateRange) => {
+                setDateFilter({ ...dateFilter, ...dateRange });
+              }}
+              onValidityChange={onValidityChange}
             />
           </div>
-        </ModalComponent>
-      )}
-    </>
+          <TransactionFilterContent
+            transactionsFilter={dashboardTypesFilter}
+            filterRef={filterRef}
+            filterContainerClassName={styles.filterContainer}
+            onChange={(filterKey, filterState) =>
+              setTypesFilter({ ...typesFilter, [filterKey]: filterState })
+            }
+          />
+        </>
+      </Drawer>
+    </div>
   );
 };
 

--- a/packages/webapp/src/containers/Finances/Report/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/Report/styles.module.scss
@@ -17,23 +17,13 @@
   font-size: 14px;
   font-family: 'Open Sans', ' SansSerif', serif;
   color: var(--teal700);
-  margin-bottom: 16px;
+  margin: 0 0 16px 8px;
   display: flex;
   gap: 4px;
 }
 
-.title {
-  color: #000;
-}
-
 .helpText {
   margin-bottom: 24px;
-}
-
-.exportContents {
-  overflow-y: auto;
-  margin: 0 -24px;
-  padding: 0 24px;
 }
 
 .dateFilterContainer {

--- a/packages/webapp/src/containers/Finances/TransactionFilter/index.jsx
+++ b/packages/webapp/src/containers/Finances/TransactionFilter/index.jsx
@@ -16,9 +16,9 @@
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import Drawer from '../../../components/Drawer';
 import FilterButton from '../../../components/Filter/FilterButton';
 import Button from '../../../components/Form/Button';
-import ModalComponent from '../../../components/Modals/ModalComponent/v2';
 import { Semibold } from '../../../components/Typography';
 import TransactionFilterContent from '../../Filter/Transactions';
 import {
@@ -45,31 +45,28 @@ const TransactionFilter = () => {
   const filterRef = useRef({});
 
   return (
-    <>
+    <div>
       <FilterButton onClick={() => setIsFilterOpen(true)} isFilterActive={isFilterActive} />
-      {/* TODO LF-3751 show contents on drawer instead of modal component for mobile view */}
-      {isFilterOpen && (
-        <ModalComponent
-          title={t('FINANCES.FILTER.TITLE')}
-          titleClassName={styles.title}
-          dismissModal={() => setIsFilterOpen(false)}
-          buttonGroup={
-            <Button fullLength onClick={handleApply} color={'primary'} disabled={!isDirty}>
-              {t('common:APPLY')}
-            </Button>
-          }
-        >
-          <div className={styles.filterContents}>
-            <Semibold className={styles.helpText}>{t('FINANCES.FILTER.HELP_TEXT')}</Semibold>
-            <TransactionFilterContent
-              transactionsFilter={transactionsFilter}
-              filterRef={filterRef}
-              onChange={() => !isDirty && setIsDirty(true)}
-            />
-          </div>
-        </ModalComponent>
-      )}
-    </>
+      <Drawer
+        isOpen={isFilterOpen}
+        title={t('FINANCES.FILTER.TITLE')}
+        onClose={() => setIsFilterOpen(false)}
+        buttonGroup={
+          <Button fullLength onClick={handleApply} color={'primary'} disabled={!isDirty}>
+            {t('common:APPLY')}
+          </Button>
+        }
+      >
+        <>
+          <Semibold className={styles.helpText}>{t('FINANCES.FILTER.HELP_TEXT')}</Semibold>
+          <TransactionFilterContent
+            transactionsFilter={transactionsFilter}
+            filterRef={filterRef}
+            onChange={() => !isDirty && setIsDirty(true)}
+          />
+        </>
+      </Drawer>
+    </div>
   );
 };
 

--- a/packages/webapp/src/containers/Finances/TransactionFilter/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/TransactionFilter/styles.module.scss
@@ -13,18 +13,8 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-.title {
-  color: #000;
-}
-
 .helpText {
   margin-bottom: 36px;
 }
 
-.filterContents {
-  overflow-y: auto;
-  // Removes parent's padding and adds internal padding so that the scroll bar shows on the side of the modal
-  margin: 0 -24px;
-  padding: 24px;
-}
 

--- a/packages/webapp/src/containers/Finances/styles.module.scss
+++ b/packages/webapp/src/containers/Finances/styles.module.scss
@@ -29,6 +29,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  overflow: auto;
 
   @media only screen and (min-width: 1024px) {
     margin: 0;

--- a/packages/webapp/src/hooks/useIsAboveBreakpoint.js
+++ b/packages/webapp/src/hooks/useIsAboveBreakpoint.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+const useIsAboveBreakpoint = (mqString) => {
+  // this will get a boolean value later, but initialize with null so that
+  // a wrong button will not be shown initially
+  const [isAboveBreakPoint, setIsAboveBreakPoint] = useState(null);
+
+  useEffect(() => {
+    const media = matchMedia(mqString);
+
+    setIsAboveBreakPoint(media.matches);
+
+    media.addEventListener('change', (e) => setIsAboveBreakPoint(e.matches));
+
+    return () => {
+      media.removeEventListener('change', setIsAboveBreakPoint);
+    };
+  }, []);
+
+  return isAboveBreakPoint;
+};
+
+export default useIsAboveBreakpoint;

--- a/packages/webapp/src/hooks/useIsAboveBreakpoint.js
+++ b/packages/webapp/src/hooks/useIsAboveBreakpoint.js
@@ -1,8 +1,23 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 import { useEffect, useState } from 'react';
 
 const useIsAboveBreakpoint = (mqString) => {
   // this will get a boolean value later, but initialize with null so that
-  // a wrong button will not be shown initially
+  // a wrong component will not be shown initially
   const [isAboveBreakPoint, setIsAboveBreakPoint] = useState(null);
 
   useEffect(() => {


### PR DESCRIPTION
**Description**

- Show finances dashboard filter and report modals in drawer in smaller screens.
- Reused @SayakaOno's logic to show/display something depending on a breakpoint and extracted it to reusable hook. CSS wasn't working here because the modal is based on MUI and it wasn't possible to hide the backdrop with CSS.
- Unrelated change -- adjust carrousel styling to make all cards the same width and make container scrollable in smaller screens. Fixed key warning.

Jira link:
https://lite-farm.atlassian.net/browse/LF-3803

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
