### PR TITLE
LF-3882 The "Save" button becomes disabled once the user changes the revenue type from "Crop Generated" to "No crop generated" once he tries to edit the revenue.

### DIFF
--- a/packages/webapp/src/containers/Finances/useCropSaleInputs.jsx
+++ b/packages/webapp/src/containers/Finances/useCropSaleInputs.jsx
@@ -210,7 +210,7 @@ export default function useCropSaleInputs(
   revenueTypes,
   selectedTypeOption,
 ) {
-  const { register, watch } = reactHookFormFunctions;
+  const { register, unregister, watch, getValues, setValue } = reactHookFormFunctions;
   const { t } = useTranslation();
 
   const managementPlans = useSelector(currentAndPlannedManagementPlansSelector) || [];
@@ -221,12 +221,16 @@ export default function useCropSaleInputs(
 
   const isCropSale = selectedRevenueType?.crop_generated;
 
-  //TODO: handle register/unregister of crop_variety sale
-  isCropSale
-    ? register(CROP_VARIETY_SALE, {
-        required: isCropSale ? true : false,
-      })
-    : null;
+  // Re-register to update 'required'
+  useEffect(() => {
+    // Maintain the value between registrations
+    const currentValue = getValues(CROP_VARIETY_SALE);
+
+    unregister(CROP_VARIETY_SALE);
+    register(CROP_VARIETY_SALE, { required: isCropSale });
+
+    setValue(CROP_VARIETY_SALE, currentValue);
+  }, [isCropSale]);
 
   const chosenVarieties = watch(CROP_VARIETY_SALE);
 


### PR DESCRIPTION
**Description**

This unregisters and-registers the `crop_variety_sale` input when `isCropSale` changes.

No idea if this should be patch scoped or not 🙂 And I'm also not sure if this is a great solution, but there is a todo in the code comments that makes me think maybe it was meant to be implemented like this?

Jira link: https://lite-farm.atlassian.net/jira/software/c/projects/LF/issues/LF-3882

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
