### PR TITLE
LF-3972b Getting a list of available animal types (two tables)

### DIFF
--- a/packages/api/db/migration/20240112220609_create_animal_type_tables.js
+++ b/packages/api/db/migration/20240112220609_create_animal_type_tables.js
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex.schema.createTable('default_animal_type', (table) => {
+    table.increments('id').primary();
+    table.string('type_key').defaultTo(null);
+  });
+
+  await knex.schema.createTable('custom_animal_type', (table) => {
+    table.increments('id').primary();
+    table.uuid('farm_id').references('farm_id').inTable('farm').notNullable();
+    table.string('type').notNullable();
+    table.boolean('deleted').notNullable().defaultTo(false);
+    table.string('created_by_user_id').references('user_id').inTable('users');
+    table.string('updated_by_user_id').references('user_id').inTable('users');
+    table.dateTime('created_at').defaultTo(new Date('2000/1/1').toISOString()).notNullable();
+    table.dateTime('updated_at').defaultTo(new Date('2000/1/1').toISOString()).notNullable();
+  });
+
+  // Add initial default types
+  const defaultTypeKeys = ['CATTLE', 'PIGS', 'CHICKEN_BROILERS', 'CHICKEN_LAYERS'];
+
+  for (const typeKey of defaultTypeKeys) {
+    await knex('default_animal_type').insert({
+      type_key: typeKey,
+    });
+  }
+
+  // Add  permissions
+  await knex('permissions').insert([
+    { permission_id: 143, name: 'add:animal_types', description: 'add animal types' },
+    { permission_id: 144, name: 'delete:animal_types', description: 'delete animal types' },
+    { permission_id: 145, name: 'edit:animal_types', description: 'edit animal types' },
+    { permission_id: 146, name: 'get:animal_types', description: 'get animal types' },
+  ]);
+
+  await knex('rolePermissions').insert([
+    { role_id: 1, permission_id: 143 },
+    { role_id: 2, permission_id: 143 },
+    { role_id: 5, permission_id: 143 },
+    { role_id: 1, permission_id: 144 },
+    { role_id: 2, permission_id: 144 },
+    { role_id: 5, permission_id: 144 },
+    { role_id: 1, permission_id: 145 },
+    { role_id: 2, permission_id: 145 },
+    { role_id: 5, permission_id: 145 },
+    { role_id: 1, permission_id: 146 },
+    { role_id: 2, permission_id: 146 },
+    { role_id: 3, permission_id: 146 },
+    { role_id: 5, permission_id: 146 },
+  ]);
+};
+
+export const down = async function (knex) {
+  const permissions = [143, 144, 145, 146];
+
+  await knex('rolePermissions').whereIn('permission_id', permissions).del();
+  await knex('permissions').whereIn('permission_id', permissions).del();
+
+  await knex.schema.dropTable('custom_animal_type');
+  await knex.schema.dropTable('default_animal_type');
+};

--- a/packages/api/src/controllers/customAnimalTypeController.js
+++ b/packages/api/src/controllers/customAnimalTypeController.js
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
+
+const customAnimalTypeController = {
+  getCustomAnimalTypes() {
+    return async (req, res) => {
+      try {
+        const { farm_id } = req.headers;
+        const rows = await CustomAnimalTypeModel.query().where({ farm_id });
+        if (!rows.length) {
+          return res.sendStatus(404);
+        } else {
+          return res.status(200).send(rows);
+        }
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({
+          error,
+        });
+      }
+    };
+  },
+};
+
+export default customAnimalTypeController;

--- a/packages/api/src/controllers/defaultAnimalTypeController.js
+++ b/packages/api/src/controllers/defaultAnimalTypeController.js
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import DefaultAnimalTypeModel from '../models/defaultAnimalTypeModel.js';
+
+const defaultAnimalTypeController = {
+  getDefaultAnimalTypes() {
+    return async (req, res) => {
+      try {
+        const rows = await DefaultAnimalTypeModel.query();
+        if (!rows.length) {
+          return res.sendStatus(404);
+        } else {
+          return res.status(200).send(rows);
+        }
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({
+          error,
+        });
+      }
+    };
+  },
+};
+
+export default defaultAnimalTypeController;

