### PR TITLE
LF-3666b Add retire vs delete distinction to finance types

### DIFF
--- a/packages/api/db/migration/20231110195632_add-retire-vs-delete-distinction-to-finance-types.js
+++ b/packages/api/db/migration/20231110195632_add-retire-vs-delete-distinction-to-finance-types.js
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.alterTable('revenue_type', (table) => {
+    table.boolean('retired').defaultTo(false);
+  });
+
+  await knex.schema.alterTable('farmExpenseType', (table) => {
+    table.boolean('retired').defaultTo(false);
+  });
+
+  /* Data migrations to retire deleted types with associated records
+   **
+   This will only only affect types on beta and local environments! There are no custom types on production!**
+   **
+   */
+
+  // Data migration for revenue_type
+  const revenueTypeIds = await knex('sale')
+    .select('revenue_type_id')
+    .where('deleted', false)
+    .whereIn('revenue_type_id', function () {
+      this.select('revenue_type_id')
+        .from('revenue_type')
+        .whereNotNull('farm_id')
+        .andWhere('deleted', true);
+    });
+
+  await knex('revenue_type')
+    .whereIn(
+      'revenue_type_id',
+      revenueTypeIds.map((rt) => rt.revenue_type_id),
+    )
+    .update({
+      deleted: false,
+      retired: true,
+    });
+
+  // Data migration for farmExpenseType
+  const expenseTypeIds = await knex('farmExpense')
+    .select('expense_type_id')
+    .where('deleted', false)
+    .whereIn('expense_type_id', function () {
+      this.select('expense_type_id')
+        .from('farmExpenseType')
+        .whereNotNull('farm_id')
+        .andWhere('deleted', true);
+    });
+
+  await knex('farmExpenseType')
+    .whereIn(
+      'expense_type_id',
+      expenseTypeIds.map((et) => et.expense_type_id),
+    )
+    .update({
+      deleted: false,
+      retired: true,
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  // Reverting data migration for revenue_type
+  await knex('revenue_type').where('retired', true).update({
+    deleted: true,
+  });
+
+  // Reverting data migration for farmExpenseType
+  await knex('farmExpenseType').where('retired', true).update({
+    deleted: true,
+  });
+
+  await knex.schema.alterTable('revenue_type', (table) => {
+    table.dropColumn('retired');
+  });
+
+  await knex.schema.alterTable('farmExpenseType', (table) => {
+    table.dropColumn('retired');
+  });
+};

--- a/packages/api/src/controllers/baseController.js
+++ b/packages/api/src/controllers/baseController.js
@@ -211,6 +211,25 @@ export default {
   },
 
   /**
+   * To check if record is retired or not
+   * @param {Object} trx - Transaction object
+   * @param {Object} model - Database model instance
+   * @param {object} where - 'Where' condition to fetch record
+   * @async
+   * @returns {Boolean} - true or false
+   */
+  async isRetired(trx, model, where) {
+    const record = await model
+      .query(trx)
+      .context({ showHidden: true })
+      .where(where)
+      .select('retired')
+      .first();
+
+    return record.retired;
+  },
+
+  /**
    * Check if records exists in table
    * @param {object} trx - Transaction object
    * @param {object} model - Database model instance

--- a/packages/api/src/controllers/revenueTypeController.js
+++ b/packages/api/src/controllers/revenueTypeController.js
@@ -16,6 +16,7 @@
 import baseController from './baseController.js';
 
 import RevenueTypeModel from '../models/revenueTypeModel.js';
+import SaleModel from '../models/saleModel.js';
 import { transaction, Model } from 'objection';
 
 const revenueTypeController = {
@@ -32,10 +33,11 @@ const revenueTypeController = {
         const record = await baseController.existsInTable(trx, RevenueTypeModel, {
           revenue_name: data.revenue_name,
           farm_id,
+          deleted: false,
         });
 
         if (record) {
-          // if record exists throw conflict error
+          // if active record exists throw conflict error
           await trx.rollback();
           return res.status(409).send();
         } else {
@@ -100,31 +102,36 @@ const revenueTypeController = {
   delType() {
     return async (req, res) => {
       const trx = await transaction.start(Model.knex());
+      const { revenue_type_id } = req.params;
       try {
         // do not allow operations to deleted records
         if (
           await baseController.isDeleted(trx, RevenueTypeModel, {
-            revenue_type_id: req.params.revenue_type_id,
+            revenue_type_id,
           })
         ) {
           await trx.rollback();
           return res.status(404).send();
         }
 
-        const isDeleted = await baseController.delete(
-          RevenueTypeModel,
-          req.params.revenue_type_id,
-          req,
-          {
-            trx,
-          },
-        );
-        await trx.commit();
-        if (isDeleted) {
-          return res.sendStatus(200);
-        } else {
-          return res.sendStatus(404);
+        // Default to deletion
+        let updatedStatus = { retired: false, deleted: true };
+
+        const associatedRecords = await SaleModel.query(trx)
+          .where({ revenue_type_id, deleted: false })
+          .first();
+
+        if (associatedRecords) {
+          // Retire instead of delete
+          updatedStatus = { retired: true, deleted: false };
         }
+
+        await baseController.patch(RevenueTypeModel, revenue_type_id, updatedStatus, req, {
+          trx,
+        });
+
+        await trx.commit();
+        return res.status(200).json(updatedStatus);
       } catch (error) {
         await trx.rollback();
         return res.status(400).json({
@@ -144,8 +151,15 @@ const revenueTypeController = {
       };
 
       try {
-        // do not allow update to deleted records
-        if (await baseController.isDeleted(trx, RevenueTypeModel, { revenue_type_id })) {
+        // do not allow updates to deleted or retired records
+        const isRecordDeleted = await baseController.isDeleted(trx, RevenueTypeModel, {
+          revenue_type_id,
+        });
+        const isRecordRetired = await baseController.isRetired(trx, RevenueTypeModel, {
+          revenue_type_id,
+        });
+
+        if (isRecordDeleted || isRecordRetired) {
           await trx.rollback();
           return res.status(404).send();
         }

--- a/packages/api/src/models/expenseTypeModel.js
+++ b/packages/api/src/models/expenseTypeModel.js
@@ -42,9 +42,22 @@ class ExpenseType extends baseModel {
         farm_id: { type: 'string' },
         expense_translation_key: { type: 'string' },
         custom_description: { type: ['string', 'null'], minLength: 1, maxLength: 125 },
+        retired: { type: 'boolean' },
         ...this.baseProperties,
       },
       additionalProperties: false,
+      // Enforce that types cannot be both retired and deleted at the same time
+      if: {
+        properties: {
+          retired: { const: true },
+        },
+        required: ['retired'],
+      },
+      then: {
+        properties: {
+          deleted: { const: false },
+        },
+      },
     };
   }
 }

--- a/packages/api/src/models/revenueTypeModel.js
+++ b/packages/api/src/models/revenueTypeModel.js
@@ -45,8 +45,21 @@ class RevenueType extends baseModel {
         agriculture_associated: { type: 'null' },
         crop_generated: { type: 'boolean' },
         custom_description: { type: ['string', 'null'], minLength: 1, maxLength: 125 },
+        retired: { type: 'boolean' },
         ...this.baseProperties,
-        additionalProperties: false,
+      },
+      additionalProperties: false,
+      // Enforce that types cannot be both retired and deleted at the same time
+      if: {
+        properties: {
+          retired: { const: true },
+        },
+        required: ['retired'],
+      },
+      then: {
+        properties: {
+          deleted: { const: false },
+        },
       },
     };
   }

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -52,7 +52,7 @@
     },
     "SUCCESS": {
       "ADD": "Successfully created custom expense",
-      "DELETE": "Successfully deleted custom expense",
+      "DELETE": "Successfully retired custom expense",
       "UPDATE": "Successfully updated custom expense"
     }
   },

--- a/packages/webapp/src/components/Form/hookformValidationUtils.js
+++ b/packages/webapp/src/components/Form/hookformValidationUtils.js
@@ -62,8 +62,8 @@ export const hookFormUniquePropertyValidation = (objArr, property, message) => {
  * @param {Array<Object>} objArr - The array of objects to search for duplicates in.
  * @param {string} property - The property within each object to check for uniqueness.
  * @param {string} [status='deleted'] - The status property to check in the object. Defaults to 'deleted'.
- * @param {string} messageTrue - The error message to return if the status property is true.
- * @param {string} messageFalse - The error message to return if the status property is false or the object is not found.
+ * @param {string} messageStatusTrue - The error message to return if the status property is true.
+ * @param {string} messageStatusFalse - The error message to return if the status property is false or the object is not found.
  * @returns {(value: any) => string|boolean} A validation function that takes a value to validate and returns
  * either an error message or `true` if the value is unique
  */
@@ -71,17 +71,17 @@ export const hookFormUniquePropertyWithStatusValidation = ({
   objArr,
   property,
   status = 'deleted',
-  messageTrue,
-  messageFalse,
+  messageStatusTrue,
+  messageStatusFalse,
 }) => {
   return (value) => {
     const foundItem = objArr.find((item) => item[property] === value);
 
     if (foundItem) {
       if (foundItem[status]) {
-        return messageTrue;
+        return messageStatusTrue;
       }
-      return messageFalse;
+      return messageStatusFalse;
     }
 
     return true;

--- a/packages/webapp/src/containers/Finances/CustomExpenseType/AddSimpleCustomExpense.jsx
+++ b/packages/webapp/src/containers/Finances/CustomExpenseType/AddSimpleCustomExpense.jsx
@@ -49,8 +49,8 @@ function AddCustomExpense({ history }) {
           objArr: expenseTypes,
           property: 'expense_name',
           status: 'retired',
-          messageTrue: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME_RETIRED'),
-          messageFalse: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME'),
+          messageStatusTrue: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME_RETIRED'),
+          messageStatusFalse: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME'),
         })}
       />
     </HookFormPersistProvider>

--- a/packages/webapp/src/containers/Finances/CustomExpenseType/AddSimpleCustomExpense.jsx
+++ b/packages/webapp/src/containers/Finances/CustomExpenseType/AddSimpleCustomExpense.jsx
@@ -48,7 +48,7 @@ function AddCustomExpense({ history }) {
         validateInput={hookFormUniquePropertyWithStatusValidation({
           objArr: expenseTypes,
           property: 'expense_name',
-          status: 'deleted',
+          status: 'retired',
           messageTrue: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME_RETIRED'),
           messageFalse: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME'),
         })}

--- a/packages/webapp/src/containers/Finances/CustomExpenseType/EditSimpleCustomExpense.jsx
+++ b/packages/webapp/src/containers/Finances/CustomExpenseType/EditSimpleCustomExpense.jsx
@@ -63,8 +63,8 @@ function EditCustomExpense({ history, match }) {
           objArr: expenseTypesWithoutSelectedType,
           property: 'expense_name',
           status: 'retired',
-          messageTrue: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME_RETIRED'),
-          messageFalse: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME'),
+          messageStatusTrue: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME_RETIRED'),
+          messageStatusFalse: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME'),
         })}
       />
     </HookFormPersistProvider>

