### PR TITLE
LF-4023 fix finances menu item not highlighted

### DIFF
--- a/packages/webapp/src/components/Finances/FinancesCarrousel/index.jsx
+++ b/packages/webapp/src/components/Finances/FinancesCarrousel/index.jsx
@@ -30,6 +30,7 @@ import { Semibold, Text } from '../../Typography';
 import clsx from 'clsx';
 import TextButton from '../../Form/Button/TextButton';
 import {
+  ACTUAL_REVENUE_URL,
   ESTIMATED_REVENUE_URL,
   LABOUR_URL,
   OTHER_EXPENSE_URL,
@@ -84,7 +85,7 @@ const FinancesCarrousel = ({
           <div className={styles.revenueExpensesContainer}>
             <TextButton
               className={clsx([styles.revenueContainer, styles.clickableContainer])}
-              onClick={() => history.push('/finances/actual_revenue')}
+              onClick={() => history.push(ACTUAL_REVENUE_URL)}
             >
               <span>
                 <span className={styles.revenueTitle}>{t('SALE.FINANCES.TOTAL_REVENUE')}</span>

--- a/packages/webapp/src/hooks/useGetMenuItems.jsx
+++ b/packages/webapp/src/hooks/useGetMenuItems.jsx
@@ -28,8 +28,10 @@ import { useSelector } from 'react-redux';
 import { isAdminSelector } from '../containers/userFarmSlice';
 import styles from '../components/Navigation/SideMenu/styles.module.scss';
 import {
+  ACTUAL_REVENUE_URL,
   ESTIMATED_REVENUE_URL,
   FINANCES_HOME_URL,
+  FINANCES_URL,
   LABOUR_URL,
   OTHER_EXPENSE_URL,
 } from '../util/siteMapConstants';
@@ -55,7 +57,7 @@ export const useGetMenuItems = () => {
       list.splice(3, 0, {
         label: t('MENU.FINANCES'),
         icon: <FinancesIcon />,
-        path: FINANCES_HOME_URL,
+        path: FINANCES_URL,
         key: 'finances',
         subMenu: [
           {
@@ -71,7 +73,7 @@ export const useGetMenuItems = () => {
           { label: t('MENU.LABOUR_EXPENSES'), path: LABOUR_URL, key: 'labour' },
           {
             label: t('MENU.ACTUAL_REVENUES'),
-            path: '/finances/actual_revenue',
+            path: ACTUAL_REVENUE_URL,
             key: 'actual_revenue',
           },
           {

--- a/packages/webapp/src/routes/FinancesRoutes.jsx
+++ b/packages/webapp/src/routes/FinancesRoutes.jsx
@@ -16,6 +16,7 @@
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import {
+  ACTUAL_REVENUE_URL,
   ADD_CUSTOM_EXPENSE_URL,
   ADD_CUSTOM_REVENUE_URL,
   ADD_EXPENSE_URL,
@@ -82,7 +83,7 @@ const EditCustomRevenue = React.lazy(() =>
 const FinancesRoutes = () => (
   <Switch>
     <Route path={FINANCES_HOME_URL} exact component={Finances} />
-    <Route path="/finances/actual_revenue" exact component={ActualRevenue} />
+    <Route path={ACTUAL_REVENUE_URL} exact component={ActualRevenue} />
     <Route
       path={createManagementPlanEstimatedRevenueURL(':management_plan_id')}
       exact

--- a/packages/webapp/src/util/siteMapConstants.ts
+++ b/packages/webapp/src/util/siteMapConstants.ts
@@ -17,10 +17,13 @@
 //   as well as accomodating UUID types.
 
 // Finances
+
+export const FINANCES_URL = '/finances';
 export const FINANCES_HOME_URL = '/finances/transactions';
 export const REVENUE_TYPES_URL = '/finances/revenue_types';
 export const ADD_REVENUE_URL = '/finances/add_revenue';
 export const MANAGE_CUSTOM_REVENUES_URL = '/finances/manage_custom_revenues';
+export const ACTUAL_REVENUE_URL = '/finances/actual_revenue';
 export const ESTIMATED_REVENUE_URL = '/finances/estimated_revenue';
 export const LABOUR_URL = '/finances/labour';
 export const OTHER_EXPENSE_URL = '/finances/other_expense';


### PR DESCRIPTION
**Description**

When clicking on a subitem of Finances in the nav bar other than Transactions, the Finances menu item wasn't highlighted as active after hotfix 3.6.2.

Jira link:

https://lite-farm.atlassian.net/browse/LF-4023

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
