### PR TITLE
Lf 3215 a user creating a task at a location concurrently with another user retiring said location creates a task at a location that does not exist

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -13,7 +13,6 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { transaction, Model } from 'objection';
 import TaskModel from '../models/taskModel.js';
 
 import UserFarmModel from '../models/userFarmModel.js';
@@ -273,19 +272,14 @@ const taskController = {
     const nonModifiable = getNonModifiable(typeOfTask);
     return async (req, res, next) => {
       try {
-        // Only to satisfy "isDeleted" function requirement
-        const trx = await transaction.start(Model.knex());
-
         // Do not allow to create a task if location is deleted
         if (
-          await baseController.isDeleted(trx, Location, {
+          await baseController.isDeleted(null, Location, {
             [Location.idColumn]: req.body.locations[0]?.location_id,
           })
         ) {
-          await trx.rollback();
           return res.status(409).send('location deleted');
         }
-        await trx.rollback();
 
         // OC: the "noInsert" rule will not fail if a relationship is present in the graph.
         // it will just ignore the insert on it. This is just a 2nd layer of protection

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1894,7 +1894,11 @@
     "TODO": "To do",
     "TRANSPLANT": "Transplant",
     "TRANSPLANT_LOCATIONS": "Select a transplant location",
-    "UNASSIGNED": "Unassigned"
+    "UNASSIGNED": "Unassigned",
+    "CREATE": {
+      "FAILED": "Can't create the task",
+      "LOCATION_DELETED": "It seems you are trying to create a task on a deleted location. Please try again afresh!"
+    }
   },
   "UNIT": {
     "TIME": {

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1897,7 +1897,7 @@
     "UNASSIGNED": "Unassigned",
     "CREATE": {
       "FAILED": "Can't create the task",
-      "LOCATION_DELETED": "It seems you are trying to create a task on a deleted location. Please try again afresh!"
+      "LOCATION_DELETED": "Another farmer has retired your selected location. Please refresh the page to get the most recent status."
     }
   },
   "UNIT": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1895,7 +1895,11 @@
     "TODO": "Para hacer",
     "TRANSPLANT": "Trasplantar",
     "TRANSPLANT_LOCATIONS": "Seleccione una ubicación para el trasplante",
-    "UNASSIGNED": "Sin asignar"
+    "UNASSIGNED": "Sin asignar",
+    "CREATE": {
+      "FAILED": "MISSING",
+      "LOCATION_DELETED": "MISSING"
+    }
   },
   "UNIT": {
     "TIME": {

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1900,7 +1900,11 @@
     "TODO": "À faire",
     "TRANSPLANT": "Repiquage",
     "TRANSPLANT_LOCATIONS": "Sélectionnez un lieu de repiquage",
-    "UNASSIGNED": "Non attribué"
+    "UNASSIGNED": "Non attribué",
+    "CREATE": {
+      "FAILED": "MISSING",
+      "LOCATION_DELETED": "MISSING"
+    }
   },
   "UNIT": {
     "TIME": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1896,7 +1896,11 @@
     "TODO": "A fazer",
     "TRANSPLANT": "Transplantar",
     "TRANSPLANT_LOCATIONS": "Selecione um local de transplante",
-    "UNASSIGNED": "Não atribuída"
+    "UNASSIGNED": "Não atribuída",
+    "CREATE": {
+      "FAILED": "MISSING",
+      "LOCATION_DELETED": "MISSING"
+    }
   },
   "UNIT": {
     "TIME": {

--- a/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import ModalComponent from '../../../components/Modals/ModalComponent/v2';
+
 import PureTaskAssignment from '../../../components/Task/PureTaskAssignment';
 import { loginSelector, userFarmEntitiesSelector, userFarmSelector } from '../../userFarmSlice';
 import { useDispatch, useSelector } from 'react-redux';
@@ -27,6 +29,8 @@ export default function TaskManagement({ history, match, location }) {
   const persistedFormData = useSelector(hookFormPersistSelector);
   const [isFarmWorker] = useState(userFarm.role_id === 3);
   const worker = users[userFarm.user_id];
+
+  const [showCannotCreateModal, setShowCannotCreateModal] = useState(false);
 
   const defaultAssignee = useMemo(() => {
     let { assignee } = persistedFormData;
@@ -101,7 +105,7 @@ export default function TaskManagement({ history, match, location }) {
         delete postData[key];
       }
     });
-    dispatch(createTask(postData));
+    dispatch(createTask({ ...postData, setShowCannotCreateModal }));
 
     // for user who does not have a wage set, take the hourly wage action
     if (showHourlyWageInputs) {
@@ -124,17 +128,31 @@ export default function TaskManagement({ history, match, location }) {
     console.log('onError called');
   };
 
+  const dismissModal = () => {
+    setShowCannotCreateModal(false);
+    history.push('/tasks');
+  };
   return (
-    <HookFormPersistProvider>
-      <PureTaskAssignment
-        onSubmit={onSubmit}
-        handleGoBack={handleGoBack}
-        onError={onError}
-        isFarmWorker={isFarmWorker}
-        currencySymbol={currencySymbol}
-        override={override}
-        {...taskAssignForm}
-      />
-    </HookFormPersistProvider>
+    <>
+      <HookFormPersistProvider>
+        <PureTaskAssignment
+          onSubmit={onSubmit}
+          handleGoBack={handleGoBack}
+          onError={onError}
+          isFarmWorker={isFarmWorker}
+          currencySymbol={currencySymbol}
+          override={override}
+          {...taskAssignForm}
+        />
+      </HookFormPersistProvider>
+      {showCannotCreateModal && (
+        <ModalComponent
+          title={t('TASK.CREATE.FAILED')}
+          contents={[t('TASK.CREATE.LOCATION_DELETED')]}
+          dismissModal={dismissModal}
+          error
+        />
+      )}
+    </>
   );
 }

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -530,7 +530,7 @@ const getPostTaskReqBody = (
 export const createTask = createAction('createTaskSaga');
 
 export function* createTaskSaga({ payload }) {
-  let { returnPath, ...data } = payload;
+  let { returnPath, setShowCannotCreateModal, ...data } = payload;
 
   const { taskUrl } = apiConfig;
   let { user_id, farm_id } = yield select(loginSelector);
@@ -572,7 +572,11 @@ export function* createTaskSaga({ payload }) {
     }
   } catch (e) {
     console.log(e);
-    yield put(enqueueErrorSnackbar(i18n.t('message:TASK.CREATE.FAILED')));
+    if (e.response.data === 'location deleted') {
+      setShowCannotCreateModal(true);
+    } else {
+      yield put(enqueueErrorSnackbar(i18n.t('message:TASK.CREATE.FAILED')));
+    }
   }
 }
 


### PR DESCRIPTION
**Description**

When two users are logged on to the same farm and one user begins the task creation flow at a particular location while another user attempts to retire the same location, the tasks are created at a location that does not exist on the farm

Jira link:https://lite-farm.atlassian.net/browse/LF-3215

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- Start to create a new task
- Before finishing the task creation flow, delete the location by setting the "deleted = true" in database to mimic the behaviour that another user has deleted the location at the same time.
- Try to save the task. Error will occur and a modal will be displayed giving info of the error.

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
