### PR TITLE
LF-3921c Remove reference to file-specific locations in nginx server block

### DIFF
--- a/packages/webapp/nginx.conf
+++ b/packages/webapp/nginx.conf
@@ -48,21 +48,6 @@ http {
 
         # Set Cache-Control for various pwa-critical routes
         # See https://vite-pwa-org.netlify.app/deployment/nginx.html#cache-control
-        location = /index.html {
-            root /var/www/litefarm;
-            add_header Cache-Control "public, max-age=0, must-revalidate" always;
-        }
-
-        location = /manifest.webmanifest {
-            root /var/www/litefarm;
-            add_header Cache-Control "public, max-age=0, must-revalidate" always;
-        }
-
-        location = /sw.js {
-            root /var/www/litefarm;
-            add_header Cache-Control "public, max-age=0, must-revalidate" always;
-        }
-
         location ^~ /assets/ {
             root /var/www/litefarm;
             add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";


### PR DESCRIPTION
**Description**

The previous nginx configuration ruined routing to the webmanifest and the service worker. Why that happened, I'm not sure, but the [vite pwa documentation](https://vite-pwa-org.netlify.app/deployment/nginx.html) did warn:

> NGINX match precedences for locations are not very intuitive and error prone if you do not know the [exact rules](https://docs.nginx.com/nginx/admin-guide/web-server/web-server/#location_priority).

True indeed (I really don't understand nginx!) I am removing the references to individual files. I was following the directive 

> Double check that you do not have caching features enabled, especially immutable, on locations like:
>
>  /
/sw.js
/index.html
/manifest.webmanifest

but in the actual code example those files were not explicitly included so I'll next test following the sample code verbatim 🙂 

PS: I don't know why the symptom was the translation files breaking!

Jira link: https://lite-farm.atlassian.net/browse/LF-3921

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
