### PR TITLE
LF-3944 Some translations become broken when the user refreshes the page and snackbar translations are always missing

### DIFF
--- a/packages/webapp/src/components/Navigation/index.jsx
+++ b/packages/webapp/src/components/Navigation/index.jsx
@@ -10,6 +10,7 @@ import {
   NavBarNotificationSpotlightProvider,
 } from './NavbarSpotlightProvider';
 import styles from './styles.module.scss';
+import { useTranslation } from 'react-i18next';
 
 export default function PureNavigation({
   showNavigationSpotlight,
@@ -22,6 +23,26 @@ export default function PureNavigation({
   isCompactSideMenu,
   setIsCompactSideMenu,
 }) {
+  // This namespacing is needed for translations to work throughout the app
+  const { t } = useTranslation([
+    'translation',
+    'crop',
+    'common',
+    'disease',
+    'task',
+    'expense',
+    'revenue',
+    'fertilizer',
+    'message',
+    'gender',
+    'role',
+    'crop_nutrients',
+    'harvest_uses',
+    'soil',
+    'certifications',
+    'crop_group',
+  ]);
+
   // Side Drawer
   const [isSideMenuOpen, setIsSideMenuOpen] = useState(false);
 


### PR DESCRIPTION
**Description**

*As tested in group*

Using `git bisect` commit 7f631d24bc5526cf7aaf7eefe63488f871fadd11 was identified as being responsible for the current translation issues. Also confirmed at that time that it is actually the namespacing in this hook (i.e. the inclusion of 'messages' in that array) which controls the availability of the translation elsewhere in app.

Note: we are NOT entirely sure why this should be, but we are restoring to the previous state/behaviour. We also, for consistency, added the reference to the one omitted translation file (`revenue`). We are not currently seeing errors on revenue translations, but did at one point [fairly recently](https://litefarm.slack.com/archives/C014931NRFY/p1701365564357259).

Jira link: https://lite-farm.atlassian.net/browse/LF-3944

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Tested together and found:
- the namespacing itself is necessary (e.g. removing 'messages' from the namespace array means the snackbars will continue to break)
- (really inexplicably) the call should happen in the Pure Component; calling in the wrapping container didn't fix the error

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
