### PR TITLE
LF-3870: Search for expense does not work for all types

### DIFF
--- a/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/index.jsx
+++ b/packages/webapp/src/containers/Finances/AddSale/RevenueTypes/index.jsx
@@ -24,6 +24,7 @@ import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookF
 import { hookFormPersistSelector } from '../../../hooks/useHookFormPersist/hookFormPersistSlice';
 import ManageCustomRevenueTypesSpotlight from '../ManageCustomRevenueTypeSpotlight';
 import useSortedRevenueTypes from './useSortedRevenueTypes';
+import { getFinanceTypeSearchableStringFunc } from '../../util';
 
 export const icons = {
   CROP_SALE: <CropSaleIcon />,
@@ -34,15 +35,6 @@ export default function RevenueTypes({ useHookFormPersist, history }) {
   const { t } = useTranslation(['translation', 'revenue']);
   const revenueTypes = useSortedRevenueTypes();
   const persistedFormData = useSelector(hookFormPersistSelector);
-
-  const getSearchableString = (type) => {
-    const description =
-      type.farm_id === null
-        ? t(`revenue:${type.revenue_translation_key}.CUSTOM_DESCRIPTION`)
-        : type.custom_description;
-
-    return [type.revenue_name, description].filter(Boolean).join(' ');
-  };
 
   const getOnTileClickFunc = (setValue) => {
     return (typeId) => {
@@ -92,7 +84,7 @@ export default function RevenueTypes({ useHookFormPersist, history }) {
           info: t('FINANCES.CANT_FIND.INFO_REVENUE'),
           manage: t('FINANCES.CANT_FIND.MANAGE_REVENUE'),
         }}
-        getSearchableString={getSearchableString}
+        getSearchableString={getFinanceTypeSearchableStringFunc('revenue')}
         searchPlaceholderText={t('FINANCES.SEARCH.REVENUE_TYPES')}
         iconLinkId={'manageCustomRevenueType'}
         Wrapper={ManageCustomRevenueTypesSpotlight}

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
@@ -77,12 +77,15 @@ class ExpenseCategories extends Component {
   }
 
   getSearchableString = (type) => {
+    const expenseName =
+      type.farm_id === null
+        ? this.props.t(`expense:${type.expense_translation_key}.EXPENSE_NAME`)
+        : type.expense_name;
     const description =
       type.farm_id === null
         ? this.props.t(`expense:${type.expense_translation_key}.CUSTOM_DESCRIPTION`)
         : type.custom_description;
-
-    return [type.expense_name, description].filter(Boolean).join(' ');
+    return [expenseName, description].filter(Boolean).join(' ');
   };
 
   render() {

--- a/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
+++ b/packages/webapp/src/containers/Finances/NewExpense/ExpenseCategories/index.jsx
@@ -24,6 +24,7 @@ import PureFinanceTypeSelection from '../../../../components/Finances/PureFinanc
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
 import labelIconStyles from '../../../../components/Tile/styles.module.scss';
 import { listItemTypes } from '../../../../components/List/constants';
+import { getFinanceTypeSearchableStringFunc } from '../../util';
 
 export const icons = {
   EQUIPMENT: <EquipIcon />,
@@ -54,7 +55,6 @@ class ExpenseCategories extends Component {
 
     this.addRemoveType = this.addRemoveType.bind(this);
     this.nextPage = this.nextPage.bind(this);
-    this.getSearchableString = this.getSearchableString.bind(this);
   }
 
   nextPage(event) {
@@ -75,18 +75,6 @@ class ExpenseCategories extends Component {
       selectedTypes,
     });
   }
-
-  getSearchableString = (type) => {
-    const expenseName =
-      type.farm_id === null
-        ? this.props.t(`expense:${type.expense_translation_key}.EXPENSE_NAME`)
-        : type.expense_name;
-    const description =
-      type.farm_id === null
-        ? this.props.t(`expense:${type.expense_translation_key}.CUSTOM_DESCRIPTION`)
-        : type.custom_description;
-    return [expenseName, description].filter(Boolean).join(' ');
-  };
 
   render() {
     const { expenseTypes } = this.props;
@@ -147,7 +135,7 @@ class ExpenseCategories extends Component {
             addRemove: () => this.addRemoveType(miscellaneous_type_id),
             selected: this.state.selectedTypes.includes(miscellaneous_type_id),
           }}
-          getSearchableString={this.getSearchableString}
+          getSearchableString={getFinanceTypeSearchableStringFunc('expense')}
           searchPlaceholderText={this.props.t('FINANCES.SEARCH.EXPENSE_TYPES')}
         />
       </HookFormPersistProvider>

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -267,3 +267,23 @@ export const formatTransactionDate = (date, language = getLanguageFromLocalStora
   }
   return new Intl.DateTimeFormat(language, { dateStyle: 'long' }).format(dateObj);
 };
+
+/**
+ * Returns a function that constructs a searchable string of an expense type or a revenue type.
+ *
+ * @param {string} typeCategory - The category of the type ('expense' or 'revenue')
+ * @returns {function} getSearchableString function that takes a type and returns a searchable string.
+ */
+export const getFinanceTypeSearchableStringFunc = (typeCategory) => (type) => {
+  const nameKey = `${typeCategory}_name`;
+  const translationKey = `${typeCategory}_translation_key`;
+  const TYPE_CATEGORY = typeCategory.toUpperCase();
+
+  const typeName = type.farm_id
+    ? type[nameKey]
+    : i18n.t(`${typeCategory}:${type[translationKey]}.${TYPE_CATEGORY}_NAME`);
+  const description = type.farm_id
+    ? type.custom_description
+    : i18n.t(`${typeCategory}:${type[translationKey]}.CUSTOM_DESCRIPTION`);
+  return [typeName, description].filter(Boolean).join(' ');
+};


### PR DESCRIPTION
**Description**

Use translations for default expense types' expense names for searching instead of types' `expense_name`.

Jira link: https://lite-farm.atlassian.net/browse/LF-3870

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
