### PR TITLE
LF-3902 The white screen is displayed during the creation of a crop plan once the user will click on the "Germination" or "Initial harvest" field.

### DIFF
--- a/packages/webapp/src/components/Form/InputDuration/index.jsx
+++ b/packages/webapp/src/components/Form/InputDuration/index.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { addDaysToDate, getDateInputFormat } from '../../../util/moment';
-import { getLocalizedDateString } from '../../RepeatCropPlan/utils';
+import { addDaysToDate, getDateInputFormat, getLocalizedDateString } from '../../../util/moment';
 import { Semibold } from '../../Typography';
 import Input, { integerOnKeyDown } from '../Input';
 import styles from './styles.module.scss';


### PR DESCRIPTION
**Description**

Import `getLocalizedDateString` from the right file.
The file we were importing from was accidentally changed [here](https://github.com/LiteFarmOrg/LiteFarm/pull/3004/files#diff-614834b019de4f385436d70d51f41545183db3811f9ea1279efb18a11cc8c119).

Jira link:
- https://lite-farm.atlassian.net/browse/LF-3902
- https://lite-farm.atlassian.net/browse/LF-3885

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
