### PR TITLE
LF-4027: Add gender and birth year to user profile

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1346,7 +1346,7 @@
       "PHONE_NUMBER": "Phone Number",
       "PORTUGUESE": "Portuguese",
       "SPANISH": "Spanish",
-      "USER_ADDRESS": "User Address"
+      "USER_ADDRESS": "Address"
     },
     "ACCOUNT_TAB": "Account",
     "ERROR": {

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -1347,7 +1347,7 @@
       "PHONE_NUMBER": "Número de teléfono",
       "PORTUGUESE": "Portugués",
       "SPANISH": "Español",
-      "USER_ADDRESS": "Dirección de usuario"
+      "USER_ADDRESS": "Dirección"
     },
     "ACCOUNT_TAB": "Cuenta",
     "ERROR": {

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -1347,7 +1347,7 @@
       "PHONE_NUMBER": "Número de telefone",
       "PORTUGUESE": "Português",
       "SPANISH": "Espanhol",
-      "USER_ADDRESS": "Endereço do usuário"
+      "USER_ADDRESS": "Endereço"
     },
     "ACCOUNT_TAB": "Conta",
     "ERROR": {

--- a/packages/webapp/src/components/CreateUserAccount/index.jsx
+++ b/packages/webapp/src/components/CreateUserAccount/index.jsx
@@ -10,6 +10,7 @@ import { PasswordError } from '../Form/Errors';
 import ReactSelect from '../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../locales/i18n';
+import useGenderOptions from '../../hooks/useGenderOptions';
 
 export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNotSSO }) {
   const {
@@ -39,12 +40,7 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNot
     isTooShort,
   } = validatePasswordWithErrors(password);
 
-  const genderOptions = [
-    { value: 'MALE', label: t('gender:MALE') },
-    { value: 'FEMALE', label: t('gender:FEMALE') },
-    { value: 'OTHER', label: t('gender:OTHER') },
-    { value: 'PREFER_NOT_TO_SAY', label: t('gender:PREFER_NOT_TO_SAY') },
-  ];
+  const genderOptions = useGenderOptions();
 
   const languageOptions = [
     { value: 'en', label: t('PROFILE.ACCOUNT.ENGLISH') },

--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -9,6 +9,7 @@ import { Controller, useForm } from 'react-hook-form';
 import ReactSelect from '../Form/ReactSelect';
 import { useTranslation } from 'react-i18next';
 import { getFirstNameLastName } from '../../util';
+import useGenderOptions from '../../hooks/useGenderOptions';
 
 export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, roleOptions = [] }) {
   const {
@@ -40,12 +41,7 @@ export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, rol
   }, [selectedRoleId]);
   const { t } = useTranslation(['translation', 'common', 'gender']);
   const title = t('INVITE_USER.TITLE');
