### PR TITLE
LF-3923b Remove header gradient from farm selection page

### DIFF
--- a/packages/webapp/src/assets/mixin.scss
+++ b/packages/webapp/src/assets/mixin.scss
@@ -1,15 +1,3 @@
-@mixin gradient() {
-  background: linear-gradient(
-                  96.68deg,
-                  #78c99e -4.29%,
-                  #c7efd3 24.32%,
-                  #e3f8ec 35.52%,
-                  #e3f8ec 64.28%,
-                  #c7efd3 80.81%,
-                  #78c99e 125.09%
-  );
-}
-
 @mixin fontFamily() {
   font-family: 'Open Sans', ' SansSerif', serif;
 }

--- a/packages/webapp/src/components/Navigation/NavBar/index.jsx
+++ b/packages/webapp/src/components/Navigation/NavBar/index.jsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     right: '8px',
   },
   appBar: {
-    background: 'none',
+    background: 'white',
     boxShadow: 'none',
     height: 'var(--global-navbar-height)',
     [theme.breakpoints.up('md')]: {

--- a/packages/webapp/src/components/Navigation/NoFarmNavBar/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/NoFarmNavBar/styles.module.scss
@@ -16,7 +16,7 @@
 
 .navBar {
   top: 0;
-  @include gradient();
+  background: white;
   width: 100%;
   max-width: 1024px;
   height: 76px;


### PR DESCRIPTION
**Description**

This is the visual change to test:
- #3031 

It removes the gradient from the farm selection page, and restores a white background to the logged in header. In the previous code test PR, I had removed the navBar background entirely, which rendered it transparent, as @den4ik1203 discovered 🙂 

Jira link: https://lite-farm.atlassian.net/browse/LF-3923

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

This is for testing on merge to beta.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
