### PR TITLE
LF-3923c Revert visual changes from LF-3923b

### DIFF
--- a/packages/webapp/src/assets/mixin.scss
+++ b/packages/webapp/src/assets/mixin.scss
@@ -1,3 +1,15 @@
+@mixin gradient() {
+  background: linear-gradient(
+                  96.68deg,
+                  #78c99e -4.29%,
+                  #c7efd3 24.32%,
+                  #e3f8ec 35.52%,
+                  #e3f8ec 64.28%,
+                  #c7efd3 80.81%,
+                  #78c99e 125.09%
+  );
+}
+
 @mixin fontFamily() {
   font-family: 'Open Sans', ' SansSerif', serif;
 }

--- a/packages/webapp/src/components/Navigation/NavBar/index.jsx
+++ b/packages/webapp/src/components/Navigation/NavBar/index.jsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     right: '8px',
   },
   appBar: {
-    background: 'white',
+    background: 'none',
     boxShadow: 'none',
     height: 'var(--global-navbar-height)',
     [theme.breakpoints.up('md')]: {

--- a/packages/webapp/src/components/Navigation/NoFarmNavBar/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/NoFarmNavBar/styles.module.scss
@@ -16,7 +16,7 @@
 
 .navBar {
   top: 0;
-  background: white;
+  @include gradient();
   width: 100%;
   max-width: 1024px;
   height: 76px;


### PR DESCRIPTION
**Description**

Reverts the visual changes from:
- #3034 

There is nothing wrong with the changes, I just would like to re-create the crash @SayakaOno discovered being on the farm creation flow when the changes went live. I will open two new PRs to revert and then restore the visual change.

Jira link: https://lite-farm.atlassian.net/browse/LF-3923

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
