### PR TITLE
LF-3800 Fixing White screen when user tries to add custom revenue.

### DIFF
--- a/packages/webapp/src/containers/Finances/AddSale/index.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/index.jsx
@@ -39,7 +39,7 @@ function AddSale() {
   const revenueTypeReactSelectOptions = mapRevenueTypesToReactSelectOptions(revenueTypes);
   const translatedRevenueName = revenueType?.farm_id
     ? revenueType?.revenue_name
-    : t(`revenue:${revenueType?.translation_key}.REVENUE_NAME`);
+    : t(`revenue:${revenueType?.revenue_translation_key}.REVENUE_NAME`);
 
   const onSubmit = (data) => {
     const newSale = mapRevenueFormDataToApiCallFormat(data, revenueTypes, null, farm.farm_id);

--- a/packages/webapp/src/containers/Finances/AddSale/index.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/index.jsx
@@ -37,10 +37,9 @@ function AddSale() {
   const revenueType = useSelector(revenueTypeByIdSelector(revenue_type_id));
   const revenueTypes = useSortedRevenueTypes();
   const revenueTypeReactSelectOptions = mapRevenueTypesToReactSelectOptions(revenueTypes);
-  const { revenue_name, revenue_translation_key, farm_id } = revenueType;
-  const translatedRevenueName = farm_id
-    ? revenue_name
-    : t(`revenue:${revenue_translation_key}.REVENUE_NAME`);
+  const translatedRevenueName = revenueType?.farm_id
+    ? revenueType?.revenue_name
+    : t(`revenue:${revenueType?.translation_key}.REVENUE_NAME`);
 
   const onSubmit = (data) => {
     const newSale = mapRevenueFormDataToApiCallFormat(data, revenueTypes, null, farm.farm_id);

--- a/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/AddExpense/index.jsx
@@ -73,7 +73,7 @@ class AddExpense extends Component {
     if (
       !missingText &&
       formattedData.length &&
-      formattedData.filter((expense) => expense.value <= 0 || isNaN(expense.value)).length === 0
+      formattedData.filter((expense) => expense.value < 0 || isNaN(expense.value)).length === 0
     ) {
       this.props.dispatch(addExpenses(formattedData));
       history.push('/finances');


### PR DESCRIPTION
 What I think its going on is the persistedFormData is not being saved fast enough for the AddSale component to retrieve it on the first render and since it's trying to destructure an object on that render it fails. As a temporary fix, just using the object instead of destructuring works.

 Also removing <= validation on finances that should be "<"

Jira link:

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
