### PR TITLE
LF-3423: disallow abandoning completed plan and viceversa

### DIFF
--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -13,26 +13,30 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import ManagementPlanModel from '../models/managementPlanModel.js';
-import ManagementPlanGroup from '../models/managementPlanGroupModel.js';
+import _pick from 'lodash/pick.js';
+import objection, { raw } from 'objection';
+import {
+  CANNOT_ABANDON_COMPLETED_PLAN,
+  CANNOT_COMPLETE_ABANDONED_PLAN,
+} from '../../../shared/constants/error.js';
 import CropManagementPlanModel from '../models/cropManagementPlanModel.js';
+import FieldWorkTypeModel from '../models/fieldWorkTypeModel.js';
+import ManagementPlanGroup from '../models/managementPlanGroupModel.js';
+import ManagementPlanModel from '../models/managementPlanModel.js';
 import ManagementTasksModel from '../models/managementTasksModel.js';
+import PlantTaskModel from '../models/plantTaskModel.js';
 import TaskModel from '../models/taskModel.js';
 import TaskTypeModel from '../models/taskTypeModel.js';
-import FieldWorkTypeModel from '../models/fieldWorkTypeModel.js';
 import TransplantTaskModel from '../models/transplantTaskModel.js';
-import PlantTaskModel from '../models/plantTaskModel.js';
 import UserFarmModel from '../models/userFarmModel.js';
-import objection, { raw } from 'objection';
-import _pick from 'lodash/pick.js';
-import knex from '../util/knex.js';
-import { sendTaskNotification, TaskNotificationTypes } from './taskController.js';
 import {
   getDatesFromManagementPlanGraph,
-  getManagementPlanGroupTemplateGraph,
   getFormattedManagementPlanData,
+  getManagementPlanGroupTemplateGraph,
 } from '../util/copyCropPlan.js';
+import knex from '../util/knex.js';
 import { getSortedDates } from '../util/util.js';
