### PR TITLE
Lf 3792 the sale will no longer be visible once the crop plan will be deleted completed or abandoned

### DIFF
--- a/packages/webapp/src/containers/managementPlanSlice.js
+++ b/packages/webapp/src/containers/managementPlanSlice.js
@@ -176,6 +176,14 @@ export const managementPlansSelector = createSelector(
     ),
 );
 
+export const allManagementPlansSelector = createSelector(
+  [managementPlanEntitiesSelector, loginSelector],
+  (managementPlanEntities, { farm_id }) =>
+    Object.values(managementPlanEntities).filter(
+      (managementPlan) => managementPlan.crop_variety.farm_id === farm_id,
+    ),
+);
+
 export const expiredManagementPlansSelector = createSelector(
   [managementPlansSelector, lastActiveDatetimeSelector],
   (managementPlans, lastActiveDatetime) => {


### PR DESCRIPTION
**Description**

This PR fixes the issue where revenue for a crop sale does not show the crop when the crop management plan for that crop is not active or planned. This can happen when the user deletes, abandons or completes a plan after generating a revenue.

Changes:
- Added a selector to select all management plans 
- Modified useSelector inside useCropSaleInputs to include management plans for crop(s) associated with that particular sale irrespective of their management plan status. 

Jira link: https://lite-farm.atlassian.net/browse/LF-3792

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