--- a/packages/webapp/src/containers/Finances/CustomExpenseType/EditSimpleCustomExpense.jsx
+++ b/packages/webapp/src/containers/Finances/CustomExpenseType/EditSimpleCustomExpense.jsx
@@ -62,7 +62,7 @@ function EditCustomExpense({ history, match }) {
         validateInput={hookFormUniquePropertyWithStatusValidation({
           objArr: expenseTypesWithoutSelectedType,
           property: 'expense_name',
-          status: 'deleted',
+          status: 'retired',
           messageTrue: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME_RETIRED'),
           messageFalse: t('EXPENSE.ADD_EXPENSE.DUPLICATE_NAME'),
         })}

--- a/packages/webapp/src/containers/Finances/CustomRevenueType/AddCustomRevenue.jsx
+++ b/packages/webapp/src/containers/Finances/CustomRevenueType/AddCustomRevenue.jsx
@@ -50,8 +50,8 @@ function AddCustomRevenue({ history }) {
           objArr: revenueTypes,
           property: 'revenue_name',
           status: 'retired',
-          messageTrue: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME_RETIRED'),
-          messageFalse: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
+          messageStatusTrue: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME_RETIRED'),
+          messageStatusFalse: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
         })}
         customFormFields={({ control, watch }) => (
           <CustomRevenueRadios control={control} watch={watch} view="add" />

--- a/packages/webapp/src/containers/Finances/CustomRevenueType/AddCustomRevenue.jsx
+++ b/packages/webapp/src/containers/Finances/CustomRevenueType/AddCustomRevenue.jsx
@@ -49,7 +49,7 @@ function AddCustomRevenue({ history }) {
         validateInput={hookFormUniquePropertyWithStatusValidation({
           objArr: revenueTypes,
           property: 'revenue_name',
-          status: 'deleted',
+          status: 'retired',
           messageTrue: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME_RETIRED'),
           messageFalse: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
         })}

--- a/packages/webapp/src/containers/Finances/CustomRevenueType/EditCustomRevenue.jsx
+++ b/packages/webapp/src/containers/Finances/CustomRevenueType/EditCustomRevenue.jsx
@@ -64,8 +64,8 @@ function EditCustomRevenue({ history, match }) {
           objArr: revenueTypesWithoutSelectedType,
           property: 'revenue_name',
           status: 'deleted',
-          messageTrue: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME_RETIRED'),
-          messageFalse: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
+          messageStatusTrue: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME_RETIRED'),
+          messageStatusFalse: t('REVENUE.ADD_REVENUE.DUPLICATE_NAME'),
         })}
         customFormFields={({ control, watch }) => (
           <CustomRevenueRadios control={control} watch={watch} view="edit" />

--- a/packages/webapp/src/containers/Finances/ExpenseDetail/index.jsx
+++ b/packages/webapp/src/containers/Finances/ExpenseDetail/index.jsx
@@ -37,11 +37,11 @@ const ExpenseDetail = ({ history, match }) => {
 
   // Dropdown should include the current expense's type even if it has been retired
   const expenseTypeArray = sortedExpenseTypes.concat(
-    currentExpenseType.deleted ? currentExpenseType : [],
+    currentExpenseType.retired ? currentExpenseType : [],
   );
 
   const expenseTypeReactSelectOptions = expenseTypeArray.map((type) => {
-    const retireSuffix = type.deleted ? ` ${t('EXPENSE.EDIT_EXPENSE.RETIRED')}` : '';
+    const retireSuffix = type.retired ? ` ${t('EXPENSE.EDIT_EXPENSE.RETIRED')}` : '';
 
     return {
       value: type.expense_type_id,

--- a/packages/webapp/src/containers/Finances/RevenueDetail/index.jsx
+++ b/packages/webapp/src/containers/Finances/RevenueDetail/index.jsx
@@ -47,7 +47,7 @@ function RevenueDetail({ history, match }) {
   }, [sale, history]);
 
   // Dropdown should include the current revenue's type even if it has been retired
-  const revenueTypesArray = revenueTypes?.concat(revenueType?.deleted ? revenueType : []);
+  const revenueTypesArray = revenueTypes?.concat(revenueType?.retired ? revenueType : []);
   const revenueTypeReactSelectOptions = mapRevenueTypesToReactSelectOptions(revenueTypesArray);
 
   const onSubmit = (data) => {

--- a/packages/webapp/src/containers/Finances/saga.js
+++ b/packages/webapp/src/containers/Finances/saga.js
@@ -341,9 +341,12 @@ export function* deleteRevenueTypeSaga({ payload: id }) {
   let { user_id, farm_id } = yield select(loginSelector);
   const header = getHeader(user_id, farm_id);
   try {
-    yield call(axios.delete, `${revenueTypeUrl}/${id}`, header);
+    const result = yield call(axios.delete, `${revenueTypeUrl}/${id}`, header);
 
-    yield put(deleteRevenueTypeSuccess(id));
+    const { deleted, retired } = result.data;
+
+    yield put(deleteRevenueTypeSuccess({ revenue_type_id: id, deleted, retired }));
+
     yield put(enqueueSuccessSnackbar(i18n.t('message:REVENUE_TYPE.SUCCESS.DELETE')));
     history.push('/manage_custom_revenues');
   } catch (e) {

--- a/packages/webapp/src/containers/Finances/selectors.js
+++ b/packages/webapp/src/containers/Finances/selectors.js
@@ -24,10 +24,14 @@ const selectedSaleSelector = createSelector(financeSelector, (state) => state.se
 
 const expenseSelector = createSelector(financeSelector, (state) => state.expenses);
 
-const allExpenseTypeSelector = createSelector(financeSelector, (state) => state.expense_types);
-
-const expenseTypeSelector = createSelector(financeSelector, (state) => {
+// Include retired (but not deleted) types
+const allExpenseTypeSelector = createSelector(financeSelector, (state) => {
   return state.expense_types?.filter((type) => !type.deleted);
+});
+
+// Active types
+const expenseTypeSelector = createSelector(financeSelector, (state) => {
+  return state.expense_types?.filter((type) => !type.deleted && !type.retired);
 });
 
 const revenueByIdSelector = (sale_id) => {
@@ -74,7 +78,7 @@ const allExpenseTypeTileContentsSelector = createSelector(financeSelector, (stat
 });
 
 const expenseTypeTileContentsSelector = createSelector(financeSelector, (state) => {
-  return sortExpenseTypes(state.expense_types).filter((type) => !type.deleted);
+  return sortExpenseTypes(state.expense_types).filter((type) => !type.deleted && !type.retired);
 });
 
 const expenseDetailDateSelector = createSelector(

--- a/packages/webapp/src/containers/Finances/useCustomExpenseTypeTileContents.js
+++ b/packages/webapp/src/containers/Finances/useCustomExpenseTypeTileContents.js
@@ -30,7 +30,7 @@ export default function useCustomExpenseTypeTileContents() {
     }
 
     const contents = expenseTypes
-      .filter((type) => !type.deleted && type.farm_id)
+      .filter((type) => !type.retired && type.farm_id)
       .sort((typeA, typeB) =>
         typeA.expense_translation_key.localeCompare(typeB.expense_translation_key),
       );

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -207,7 +207,7 @@ export const mapSalesToRevenueItems = (sales, revenueTypes, cropVarieties) => {
 export function mapRevenueTypesToReactSelectOptions(revenueTypes) {
   const { t } = useTranslation();
   return revenueTypes?.map((type) => {
-    const retireSuffix = type.deleted ? ` ${t('REVENUE.EDIT_REVENUE.RETIRED')}` : '';
+    const retireSuffix = type.retired ? ` ${t('REVENUE.EDIT_REVENUE.RETIRED')}` : '';
 
     return {
       value: type.revenue_type_id,

--- a/packages/webapp/src/containers/revenueTypeSlice.js
+++ b/packages/webapp/src/containers/revenueTypeSlice.js
@@ -28,6 +28,7 @@ export const getRevenueType = (obj) => {
     'agriculture_associated',
     'crop_generated',
     'custom_description',
+    'retired',
   ]);
 };
 

--- a/packages/webapp/src/containers/revenueTypeSlice.js
+++ b/packages/webapp/src/containers/revenueTypeSlice.js
@@ -41,11 +41,11 @@ const addManyRevenueTypes = (state, { payload: revenueTypes }) => {
   );
 };
 
-const softDeleteRevenueType = (state, { payload: revenue_type_id }) => {
+const softDeleteRevenueType = (state, { payload: { revenue_type_id, deleted, retired } }) => {
   state.loading = false;
   state.error = null;
   state.loaded = true;
-  revenueTypeAdapter.updateOne(state, { id: revenue_type_id, changes: { deleted: true } });
+  revenueTypeAdapter.updateOne(state, { id: revenue_type_id, changes: { deleted, retired } });
 };
 
 const addOneRevenueType = (state, { payload }) => {
@@ -105,19 +105,24 @@ const revenueTypeSelectors = revenueTypeAdapter.getSelectors(
 
 export const revenueTypeEntitiesSelector = revenueTypeSelectors.selectEntities;
 
+// Active types
 export const revenueTypesSelector = createSelector(
+  [revenueTypeSelectors.selectAll, loginSelector],
+  (revenueTypes, { farm_id }) => {
+    return revenueTypes.filter(
+      (revenue) =>
+        (revenue.farm_id === farm_id || !revenue.farm_id) && !revenue.deleted && !revenue.retired,
+    );
+  },
+);
+
+// Retired but not deleted types
+export const allRevenueTypesSelector = createSelector(
   [revenueTypeSelectors.selectAll, loginSelector],
   (revenueTypes, { farm_id }) => {
     return revenueTypes.filter(
       (revenue) => (revenue.farm_id === farm_id || !revenue.farm_id) && !revenue.deleted,
     );
-  },
-);
-
-export const allRevenueTypesSelector = createSelector(
-  [revenueTypeSelectors.selectAll, loginSelector],
-  (revenueTypes, { farm_id }) => {
-    return revenueTypes.filter((revenue) => revenue.farm_id === farm_id || !revenue.farm_id);
   },
 );
 


### PR DESCRIPTION
**Description**

This is the follow-up PR to the one that reserved the names of retired types and removed the under-the-hood unretire functionality:

- https://github.com/LiteFarmOrg/LiteFarm/pull/2970

This PR creates a distinction between types that should be retired (= have an associated expense/revenue at the time of retiring, should stay in the filters, are name reserved) vs deleted (= have no associated expense/revenues, should not appear in the filters, are not name reserved). The components are:
- Adding a new retired property to the database tables and models
- (This is just for beta and local environments) a **reversible** data migration that classifies previously 'retired' types into the correct category -- retired or deleted -- depending on whether they have records associated with them or not. Note this migration is reversible so it's safe to run `migrate:dev:db` and `migrate:make:rollback` when testing on this branch
- The same logic (retire types with associated records, delete otherwise) added to the delete controllers
- Passing the new retired property to the frontend and updating logic accordingly. Since the selectors themselves can be updated this wasn't too intensive a change.

What is not included/not yet implemented:
- Arguably, seeing this logic through to the end should mean that if you delete the last record associated with a retired type (OR use the one of the `edit` views to move the record off of that retired type to another active type), that 'retired' type should become 'deleted' and disappear from the filters. (Update: a new ticket will be created for this functionality)

Jira link: https://lite-farm.atlassian.net/browse/LF-3666

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
