### PR TITLE
LF-3802 include crop revenues in actual revenue calc

### DIFF
--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -82,7 +82,11 @@ export function filterSalesByDateRange(sales, startDate, endDate) {
 
 export function calcActualRevenue(transactions) {
   return transactions
-    .filter((transaction) => transaction.transactionType === transactionTypeEnum.revenue)
+    .filter(
+      ({ transactionType }) =>
+        transactionType === transactionTypeEnum.revenue ||
+        transactionType === transactionTypeEnum.cropRevenue,
+    )
     .reduce((sum, curTransaction) => sum + curTransaction.amount, 0);
 }
 


### PR DESCRIPTION
**Description**

When I made the change to make crop transactions their own category in the transaction type enum, I missed updating the util that calculates the actual revenue to include both categories.

Jira link:
https://lite-farm.atlassian.net/browse/LF-3802

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