--- a/packages/api/src/models/customAnimalTypeModel.js
+++ b/packages/api/src/models/customAnimalTypeModel.js
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import baseModel from './baseModel.js';
+
+class CustomAnimalType extends baseModel {
+  static get tableName() {
+    return 'custom_animal_type';
+  }
+
+  static get idColumn() {
+    return 'id';
+  }
+
+  // Optional JSON schema. This is not the database schema! Nothing is generated
+  // based on this. This is only used for validation. Whenever a model instance
+  // is created it is checked against this schema. http://json-schema.org/.
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['farm_id', 'type'],
+
+      properties: {
+        id: { type: 'integer' },
+        farm_id: { type: 'string' },
+        type: { type: 'string' },
+        ...this.baseProperties,
+      },
+      additionalProperties: false,
+    };
+  }
+}
+
+export default CustomAnimalType;

--- a/packages/api/src/models/defaultAnimalTypeModel.js
+++ b/packages/api/src/models/defaultAnimalTypeModel.js
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import Model from './baseFormatModel.js';
+
+class DefaultAnimalTypeModel extends Model {
+  static get tableName() {
+    return 'default_animal_type';
+  }
+
+  static get idColumn() {
+    return 'id';
+  }
+
+  // Optional JSON schema. This is not the database schema! Nothing is generated
+  // based on this. This is only used for validation. Whenever a model instance
+  // is created it is checked against this schema. http://json-schema.org/.
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['type_key'],
+
+      properties: {
+        id: { type: 'integer' },
+        type_key: { type: 'string' },
+      },
+      additionalProperties: false,
+    };
+  }
+}
+
+export default DefaultAnimalTypeModel;

--- a/packages/api/src/routes/customAnimalTypeRoute.js
+++ b/packages/api/src/routes/customAnimalTypeRoute.js
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import express from 'express';
+
+const router = express.Router();
+import CustomAnimalTypeController from '../controllers/customAnimalTypeController.js';
+import checkScope from '../middleware/acl/checkScope.js';
+
+router.get(
+  '/',
+  checkScope(['get:animal_types']),
+  CustomAnimalTypeController.getCustomAnimalTypes(),
+);
+
+export default router;

--- a/packages/api/src/routes/defaultAnimalTypeRoute.js
+++ b/packages/api/src/routes/defaultAnimalTypeRoute.js
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import express from 'express';
+
+const router = express.Router();
+import DefaultAnimalTypeController from '../controllers/defaultAnimalTypeController.js';
+
+router.get('/', DefaultAnimalTypeController.getDefaultAnimalTypes());
+
+export default router;

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -124,6 +124,8 @@ import logger from './common/logger.js';
 // import routes
 import loginRoutes from './routes/loginRoute.js';
 
+import defaultAnimalTypeRoute from './routes/defaultAnimalTypeRoute.js';
+import customAnimalTypeRoute from './routes/customAnimalTypeRoute.js';
 import cropRoutes from './routes/cropRoute.js';
 import cropVarietyRoutes from './routes/cropVarietyRoute.js';
 import fieldRoutes from './routes/fieldRoute.js';
@@ -264,6 +266,8 @@ app
   .use(checkJwt)
 
   // routes
+  .use('/default_animal_types', defaultAnimalTypeRoute)
+  .use('/custom_animal_types', customAnimalTypeRoute)
   .use('/location', locationRoute)
   .use('/userLog', userLogRoute)
   .use('/crop', cropRoutes)

