### PR TITLE
LF-4038: The app crashes on the home page once the user saves the user profile without preferred language

### DIFF
--- a/packages/webapp/src/components/Profile/Account/index.jsx
+++ b/packages/webapp/src/components/Profile/Account/index.jsx
@@ -82,6 +82,7 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
           maxLength: { value: 255, message: t('PROFILE.ERROR.LAST_NAME_LENGTH') },
         })}
         errors={errors[userFarmEnum.last_name] && errors[userFarmEnum.last_name].message}
+        optional
       />
       <Input
         label={t('PROFILE.ACCOUNT.EMAIL')}

--- a/packages/webapp/src/components/Profile/Account/index.jsx
+++ b/packages/webapp/src/components/Profile/Account/index.jsx
@@ -19,7 +19,8 @@ const useLanguageOptions = (language_preference) => {
   };
   const languageOptions = Object.values(languageOptionMap);
   const languagePreferenceOptionRef = useRef();
-  languagePreferenceOptionRef.current = languageOptionMap[language_preference];
+  languagePreferenceOptionRef.current =
+    languageOptionMap[language_preference] || language_preference;
   return { languageOptionMap, languageOptions, languagePreferenceOptionRef };
 };
 
@@ -46,6 +47,7 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
     shouldUnregister: true,
   });
   useEffect(() => {
+    // get proper translations for the selected options right after language preference is updated
     setValue(userFarmEnum.language_preference, null, { shouldValidate: false, shouldDirty: false });
     setTimeout(() => {
       setValue(userFarmEnum.language_preference, languagePreferenceOptionRef.current, {


### PR DESCRIPTION
**Description**

When the user with a non-LF language changes their profile without setting a language, `language_preference` becomes `undefined` ~~in the Redux store~~ and the `litefarm_lang` key in local storage is set to undefined in saga, which causes a crash in the home page. (Thank you Joyce!)

https://github.com/LiteFarmOrg/LiteFarm/blob/37d34dfd0fcc623567583f9c1ba48fef9ea84641/packages/webapp/src/containers/WeatherBoard/utils/index.jsx#L28-L34
(⬆️ `lang` being `undefined` causes a crash)

**Changes**
- update `useLanguageOptions` hook to keep `language_preference` as is. Currently the selected option is becoming `null` for a non-LF language.
- add `option` tag to the last name input label.

NOTE:
I realized that the selected gender does not reflect the newly saved language preference, so I created a [ticket](https://lite-farm.atlassian.net/browse/LF-4040)

Jira link: https://lite-farm.atlassian.net/browse/LF-4040

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
