### PR TITLE
LF-3815 Distinguish retired and un retired types in filter views

### DIFF
--- a/packages/webapp/src/containers/Filter/Transactions/index.jsx
+++ b/packages/webapp/src/containers/Filter/Transactions/index.jsx
@@ -41,9 +41,11 @@ const TransactionFilterContent = ({
           value: type.expense_type_id,
           // This sets the initial state of the filter pill
           default: transactionsFilter[EXPENSE_TYPE]?.[type.expense_type_id]?.active ?? true,
-          label: type.farm_id
-            ? type.expense_name
-            : t(`expense:${type.expense_translation_key}.EXPENSE_NAME`),
+          label:
+            (type.farm_id
+              ? type.expense_name
+              : t(`expense:${type.expense_translation_key}.EXPENSE_NAME`)) +
+            (type.retired ? ` ${t('EXPENSE.EDIT_EXPENSE.RETIRED')}` : ''),
         })),
         {
           value: transactionTypeEnum.labourExpense,
@@ -61,9 +63,11 @@ const TransactionFilterContent = ({
         value: type.revenue_type_id,
         // This sets the initial state of the filter pill
         default: transactionsFilter[REVENUE_TYPE]?.[type.revenue_type_id]?.active ?? true,
-        label: type.farm_id
-          ? type.revenue_name
-          : t(`revenue:${type.revenue_translation_key}.REVENUE_NAME`),
+        label:
+          (type.farm_id
+            ? type.revenue_name
+            : t(`revenue:${type.revenue_translation_key}.REVENUE_NAME`)) +
+          (type.retired ? ` ${t('REVENUE.EDIT_REVENUE.RETIRED')}` : ''),
       })),
     },
   ];

--- a/packages/webapp/src/containers/Filter/Transactions/index.jsx
+++ b/packages/webapp/src/containers/Filter/Transactions/index.jsx
@@ -17,10 +17,10 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import FilterGroup from '../../../components/Filter/FilterGroup';
-import { allExpenseTypeSelector, sortExpenseTypes } from '../../Finances/selectors';
+import { allExpenseTypeSelector } from '../../Finances/selectors';
 import { transactionTypeEnum } from '../../Finances/useTransactions';
-import useSortedRevenueTypes from '../../Finances/AddSale/RevenueTypes/useSortedRevenueTypes';
 import { EXPENSE_TYPE, REVENUE_TYPE } from '../constants';