--- a/packages/api/tests/custom_animal_type.test.js
+++ b/packages/api/tests/custom_animal_type.test.js
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import chai from 'chai';
+import util from 'util';
+
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+
+import server from './../src/server.js';
+import knex from '../src/util/knex.js';
+import { tableCleanup } from './testEnvironment.js';
+
+jest.mock('jsdom');
+jest.mock('../src/middleware/acl/checkJwt.js', () =>
+  jest.fn((req, res, next) => {
+    req.auth = {};
+    req.auth.user_id = req.get('user_id');
+    next();
+  }),
+);
+import mocks from './mock.factories.js';
+
+describe('Custom Animal Type Tests', () => {
+  let token;
+
+  beforeAll(() => {
+    token = global.token;
+  });
+
+  afterAll(async (done) => {
+    await tableCleanup(knex);
+    await knex.destroy();
+    done();
+  });
+
+  function getRequest({ user_id, farm_id }, callback) {
+    chai
+      .request(server)
+      .get('/custom_animal_types')
+      .set('user_id', user_id)
+      .set('farm_id', farm_id)
+      .end(callback);
+  }
+
+  const getRequestAsPromise = util.promisify(getRequest);
+
+  function fakeUserFarm(role = 1) {
+    return { ...mocks.fakeUserFarm(), role_id: role };
+  }
+
+  async function returnUserFarms(role) {
+    const [mainFarm] = await mocks.farmFactory();
+    const [user] = await mocks.usersFactory();
+
+    await mocks.userFarmFactory(
+      {
+        promisedUser: [user],
+        promisedFarm: [mainFarm],
+      },
+      fakeUserFarm(role),
+    );
+    return { mainFarm, user };
+  }
+
+  async function makeUserCreatedAnimalType(mainFarm) {
+    const [custom_animal_type] = await mocks.custom_animal_typeFactory({
+      promisedFarm: [mainFarm],
+    });
+    return custom_animal_type;
+  }
+
+  // GET TESTS
+  describe('GET custom animal type tests', () => {
+    test('All farm users should get custom animal type by farm id', async () => {
+      const roles = [1, 2, 3, 5];
+
+      for (const role of roles) {
+        const { mainFarm, user } = await returnUserFarms(role);
+        const custom_animal_type = await makeUserCreatedAnimalType(mainFarm);
+
+        const res = await getRequestAsPromise({ user_id: user.user_id, farm_id: mainFarm.farm_id });
+
+        expect(res.status).toBe(200);
+        res.body.forEach((type) => {
+          expect(type.farm_id).toBe(custom_animal_type.farm_id);
+        });
+      }
+    });
+
+    test('Unauthorized user should get 403 if they try to get custom animal type by farm id', async () => {
+      const { mainFarm } = await returnUserFarms(1);
+      await makeUserCreatedAnimalType(mainFarm);
+      const [unAuthorizedUser] = await mocks.usersFactory();
+
+      const res = await getRequestAsPromise({
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+      expect(res.status).toBe(403);
+      expect(res.error.text).toBe(
+        'User does not have the following permission(s): get:animal_types',
+      );
+    });
+  });
+});

--- a/packages/api/tests/default_animal_type.test.js
+++ b/packages/api/tests/default_animal_type.test.js
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import chai from 'chai';
+import util from 'util';
+
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+
+import server from './../src/server.js';
+import knex from '../src/util/knex.js';
+import { tableCleanup } from './testEnvironment.js';
+
+jest.mock('jsdom');
+jest.mock('../src/middleware/acl/checkJwt.js', () =>
+  jest.fn((req, res, next) => {
+    req.auth = {};
+    req.auth.user_id = req.get('user_id');
+    next();
+  }),
+);
+import mocks from './mock.factories.js';
+
+describe('Default Animal Type Tests', () => {
+  let token;
+
+  beforeAll(() => {
+    token = global.token;
+  });
+
+  afterAll(async (done) => {
+    await tableCleanup(knex);
+    await knex.destroy();
+    done();
+  });
+
+  function getRequest({ user_id, farm_id }, callback) {
+    chai
+      .request(server)
+      .get('/default_animal_types')
+      .set('user_id', user_id)
+      .set('farm_id', farm_id)
+      .end(callback);
+  }
+
+  const getRequestAsPromise = util.promisify(getRequest);
+
+  function fakeUserFarm(role = 1) {
+    return { ...mocks.fakeUserFarm(), role_id: role };
+  }
+
+  async function returnUserFarms(role) {
+    const [mainFarm] = await mocks.farmFactory();
+    const [user] = await mocks.usersFactory();
+
+    await mocks.userFarmFactory(
+      {
+        promisedUser: [user],
+        promisedFarm: [mainFarm],
+      },
+      fakeUserFarm(role),
+    );
+    return { mainFarm, user };
+  }
+
+  async function makeDefaultAnimalType() {
+    const [default_animal_type] = await mocks.default_animal_typeFactory();
+    return default_animal_type;
+  }
+
+  // GET TESTS
+  describe('GET animal type tests', () => {
+    test('All farm users should get default animal types', async () => {
+      const roles = [1, 2, 3, 5];
+
+      for (const role of roles) {
+        const { mainFarm, user } = await returnUserFarms(role);
+
+        await makeDefaultAnimalType();
+
+        const res = await getRequestAsPromise({ user_id: user.user_id, farm_id: mainFarm.farm_id });
+
+        expect(res.status).toBe(200);
+        expect(res.body.length).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    test('Unauthorized user should also get default animal types', async () => {
+      const { mainFarm } = await returnUserFarms(1);
+
+      await makeDefaultAnimalType();
+
+      const [unAuthorizedUser] = await mocks.usersFactory();
+
+      const res = await getRequestAsPromise({
+        user_id: unAuthorizedUser.user_id,
+        farm_id: mainFarm.farm_id,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2156,6 +2156,27 @@ async function revenue_typeFactory(
     .returning('*');
 }
 
+function fakeCustomAnimalType(defaultData = {}) {
+  const name = faker.lorem.word();
+  return {
+    type: name,
+    ...defaultData,
+  };
+}
+
+async function custom_animal_typeFactory(
+  { promisedFarm = farmFactory(), properties = {} } = {},
+  animalType = fakeCustomAnimalType(properties),
+) {
+  const [farm, user] = await Promise.all([promisedFarm, usersFactory()]);
+  const [{ farm_id }] = farm;
+  const [{ user_id }] = user;
+  const base = baseProperties(user_id);
+  return knex('custom_animal_type')
+    .insert({ farm_id, ...animalType, ...base })
+    .returning('*');
+}
+
 export default {
   weather_stationFactory,
   fakeStation,
@@ -2284,5 +2305,7 @@ export default {
   populateDefaultRevenueTypes,
   revenue_typeFactory,
   fakeRevenueType,
+  custom_animal_typeFactory,
+  fakeCustomAnimalType,
   baseProperties,
 };

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2177,6 +2177,10 @@ async function custom_animal_typeFactory(
     .returning('*');
 }
 
+async function default_animal_typeFactory() {
+  return knex('default_animal_type').insert({ type_key: faker.lorem.word() }).returning('*');
+}
+
 export default {
   weather_stationFactory,
   fakeStation,
@@ -2307,5 +2311,6 @@ export default {
   fakeRevenueType,
   custom_animal_typeFactory,
   fakeCustomAnimalType,
+  default_animal_typeFactory,
   baseProperties,
 };

--- a/packages/api/tests/testEnvironment.js
+++ b/packages/api/tests/testEnvironment.js
@@ -115,6 +115,7 @@ async function tableCleanup(knex) {
     DELETE FROM "pesticide";
     DELETE FROM "task_type";
     DELETE FROM "farmDataSchedule";
+    DELETE FROM "default_animal_type";
     DELETE FROM "custom_animal_type";
     DELETE FROM "userFarm";
     DELETE FROM "farm";

--- a/packages/api/tests/testEnvironment.js
+++ b/packages/api/tests/testEnvironment.js
@@ -115,6 +115,7 @@ async function tableCleanup(knex) {
     DELETE FROM "pesticide";
     DELETE FROM "task_type";
     DELETE FROM "farmDataSchedule";
+    DELETE FROM "custom_animal_type";
     DELETE FROM "userFarm";
     DELETE FROM "farm";
     DELETE FROM "users" WHERE user_id <> '1';


### PR DESCRIPTION
**Description**

As discussed today in tech daily, here is a re-write of PR https://github.com/LiteFarmOrg/LiteFarm/pull/3074 but separating the default and custom animal type functionalities for evaluation 🙂 

Jira link: https://lite-farm.atlassian.net/browse/LF-3972

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

As before: Postman and new API tests. Note the `custom_animal_type` tests are basically unchanged from the previous tests.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
