### PR TITLE
LF-4037: add default to last name

### DIFF
--- a/packages/api/db/migration/20240125135642_add_user_last_name_default.js
+++ b/packages/api/db/migration/20240125135642_add_user_last_name_default.js
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  await knex.schema.alterTable('users', (table) => {
+    table.string('last_name').notNullable().defaultTo('').alter();
+  });
+};
+
+export const down = async function (knex) {
+  await knex.schema.alterTable('users', (table) => {
+    table.string('last_name').notNullable().defaultTo(null).alter();
+  });
+};

--- a/packages/api/src/controllers/loginController.js
+++ b/packages/api/src/controllers/loginController.js
@@ -158,6 +158,7 @@ const loginController = {
           isInvited: user?.status_id === 2,
         });
       } catch (err) {
+        console.error(err);
         return res.status(400).json({
           err,
         });

--- a/packages/api/src/models/userModel.js
+++ b/packages/api/src/models/userModel.js
@@ -85,7 +85,7 @@ class User extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['first_name', 'last_name', 'email'],
+      required: ['first_name', 'email'],
 
       properties: {
         user_id: { type: 'string' },


### PR DESCRIPTION
**Description**

Add default of `''` to `last_name` colum in `users` table.
We're currently not setting a default at the db level and have a fallback of '' on the client when we send out the user information from an invitation. To avoid having to set this fallback in each place where we add a user, I defaulted the column and made the field not required at the model level.

Jira link:
https://lite-farm.atlassian.net/browse/LF-4037

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested bug by creating a Google account without a last name and verifying that I could use it to log into Litefarm.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
