### PR TITLE
LF-3883 Can't edit the description of a type that shares the name of a deleted type

### DIFF
--- a/packages/api/src/controllers/farmExpenseTypeController.js
+++ b/packages/api/src/controllers/farmExpenseTypeController.js
@@ -151,8 +151,19 @@ const farmExpenseTypeController = {
           return res.status(404).send();
         }
 
-        // if record exists then throw Conflict error
-        if (await this.existsInFarm(trx, farm_id, data.expense_name, expense_type_id)) {
+        // if non-deleted record exists then throw Conflict error
+        if (
+          await baseController.existsInTable(
+            trx,
+            ExpenseTypeModel,
+            {
+              expense_name: data.expense_name,
+              farm_id,
+              deleted: false,
+            },
+            { expense_type_id },
+          )
+        ) {
           await trx.rollback();
           return res.status(409).send();
         }

--- a/packages/api/src/controllers/revenueTypeController.js
+++ b/packages/api/src/controllers/revenueTypeController.js
@@ -164,7 +164,7 @@ const revenueTypeController = {
           return res.status(404).send();
         }
 
-        // if record exists then throw Conflict error
+        // if non-deleted record exists then throw Conflict error
         if (
           await baseController.existsInTable(
             trx,
@@ -172,6 +172,7 @@ const revenueTypeController = {
             {
               revenue_name: data.revenue_name,
               farm_id,
+              deleted: false,
             },
             { revenue_type_id },
           )


### PR DESCRIPTION
**Description**

Fixes both finance type update controllers to reflect the fact that records can now have the same name as long as one is `deleted`.

Jira link: https://lite-farm.atlassian.net/browse/LF-3883

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
