### PR TITLE
LF-3805: Add transaction menu is shown below expanded table header on mobile

### DIFF
--- a/packages/webapp/src/components/Menu/FloatingButtonMenu/styles.module.scss
+++ b/packages/webapp/src/components/Menu/FloatingButtonMenu/styles.module.scss
@@ -44,4 +44,5 @@
   position: fixed;
   bottom: 16px;
   right: 16px;
+  z-index: 100;
 }


### PR DESCRIPTION
**Description**

Update FloatingButtonMenu z-index to 1000.
I set it to be carrousel < FloatingButtonMenu < drawer.


Jira link: https://lite-farm.atlassian.net/browse/LF-3805

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
