### PR TITLE
Lf 3955 the white screen is displayed once the user deletes a crop plan for a wild crop with the transplant task in it and clicks on the button 2 times

### DIFF
--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -75,7 +75,7 @@ export default function PureManagementTasks({
         )
       }
     >
-      <CropHeader onBackClick={() => history.go(-1)} variety={variety} />
+      <CropHeader onBackClick={onBack} variety={variety} />
 
       <div className={styles.titlewrapper}>
         <Label className={styles.title} style={{ marginTop: '24px' }}>

--- a/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
+++ b/packages/webapp/src/components/Crop/ManagementDetail/ManagementPlanTasks.jsx
@@ -75,7 +75,7 @@ export default function PureManagementTasks({
         )
       }
     >
-      <CropHeader onBackClick={onBack} variety={variety} />
+      <CropHeader onBackClick={() => history.go(-1)} variety={variety} />
 
       <div className={styles.titlewrapper}>
         <Label className={styles.title} style={{ marginTop: '24px' }}>

--- a/packages/webapp/src/components/Crop/PlantedAlready/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantedAlready/index.jsx
@@ -56,6 +56,11 @@ export default function PurePlantedAlready({
   const MAX_SEEDLING_AGE = 999;
 
   useEffect(() => {
+    const persistedFormDataIsEmpty = Object.keys(persistedFormData).length === 0;
+    if (persistedFormDataIsEmpty) {
+      history.back();
+    }
+
     if (persistedFormData.crop_management_plan?.seed_date) {
       const currentDate = getDateInputFormat(new Date());
       const newAge = getDateDifference(

--- a/packages/webapp/src/components/Crop/PlantedAlready/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantedAlready/index.jsx
@@ -56,11 +56,6 @@ export default function PurePlantedAlready({
   const MAX_SEEDLING_AGE = 999;
 
   useEffect(() => {
-    const persistedFormDataIsEmpty = Object.keys(persistedFormData).length === 0;
-    if (persistedFormDataIsEmpty) {
-      history.back();
-    }
-
     if (persistedFormData.crop_management_plan?.seed_date) {
       const currentDate = getDateInputFormat(new Date());
       const newAge = getDateDifference(

--- a/packages/webapp/src/components/Crop/PlantedAlready/index.jsx
+++ b/packages/webapp/src/components/Crop/PlantedAlready/index.jsx
@@ -56,7 +56,7 @@ export default function PurePlantedAlready({
   const MAX_SEEDLING_AGE = 999;
 
   useEffect(() => {
-    if (persistedFormData.crop_management_plan.seed_date) {
+    if (persistedFormData.crop_management_plan?.seed_date) {
       const currentDate = getDateInputFormat(new Date());
       const newAge = getDateDifference(
         persistedFormData.crop_management_plan.seed_date,
@@ -99,6 +99,7 @@ export default function PurePlantedAlready({
     } else if (!cropVariety.can_be_cover_crop) {
       setValue(FOR_COVER, false);
     }
+
     history.push(submitPath, location?.state);
   };
   const onGoBack = () => history.back();

--- a/packages/webapp/src/containers/Crop/AddManagementPlan/PlantingLocation/index.jsx
+++ b/packages/webapp/src/containers/Crop/AddManagementPlan/PlantingLocation/index.jsx
@@ -23,6 +23,7 @@ export default function PlantingLocation({ history, match }) {
   const { interested } = useSelector(certifierSurveySelector);
 
   return (
+    // TODO: remove key property after multi step form/navigation logic refactor
     <Fragment key={`${variety_id}-${isFinalLocationPage}`}>
       <HookFormPersistProvider>
         <PurePlantingLocation

--- a/packages/webapp/src/containers/Crop/AddManagementPlan/PlantingLocation/index.jsx
+++ b/packages/webapp/src/containers/Crop/AddManagementPlan/PlantingLocation/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import PurePlantingLocation from '../../../../components/Crop/PlantingLocation';
 import { HookFormPersistProvider } from '../../../hooks/useHookFormPersist/HookFormPersistProvider';
@@ -23,7 +23,7 @@ export default function PlantingLocation({ history, match }) {
   const { interested } = useSelector(certifierSurveySelector);
 
   return (
-    <>
+    <Fragment key={`${variety_id}-${isFinalLocationPage}`}>
       <HookFormPersistProvider>
         <PurePlantingLocation
           isFinalLocationPage={isFinalLocationPage}
@@ -37,6 +37,6 @@ export default function PlantingLocation({ history, match }) {
         />
       </HookFormPersistProvider>
       {needs_transplant && !already_in_ground && <TransplantSpotlight is_seed={is_seed} />}
-    </>
+    </Fragment>
   );
 }


### PR DESCRIPTION
**Description**

**About the bug:**
For some reason when you create a crop plan answering these questions like this:
```
“Will you be planting this crop or is it already in the ground?” - In ground
“Are you harvesting a wild crop?” - Yes
“Will this crop be transplanted?” - Yes
```
After the creation is complete the first route of the creation flow: “add_management_plan/planted_already” stays on the browser history, and, when the user tries to go back using the browser go back button or the LiteFarm internal go back button, instead of being redirected to the crop management route the user is redirected to the planted_already route.

**About the solution:**
I was not able to identify what is causing this bug, so the changes that I've made are not the best way to fix this issue but minimize it by redirecting the user to the correct route and preventing the user from viewing an empty white screen.

Jira link: https://lite-farm.atlassian.net/browse/LF-3955

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Steps to reproduce:
1. Open the website  
2. Login with your account
3. Click on the Crops > Select any crop 
4. Click on the “Add a plan” button
5. Will you be planting this crop or is it already in the ground?  In Ground
6. Put Any Age 
7. Are you harvesting a wild crop? Yes 
8. Click on the “Continue” button
9. Will this crop be transplanted? Yes 
10. Complete the creation flow.
11. Click on the browser go-back button or the internal LiteFarm go-back button component “<“based on the Header.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
