### PR TITLE
LF-3809: No actions are triggered once the user clicks on the "Upload" button, once the user added the csv file

### DIFF
--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -24,6 +24,7 @@ import { getLanguageFromLocalStorage } from '../../../../util/getLanguageFromLoc
 export function useValidateBulkSensorData(onUpload, t) {
   const bulkSensorsUploadResponse = useSelector(bulkSensorsUploadSliceSelector);
   const [disabled, setDisabled] = useState(null);
+  const [selectedFile, setSelectedFile] = useState(null);
   const [selectedFileName, setSelectedFileName] = useState('');
   const [sheetErrors, setSheetErrors] = useState([]);
   const [errorCount, setErrorCount] = useState(0);
@@ -105,9 +106,8 @@ export function useValidateBulkSensorData(onUpload, t) {
 
   const onUploadClicked = async (e) => {
     e.preventDefault();
-    const file = fileInputRef.current.files[0];
-    if (!file) return;
-    onUpload(file);
+    if (!selectedFile) return;
+    onUpload(selectedFile);
   };
 
   const getFileExtension = (fileName) => fileName.split('.').pop();
@@ -118,6 +118,7 @@ export function useValidateBulkSensorData(onUpload, t) {
     try {
       const fileExtension = getFileExtension(file?.name);
       setSelectedFileName(file?.name);
+      setSelectedFile(file);
 
       const fileString = await readFile(file);
 


### PR DESCRIPTION
**Description**

`<input type="file" />` does not retain previously selected file data. So if you select a file, click the input again to select a file and click "cancel", `e.target.files` (`fileInputRef.current.files[0]` in the actual code) does not have any file information.
This PR adds a state to keep the file data that will be used for uploading.

Jira link: https://lite-farm.atlassian.net/browse/LF-3809

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