+import { allRevenueTypesSelector } from '../../revenueTypeSlice';
 
 const TransactionFilterContent = ({
   transactionsFilter,
@@ -29,8 +29,8 @@ const TransactionFilterContent = ({
   onChange,
 }) => {
   const { t } = useTranslation(['translation', 'filter']);
-  const expenseTypes = sortExpenseTypes(useSelector(allExpenseTypeSelector));
-  const revenueTypes = useSortedRevenueTypes({ selectorType: 'all' });
+  const expenseTypes = useSelector(allExpenseTypeSelector);
+  const revenueTypes = useSelector(allRevenueTypesSelector);
 
   const filters = [
     {
@@ -74,7 +74,7 @@ const TransactionFilterContent = ({
 
   return (
     <FilterGroup
-      filters={filters}
+      filters={[sortFilterOptions(filters[0]), sortFilterOptions(filters[1])]}
       filterRef={filterRef}
       filterContainerClassName={filterContainerClassName}
       onChange={onChange}
@@ -93,3 +93,10 @@ TransactionFilterContent.propTypes = {
 };
 
 export default TransactionFilterContent;
+
+const sortFilterOptions = (filters) => {
+  return {
+    ...filters,
+    options: [...filters.options.sort((typeA, typeB) => typeA.label.localeCompare(typeB.label))],
+  };
+};

--- a/packages/webapp/src/containers/Filter/Transactions/index.jsx
+++ b/packages/webapp/src/containers/Filter/Transactions/index.jsx
@@ -74,7 +74,7 @@ const TransactionFilterContent = ({
 
   return (
     <FilterGroup
-      filters={[sortFilterOptions(filters[0]), sortFilterOptions(filters[1])]}
+      filters={filters.map(filter => sortFilterOptions(filter))}
       filterRef={filterRef}
       filterContainerClassName={filterContainerClassName}
       onChange={onChange}

--- a/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/useSortedRevenueTypes.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/useSortedRevenueTypes.jsx
@@ -33,25 +33,25 @@ export default function useSortedRevenueTypes({ selectorType = 'default' } = {})
   }, []);
 
   useEffect(() => {
-    const defaultTypes = [];
-    const customTypes = [];
-    revenueTypes?.forEach((type) => {
-      const arrayToUpdate = type.farm_id ? customTypes : defaultTypes;
-      arrayToUpdate.push(type);
-    });
+    const allTypes = revenueTypes ?? [];
 
-    const allTypes = [
-      ...defaultTypes.sort((typeA, typeB) =>
-        t(`revenue:${typeA.revenue_translation_key}.REVENUE_NAME`).localeCompare(
-          t(`revenue:${typeB.revenue_translation_key}.REVENUE_NAME`),
-        ),
-      ),
-      ...customTypes.sort((typeA, typeB) =>
-        typeA.revenue_translation_key.localeCompare(typeB.revenue_translation_key),
-      ),
+    const sortedTypes = [
+      ...allTypes.sort((typeA, typeB) => {
+        const compareKeyA =
+          typeA.farm_id === null
+            ? t(`revenue:${typeA.revenue_translation_key}.REVENUE_NAME`)
+            : typeA.revenue_translation_key;
+
+        const compareKeyB =
+          typeB.farm_id === null
+            ? t(`revenue:${typeB.revenue_translation_key}.REVENUE_NAME`)
+            : typeB.revenue_translation_key;
+
+        return compareKeyA.localeCompare(compareKeyB);
+      }),
     ];
 
-    setSortedTypes(allTypes);
+    setSortedTypes(sortedTypes);
   }, [revenueTypes]);
 
   return sortedtypes;

--- a/packages/webapp/src/containers/Finances/Report/index.jsx
+++ b/packages/webapp/src/containers/Finances/Report/index.jsx
@@ -26,8 +26,7 @@ import TransactionFilterContent from '../../Filter/Transactions';
 import { EXPENSE_TYPE, REVENUE_TYPE } from '../../Filter/constants';
 import { transactionsFilterSelector } from '../../filterSlice';
 import { downloadFinanceReport } from '../saga';
-import { allExpenseTypeSelector, dateRangeDataSelector, sortExpenseTypes } from '../selectors';
-import useSortedRevenueTypes from '../AddSale/RevenueTypes/useSortedRevenueTypes';
+import { allExpenseTypeSelector, dateRangeDataSelector } from '../selectors';
 import useTransactions from '../useTransactions';
 import styles from './styles.module.scss';
 import { useCurrencySymbol } from '../../hooks/useCurrencySymbol';
@@ -39,14 +38,15 @@ import {
   formatTransactions,
   createDefaultTypeFilter,
 } from './reportFormattingUtils';
+import { allRevenueTypesSelector } from '../../revenueTypeSlice';
 
 const Report = () => {
   const { t } = useTranslation();
 
   const dashboardDateFilter = useSelector(dateRangeDataSelector);
   const dashboardTypesFilter = useSelector(transactionsFilterSelector);
-  const expenseTypes = sortExpenseTypes(useSelector(allExpenseTypeSelector));
-  const revenueTypes = useSortedRevenueTypes({ selectorType: 'all' });
+  const expenseTypes = useSelector(allExpenseTypeSelector);
+  const revenueTypes = useSelector(allRevenueTypesSelector);
 
   const [isExportReportOpen, setIsExportReportOpen] = useState(false);
   const [dateFilter, setDateFilter] = useState(dashboardDateFilter);

--- a/packages/webapp/src/containers/Finances/Report/reportFormattingUtils.js
+++ b/packages/webapp/src/containers/Finances/Report/reportFormattingUtils.js
@@ -57,7 +57,7 @@ export const createDefaultTypeFilter = ({ types, translate, typeCategory }) => {
   const retiredKey = `${typeCategory}_RETIRED`;
   const TYPE_CATEGORY = typeCategory.toUpperCase();
 
-  let filterObject = types.reduce(
+  const filterObject = types.reduce(
     (filterObject, type) => ({
       ...filterObject,
       [type[typeIdKey]]: {
@@ -78,9 +78,9 @@ export const createDefaultTypeFilter = ({ types, translate, typeCategory }) => {
   }
 
   // Sort the config object by label
-  filterObject = Object.fromEntries(
+  const sortedFilterObject = Object.fromEntries(
     Object.entries(filterObject).sort((a, b) => a[1].label.localeCompare(b[1].label)),
   );
 
-  return filterObject;
+  return sortedFilterObject;
 };

--- a/packages/webapp/src/containers/Finances/Report/reportFormattingUtils.js
+++ b/packages/webapp/src/containers/Finances/Report/reportFormattingUtils.js
@@ -43,7 +43,7 @@ export const formatTransactions = (transactions, t) =>
   }));
 
 /**
- * Constructs a filter object for given types (either expense or revenue).
+ * Constructs a sorted filter object for given types (either expense or revenue).
  *
  * @param {Array} types - Array of type objects
  * @param {Function} translate - Translation function from i18next-react
@@ -54,15 +54,19 @@ export const createDefaultTypeFilter = ({ types, translate, typeCategory }) => {
   const typeIdKey = `${typeCategory}_type_id`;
   const nameKey = `${typeCategory}_name`;
   const translationKey = `${typeCategory}_translation_key`;
+  const retiredKey = `${typeCategory}_RETIRED`;
+  const TYPE_CATEGORY = typeCategory.toUpperCase();
 
-  const filterObject = types.reduce(
+  let filterObject = types.reduce(
     (filterObject, type) => ({
       ...filterObject,
       [type[typeIdKey]]: {
         active: true,
-        label: type.farm_id
-          ? type[nameKey]
-          : translate(`${typeCategory}:${type[translationKey]}.${typeCategory.toUpperCase()}_NAME`),
+        label:
+          (type.farm_id
+            ? type[nameKey]
+            : translate(`${typeCategory}:${type[translationKey]}.${TYPE_CATEGORY}_NAME`)) +
+          (type.retired ? ` ${translate(`${TYPE_CATEGORY}.EDIT_${TYPE_CATEGORY}.RETIRED`)}` : ''),
       },
     }),
     {},
@@ -72,6 +76,11 @@ export const createDefaultTypeFilter = ({ types, translate, typeCategory }) => {
   if (typeCategory === 'expense') {
     filterObject['LABOUR'] = { active: true, label: translate('SALE.FINANCES.LABOUR_LABEL') };
   }
+
+  // Sort the config object by label
+  filterObject = Object.fromEntries(
+    Object.entries(filterObject).sort((a, b) => a[1].label.localeCompare(b[1].label)),
+  );
 
   return filterObject;
 };

--- a/packages/webapp/src/containers/Finances/selectors.js
+++ b/packages/webapp/src/containers/Finances/selectors.js
@@ -53,24 +53,21 @@ const expenseTypeByIdSelector = (expense_type_id) => {
 };
 
 export const sortExpenseTypes = (expenseTypes) => {
-  const defaultTypes = [];
-  const customTypes = [];
+  const allTypes = expenseTypes ?? [];
 
-  expenseTypes?.forEach((type) => {
-    const arrayToUpdate = type.farm_id ? customTypes : defaultTypes;
-    arrayToUpdate.push(type);
+  return [...allTypes].sort((typeA, typeB) => {
+    const compareKeyA =
+      typeA.farm_id === null
+        ? i18n.t(`expense:${typeA.expense_translation_key}.EXPENSE_NAME`)
+        : typeA.expense_translation_key;
+
+    const compareKeyB =
+      typeB.farm_id === null
+        ? i18n.t(`expense:${typeB.expense_translation_key}.EXPENSE_NAME`)
+        : typeB.expense_translation_key;
+
+    return compareKeyA.localeCompare(compareKeyB);
   });
-
-  return [
-    ...defaultTypes.sort((typeA, typeB) =>
-      i18n
-        .t(`expense:${typeA.expense_translation_key}.EXPENSE_NAME`)
-        .localeCompare(i18n.t(`expense:${typeB.expense_translation_key}.EXPENSE_NAME`)),
-    ),
-    ...customTypes.sort((typeA, typeB) =>
-      typeA.expense_translation_key.localeCompare(typeB.expense_translation_key),
-    ),
-  ];
 };
 
 const allExpenseTypeTileContentsSelector = createSelector(financeSelector, (state) => {


### PR DESCRIPTION
**Description**

This PR:
- Adds the 'retired' suffix to the filter pills (and the list of selected filters in the Excel report settings worksheet)
- Sorts all expense and revenue types (in type selection, filters, and report settings) completely alphabetically, rather than default > custom

Jira link: https://lite-farm.atlassian.net/browse/LF-3815

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
