### PR TITLE
LF-3778b Clean up unused translations using i18n script

### DIFF
--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -6,11 +6,15 @@
   "ATTACHMENTS": {
     "ERROR": {
       "CREATE": "Failed to create document",
+      "FAILED_ARCHIVE": "Failed to archive document",
+      "FAILED_UNARCHIVE": "Failed to unarchive document",
       "FAILED_UPLOAD": "Failed to upload attachments",
       "UPDATE": "Failed to update document"
     },
     "SUCCESS": {
+      "ARCHIVE": "Successfully archived document",
       "CREATE": "Successfully created document",
+      "UNARCHIVE": "Successfully unarchived document",
       "UPDATE": "Successfully updated document"
     }
   },

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -438,6 +438,9 @@
       "VALID_UNTIL": "Valid until"
     },
     "ADD_DOCUMENT": "Add a new document",
+    "ARCHIVE": "Archive",
+    "ARCHIVE_DOCUMENT": "Archive document?",
+    "ARCHIVE_DOCUMENT_TEXT": "Archiving this document will move it to the archived section of your documents, but not delete it. Archived documents will not be exported for your certifications. Do you want to proceed?",
     "ARCHIVED": "Archived",
     "CANCEL": "Cancel",
     "CANCEL_MODAL": "document creation",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -472,6 +472,9 @@
       "SOIL_SAMPLE_RESULTS": "Soil sample results",
       "WATER_SAMPLE_RESULTS": "Water sample results"
     },
+    "UNARCHIVE": "Unarchive",
+    "UNARCHIVE_DOCUMENT": "Unarchive document?",
+    "UNARCHIVE_DOCUMENT_TEXT": "Unarchiving this document will return it to your list of currently valid documents. Valid documents will be exported for your certifications. Do you want to proceed?",
     "VALID": "Valid"
   },
   "ENTER_PASSWORD": {

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -90,7 +90,14 @@
       "SET_AS_DEFAULT_TYPE_FOR_THIS_LOCATION": "Set as default type for this location",
       "TOTAL_WATER_USAGE": "Total Water Usage",
       "TYPE": {
-        "OTHER": "Other"
+        "CHANNEL": "Channel",
+        "DRIP": "Drip",
+        "FLOOD": "Flood",
+        "HAND_WATERING": "Hand Watering",
+        "OTHER": "Other",
+        "PIVOT": "Pivot",
+        "SPRINKLER": "Sprinkler",
+        "SUB_SURFACE": "Subsurface"
       },
       "TYPE_OF_IRRIGATION": "Type of Irrigation",
       "VOLUME": "Volume",

--- a/packages/webapp/public/locales/es/message.json
+++ b/packages/webapp/public/locales/es/message.json
@@ -6,11 +6,15 @@
   "ATTACHMENTS": {
     "ERROR": {
       "CREATE": "No se pudo crear el documento",
+      "FAILED_ARCHIVE": "No se pudo archivar el documento",
+      "FAILED_UNARCHIVE": "No se pudo desarchivar el documento",
       "FAILED_UPLOAD": "No se pudo subir los archivos adjuntos",
       "UPDATE": "No se pudo actualizar el documento"
     },
     "SUCCESS": {
+      "ARCHIVE": "Documento archivado exitosamente",
       "CREATE": "Documento creado exitosamente",
+      "UNARCHIVE": "Documento desarchivado con éxito",
       "UPDATE": "Documento actualizado exitosamente"
     }
   },

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -471,6 +471,9 @@
       "SOIL_SAMPLE_RESULTS": "Resultados de muestras del suelo",
       "WATER_SAMPLE_RESULTS": "Resultados de la muestra de agua"
     },
