### PR TITLE
LF-3932: Fix broken styles due to navigation update

### DIFF
--- a/packages/webapp/src/App.jsx
+++ b/packages/webapp/src/App.jsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import Navigation from './containers/Navigation';
 import history from './history';
 import clsx from 'clsx';
@@ -24,10 +24,16 @@ import styles from './styles.module.scss';
 import Routes from './routes';
 
 function App() {
+  const [isCompactSideMenu, setIsCompactSideMenu] = useState(false);
+
   return (
     <div className={clsx(styles.container)}>
       <Suspense fallback={null}>
-        <Navigation history={history}>
+        <Navigation
+          history={history}
+          isCompactSideMenu={isCompactSideMenu}
+          setIsCompactSideMenu={setIsCompactSideMenu}
+        >
           <div className={styles.app}>
             <OfflineDetector />
             <SnackbarProvider
@@ -35,7 +41,10 @@ function App() {
                 vertical: 'bottom',
                 horizontal: 'center',
               }}
-              classes={{ root: styles.root, containerRoot: styles.root }}
+              classes={{
+                root: clsx(styles.root, isCompactSideMenu ? styles.isCompact : styles.isExpanded),
+                containerRoot: styles[`containerRoot${isCompactSideMenu ? 'WithCompactMenu' : ''}`],
+              }}
               content={(key, message) => <NotistackSnackbar id={key} message={message} />}
             >
               <Routes />

--- a/packages/webapp/src/components/ChooseFarm/index.jsx
+++ b/packages/webapp/src/components/ChooseFarm/index.jsx
@@ -1,6 +1,6 @@
+import { useTheme } from '@mui/material';
 import Layout from '../Layout';
 import Button from '../Form/Button';
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Title, Underlined } from '../Typography';
 import ChooseFarmMenuItem from './ChooseFarmMenu/ChooseFarmMenuItem';
