### PR TITLE
LF-3814 The white screen is displayed once the user Updates the user info without actually selected the preferred LiteFarm Language

### DIFF
--- a/packages/api/src/controllers/userController.js
+++ b/packages/api/src/controllers/userController.js
@@ -321,6 +321,7 @@ const userController = {
           'user_id',
           'gender',
           'birth_year',
+          'language_preference',
         );
 
       if (!data) {


### PR DESCRIPTION
**Description**

This one was a bit weird! The symptom is that the `language_preference` property is missing from the `userFarm` Redux entity when the `userFarmSelector` is called from `<Account />`, but ONLY if you go there directly after creating a new farm, rather than after logging in. In the Jira ticket there is one "symptom-level" fix for this issue.

The cause is that this GET request in `postFarmSaga` doesn't return the `language_preference` property:

``` 
call(axios.get, userUrl + '/' + user_id, header),`
```

This is the `getUserByID` controller. What I consider a bit weird is that it's actually not called anywhere else in app except within this Add Farm saga / flow (or at least, that's how it appears after a frontend code search) 🤷 

Jira link: https://lite-farm.atlassian.net/browse/LF-3814

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I tested the flow by logging (not very high-tech) through the Add Farm > `postFarm` >  `postFarmSuccess` > Account. I found the lacking `language_preference` property to occur on both new and existing accounts after Add Farm. After login these sagas are not used and the `user` object is populated elsewhere.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