+    "UNARCHIVE": "Desarchivar",
+    "UNARCHIVE_DOCUMENT": "¿Desarchivar documento?",
+    "UNARCHIVE_DOCUMENT_TEXT": "Desarchivar este documento lo devolverá a su lista de documentos actualmente válidos. Los documentos válidos se exportarán para sus certificaciones. Quiere proceder?",
     "VALID": "Válido"
   },
   "ENTER_PASSWORD": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -437,6 +437,9 @@
       "VALID_UNTIL": "Válido hasta"
     },
     "ADD_DOCUMENT": "Agregar un nuevo documento",
+    "ARCHIVE": "Archivar",
+    "ARCHIVE_DOCUMENT": "Archivar documento",
+    "ARCHIVE_DOCUMENT_TEXT": "Archivar este documento lo moverá a la sección de archivado de sus documentos, pero no lo eliminará. Los documentos archivados no se exportarán para sus certificaciones. Quiere proceder?",
     "ARCHIVED": "Archivado",
     "CANCEL": "Cancelar",
     "CANCEL_MODAL": "creación de documentos",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -90,7 +90,14 @@
       "SET_AS_DEFAULT_TYPE_FOR_THIS_LOCATION": "Establecer como tipo predeterminado para esta ubicación",
       "TOTAL_WATER_USAGE": "Uso de agua total",
       "TYPE": {
-        "OTHER": "Otros"
+        "CHANNEL": "Canal",
+        "DRIP": "Goteo",
+        "FLOOD": "Inundación",
+        "HAND_WATERING": "Riego a mano",
+        "OTHER": "Otros",
+        "PIVOT": "Pivote",
+        "SPRINKLER": "Aspersor",
+        "SUB_SURFACE": "Subsuperficie"
       },
       "TYPE_OF_IRRIGATION": "Tipo de riego",
       "VOLUME": "Volumen",

--- a/packages/webapp/public/locales/fr/message.json
+++ b/packages/webapp/public/locales/fr/message.json
@@ -6,11 +6,15 @@
   "ATTACHMENTS": {
     "ERROR": {
       "CREATE": "Erreur à la création du document",
+      "FAILED_ARCHIVE": "Erreur à l'archivage du document",
+      "FAILED_UNARCHIVE": "Erreur à la restauration du document",
       "FAILED_UPLOAD": "Erreur au téléchargement du document",
       "UPDATE": "Erreur à la mise à jour"
     },
     "SUCCESS": {
+      "ARCHIVE": "Document archivé",
       "CREATE": "Document créé",
+      "UNARCHIVE": "Document restauré",
       "UPDATE": "Document mis à jour"
     }
   },

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -90,7 +90,14 @@
       "SET_AS_DEFAULT_TYPE_FOR_THIS_LOCATION": "Sélectionner ce type par défaut pour cet emplacement",
       "TOTAL_WATER_USAGE": "Utilisation totale de l’eau",
       "TYPE": {
-        "OTHER": "Autre type d'irrigation"
+        "CHANNEL": "Irrigation des canaux",
+        "DRIP": "Irrigation goutte à goutte",
+        "FLOOD": "Irrigation par inondation",
+        "HAND_WATERING": "Arrosage manuel",
+        "OTHER": "Autre type d'irrigation",
+        "PIVOT": "Irrigation par pivot",
+        "SPRINKLER": "Irrigation par aspersion",
+        "SUB_SURFACE": "Irrigation souterraine"
       },
       "TYPE_OF_IRRIGATION": "Type d'arrosage",
       "VOLUME": "Volume",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -472,6 +472,9 @@
       "SOIL_SAMPLE_RESULTS": "Résultats des échantillons de sol",
       "WATER_SAMPLE_RESULTS": "Résultats des échantillons d'eau"
     },
+    "UNARCHIVE": "Désarchiver",
+    "UNARCHIVE_DOCUMENT": "Désarchiver le document\u00a0?",
+    "UNARCHIVE_DOCUMENT_TEXT": "L'annulation de l'archivage de ce document remettra celui-ci dans votre liste de documents valides. Les documents valides seront exportés pour vos certifications. Voulez-vous continuer\u00a0?",
     "VALID": "Valide"
   },
   "ENTER_PASSWORD": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -438,6 +438,9 @@
       "VALID_UNTIL": "Valable jusqu'au"
     },
     "ADD_DOCUMENT": "Ajouter un nouveau document",