@@ -20,11 +20,18 @@ export default function PureChooseFarmScreen({
   title = 'Choose your farm',
 }) {
   const { t } = useTranslation(['translation', 'common']);
+  const theme = useTheme();
 
   return (
     <Layout
-      hasWhiteBackground
-      classes={{ footer: { position: 'fixed', maxWidth: '1024px' } }}
+      classes={{
+        footer: {
+          position: 'sticky',
+          backgroundColor: theme.palette.background.default,
+          paddingTop: '24px',
+        },
+        container: { paddingBottom: '104px' },
+      }}
       buttonGroup={
         <>
           {!isOnBoarding && (

--- a/packages/webapp/src/components/Navigation/SideMenu/index.jsx
+++ b/packages/webapp/src/components/Navigation/SideMenu/index.jsx
@@ -201,8 +201,14 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
   );
 };
 
-const PureSideMenu = ({ history, isMobile, isDrawerOpen, onDrawerClose }) => {
-  const [isCompact, setIsCompactSideMenu] = useState(false);
+const PureSideMenu = ({
+  history,
+  isMobile,
+  isDrawerOpen,
+  onDrawerClose,
+  isCompact,
+  setIsCompactSideMenu,
+}) => {
   const [hasBeenExpanded, setHasBeenExpanded] = useState(false);
 
   const toggleSideMenu = () => {
@@ -249,6 +255,8 @@ PureSideMenu.propTypes = {
   isMobile: PropTypes.bool.isRequired,
   isDrawerOpen: PropTypes.bool,
   onDrawerClose: PropTypes.func,
+  isCompact: PropTypes.bool,
+  setIsCompactSideMenu: PropTypes.func,
 };
 
 export default PureSideMenu;

--- a/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
+++ b/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
@@ -221,11 +221,19 @@ const TopMenu = ({ history, isMobile, showNavigation, onClickBurger }) => {
     </>
   );
 
-  const Logo = ({ withoutWords }) => {
+  const Logo = ({ withoutWords, withLink, ...props }) => {
     return withoutWords ? (
-      <IconLogo alt="LiteFarm Logo" className={styles.logo} />
+      <IconLogo
+        alt="LiteFarm Logo"
+        className={clsx(styles.logo, withLink && styles.withLink)}
+        {...props}
+      />
     ) : (
-      <WordsLogo alt="LiteFarm Logo" className={clsx(styles.logo, styles.paddingTopBottom)} />
+      <WordsLogo
+        alt="LiteFarm Logo"
+        className={clsx(styles.logo, withLink && styles.withLink, styles.paddingTopBottom)}
+        {...props}
+      />
     );
   };
 
@@ -235,7 +243,9 @@ const TopMenu = ({ history, isMobile, showNavigation, onClickBurger }) => {
         className={clsx(styles.toolbar, (!showNavigation || isMobile) && styles.centerContent)}
       >
         {!showNavigation ? <Logo /> : showMainNavigation}
-        {showNavigation && isMobile && <Logo withoutWords />}
+        {showNavigation && isMobile && (
+          <Logo withoutWords withLink onClick={() => history.push('/')} />
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/packages/webapp/src/components/Navigation/TopMenu/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/TopMenu/styles.module.scss
@@ -15,8 +15,11 @@
 
 .logo {
   position: absolute;
-  cursor: pointer;
   margin-left: var(--global-sidebar-width);
+
+  &.withLink {
+    cursor: pointer;
+  }
 }
 
 .paddingTopBottom {

--- a/packages/webapp/src/components/Navigation/index.jsx
+++ b/packages/webapp/src/components/Navigation/index.jsx
@@ -19,6 +19,8 @@ export default function PureNavigation({
   isFarmSelected,
   hidden,
   children,
+  isCompactSideMenu,
+  setIsCompactSideMenu,
 }) {
   // Side Drawer
   const [isSideMenuOpen, setIsSideMenuOpen] = useState(false);
@@ -39,6 +41,8 @@ export default function PureNavigation({
             isMobile={isMobile}
             isDrawerOpen={isSideMenuOpen}
             onDrawerClose={closeSideMenu}
+            isCompact={isCompactSideMenu}
+            setIsCompactSideMenu={setIsCompactSideMenu}
           />
           <NavbarSpotlightProvider
             open={!showNotificationSpotlight && showNavigationSpotlight}
@@ -69,4 +73,6 @@ PureNavigation.propTypes = {
   history: PropTypes.object,
   isFarmSelected: PropTypes.bool,
   hidden: PropTypes.bool,
+  isCompactSideMenu: PropTypes.bool,
+  setIsCompactSideMenu: PropTypes.func,
 };

--- a/packages/webapp/src/components/Profile/People/index.jsx
+++ b/packages/webapp/src/components/Profile/People/index.jsx
@@ -7,7 +7,7 @@ import Table from '../../Table';
 import ProfileLayout from '../ProfileLayout';
 
 export default function PurePeople({ users, history, isAdmin }) {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['translation', 'role']);
   const [searchString, setSearchString] = useState('');
   const onChange = (e) => {
     setSearchString(e.target.value);

--- a/packages/webapp/src/components/WeatherBoard/assets/weatherBoard.module.scss
+++ b/packages/webapp/src/components/WeatherBoard/assets/weatherBoard.module.scss
@@ -62,7 +62,13 @@
   padding-top: 16px;
 }
 
-@media only screen and (min-width: 960px) {
+@include sm-breakpoint {
+  .container {
+    font-size: 2.8vw;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
   .container {
     transform: translateY(calc((100vh - 399px) * 0.65 - 110px));
     margin: 0 auto 0 auto;

--- a/packages/webapp/src/containers/Navigation/index.jsx
+++ b/packages/webapp/src/containers/Navigation/index.jsx
@@ -21,7 +21,7 @@ import useIsFarmSelected from '../../hooks/useIsFarmSelected';
 import { CUSTOM_SIGN_UP } from '../CustomSignUp/constants';
 import useHistoryLocation from '../hooks/useHistoryLocation';
 
-const Navigation = ({ history, children }) => {
+const Navigation = ({ history, children, ...props }) => {
   const dispatch = useDispatch();
   const historyLocation = useHistoryLocation(history);
   const isCustomSignupPage = historyLocation.state?.component === CUSTOM_SIGN_UP;
@@ -39,6 +39,7 @@ const Navigation = ({ history, children }) => {
       history={history}
       isFarmSelected={isFarmSelected}
       hidden={isCustomSignupPage}
+      {...props}
     >
       {children}
     </PureNavigation>

--- a/packages/webapp/src/styles.module.scss
+++ b/packages/webapp/src/styles.module.scss
@@ -32,9 +32,24 @@
   display: flex;
   flex-direction: column;
   position: relative;
-}
 
-.root {
-  width: calc(100vw - 48px);
-  max-width: 976px;
+  @include sm-breakpoint {
+    .containerRoot {
+      left: calc((100vw - var(--global-side-menu-width)) / 2 + var(--global-side-menu-width));
+    }
+    .containerRootWithCompactMenu {
+      left: calc((100vw - var(--global-compact-side-menu-width)) / 2 + var(--global-compact-side-menu-width));
+    }
+  }
+
+  .root {
+    max-width: calc(1024px - 48px);
+
+    &.isCompact {
+      width: calc((100vw - var(--global-compact-side-menu-width)) - 48px);
+    }
+    &.isExpanded {
+      width: calc((100vw - var(--global-side-menu-width)) - 48px);
+    }
+  }
 }


### PR DESCRIPTION
**Description**

This PR fixes three things that got broken by the navigation update.
1. adjust the snackbar position so that it is placed in the centre of the main content. (I moved `isCompactSideMenu` state up to `App` component which I didn't like. Let me know if you have suggestions)
2. fix farm selection buttons to fit in the main content. I had to pass styles, which we probably don't want to.
3. fix roles translations in people page
4. fix overflowing `WeatherBoard` on the home page
5. add a link to the homepage to the logo on mobile `TopMenu`

Jira link: https://lite-farm.atlassian.net/browse/LF-3932

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
