### PR TITLE
LF-3866 Could not download finance report

### DIFF
--- a/packages/api/src/util/generateFinanceReport.js
+++ b/packages/api/src/util/generateFinanceReport.js
@@ -34,7 +34,7 @@ export const generateTransactionsList = ({
   title,
 }) => {
   const workbook = new ExcelJS.Workbook();
-  const worksheet = workbook.addWorksheet(title);
+  const worksheet = workbook.addWorksheet(getFallbackTitle(title, 'Transactions'));
 
   addHeadersToWorksheet(worksheet, reportHeaders);
   setWorksheetColumnWidths(worksheet, [36, 18, 12, 14]);
@@ -67,7 +67,7 @@ export const addConfigurationWorksheet = ({
   language,
   title,
 }) => {
-  const worksheet = workbook.addWorksheet(title);
+  const worksheet = workbook.addWorksheet(getFallbackTitle(title, 'Export Settings'));
 
   const expenseTypes = generateTypeCountAndList(config.typesFilter.EXPENSE_TYPE);
   const revenueTypes = generateTypeCountAndList(config.typesFilter.REVENUE_TYPE);
@@ -223,4 +223,15 @@ function addConfigDataRows({
  */
 const formatDate = (date, language = 'en') => {
   return new Date(date).toLocaleDateString(language);
+};
+
+/**
+ * Returns the translated worksheet title, or English fallback if necessary
+ *
+ * @param {string} title - The translated title string to check.
+ * @param {string} defaultTitle - The default title to use if the original is missing or marked as 'MISSING'.
+ * @returns {string} - The original title or the default title if the original is missing or 'MISSING'.
+ */
+const getFallbackTitle = (title, defaultTitle) => {
+  return !title || title === 'MISSING' ? defaultTitle : title;
 };


### PR DESCRIPTION
**Description**

This isn't an issue that we would have seen on production (provided all translation strings currently marked as "MISSING" are supplied!)

ExcelJS names the worksheet titles with a translated string that we provide. Two worksheets cannot have the same name. However, in PT and FR currently, those translations are `"MISSING"` and the worksheet generation was failing with error:

`'Worksheet name already exists: MISSING'`

To prevent the worksheet generation from failing in this case (and in the future if when we add new languages but haven't finished the translation work) I added a small function to provide a fallback in English.

Jira link: https://lite-farm.atlassian.net/browse/LF-3866

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Tested the cases of 1) translation string supplied (e.g. ES right now), 2) translation string as `"MISSING"`, 3) translation string missing entirely from the file.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
