### PR TITLE
LF-3972 Getting a list of available animal types

### DIFF
--- a/packages/api/db/migration/20240110204504_create_animal_type_table.js
+++ b/packages/api/db/migration/20240110204504_create_animal_type_table.js
@@ -17,14 +17,14 @@ export const up = async function (knex) {
   await knex.schema.createTable('animal_type', (table) => {
     table.increments('id').primary();
     table.uuid('farm_id').references('farm_id').inTable('farm').defaultTo(null);
-    table.string('type').defaultTo(null);
-    table.string('type_key').defaultTo(null);
+    table.string('custom_type_name').defaultTo(null);
+    table.string('default_type_key').defaultTo(null);
     table.boolean('deleted').notNullable().defaultTo(false);
     table.string('created_by_user_id').references('user_id').inTable('users');
     table.string('updated_by_user_id').references('user_id').inTable('users');
     table.dateTime('created_at').defaultTo(new Date('2000/1/1').toISOString()).notNullable();
     table.dateTime('updated_at').defaultTo(new Date('2000/1/1').toISOString()).notNullable();
-    table.check('?? is not null or ?? is not null', ['type', 'type_key']);
+    table.check('?? is not null or ?? is not null', ['custom_type_name', 'default_type_key']);
   });
 
   // Add initial default types
@@ -33,8 +33,8 @@ export const up = async function (knex) {
   for (const typeKey of defaultTypeKeys) {
     await knex('animal_type').insert({
       farm_id: null,
-      type: null, // only provide for user-created types (i.e. without translation keys)
-      type_key: typeKey,
+      custom_type_name: null, // only provide for user-created types (i.e. without translation keys)
+      default_type_key: typeKey,
       deleted: false,
       created_by_user_id: '1',
       updated_by_user_id: '1',

--- a/packages/api/db/migration/20240110204504_create_animal_type_table.js
+++ b/packages/api/db/migration/20240110204504_create_animal_type_table.js
@@ -22,8 +22,9 @@ export const up = async function (knex) {
     table.boolean('deleted').notNullable().defaultTo(false);
     table.string('created_by_user_id').references('user_id').inTable('users');
     table.string('updated_by_user_id').references('user_id').inTable('users');
-    table.dateTime('created_at').notNullable();
-    table.dateTime('updated_at').notNullable();
+    table.dateTime('created_at').defaultTo(new Date('2000/1/1').toISOString()).notNullable();
+    table.dateTime('updated_at').defaultTo(new Date('2000/1/1').toISOString()).notNullable();
+    table.check('?? is not null or ?? is not null', ['type', 'type_key']);
   });
 
   // Add initial default types
@@ -37,8 +38,6 @@ export const up = async function (knex) {
       deleted: false,
       created_by_user_id: '1',
       updated_by_user_id: '1',
-      created_at: new Date('2000/1/1').toISOString(),
-      updated_at: new Date('2000/1/1').toISOString(),
     });
   }
 

--- a/packages/api/db/migration/20240110204504_create_animal_type_table.js
+++ b/packages/api/db/migration/20240110204504_create_animal_type_table.js
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex.schema.createTable('animal_type', (table) => {
+    table.increments('id').primary();
+    table.uuid('farm_id').references('farm_id').inTable('farm').defaultTo(null);
+    table.string('type').defaultTo(null);
+    table.string('type_key').defaultTo(null);
+    table.boolean('deleted').notNullable().defaultTo(false);
+    table.string('created_by_user_id').references('user_id').inTable('users');
+    table.string('updated_by_user_id').references('user_id').inTable('users');
+    table.dateTime('created_at').notNullable();
+    table.dateTime('updated_at').notNullable();
+  });
+
+  // Add initial default types
+  const defaultTypeKeys = ['CATTLE', 'PIGS', 'CHICKEN_BROILERS', 'CHICKEN_LAYERS'];
+
+  for (const typeKey of defaultTypeKeys) {
+    await knex('animal_type').insert({
+      farm_id: null,
+      type: null, // only provide for user-created types (i.e. without translation keys)
+      type_key: typeKey,
+      deleted: false,
+      created_by_user_id: '1',
+      updated_by_user_id: '1',
+      created_at: new Date('2000/1/1').toISOString(),
+      updated_at: new Date('2000/1/1').toISOString(),
+    });
+  }
+
+  // Add  permissions
+  await knex('permissions').insert([
+    { permission_id: 143, name: 'add:animal_types', description: 'add animal types' },
+    { permission_id: 144, name: 'delete:animal_types', description: 'delete animal types' },
+    { permission_id: 145, name: 'edit:animal_types', description: 'edit animal types' },
+    { permission_id: 146, name: 'get:animal_types', description: 'get animal types' },
+  ]);
+
+  await knex('rolePermissions').insert([
+    { role_id: 1, permission_id: 143 },
+    { role_id: 2, permission_id: 143 },
+    { role_id: 5, permission_id: 143 },
+    { role_id: 1, permission_id: 144 },
+    { role_id: 2, permission_id: 144 },
+    { role_id: 5, permission_id: 144 },
+    { role_id: 1, permission_id: 145 },
+    { role_id: 2, permission_id: 145 },
+    { role_id: 5, permission_id: 145 },
+    { role_id: 1, permission_id: 146 },
+    { role_id: 2, permission_id: 146 },
+    { role_id: 3, permission_id: 146 },
+    { role_id: 5, permission_id: 146 },
+  ]);
+};
+
+export const down = async function (knex) {
+  const permissions = [143, 144, 145, 146];
+
+  await knex('rolePermissions').whereIn('permission_id', permissions).del();
+  await knex('permissions').whereIn('permission_id', permissions).del();
+
+  await knex.schema.dropTable('animal_type');
+};

--- a/packages/api/src/controllers/animalTypeController.js
+++ b/packages/api/src/controllers/animalTypeController.js
@@ -16,7 +16,7 @@
 import AnimalTypeModel from '../models/animalTypeModel.js';
 
 const animalTypeController = {
-  getFarmAnimalType() {
+  getFarmAnimalTypes() {
     return async (req, res) => {
       try {
         const { farm_id } = req.headers;

--- a/packages/api/src/controllers/animalTypeController.js
+++ b/packages/api/src/controllers/animalTypeController.js
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import AnimalTypeModel from '../models/animalTypeModel.js';
+
+const animalTypeController = {
+  getFarmAnimalType() {
+    return async (req, res) => {
+      try {
+        const { farm_id } = req.headers;
+        const rows = await AnimalTypeModel.query().where('farm_id', null).orWhere({ farm_id });
+        if (!rows.length) {
+          return res.sendStatus(404);
+        } else {
+          return res.status(200).send(rows);
+        }
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({
+          error,
+        });
+      }
+    };
+  },
+};
+
+export default animalTypeController;

--- a/packages/api/src/models/animalTypeModel.js
+++ b/packages/api/src/models/animalTypeModel.js
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import baseModel from './baseModel.js';
+
+class AnimalType extends baseModel {
+  static get tableName() {
+    return 'animal_type';
+  }
+
+  static get idColumn() {
+    return 'id';
+  }
+
+  // Optional JSON schema. This is not the database schema! Nothing is generated
+  // based on this. This is only used for validation. Whenever a model instance
+  // is created it is checked against this schema. http://json-schema.org/.
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['farm_id', 'type'],
+
+      properties: {
+        id: { type: 'integer' },
+        farm_id: { type: 'string' },
+        type: { type: 'string' },
+        // type_key will not be provided for user-generated types and should default to null
+        ...this.baseProperties,
+      },
+      additionalProperties: false,
+    };
+  }
+}
+
+export default AnimalType;

--- a/packages/api/src/models/animalTypeModel.js
+++ b/packages/api/src/models/animalTypeModel.js
@@ -30,13 +30,13 @@ class AnimalType extends baseModel {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['farm_id', 'type'],
+      required: ['farm_id', 'custom_type_name'],
 
       properties: {
         id: { type: 'integer' },
         farm_id: { type: 'string' },
-        type: { type: 'string' },
-        // type_key will not be provided for user-generated types and should default to null
+        custom_type_name: { type: 'string' },
+        // default_type_key will not be provided for user-generated types and should default to null
         ...this.baseProperties,
       },
       additionalProperties: false,

--- a/packages/api/src/routes/animalTypeRoute.js
+++ b/packages/api/src/routes/animalTypeRoute.js
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import express from 'express';
+
+const router = express.Router();
+import AnimalTypeController from '../controllers/animalTypeController.js';
+import checkScope from '../middleware/acl/checkScope.js';
+
+router.get('/', checkScope(['get:animal_types']), AnimalTypeController.getFarmAnimalType());
+
+export default router;

--- a/packages/api/src/routes/animalTypeRoute.js
+++ b/packages/api/src/routes/animalTypeRoute.js
@@ -19,6 +19,6 @@ const router = express.Router();
 import AnimalTypeController from '../controllers/animalTypeController.js';
 import checkScope from '../middleware/acl/checkScope.js';
 
-router.get('/', checkScope(['get:animal_types']), AnimalTypeController.getFarmAnimalType());
+router.get('/', checkScope(['get:animal_types']), AnimalTypeController.getFarmAnimalTypes());
 
 export default router;

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -124,6 +124,7 @@ import logger from './common/logger.js';
 // import routes
 import loginRoutes from './routes/loginRoute.js';
 
+import animalTypeRoute from './routes/animalTypeRoute.js';
 import cropRoutes from './routes/cropRoute.js';
 import cropVarietyRoutes from './routes/cropVarietyRoute.js';
 import fieldRoutes from './routes/fieldRoute.js';
@@ -264,6 +265,7 @@ app
   .use(checkJwt)
 
   // routes
+  .use('/animal_type', animalTypeRoute)
   .use('/location', locationRoute)
   .use('/userLog', userLogRoute)
   .use('/crop', cropRoutes)

--- a/packages/api/tests/animal_type.test.js
+++ b/packages/api/tests/animal_type.test.js
@@ -90,7 +90,7 @@ describe('Animal Type Tests', () => {
   });
 
   // GET TESTS
-  describe('Get animal type tests', () => {
+  describe('GET animal type tests', () => {
     test('All users should get animal type by farm id (or null)', async () => {
       const roles = [1, 2, 3, 5];
 

--- a/packages/api/tests/animal_type.test.js
+++ b/packages/api/tests/animal_type.test.js
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import chai from 'chai';
+import util from 'util';
+
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+
+import server from './../src/server.js';
+import knex from '../src/util/knex.js';
+import { tableCleanup } from './testEnvironment.js';
+
+jest.mock('jsdom');
+jest.mock('../src/middleware/acl/checkJwt.js', () =>
+  jest.fn((req, res, next) => {
+    req.auth = {};
+    req.auth.user_id = req.get('user_id');
+    next();
+  }),
+);
+import mocks from './mock.factories.js';
+
+describe('Animal Type Tests', () => {
+  let token;
+  let farm;
+  let newOwner;
+
+  beforeAll(() => {
+    token = global.token;
+  });
+
+  function getRequest({ user_id = newOwner.user_id, farm_id = farm.farm_id }, callback) {
+    chai
+      .request(server)
+      .get('/animal_type')
+      .set('user_id', user_id)
+      .set('farm_id', farm_id)
+      .end(callback);
+  }
+
+  const getRequestAsPromise = util.promisify(getRequest);
+
+  function fakeUserFarm(role = 1) {
+    return { ...mocks.fakeUserFarm(), role_id: role };
+  }
+
+  async function returnUserFarms(role) {
+    const [mainFarm] = await mocks.farmFactory();
+    const [user] = await mocks.usersFactory();
+
+    await mocks.userFarmFactory(
+      {
+        promisedUser: [user],
+        promisedFarm: [mainFarm],
+      },
+      fakeUserFarm(role),
+    );
+    return { mainFarm, user };
+  }
+
+  async function makeUserCreatedAnimalType(mainFarm) {
+    const [animal_type] = await mocks.animal_typeFactory({
+      promisedFarm: [mainFarm],
+    });
+    return animal_type;
+  }
+
+  beforeEach(async () => {
+    [farm] = await mocks.farmFactory();
+    [newOwner] = await mocks.usersFactory();
+  });
+
+  afterAll(async (done) => {
+    await tableCleanup(knex);
+    await knex.destroy();
+    done();
+  });
+
+  // GET TESTS
+  describe('Get animal type tests', () => {
+    test('All users should get animal type by farm id (or null)', async () => {
+      const roles = [1, 2, 3, 5];
+
+      for (const role of roles) {
+        const { mainFarm, user } = await returnUserFarms(role);
+        const animal_type = await makeUserCreatedAnimalType(mainFarm);
+
+        const res = await getRequestAsPromise({ user_id: user.user_id, farm_id: mainFarm.farm_id });
+
+        expect(res.status).toBe(200);
+        res.body.forEach((type) => {
+          expect({ farm_id: type.farm_id }).toMatchObject({
+            farm_id: type.farm_id ? animal_type.farm_id : null,
+          });
+        });
+      }
+    });
+
+    test('Unauthorized user should get 403 if they try to get animal type by farm id (or null)', async () => {
+      const { mainFarm } = await returnUserFarms(1);
+      await makeUserCreatedAnimalType(mainFarm);
+      const [unAuthorizedUser] = await mocks.usersFactory();
+
+      const res = await getRequestAsPromise({
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): get:animal_types',
+      );
+    });
+  });
+});

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2159,7 +2159,7 @@ async function revenue_typeFactory(
 function fakeAnimalType(defaultData = {}) {
   const name = faker.lorem.word();
   return {
-    type: name,
+    custom_type_name: name,
     ...defaultData,
   };
 }

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2156,6 +2156,27 @@ async function revenue_typeFactory(
     .returning('*');
 }
 
+function fakeAnimalType(defaultData = {}) {
+  const name = faker.lorem.word();
+  return {
+    type: name,
+    ...defaultData,
+  };
+}
+
+async function animal_typeFactory(
+  { promisedFarm = farmFactory(), properties = {} } = {},
+  animalType = fakeAnimalType(properties),
+) {
+  const [farm, user] = await Promise.all([promisedFarm, usersFactory()]);
+  const [{ farm_id }] = farm;
+  const [{ user_id }] = user;
+  const base = baseProperties(user_id);
+  return knex('animal_type')
+    .insert({ farm_id, ...animalType, ...base })
+    .returning('*');
+}
+
 export default {
   weather_stationFactory,
   fakeStation,
@@ -2284,5 +2305,7 @@ export default {
   populateDefaultRevenueTypes,
   revenue_typeFactory,
   fakeRevenueType,
+  animal_typeFactory,
+  fakeAnimalType,
   baseProperties,
 };

--- a/packages/api/tests/testEnvironment.js
+++ b/packages/api/tests/testEnvironment.js
@@ -115,6 +115,7 @@ async function tableCleanup(knex) {
     DELETE FROM "pesticide";
     DELETE FROM "task_type";
     DELETE FROM "farmDataSchedule";
+    DELETE FROM "animal_type";
     DELETE FROM "userFarm";
     DELETE FROM "farm";
     DELETE FROM "users" WHERE user_id <> '1';


### PR DESCRIPTION
**Description**

Here we go livestock! 😄 

This is the database table and GET endpoint for animal types. In looking through Jira, it seems the API endpoints have slightly re-designed (right @antsgar?); you can see it more clearly in the ticket for the GET endpoint for breeds, which has a query parameter. The only new element here is the removal of `farm_id` from the route and consequently a change to the route middleware pattern.

Jira link: https://lite-farm.atlassian.net/browse/LF-3972

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Inspected the table and tested the new route (GET `/animal_type`) on Postman. Created new tests modelled after `revenue_type.test.js`

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