+import { TaskNotificationTypes, sendTaskNotification } from './taskController.js';
 const { transaction, Model } = objection;
 
 const managementPlanController = {
@@ -458,10 +462,24 @@ const managementPlanController = {
   completeManagementPlan() {
     return async (req, res) => {
       try {
+        const managementPlan = await ManagementPlanModel.query()
+          .context(req.auth)
+          .where({ management_plan_id: req.params.management_plan_id, deleted: false })
+          .first();
+
+        if (!managementPlan) {
+          return res.status(404).send('Management plan not found');
+        }
+
+        if (managementPlan.abandon_date) {
+          return res.status(400).send(CANNOT_COMPLETE_ABANDONED_PLAN);
+        }
+
         const result = await ManagementPlanModel.query()
           .context(req.auth)
           .where({ management_plan_id: req.params.management_plan_id })
           .patch(_pick(req.body, ['complete_date', 'complete_notes', 'rating']));
+
         if (result) {
           return res.sendStatus(200);
         } else {
@@ -491,6 +509,10 @@ const managementPlanController = {
 
         if (!managementPlan) {
           return res.status(404).send('Management plan not found');
+        }
+
+        if (managementPlan.complete_date) {
+          return res.status(400).send(CANNOT_ABANDON_COMPLETED_PLAN);
         }
 
         const result = await ManagementPlanModel.transaction(async (trx) => {

--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -472,7 +472,7 @@ const managementPlanController = {
         }
 
         if (managementPlan.abandon_date) {
-          return res.status(400).send(CANNOT_COMPLETE_ABANDONED_PLAN);
+          return res.status(409).send(CANNOT_COMPLETE_ABANDONED_PLAN);
         }
 
         const result = await ManagementPlanModel.query()
@@ -512,7 +512,7 @@ const managementPlanController = {
         }
 
         if (managementPlan.complete_date) {
-          return res.status(400).send(CANNOT_ABANDON_COMPLETED_PLAN);
+          return res.status(409).send(CANNOT_ABANDON_COMPLETED_PLAN);
         }
 
         const result = await ManagementPlanModel.transaction(async (trx) => {

--- a/packages/shared/constants/error.js
+++ b/packages/shared/constants/error.js
@@ -1,0 +1,2 @@
+export const CANNOT_COMPLETE_ABANDONED_PLAN = "Cannot complete management plan with an abandon date"
+export const CANNOT_ABANDON_COMPLETED_PLAN = "Cannot abandon management plan with a complete date"

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1036,7 +1036,7 @@
   "MANAGEMENT_PLAN": {
     "ABANDON": {
       "CANT_ABANDON_COMPLETED": "Can't abandon crop plan",
-      "CANT_ABANDON_CONCURRENT_USER": "Another farmer has completed this plan. Please refresh the page to get the most recent status."
+      "CANT_ABANDON_CONCURRENT_USER": "Another farmer has completed this plan. Please navigate back to get the most recent status for plans."
     },
     "ABANDON_MANAGEMENT_PLAN_CONTENT": "Abandoning this crop plan will abandon all the incomplete tasks associated with it and remove it from your farm map.",
     "ABANDON_MANAGEMENT_PLAN_TITLE": "Abandon crop plan?",
@@ -1051,7 +1051,7 @@
       "ABANDON_PLAN": "Abandon plan",
       "ABANDON_REASON": "Reason for abandoning",
       "CANT_COMPLETE_ABANDONED": "Can't complete crop plan",
-      "CANT_COMPLETE_CONCURRENT_USER": "Another farmer has abandoned this plan. Please refresh the page to get the most recent status.",
+      "CANT_COMPLETE_CONCURRENT_USER": "Another farmer has abandoned this plan. Please navigate back to get the most recent status for plans.",
       "COMPLETE_PLAN": "Complete plan",
       "DATE_OF_CHANGE": "Date of status change",
       "FUTURE_DATE_INVALID": "May not be in the future",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1034,6 +1034,10 @@
     "TASKS": "Tasks"
   },
   "MANAGEMENT_PLAN": {
+    "ABANDON": {
+      "CANT_ABANDON_COMPLETED": "Can't abandon crop plan",
+      "CANT_ABANDON_CONCURRENT_USER": "Another farmer has completed this plan. Please refresh the page to get the most recent status."
+    },
     "ABANDON_MANAGEMENT_PLAN_CONTENT": "Abandoning this crop plan will abandon all the incomplete tasks associated with it and remove it from your farm map.",
     "ABANDON_MANAGEMENT_PLAN_TITLE": "Abandon crop plan?",
     "ADD_MANAGEMENT_PLAN": "Add a crop plan",
@@ -1046,6 +1050,8 @@
       "ABANDON_NOTES": "Abandonment notes",
       "ABANDON_PLAN": "Abandon plan",
       "ABANDON_REASON": "Reason for abandoning",
+      "CANT_COMPLETE_ABANDONED": "Can't complete crop plan",
+      "CANT_COMPLETE_CONCURRENT_USER": "Another farmer has abandoned this plan. Please refresh the page to get the most recent status.",
       "COMPLETE_PLAN": "Complete plan",
       "DATE_OF_CHANGE": "Date of status change",
       "FUTURE_DATE_INVALID": "May not be in the future",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -496,7 +496,7 @@
       "CUSTOM_EXPENSE_NAME": "Nombre del gasto personalizado",
       "CUSTOM_EXPENSE_TYPE": "Tipo de gasto personalizado",
       "DUPLICATE_NAME": "Ya existe un tipo de gasto con este nombre. Por favor, elija uno diferente.",
-      "DUPLICATE_NAME_RETIRED": "MISSING",
+      "DUPLICATE_NAME_RETIRED": "Ya existe un tipo de gasto retirado con este nombre. Por favor, elija uno diferente.",
       "FLOW": "creación de gasto",
       "MANAGE_CUSTOM_EXPENSE_TYPE": "Administrar tipos de gasto personalizados",
       "NEW_EXPENSE_ITEM": "Nuevo gasto",
@@ -837,10 +837,10 @@
     },
     "MANAGE_CUSTOM_TYPE": "Administrar tipos personalizados",
     "REPORT": {
-      "DATES": "MISSING",
-      "SETTINGS": "MISSING",
-      "TRANSACTION": "MISSING",
-      "TRANSACTIONS": "MISSING"
+      "DATES": "Fechas",
+      "SETTINGS": "Configuración del reporte",
+      "TRANSACTION": "Transacción",
+      "TRANSACTIONS": "Transacciones"
     },
     "REVENUE": "Ingresos",
     "SEARCH": {
@@ -1035,6 +1035,10 @@
     "TASKS": "Tareas"
   },
   "MANAGEMENT_PLAN": {
+    "ABANDON": {
+      "CANT_ABANDON_COMPLETED": "No se puede abandonar el plan de cultivo",
+      "CANT_ABANDON_CONCURRENT_USER": "Otro usuario ha completado este plan. Por favor, refresque la página para obtener su estado más reciente."
+    },
     "ABANDON_MANAGEMENT_PLAN_CONTENT": "Abandonar este plan de cultivo abandonará todas las tareas incompletas asociadas con él y lo eliminará del mapa de su granja.",
     "ABANDON_MANAGEMENT_PLAN_TITLE": "Quiere abandonar el plan de cultivo?",
     "ADD_MANAGEMENT_PLAN": "Agregar un plan de cultivo",
@@ -1047,6 +1051,8 @@
       "ABANDON_NOTES": "Notas de abandono",
       "ABANDON_PLAN": "Abandonar plan",
       "ABANDON_REASON": "Razón para abandonar",
+      "CANT_COMPLETE_ABANDONED": "No se puede completar el plan de cultivo",
+      "CANT_COMPLETE_CONCURRENT_USER": "Otro usuario ha abandonado este plan. Por favor, refresque la página para obtener su estado más reciente.",
       "COMPLETE_PLAN": "Completar plan",
       "DATE_OF_CHANGE": "Fecha de cambio de estado",
       "FUTURE_DATE_INVALID": "No puede ser en el futuro",
@@ -1078,7 +1084,7 @@
     "DELETE": {
       "CANT_DELETE_ABANDON": "Abandonar",
       "CANT_DELETE_ABANDON_INSTEAD": "¿Desea abandonar en lugar de eliminar?",
-      "CANT_DELETE_CONCURRENT_USER": "MISSING",
+      "CANT_DELETE_CONCURRENT_USER": "Otro usuario ha abandonado o completado una tarea en este plan. Por favor, refresque la página para obtener su estado más reciente.",
       "CANT_DELETE_MODIFIED_PLAN": "No se puede eliminar el plan de cultivo",
       "CONFIRM_DELETION": "Confirmar eliminación",
       "DELETE_PLAN": "Eliminar plan de cultivo",
@@ -1423,7 +1429,7 @@
       "CUSTOM_REVENUE_NAME": "Nombre de ingreso personalizado",
       "CUSTOM_REVENUE_TYPE": "Tipo de ingreso personalizado",
       "DUPLICATE_NAME": "Ya existe un tipo de ingreso con este nombre. Por favor, elija uno diferente.",
-      "DUPLICATE_NAME_RETIRED": "MISSING"
+      "DUPLICATE_NAME_RETIRED": "Ya existe un tipo de ingreso retirado con este nombre. Por favor, elija uno diferente."
     },
     "CUSTOM_REVENUE_DESCRIPTION": "Descripción de tipo de ingreso personalizado",
     "DELETE": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1037,7 +1037,7 @@
   "MANAGEMENT_PLAN": {
     "ABANDON": {
       "CANT_ABANDON_COMPLETED": "No se puede abandonar el plan de cultivo",
-      "CANT_ABANDON_CONCURRENT_USER": "Otro usuario ha completado este plan. Por favor, refresque la página para obtener su estado más reciente."
+      "CANT_ABANDON_CONCURRENT_USER": "Otro usuario ha completado este plan. Por favor, navegue hacia atrás para obtener el estado más reciente de sus planes."
     },
     "ABANDON_MANAGEMENT_PLAN_CONTENT": "Abandonar este plan de cultivo abandonará todas las tareas incompletas asociadas con él y lo eliminará del mapa de su granja.",
     "ABANDON_MANAGEMENT_PLAN_TITLE": "Quiere abandonar el plan de cultivo?",
@@ -1052,7 +1052,7 @@
       "ABANDON_PLAN": "Abandonar plan",
       "ABANDON_REASON": "Razón para abandonar",
       "CANT_COMPLETE_ABANDONED": "No se puede completar el plan de cultivo",
-      "CANT_COMPLETE_CONCURRENT_USER": "Otro usuario ha abandonado este plan. Por favor, refresque la página para obtener su estado más reciente.",
+      "CANT_COMPLETE_CONCURRENT_USER": "Otro usuario ha abandonado este plan. Por favor, navegue hacia atrás para obtener su estado más reciente de sus planes.",
       "COMPLETE_PLAN": "Completar plan",
       "DATE_OF_CHANGE": "Fecha de cambio de estado",
       "FUTURE_DATE_INVALID": "No puede ser en el futuro",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -836,6 +836,12 @@
       "REVENUE_TYPE": "Types de revenu",
       "TITLE": "Filtrer les transactions"
     },
+    "REPORT": {
+      "DATES": "MISSING",
+      "SETTINGS": "MISSING",
+      "TRANSACTION": "MISSING",
+      "TRANSACTIONS": "MISSING"
+    },
     "REVENUE": "Revenu",
     "SEARCH": {
       "EXPENSE_TYPES": "Rechercher un type de dépense",
@@ -1029,6 +1035,10 @@
     "TASKS": "Tâches"
   },
   "MANAGEMENT_PLAN": {
+    "ABANDON": {
+      "CANT_ABANDON_COMPLETED": "MISSING",
+      "CANT_ABANDON_CONCURRENT_USER": "MISSING"
+    },
     "ABANDON_MANAGEMENT_PLAN_CONTENT": "Abandonner ce plan de culture abandonnera toutes les tâches incomplètes qui lui sont associées et le supprimera de votre carte de ferme.",
     "ABANDON_MANAGEMENT_PLAN_TITLE": "Abandonner le plan de culture\u00a0?",
     "ADD_MANAGEMENT_PLAN": "Ajouter un plan de culture",
@@ -1041,6 +1051,8 @@
       "ABANDON_NOTES": "Notes d'abandon",
       "ABANDON_PLAN": "Abandonner le plan",
       "ABANDON_REASON": "Raison de l'abandon",
+      "CANT_COMPLETE_ABANDONED": "MISSING",
+      "CANT_COMPLETE_CONCURRENT_USER": "MISSING",
       "COMPLETE_PLAN": "Plan terminé",
       "DATE_OF_CHANGE": "Date de changement de statut",
       "FUTURE_DATE_INVALID": "Doit être révolue",
@@ -1155,13 +1167,13 @@
     "SELECT_CURRENT_LOCATION": "Sélectionnez l'emplacement actuel de la culture",
     "SELECTED_STARTING_LOCATION": "Sélectionnez toujours ceci comme emplacement de départ pour les cultures qui seront transplantées",
     "SPOTLIGHT_HERE_YOU_CAN": "Ici, vous pouvez\u00a0:",
+    "STARTED": "Commencé",
     "STATUS": {
       "ABANDONED": "Abandonné",
       "ACTIVE": "Actif",
       "COMPLETED": "Terminé",
       "PLANNED": "Planifié"
     },
-    "STARTED": "Commencé",
     "SUPPLIER": "Fournisseur",
     "TERMINATION": "clôture",
     "TERMINATION_DATE": "Quand voulez vous clôturer cette culture\u00a0?",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -835,6 +835,12 @@
       "REVENUE_TYPE": "Tipos de receita",
       "TITLE": "Filtrar transações"
     },
+    "REPORT": {
+      "DATES": "MISSING",
+      "SETTINGS": "MISSING",
+      "TRANSACTION": "MISSING",
+      "TRANSACTIONS": "MISSING"
+    },
     "REVENUE": "Receita",
     "SEARCH": {
       "EXPENSE_TYPES": "Procurar tipo de despesa",
@@ -1028,6 +1034,10 @@
     "TASKS": "Tarefas"
   },
   "MANAGEMENT_PLAN": {
+    "ABANDON": {
+      "CANT_ABANDON_COMPLETED": "MISSING",
+      "CANT_ABANDON_CONCURRENT_USER": "MISSING"
+    },
     "ABANDON_MANAGEMENT_PLAN_CONTENT": "Abandonar este plano de cultivo ira abandonar todas as tarefas incompletas associadas a ele e removê-lo do mapa de sua propriedade",
     "ABANDON_MANAGEMENT_PLAN_TITLE": "Abandonar plano de cultivo?",
     "ADD_MANAGEMENT_PLAN": "Adicionar um plano de cultivo",
@@ -1040,6 +1050,8 @@
       "ABANDON_NOTES": "Notas de abandono",
       "ABANDON_PLAN": "Abandonar plano",
       "ABANDON_REASON": "Razão do abandono",
+      "CANT_COMPLETE_ABANDONED": "MISSING",
+      "CANT_COMPLETE_CONCURRENT_USER": "MISSING",
       "COMPLETE_PLAN": "Completar plano",
       "DATE_OF_CHANGE": "Data de alteração da situação",
       "FUTURE_DATE_INVALID": "Pode não ser no futuro",

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -1,20 +1,22 @@
-import Form from '../../Form';
-import CropHeader from '../CropHeader';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import Button from '../../Form/Button';
 import { useTranslation } from 'react-i18next';
-import { Title } from '../../Typography';
-import ReactSelect from '../../Form/ReactSelect';
-import Rating from '../../Rating';
-import InputAutoSize from '../../Form/InputAutoSize';
-import Input, { getInputErrors } from '../../Form/Input';
-import { StatusLabel } from '../../CardWithStatus/StatusLabel';
-import { managementPlanStatusTranslateKey } from '../../CardWithStatus/ManagementPlanCard/ManagementPlanCard';
-import { getDateInputFormat } from '../../../util/moment';
-import AbandonManagementPlanModal from '../../Modals/AbandonManagementPlanModal';
 import i18n from '../../../locales/i18n';
+import { getDateInputFormat } from '../../../util/moment';
+import { managementPlanStatusTranslateKey } from '../../CardWithStatus/ManagementPlanCard/ManagementPlanCard';
+import { StatusLabel } from '../../CardWithStatus/StatusLabel';
+import Form from '../../Form';
+import Button from '../../Form/Button';
+import Input, { getInputErrors } from '../../Form/Input';
 import { isNotInFuture } from '../../Form/Input/utils';
+import InputAutoSize from '../../Form/InputAutoSize';
+import ReactSelect from '../../Form/ReactSelect';
+import AbandonManagementPlanModal from '../../Modals/AbandonManagementPlanModal';
+import UnableToAbandonPlanModal from '../../Modals/UnableToAbandonPlanModal';
+import UnableToCompletePlanModal from '../../Modals/UnableToCompletePlanModal';
+import Rating from '../../Rating';
+import { Title } from '../../Typography';
+import CropHeader from '../CropHeader';
 
 export const SOMETHING_ELSE = 'Something Else';
 export const defaultAbandonManagementPlanReasonOptions = [
@@ -64,11 +66,20 @@ export function PureCompleteManagementPlan({
   const CREATED_ABANDON_REASON = 'created_abandon_reason';
 
   const [showAbandonModal, setShowAbandonModal] = useState(false);
+  const [showCannotCompleteModal, setShowCannotCompleteModal] = useState(false);
+  const [showCannotAbandonModal, setShowCannotAbandonModal] = useState(false);
 
   const completed = status === 'completed';
   const abandoned = status === 'abandoned';
 
   const disabled = !isValid;
+
+  const displayCannotAbandonModal = () => {
+    setShowAbandonModal(false);
+    setShowCannotAbandonModal(true);
+  };
+
+  const displayCannotCompleteModal = () => setShowCannotCompleteModal(true);
 
   return (
     <Form
@@ -79,7 +90,11 @@ export function PureCompleteManagementPlan({
           </Button>
         )
       }
-      onSubmit={handleSubmit(isAbandonPage ? () => setShowAbandonModal(true) : onSubmit)}
+      onSubmit={handleSubmit(
+        isAbandonPage
+          ? () => setShowAbandonModal(true)
+          : (data) => onSubmit(data, displayCannotCompleteModal),
+      )}
     >
       <CropHeader variety={crop_variety} onBackClick={onGoBack} />
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -176,8 +191,14 @@ export function PureCompleteManagementPlan({
       {showAbandonModal && isAbandonPage && (
         <AbandonManagementPlanModal
           dismissModal={() => setShowAbandonModal(false)}
-          onAbandon={() => onSubmit(getValues())}
+          onAbandon={() => onSubmit(getValues(), displayCannotAbandonModal)}
         />
+      )}
+      {showCannotAbandonModal && (
+        <UnableToAbandonPlanModal dismissModal={() => setShowCannotAbandonModal(false)} />
+      )}
+      {showCannotCompleteModal && (
+        <UnableToCompletePlanModal dismissModal={() => setShowCannotCompleteModal(false)} />
       )}
     </Form>
   );

--- a/packages/webapp/src/components/Modals/UnableToAbandonPlanModal/index.jsx
+++ b/packages/webapp/src/components/Modals/UnableToAbandonPlanModal/index.jsx
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useTranslation } from 'react-i18next';
+import ModalComponent from '../ModalComponent/v2';
+
+export default function UnableToAbandonPlanModal({ dismissModal }) {
+  const { t } = useTranslation();
+  return (
+    <ModalComponent
+      title={t('MANAGEMENT_PLAN.ABANDON.CANT_ABANDON_COMPLETED')}
+      contents={[t('MANAGEMENT_PLAN.ABANDON.CANT_ABANDON_CONCURRENT_USER')]}
+      dismissModal={dismissModal}
+      error
+    />
+  );
+}

--- a/packages/webapp/src/components/Modals/UnableToCompletePlanModal/index.jsx
+++ b/packages/webapp/src/components/Modals/UnableToCompletePlanModal/index.jsx
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useTranslation } from 'react-i18next';
+import ModalComponent from '../ModalComponent/v2';
+
+export default function UnableToCompletePlanModal({ dismissModal }) {
+  const { t } = useTranslation();
+  return (
+    <ModalComponent
+      title={t('MANAGEMENT_PLAN.COMPLETE_PLAN.CANT_COMPLETE_ABANDONED')}
+      contents={[t('MANAGEMENT_PLAN.COMPLETE_PLAN.CANT_COMPLETE_CONCURRENT_USER')]}
+      dismissModal={dismissModal}
+      error
+    />
+  );
+}

--- a/packages/webapp/src/containers/Crop/CompleteManagementPlan/AbandonManagementPlan.jsx
+++ b/packages/webapp/src/containers/Crop/CompleteManagementPlan/AbandonManagementPlan.jsx
@@ -1,15 +1,15 @@
+import { useDispatch, useSelector } from 'react-redux';
 import {
   PureCompleteManagementPlan,
   SOMETHING_ELSE,
 } from '../../../components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan';
-import { useDispatch, useSelector } from 'react-redux';
 import { cropVarietySelector } from '../../cropVarietySlice';
+import {
+  managementPlanByManagementPlanIDSelector,
+  managementPlanSelector,
+} from '../../managementPlanSlice';
 import { abandonManagementPlan } from './saga';
 import { useAbandonReasonOptions } from './useAbandonReasonOptions';
-import {
-  managementPlanSelector,
-  managementPlanByManagementPlanIDSelector,
-} from '../../managementPlanSlice';
 
 export default function AbandonManagementPlan({ match, history, location }) {
   const management_plan_id = match.params.management_plan_id;
@@ -31,7 +31,7 @@ export default function AbandonManagementPlan({ match, history, location }) {
   const onGoBack = () => {
     history.push(`/crop/${crop_variety_id}/management`, location?.state);
   };
-  const onSubmit = (data) => {
+  const onSubmit = (data, displayCannotAbandonModal) => {
     const reqBody = {
       crop_variety_id,
       management_plan_id,
@@ -43,7 +43,7 @@ export default function AbandonManagementPlan({ match, history, location }) {
           : data.abandon_reason.value,
     };
 
-    dispatch(abandonManagementPlan(reqBody));
+    dispatch(abandonManagementPlan({ displayCannotAbandonModal, ...reqBody }));
   };
   return (
     <PureCompleteManagementPlan

--- a/packages/webapp/src/containers/Crop/CompleteManagementPlan/CompleteManagementPlan.jsx
+++ b/packages/webapp/src/containers/Crop/CompleteManagementPlan/CompleteManagementPlan.jsx
@@ -1,11 +1,11 @@
-import { PureCompleteManagementPlan } from '../../../components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan';
 import { useDispatch, useSelector } from 'react-redux';
+import { PureCompleteManagementPlan } from '../../../components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan';
 import { cropVarietySelector } from '../../cropVarietySlice';
-import { completeManagementPlan } from './saga';
 import {
-  managementPlanSelector,
   managementPlanByManagementPlanIDSelector,
+  managementPlanSelector,
 } from '../../managementPlanSlice';
+import { completeManagementPlan } from './saga';
 
 export default function CompleteManagementPlan({ match, history, location }) {
   const management_plan_id = match.params.management_plan_id;
@@ -28,8 +28,15 @@ export default function CompleteManagementPlan({ match, history, location }) {
       location?.state,
     );
   };
-  const onSubmit = (data) => {
-    dispatch(completeManagementPlan({ crop_variety_id, management_plan_id, ...data }));
+  const onSubmit = (data, displayCannotCompleteModal) => {
+    dispatch(
+      completeManagementPlan({
+        displayCannotCompleteModal,
+        crop_variety_id,
+        management_plan_id,
+        ...data,
+      }),
+    );
   };
   return (
     <PureCompleteManagementPlan

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import mdx from '@mdx-js/rollup';
-import svgrPlugin from 'vite-plugin-svgr';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { defineConfig } from 'vite';
 import IstanbulPlugin from 'vite-plugin-istanbul';
 import { VitePWA } from 'vite-plugin-pwa';
+import svgrPlugin from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -36,5 +37,10 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+  },
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
   },
 });


### PR DESCRIPTION
**Description**

Fixed concurrency issue where if a user completes a crop plan and the other one tries to abandon it without reloading the screen, or vice versa, we should prevent this from happening and show an error modal.

Jira link:

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested locally by attempting the concurrent completing/abandoning with two different accounts.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
