### PR TITLE
LF-3778c Clean up unused translations using i18n script

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -541,9 +541,15 @@
     "BARN": {
       "ANIMALS": "Is this area used for housing animals?",
       "COLD_STORAGE": "Does this barn have cold storage?",
+      "EDIT_TITLE": "Edit barn",
+      "NAME": "Barn name",
+      "TITLE": "Add barn",
       "WASH_PACK": "Does this barn have a wash and pack station?"
     },
     "BUFFER_ZONE": {
+      "EDIT_TITLE": "Edit buffer zone",
+      "NAME": "Buffer zone name",
+      "TITLE": "Add buffer zone",
       "WIDTH": "Buffer zone width"
     },
     "BULK_UPLOAD_SENSORS": {
@@ -595,6 +601,11 @@
     "BULK_UPLOAD_TRANSITION": {
       "BODY": "We’ll notify you once your upload is complete and your sensors have been created. Feel free to navigate away from this window.",
       "TITLE": "This is taking longer than expected..."
+    },
+    "CEREMONIAL_AREA": {
+      "EDIT_TITLE": "Edit ceremonial area",
+      "NAME": "Ceremonial area name",
+      "TITLE": "Add ceremonial area"
     },
     "CONFIRM_RETIRE": {
       "BODY": "Retiring this location will remove it from the farm map.",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -540,9 +540,15 @@
     "BARN": {
       "ANIMALS": "Se usa este granero para abrigar animales?",
       "COLD_STORAGE": "Tiene este granero almacenamiento en frio?",
+      "EDIT_TITLE": "Editar granero",
+      "NAME": "Nombre de granero",
+      "TITLE": "Agregar Granero",
       "WASH_PACK": "Tiene este granero una estacion de lavado y empacado?"
     },
     "BUFFER_ZONE": {
+      "EDIT_TITLE": "Editar delimitante",
+      "NAME": "Nombre de zona delimitante",
+      "TITLE": "Agregar zona delimitante",
       "WIDTH": "Ancho de la zona delimitante"
     },
     "BULK_UPLOAD_SENSORS": {
@@ -594,6 +600,11 @@
     "BULK_UPLOAD_TRANSITION": {
       "BODY": "Le notificaremos una vez que su carga se haya completado y sus sensores se han creado. Puede salir de esta ventana.",
       "TITLE": "Esto está tardando más de lo esperado..."
+    },
+    "CEREMONIAL_AREA": {
+      "EDIT_TITLE": "Editar area ceremonial",
+      "NAME": "Nombre de area ceremonial",
+      "TITLE": "Agregar area ceremonial"
     },
     "CONFIRM_RETIRE": {
       "BODY": "Retirar esta ubicación la eliminará del mapa de la granja.",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -541,9 +541,15 @@
     "BARN": {
       "ANIMALS": "Cette zone est-elle utilisée pour loger des animaux\u00a0?",
       "COLD_STORAGE": "Cette grange a-t-elle une chambre froide\u00a0?",
+      "EDIT_TITLE": "Modifier la grange",
+      "NAME": "Nom de la grange",
+      "TITLE": "Ajouter une grange",
       "WASH_PACK": "Cette grange a-t-elle une station de lavage et d'emballage\u00a0?"
     },
     "BUFFER_ZONE": {
+      "EDIT_TITLE": "Modifier la zone tampon",
+      "NAME": "Nom de la zone tampon",
+      "TITLE": "Ajouter une zone tampon",
       "WIDTH": "Largeur de la zone tampon"
     },
     "BULK_UPLOAD_SENSORS": {
@@ -595,6 +601,11 @@
     "BULK_UPLOAD_TRANSITION": {
       "BODY": "Nous vous informerons quand votre téléchargement est terminé et vos capteurs ont été créés. Vous pouvez quitter cette fenêtre.",
       "TITLE": "Cela prend plus de temps que prévu..."
+    },
+    "CEREMONIAL_AREA": {
+      "EDIT_TITLE": "Modifier la zone de cérémonie",
+      "NAME": "Nom de la zone de cérémonie",
+      "TITLE": "Ajouter une zone de cérémonie"
     },
     "CONFIRM_RETIRE": {
       "BODY": "Retirer cet emplacement le supprimera de la carte de la ferme.",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -540,9 +540,15 @@
     "BARN": {
       "ANIMALS": "Esta área é usada para abrigar animais?",
       "COLD_STORAGE": "Este celeiro tem câmara fria?",
+      "EDIT_TITLE": "Editar celeiro",
+      "NAME": "Nome do celeiro",
+      "TITLE": "Adicionar celeiro",
       "WASH_PACK": "Este celeiro tem uma estação de lavação e embalagem?"
     },
     "BUFFER_ZONE": {
+      "EDIT_TITLE": "Editar zona de amortecimento/proteção",
+      "NAME": "Zona de amortecimento/proteção",
+      "TITLE": "Adicionar zona de amortecimento/proteção",
       "WIDTH": "Largura da zona de amortecimento/proteção"
     },
     "BULK_UPLOAD_SENSORS": {
@@ -594,6 +600,11 @@
     "BULK_UPLOAD_TRANSITION": {
       "BODY": "Notificaremos você assim que o upload for concluído e os sensores forem criados. Sinta-se à vontade para sair desta janela",
       "TITLE": "Isso está demorando mais do que o esperado."
+    },
+    "CEREMONIAL_AREA": {
+      "EDIT_TITLE": "Editar área cerimonial",
+      "NAME": "Nome da área cerimonial",
+      "TITLE": "Adicionar área cerimonial"
     },
     "CONFIRM_RETIRE": {
       "BODY": "Remover esta área fará com que ela seja retirada do mapa do sítio/fazenda.",


### PR DESCRIPTION

**Description**

Restores YET MORE translations.

Jira link: https://lite-farm.atlassian.net/browse/LF-3778

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
