### PR TITLE
LF-3608: Although the success pop up message is displayed, the harvest task won't be created, it actually creates an empty harvest task.

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskCrops/index.jsx
@@ -215,7 +215,9 @@ const PureTaskCrops = ({
   const disabled = isRequired && !selectedManagementPlanIds?.length;
 
   useEffect(() => {
-    defaultManagementPlanId && setSelectedManagementPlanIds([parseInt(defaultManagementPlanId)]);
+    if (defaultManagementPlanId && managementPlanIds.includes(+defaultManagementPlanId)) {
+      setSelectedManagementPlanIds([parseInt(defaultManagementPlanId)]);
+    }
   }, []);
 
   return (

--- a/packages/webapp/src/containers/Task/TaskDate/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskDate/index.jsx
@@ -51,21 +51,13 @@ function TaskDate({ history, match, location }) {
         },
       );
       if (transplantTask) {
-        console.log('transplantTask');
         location.state.location = transplantTask.locations[0];
-        console.log(location.state);
       } else if (plantingTask) {
-        console.log('plantingTask');
         location.state.location = plantingTask.locations[0];
-        console.log(location.state);
       } else if (mostRecentlyCompleted) {
-        console.log('mostRecentlyCompleted');
         location.state.location = mostRecentlyCompleted.locations[0];
-        console.log(location.state);
       } else if (nextUpcoming) {
-        console.log('nextUpcoming');
         location.state.location = nextUpcoming.locations[0];
-        console.log(location.state);
       }
     }
 


### PR DESCRIPTION
**Description**

<img width="500" alt="Screenshot 2023-11-10 at 3 36 55 PM" src="https://github.com/LiteFarmOrg/LiteFarm/assets/33141219/f896cdd6-53ef-49d0-9ae6-e403dc28ab14">

In this page above, the user is not allowed to "continue" to the next page without selecting a plan. The bug is that a plan that is not available as an option on this page is "selected" under the hood. This PR adds a check if the plan is available as an option before "selecting" it.

Details:
When creating a harvest task from a crop plan, the crop plan you selected is selected as a "plan that will be affected" by default. If you change the location to create a harvest task for another plan, the crop plan you selected should be deselected because the plan is not for the location you selected. (you will not see the plan as an option, but it remains "selected")

I added a check if the crop plan selected in the previous page is available for the location before setting it as "selected plan". 
(Also, console.log on the same page is removed)

Jira link: https://lite-farm.atlassian.net/browse/LF-3608

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