+    "ARCHIVE": "Archiver",
+    "ARCHIVE_DOCUMENT": "Archiver document\u00a0?",
+    "ARCHIVE_DOCUMENT_TEXT": "L'archivage de ce document le déplacera vers la section archivée de vos documents, mais ne le supprimera pas. Les documents archivés ne seront pas exportés pour vos certifications. Voulez-vous continuer\u00a0?",
     "ARCHIVED": "Archivé",
     "CANCEL": "Annuler",
     "CANCEL_MODAL": "création de document",

--- a/packages/webapp/public/locales/pt/message.json
+++ b/packages/webapp/public/locales/pt/message.json
@@ -6,11 +6,15 @@
   "ATTACHMENTS": {
     "ERROR": {
       "CREATE": "Falha ao criar documento",
+      "FAILED_ARCHIVE": "Falha ao arquivar o documento",
+      "FAILED_UNARCHIVE": "Falha ao desarquivar documento",
       "FAILED_UPLOAD": "Anexos não carregados",
       "UPDATE": "Falha ao atualizar o documento"
     },
     "SUCCESS": {
+      "ARCHIVE": "Documento arquivado com sucesso",
       "CREATE": "Documento criado com sucesso",
+      "UNARCHIVE": "Documento desarquivado com sucesso",
       "UPDATE": "Documento atualizado com sucesso"
     }
   },

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -471,6 +471,9 @@
       "SOIL_SAMPLE_RESULTS": "Resultados da amostra de solo",
       "WATER_SAMPLE_RESULTS": "Resultados da amostra de água"
     },
+    "UNARCHIVE": "Desarquivar",
+    "UNARCHIVE_DOCUMENT": "Documento desarquivado?",
+    "UNARCHIVE_DOCUMENT_TEXT": "Desarquivar este documento irá devolvê-lo à sua lista de documentos atualmente válidos. Os documentos válidos serão exportados para suas certificações. Você quer prosseguir?",
     "VALID": "Válido"
   },
   "ENTER_PASSWORD": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -437,6 +437,9 @@
       "VALID_UNTIL": "Válido até"
     },
     "ADD_DOCUMENT": "Adicionar um novo documento",
+    "ARCHIVE": "Arquivar",
+    "ARCHIVE_DOCUMENT": "Arquivar documento?",
+    "ARCHIVE_DOCUMENT_TEXT": "Arquivar este documento o moverá para a seção arquivada de seus documentos, mas não o excluirá. Os documentos arquivados não serão exportados para suas certificações. Você quer prosseguir?",
     "ARCHIVED": "Arquivado",
     "CANCEL": "Cancelar",
     "CANCEL_MODAL": "criação de documento",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -90,7 +90,14 @@
       "SET_AS_DEFAULT_TYPE_FOR_THIS_LOCATION": "Definir como padrão para esta área",
       "TOTAL_WATER_USAGE": "Uso de água total",
       "TYPE": {
-        "OTHER": "Outro"
+        "CHANNEL": "Canal",
+        "DRIP": "Gotejamento",
+        "FLOOD": "Inundação",
+        "HAND_WATERING": "Rega manual",
+        "OTHER": "Outro",
+        "PIVOT": "Pivô",
+        "SPRINKLER": "Aspersor",
+        "SUB_SURFACE": "Subsuperficial"
       },
       "TYPE_OF_IRRIGATION": "Tipo de Irrigação",
       "VOLUME": "Volume",


### PR DESCRIPTION
**Description**

Restores more over-aggressively removed translations from the `i18n` script. These were caught by Denis in context.

Jira link: https://lite-farm.atlassian.net/browse/LF-3778

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Other: More code searching. These strings were part of dynamically generated template literals that are often hard to search up the way that normal translation strings are (we should probably abstain from this as much as possible in the future!)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
