### PR TITLE
Lf 2200 allow the user to upload a custom image for the lf homepage background

### DIFF
--- a/packages/webapp/src/components/Home/home.module.scss
+++ b/packages/webapp/src/components/Home/home.module.scss
@@ -5,6 +5,16 @@
   background-size: cover;
   background-position: center;
   flex: 1;
+  animation: fade 0.5s linear;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .title {

--- a/packages/webapp/src/containers/Home/index.jsx
+++ b/packages/webapp/src/containers/Home/index.jsx
@@ -17,19 +17,22 @@ import {
 
 import PreparingExportModal from '../../components/Modals/PreparingExportModal';
 import { getAlert } from '../Navigation/Alert/saga.js';
+import useMediaWithAuthentication from '../hooks/useMediaWithAuthentication';
 
 export default function Home({ history }) {
   const { t } = useTranslation();
   const userFarm = useSelector(userFarmSelector);
-  const imgUrl = getSeason(userFarm?.grid_points?.lat);
+  const defaultImageUrl = getSeason(userFarm?.grid_points?.lat);
   const { showSpotLight, showExportModal } = useSelector(chooseFarmFlowSelector);
   const dispatch = useDispatch();
   const showSwitchFarmModal = useSelector(switchFarmSelector);
   const dismissPopup = () => dispatch(endSwitchFarmModal(userFarm.farm_id));
   const dismissExportModal = () => dispatch(endExportModal(userFarm.farm_id));
-
   const showHelpRequestModal = useSelector(showHelpRequestModalSelector);
   const showRequestConfirmationModalOnClick = () => dispatch(dismissHelpRequestModal());
+  const { mediaUrl: authenticatedImageUrl, isLoading } = useMediaWithAuthentication({
+    fileUrls: [userFarm.farm_image_url],
+  });
 
   useEffect(() => {
     dispatch(getAlert());
@@ -39,7 +42,7 @@ export default function Home({ history }) {
     <PureHome
       greeting={t('HOME.GREETING')}
       first_name={userFarm?.first_name}
-      imgUrl={userFarm.farm_image_url || imgUrl}
+      imgUrl={authenticatedImageUrl || (isLoading ? '' : defaultImageUrl)}
     >
       {userFarm ? <WeatherBoard /> : null}
       {showSwitchFarmModal && !showSpotLight && <FarmSwitchOutro onFinish={dismissPopup} />}

--- a/packages/webapp/src/containers/hooks/useMediaWithAuthentication.js
+++ b/packages/webapp/src/containers/hooks/useMediaWithAuthentication.js
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import JSZip from 'jszip';
+import { useEffect, useState } from 'react';
+import { mediaEnum } from '../MediaWithAuthentication/constants';
+
+export default function useMediaWithAuthentication({
+  fileUrls = [],
+  title = '',
+  extensionName = '',
+  mediaType = mediaEnum.IMAGE,
+}) {
+  const [mediaUrl, setMediaUrl] = useState();
+  const [zipContent, setZipContent] = useState();
+
+  useEffect(() => {
+    const config = {
+      headers: {
+        Authorization: 'Bearer ' + localStorage.getItem('farm_token'),
+      },
+      responseType: 'arraybuffer',
+      method: 'GET',
+    };
+    let subscribed;
+
+    const fetchMediaUrls = async () => {
+      try {
+        subscribed = true;
+        if (mediaType === mediaEnum.ZIP) {
+          const zip = new JSZip();
+          const folder = zip.folder(title);
+
+          await Promise.all(
+            fileUrls.map(async (fileUrl) => {
+              const url = new URL(fileUrl);
+              if (import.meta.env.VITE_ENV !== 'development') {
+                url.hostname = 'images.litefarm.workers.dev';
+              }
+              return fetch(url.toString(), config).then((response) => {
+                const blobFilePromise = response.blob();
+                folder.file(url.href.substring(url.href.lastIndexOf('/')), blobFilePromise);
+              });
+            }),
+          );
+          const content = await zip.generateAsync({ type: 'base64' });
+          subscribed && setZipContent(content);
+        } else {
+          const fileUrl = fileUrls[0];
+          if (fileUrl) {
+            if (import.meta.env.VITE_ENV === 'development') {
+              subscribed && setMediaUrl(fileUrl);
+            } else {
+              const url = new URL(fileUrl);
+              url.hostname = 'images.litefarm.workers.dev';
+              const response = await fetch(url.toString(), config);
+              const blobFile = await response.blob();
+              subscribed && setMediaUrl(URL.createObjectURL(blobFile));
+            }
+          }
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    fetchMediaUrls();
+    return () => (subscribed = false);
+  }, []);
+
+  return {
+    mediaUrl,
+    zipContent,
+  };
+}

--- a/packages/webapp/src/containers/hooks/useMediaWithAuthentication.js
+++ b/packages/webapp/src/containers/hooks/useMediaWithAuthentication.js
@@ -25,6 +25,7 @@ export default function useMediaWithAuthentication({
 }) {
   const [mediaUrl, setMediaUrl] = useState();
   const [zipContent, setZipContent] = useState();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const config = {
@@ -73,6 +74,8 @@ export default function useMediaWithAuthentication({
         }
       } catch (e) {
         console.log(e);
+      } finally {
+        setIsLoading(false);
       }
     };
     fetchMediaUrls();
@@ -82,5 +85,6 @@ export default function useMediaWithAuthentication({
   return {
     mediaUrl,
     zipContent,
+    isLoading,
   };
 }


### PR DESCRIPTION
**Description**

Fix for the image not appearing on home page after user uploads custom image.

**Changes**

Created a custom hook from the MediaWithAuthentication component so the url can be directly passed into PureFarm which sets the background image using css. Also added a fade transition to avoid the image popping in suddenly.

Jira link: https://lite-farm.atlassian.net/browse/LF-2200

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

This is hard to test locally because it relies on the cloudflare worker and thats only used in beta and production. 

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
