### PR TITLE
LF-3821 Failure when editing greenhouse details

### DIFF
--- a/packages/api/src/models/greenhouseModel.js
+++ b/packages/api/src/models/greenhouseModel.js
@@ -17,6 +17,21 @@ import Model from './baseFormatModel.js';
 import organicHistoryModel from './organicHistoryModel.js';
 
 class Greenhouse extends Model {
+  // Code from gardenModel.js and fieldModel.js
+  // Converts datetimes to date strings by stripping the time component
+  $parseJson(json, opt) {
+    json = super.$parseJson(json, opt);
+    const pgDateTypeFields = ['transition_date'];
+    if (Object.keys(json).some((e) => pgDateTypeFields.includes(e))) {
+      Object.keys(json).forEach((key) => {
+        if (pgDateTypeFields.includes(key) && json[key]) {
+          json[key] = json[key].split('T')[0];
+        }
+      });
+    }
+    return json;
+  }
+
   static get tableName() {
     return 'greenhouse';
   }


### PR DESCRIPTION
**Description**

The other two locations that refer to a 'transition_date' in their API models (`fieldModel.js` and `gardenModel.js`) have some code that converts the 'transition_date' datetime string into a date by stripping off the time information.

Without that bit, the transition date format being sent to the database (e.g. `"2023-11-07T00:00:00.000"`) was triggering the model validation error `'greenhouse.transition_date: must match format "date"'`. There is definitely more than one way to fix this but I chose to keep the parallelism to the other corresponding locations.

Jira link: https://lite-farm.atlassian.net/browse/LF-3821

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I followed the steps in the linked video 🙂 

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
