### PR TITLE
LF-3806 Report is sent an undefined filter config when the dashboard or report filter settings have not been modified

### DIFF
--- a/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/useSortedRevenueTypes.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/useSortedRevenueTypes.jsx
@@ -17,14 +17,16 @@ import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { getRevenueTypes } from '../../saga';
-import { revenueTypesSelector } from '../../../revenueTypeSlice';
+import { revenueTypesSelector, allRevenueTypesSelector } from '../../../revenueTypeSlice';
 
-export default function useSortedRevenueTypes() {
+export default function useSortedRevenueTypes({ selectorType = 'default' } = {}) {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
   const [sortedtypes, setSortedTypes] = useState([]);
-  const revenueTypes = useSelector(revenueTypesSelector);
+
+  const selector = selectorType === 'all' ? allRevenueTypesSelector : revenueTypesSelector;
+  const revenueTypes = useSelector(selector);
 
   useEffect(() => {
     dispatch(getRevenueTypes());
@@ -56,6 +58,9 @@ export default function useSortedRevenueTypes() {
 }
 
 useSortedRevenueTypes.propTypes = {
+  props: PropTypes.shape({
+    selectorType: PropTypes.string,
+  }),
   useHookFormPersist: PropTypes.func,
   history: PropTypes.object,
 };

--- a/packages/webapp/src/containers/Finances/Report/index.jsx
+++ b/packages/webapp/src/containers/Finances/Report/index.jsx
@@ -26,8 +26,8 @@ import TransactionFilterContent from '../../Filter/Transactions';
 import { EXPENSE_TYPE, REVENUE_TYPE } from '../../Filter/constants';
 import { transactionsFilterSelector } from '../../filterSlice';
 import { downloadFinanceReport } from '../saga';
-import { allExpenseTypeSelector, dateRangeDataSelector } from '../selectors';
-import { allRevenueTypesSelector } from '../../revenueTypeSlice';
+import { allExpenseTypeSelector, dateRangeDataSelector, sortExpenseTypes } from '../selectors';
+import useSortedRevenueTypes from '../AddSale/RevenueTypes/useSortedRevenueTypes';
 import useTransactions from '../useTransactions';
 import styles from './styles.module.scss';
 import { useCurrencySymbol } from '../../hooks/useCurrencySymbol';
@@ -45,8 +45,8 @@ const Report = () => {
 
   const dashboardDateFilter = useSelector(dateRangeDataSelector);
   const dashboardTypesFilter = useSelector(transactionsFilterSelector);
-  const expenseTypes = useSelector(allExpenseTypeSelector);
-  const revenueTypes = useSelector(allRevenueTypesSelector);
+  const expenseTypes = sortExpenseTypes(useSelector(allExpenseTypeSelector));
+  const revenueTypes = useSortedRevenueTypes({ selectorType: 'all' });
 
   const [isExportReportOpen, setIsExportReportOpen] = useState(false);
   const [dateFilter, setDateFilter] = useState(dashboardDateFilter);

--- a/packages/webapp/src/containers/Finances/Report/index.jsx
+++ b/packages/webapp/src/containers/Finances/Report/index.jsx
@@ -26,7 +26,8 @@ import TransactionFilterContent from '../../Filter/Transactions';
 import { EXPENSE_TYPE, REVENUE_TYPE } from '../../Filter/constants';
 import { transactionsFilterSelector } from '../../filterSlice';
 import { downloadFinanceReport } from '../saga';
-import { dateRangeDataSelector } from '../selectors';
+import { allExpenseTypeSelector, dateRangeDataSelector } from '../selectors';
+import { allRevenueTypesSelector } from '../../revenueTypeSlice';
 import useTransactions from '../useTransactions';
 import styles from './styles.module.scss';
 import { useCurrencySymbol } from '../../hooks/useCurrencySymbol';
@@ -36,6 +37,7 @@ import {
   generateReportHeaders,
   generateWorksheetTitles,
   formatTransactions,
+  createDefaultTypeFilter,
 } from './reportFormattingUtils';
 
 const Report = () => {
@@ -43,6 +45,8 @@ const Report = () => {
 
   const dashboardDateFilter = useSelector(dateRangeDataSelector);
   const dashboardTypesFilter = useSelector(transactionsFilterSelector);
+  const expenseTypes = useSelector(allExpenseTypeSelector);
+  const revenueTypes = useSelector(allRevenueTypesSelector);
 
   const [isExportReportOpen, setIsExportReportOpen] = useState(false);
   const [dateFilter, setDateFilter] = useState(dashboardDateFilter);
@@ -144,7 +148,22 @@ const Report = () => {
         transactions: formatTransactions(transactions, t),
         config: {
           dateFilter,
-          typesFilter,
+          typesFilter: {
+            EXPENSE_TYPE:
+              typesFilter.EXPENSE_TYPE ??
+              createDefaultTypeFilter({
+                types: expenseTypes,
+                translate: t,
+                typeCategory: 'expense',
+              }),
+            REVENUE_TYPE:
+              typesFilter.REVENUE_TYPE ??
+              createDefaultTypeFilter({
+                types: revenueTypes,
+                translate: t,
+                typeCategory: 'revenue',
+              }),
+          },
         },
         reportHeaders: generateReportHeaders(t),
         configSheetHeaders: generateConfigSheetHeaders(t),

--- a/packages/webapp/src/containers/Finances/Report/reportFormattingUtils.js
+++ b/packages/webapp/src/containers/Finances/Report/reportFormattingUtils.js
@@ -41,3 +41,37 @@ export const formatTransactions = (transactions, t) =>
     date: new Date(item.date),
     amount: item.amount,
   }));
+
+/**
+ * Constructs a filter object for given types (either expense or revenue).
+ *
+ * @param {Array} types - Array of type objects
+ * @param {Function} translate - Translation function from i18next-react
+ * @param {string} typeCategory - The category of the type ('expense' or 'revenue')
+ * @returns {Object} Filter object with type ids as keys and {active, label} as values.
+ */
+export const createDefaultTypeFilter = ({ types, translate, typeCategory }) => {
+  const typeIdKey = `${typeCategory}_type_id`;
+  const nameKey = `${typeCategory}_name`;
+  const translationKey = `${typeCategory}_translation_key`;
+
+  const filterObject = types.reduce(
+    (filterObject, type) => ({
+      ...filterObject,
+      [type[typeIdKey]]: {
+        active: true,
+        label: type.farm_id
+          ? type[nameKey]
+          : translate(`${typeCategory}:${type[translationKey]}.${typeCategory.toUpperCase()}_NAME`),
+      },
+    }),
+    {},
+  );
+
+  // Add LABOUR at the end if typeCategory is 'expense'
+  if (typeCategory === 'expense') {
+    filterObject['LABOUR'] = { active: true, label: translate('SALE.FINANCES.LABOUR_LABEL') };
+  }
+
+  return filterObject;
+};

--- a/packages/webapp/src/containers/Finances/selectors.js
+++ b/packages/webapp/src/containers/Finances/selectors.js
@@ -48,7 +48,7 @@ const expenseTypeByIdSelector = (expense_type_id) => {
   });
 };
 
-const sortExpenseTypes = (expenseTypes) => {
+export const sortExpenseTypes = (expenseTypes) => {
   const defaultTypes = [];
   const customTypes = [];
 


### PR DESCRIPTION
**Description**

Type filters are initially `undefined` (and transactions are unfiltered) until the user interacts with one of the type filter modals (/drawers). Since the user can export a transaction report without setting a type filter, a "fake" filter object had to be constructed to give the Excel worksheet and the `filter_config` database column the correct "all types active" data for this situation.

Jira link: https://lite-farm.atlassian.net/browse/LF-3806

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I tested this by looking at the output on the Excel report, second worksheet. The goal was to have the output indistinguishable from when the filters were manually applied as "Select All".

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
