### PR TITLE
LF-3799-Transactions-added-with-today-s-date-are-shown-as-Yesterday

### DIFF
--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -198,6 +198,7 @@ app.set('json replacer', (key, value) => {
     'transition_date',
     'transplant_date',
     'valid_until',
+    'sale_date',
   ];
 
   if (value && pgDateTypeFields.includes(key)) {


### PR DESCRIPTION
**Description**

Issue is that on finance view, today's sales appeared on "Yesterday" section, this was because the POST sent was only sending the date without TZ and the backend was making a mess when interpreting the time.

So in this PR I changed the sales POST to have the TZ (and the backend to accept the timezoned date).

Jira link: https://lite-farm.atlassian.net/browse/LF-3799

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

I have test to create sales on a custom revenew type and on the default one, configuring my computer to have a TZ where the day is the same as my backend configuration, and a TZ where it is the next day, and as the TZ is now being taken into account, it seems to work ok.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
