### PR TITLE
LF-3942 Fix release card update timing and test logout

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1384,6 +1384,9 @@
     "CLEAR": "Clear",
     "CLEAR_ALL": "Clear all"
   },
+  "RELEASE": {
+    "LITEFARM_UPDATED": "LiteFarm v{{version}} is now available!"
+  },
   "REPEAT_PLAN": {
     "AFTER": "After",
     "COMPLETION": "completion",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1385,6 +1385,9 @@
     "CLEAR": "Borrar",
     "CLEAR_ALL": "Borrar todo"
   },
+  "RELEASE": {
+    "LITEFARM_UPDATED": "LiteFarm v{{version}} ya está disponible!"
+  },
   "REPEAT_PLAN": {
     "AFTER": "Después",
     "COMPLETION": "terminó",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -1386,6 +1386,9 @@
     "CLEAR": "Supprimer",
     "CLEAR_ALL": "Supprimer tout"
   },
+  "RELEASE": {
+    "LITEFARM_UPDATED": "LiteFarm v{{version}} est maintenant disponible\u00a0!"
+  },
   "REPEAT_PLAN": {
     "AFTER": "Après",
     "COMPLETION": "finalisation",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1385,6 +1385,9 @@
     "CLEAR": "Limpar",
     "CLEAR_ALL": "Limpar tudo"
   },
+  "RELEASE": {
+    "LITEFARM_UPDATED": "LiteFarm v{{version}} já está disponível!"
+  },
   "REPEAT_PLAN": {
     "AFTER": "Após",
     "COMPLETION": "conclusão",

--- a/packages/webapp/src/components/Card/NewReleaseCard/NewReleaseCard.jsx
+++ b/packages/webapp/src/components/Card/NewReleaseCard/NewReleaseCard.jsx
@@ -1,36 +1,27 @@
 import Card from '../index';
 import { ReactComponent as Star } from '../../../assets/images/signUp/new_feature.svg';
 import { Semibold, Text } from '../../Typography';
-import styles from '../../Typography/typography.module.scss';
+import typography from '../../Typography/typography.module.scss';
+import styles from './styles.module.css';
 import { useTranslation } from 'react-i18next';
-import { colors } from '../../../assets/theme';
+import { APP_VERSION } from '../../../util/constants';
 
 export function NewReleaseCard({ style }) {
   const { t } = useTranslation();
   return (
-    <Card
-      color={'info'}
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        gap: '16px',
-        alignItems: 'center',
-        padding: '16px',
-        ...style,
-      }}
-    >
+    <Card color={'info'} style={{ ...style }} className={styles.card}>
       <Star />
       <div>
-        <Semibold style={{ color: colors.teal700, marginBottom: '12px', lineHeight: '20px' }}>
-          {t('SIGNUP.LITEFARM_UPDATED')}
+        <Semibold className={styles.updated}>
+          {t('RELEASE.LITEFARM_UPDATED', { version: APP_VERSION })}
         </Semibold>
-        <Text style={{ margin: 0, lineHeight: '18px' }}>
+        <Text className={styles.changes}>
           {t('SIGNUP.CHANGES')}{' '}
           <a
             href={'https://www.litefarm.org/post/an-investment-in-finances'}
             target="_blank"
             rel="noreferrer"
-            className={styles.underlined}
+            className={typography.underlined}
           >
             {t('common:HERE')}
           </a>

--- a/packages/webapp/src/components/Card/NewReleaseCard/NewReleaseCard.jsx
+++ b/packages/webapp/src/components/Card/NewReleaseCard/NewReleaseCard.jsx
@@ -2,7 +2,7 @@ import Card from '../index';
 import { ReactComponent as Star } from '../../../assets/images/signUp/new_feature.svg';
 import { Semibold, Text } from '../../Typography';
 import typography from '../../Typography/typography.module.scss';
-import styles from './styles.module.css';
+import styles from './styles.module.scss';
 import { useTranslation } from 'react-i18next';
 import { APP_VERSION } from '../../../util/constants';
 

--- a/packages/webapp/src/components/Card/NewReleaseCard/styles.module.css
+++ b/packages/webapp/src/components/Card/NewReleaseCard/styles.module.css
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2023 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+.card {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
+    padding-block: 16px;
+    padding-inline: 8px;
+}
+
+.updated {
+    color: var(--teal700);
+    margin-bottom: 12px;
+    line-height: 20px;
+}
+
+.changes {
+    margin: 0;
+    line-height: 18px;
+}
+

--- a/packages/webapp/src/components/Card/NewReleaseCard/styles.module.scss
+++ b/packages/webapp/src/components/Card/NewReleaseCard/styles.module.scss
@@ -14,22 +14,21 @@
  */
 
 .card {
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    align-items: center;
-    padding-block: 16px;
-    padding-inline: 8px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+  padding-block: 16px;
+  padding-inline: 8px;
 }
 
 .updated {
-    color: var(--teal700);
-    margin-bottom: 12px;
-    line-height: 20px;
+  color: var(--teal700);
+  margin-bottom: 12px;
+  line-height: 20px;
 }
 
 .changes {
-    margin: 0;
-    line-height: 18px;
+  margin: 0;
+  line-height: 18px;
 }
-

--- a/packages/webapp/src/util/constants.js
+++ b/packages/webapp/src/util/constants.js
@@ -5,4 +5,6 @@ export const DO_ORIGIN_URL = `https://${
 export const DO_CDN_URL = `https://${
   import.meta.env.VITE_DO_BUCKET_NAME
 }.nyc3.cdn.digitaloceanspaces.com`;
-export const APP_VERSION = '3.5.1';
+
+// Changing this forces logout and updates the new release card
+export const APP_VERSION = '3.5.2.1';


### PR DESCRIPTION
**Description**

Only code changes:
- Fixed handling of the translation on the New Release Card, so that it tracks the application version and is updated in tandem with client update, not before
- Changes to CSS of that card (decreasing padding to fit more version digits, moving inline CSS to module)

Existing functionality being tested:
- Included a version change in this PR to test the _existing_ logout functionality (please see Jira ticket for details)
- As far as I can tell, the webapp is already configured correctly to force logout when the app version constant is changed. As we don't change versions on integration, I have never seen this behaviour before on beta and would like to observe it

Jira link: https://lite-farm.atlassian.net/browse/LF-3942

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Logout functionality can be tested in two ways, but both are only approximations of beta/prod:

_Simple test_

1. Change the constant `APP_VERSION` while running `pnpm dev`. You should immediately be logged out as soon as the application reloads.

_Closer (but imperfect) approximation to hosted environments_

1. Check out this branch. Run `pnpm vite build` and `pnpm vite preview`. Open the `localhost` preview
2. Change `APP_VERSION` and rebuild. Once build, reload the preview once to start the new service worker install (almost instantaneous on localhost), and reload a second time to update the application. You should be immediately logged out.

**NOTE:** This preview and build method is 100% susceptible to the TypeError on route change (the service worker does not behave like the hosted version in terms of the caching the app), so you cannot navigate _anywhere_ once the second vite build completes. Only reload.

Because neither of the above are perfect approximations for beta/prod, this needs to also be tested upon merge.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