-  const genderOptions = [
-    { value: 'MALE', label: t('gender:MALE') },
-    { value: 'FEMALE', label: t('gender:FEMALE') },
-    { value: 'OTHER', label: t('gender:OTHER') },
-    { value: 'PREFER_NOT_TO_SAY', label: t('gender:PREFER_NOT_TO_SAY') },
-  ];
+  const genderOptions = useGenderOptions();
   const languageOptions = [
     { value: 'en', label: t('PROFILE.ACCOUNT.ENGLISH') },
     { value: 'es', label: t('PROFILE.ACCOUNT.SPANISH') },

--- a/packages/webapp/src/components/InvitedUserCreateAccount/index.jsx
+++ b/packages/webapp/src/components/InvitedUserCreateAccount/index.jsx
@@ -9,6 +9,7 @@ import ReactSelect from '../Form/ReactSelect';
 import Input, { getInputErrors, integerOnKeyDown } from '../Form/Input';
 import { PasswordError } from '../Form/Errors';
 import { validatePasswordWithErrors } from '../Signup/utils';
+import useGenderOptions from '../../hooks/useGenderOptions';
 
 export default function PureInvitedUserCreateAccountPage({
   onSubmit,
@@ -44,12 +45,7 @@ export default function PureInvitedUserCreateAccountPage({
   });
 
   const { t } = useTranslation(['translation', 'gender']);
-  const genderOptions = [
-    { value: 'MALE', label: t('gender:MALE') },
-    { value: 'FEMALE', label: t('gender:FEMALE') },
-    { value: 'OTHER', label: t('gender:OTHER') },
-    { value: 'PREFER_NOT_TO_SAY', label: t('gender:PREFER_NOT_TO_SAY') },
-  ];
+  const genderOptions = useGenderOptions();
   const validEmailRegex = RegExp(/^$|^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i);
 
   const onError = (error) => {

--- a/packages/webapp/src/components/Profile/Account/index.jsx
+++ b/packages/webapp/src/components/Profile/Account/index.jsx
@@ -7,6 +7,7 @@ import React, { useEffect, useRef } from 'react';
 import Button from '../../Form/Button';
 import PropTypes from 'prop-types';
 import ProfileLayout from '../ProfileLayout';
+import useGenderOptions from '../../../hooks/useGenderOptions';
 
 const useLanguageOptions = (language_preference) => {
   const { t } = useTranslation();
@@ -23,6 +24,7 @@ const useLanguageOptions = (language_preference) => {
 };
 
 export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
+  const genderOptions = useGenderOptions();
   const { languageOptions, languagePreferenceOptionRef } = useLanguageOptions(
     userFarm.language_preference,
   );
@@ -35,7 +37,12 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
     formState: { isValid, isDirty, errors },
   } = useForm({
     mode: 'onChange',
-    defaultValues: userFarm,
+    defaultValues: {
+      ...userFarm,
+      [userFarmEnum.gender]: genderOptions.find(
+        ({ value }) => value === userFarm[userFarmEnum.gender],
+      ),
+    },
     shouldUnregister: true,
   });
   useEffect(() => {
@@ -92,10 +99,40 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
       />
       <Controller
         control={control}
+        name={userFarmEnum.gender}
+        render={({ field: { onChange, value } }) => (
+          <ReactSelect
+            label={t('CREATE_USER.GENDER')}
+            options={genderOptions}
+            onChange={onChange}
+            value={value}
+            toolTipContent={t('CREATE_USER.GENDER_TOOLTIP')}
+          />
+        )}
+      />
+      <Controller
+        control={control}
         name={userFarmEnum.language_preference}
         render={({ field }) => (
           <ReactSelect label={t('PROFILE.ACCOUNT.LANGUAGE')} options={languageOptions} {...field} />
         )}
+      />
+      <Input
+        label={t('CREATE_USER.BIRTH_YEAR')}
+        type="number"
+        onKeyPress={integerOnKeyDown}
+        hookFormRegister={register(userFarmEnum.birth_year, {
+          min: 1900,
+          max: new Date().getFullYear(),
+          valueAsNumber: true,
+        })}
+        toolTipContent={t('CREATE_USER.BIRTH_YEAR_TOOLTIP')}
+        errors={
+          errors[userFarmEnum.birth_year] &&
+          (errors[userFarmEnum.birth_year].message ||
+            `${t('CREATE_USER.BIRTH_YEAR_ERROR')} ${new Date().getFullYear()}`)
+        }
+        optional
       />
       <Input
         label={t('PROFILE.ACCOUNT.USER_ADDRESS')}
@@ -116,6 +153,9 @@ PureAccount.propTypes = {
     email: PropTypes.string,
     phone_number: PropTypes.string,
     user_address: PropTypes.string,
+    language_preference: PropTypes.string,
+    gender: PropTypes.oneOf(['MALE', 'FEMALE', 'OTHER', 'PREFER_NOT_TO_SAY']),
+    birth_year: PropTypes.number,
   }).isRequired,
   onSubmit: PropTypes.func,
 };

--- a/packages/webapp/src/components/Profile/Account/index.jsx
+++ b/packages/webapp/src/components/Profile/Account/index.jsx
@@ -97,6 +97,32 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
         errors={errors[userFarmEnum.phone_number] && errors[userFarmEnum.phone_number].message}
         optional
       />
+      <Input
+        label={t('PROFILE.ACCOUNT.USER_ADDRESS')}
+        hookFormRegister={register(userFarmEnum.user_address, {
+          required: false,
+          maxLength: { value: 255, message: t('PROFILE.ERROR.USER_ADDRESS_LENGTH') },
+        })}
+        errors={errors[userFarmEnum.user_address] && errors[userFarmEnum.user_address].message}
+        optional
+      />
+      <Input
+        label={t('CREATE_USER.BIRTH_YEAR')}
+        type="number"
+        onKeyPress={integerOnKeyDown}
+        hookFormRegister={register(userFarmEnum.birth_year, {
+          min: 1900,
+          max: new Date().getFullYear(),
+          valueAsNumber: true,
+        })}
+        toolTipContent={t('CREATE_USER.BIRTH_YEAR_TOOLTIP')}
+        errors={
+          errors[userFarmEnum.birth_year] &&
+          (errors[userFarmEnum.birth_year].message ||
+            `${t('CREATE_USER.BIRTH_YEAR_ERROR')} ${new Date().getFullYear()}`)
+        }
+        optional
+      />
       <Controller
         control={control}
         name={userFarmEnum.gender}
@@ -116,32 +142,6 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
         render={({ field }) => (
           <ReactSelect label={t('PROFILE.ACCOUNT.LANGUAGE')} options={languageOptions} {...field} />
         )}
-      />
-      <Input
-        label={t('CREATE_USER.BIRTH_YEAR')}
-        type="number"
-        onKeyPress={integerOnKeyDown}
-        hookFormRegister={register(userFarmEnum.birth_year, {
-          min: 1900,
-          max: new Date().getFullYear(),
-          valueAsNumber: true,
-        })}
-        toolTipContent={t('CREATE_USER.BIRTH_YEAR_TOOLTIP')}
-        errors={
-          errors[userFarmEnum.birth_year] &&
-          (errors[userFarmEnum.birth_year].message ||
-            `${t('CREATE_USER.BIRTH_YEAR_ERROR')} ${new Date().getFullYear()}`)
-        }
-        optional
-      />
-      <Input
-        label={t('PROFILE.ACCOUNT.USER_ADDRESS')}
-        hookFormRegister={register(userFarmEnum.user_address, {
-          required: false,
-          maxLength: { value: 255, message: t('PROFILE.ERROR.USER_ADDRESS_LENGTH') },
-        })}
-        errors={errors[userFarmEnum.user_address] && errors[userFarmEnum.user_address].message}
-        optional
       />
     </ProfileLayout>
   );

--- a/packages/webapp/src/components/Profile/EditUser/index.jsx
+++ b/packages/webapp/src/components/Profile/EditUser/index.jsx
@@ -12,6 +12,7 @@ import InvalidRevokeUserAccessModal from '../../Modals/InvalidRevokeUserAccessMo
 import Checkbox from '../../Form/Checkbox';
 import { useSelector } from 'react-redux';
 import { userFarmsByFarmSelector } from '../../../containers/userFarmSlice';
+import useGenderOptions from '../../../hooks/useGenderOptions';
 
 export default function PureEditUser({
   userFarm,
@@ -41,12 +42,7 @@ export default function PureEditUser({
   const userFarms = useSelector(userFarmsByFarmSelector);
   const adminRoles = [1, 2, 5];
 
-  const genderOptions = [
-    { value: 'MALE', label: t('gender:MALE') },
-    { value: 'FEMALE', label: t('gender:FEMALE') },
-    { value: 'OTHER', label: t('gender:OTHER') },
-    { value: 'PREFER_NOT_TO_SAY', label: t('gender:PREFER_NOT_TO_SAY') },
-  ];
+  const genderOptions = useGenderOptions();
   const languageOptions = [
     { value: 'en', label: t('PROFILE.ACCOUNT.ENGLISH') },
     { value: 'es', label: t('PROFILE.ACCOUNT.SPANISH') },

--- a/packages/webapp/src/hooks/useGenderOptions.jsx
+++ b/packages/webapp/src/hooks/useGenderOptions.jsx
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useTranslation } from 'react-i18next';
+
+const useGenderOptions = () => {
+  const { t } = useTranslation();
+
+  return [
+    { value: 'MALE', label: t('gender:MALE') },
+    { value: 'FEMALE', label: t('gender:FEMALE') },
+    { value: 'OTHER', label: t('gender:OTHER') },
+    { value: 'PREFER_NOT_TO_SAY', label: t('gender:PREFER_NOT_TO_SAY') },
+  ];
+};
+
+export default useGenderOptions;

--- a/packages/webapp/src/stories/Pages/Profile/Account.stories.jsx
+++ b/packages/webapp/src/stories/Pages/Profile/Account.stories.jsx
@@ -20,6 +20,9 @@ Primary.args = {
     email: 'example@litefarm.org',
     phone_number: '123456789',
     user_address: 'litefarm',
+    language_preference: 'fr',
+    gender: 'MALE',
+    birth_year: 2000,
   },
 };
 Primary.parameters = {


### PR DESCRIPTION
**Description**

- create `useGenderOptions` hook and use it in components
- add gender and birth year inputs to `Account` component
- update the account [story](http://localhost:6006/?path=/story/form-profile-account--primary)
- update label `User Address` to `Address` and change the order of the inputs based on Loïc's [suggestion](https://lite-farm.atlassian.net/browse/LF-4027?focusedCommentId=16860)

Jira link: https://lite-farm.atlassian.net/browse/LF-4027

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
