### PR TITLE
LF-3817 Unmount PureEnterPasswordPage when visibility changes

### DIFF
--- a/packages/webapp/src/containers/CustomSignUp/index.jsx
+++ b/packages/webapp/src/containers/CustomSignUp/index.jsx
@@ -149,6 +149,7 @@ function CustomSignUp() {
             forgotPassword={forgotPassword}
             isChrome={isChrome()}
             isVisible={showPureEnterPasswordPage}
+            key={showPureEnterPasswordPage} // unmount the component when visibility is changed
           />
           {showResetModal && <ResetPassword email={email} dismissModal={dismissModal} />}
         </Hidden>


### PR DESCRIPTION
**Description**

Small fix to unmount the `<PureEnterPasswordPage />` component when its visibility is toggled.

Jira link: https://lite-farm.atlassian.net/browse/LF-3817

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
