### PR TITLE
Fix for compile typeError

### DIFF
--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -43,4 +43,7 @@ export default defineConfig({
       '@shared': path.resolve(__dirname, '../shared'),
     },
   },
+  optimizeDeps: {
+    include: ['@mui/material/Tooltip'],
+  },
 });


### PR DESCRIPTION
**Description**
![Screenshot 2024-02-09 at 2 48 46 PM](https://github.com/LiteFarmOrg/LiteFarm/assets/30075973/e70a7d8b-01fc-433d-8df0-68fcb35e8665)

Some updated package is triggering an inconsistently replicable bug shown above. 

There seems to be some issue with how vite compiles and how some MUI modules use esm vs cjs. From what I can tell vite is not compiling right but some MUI modules are being updated to new conventions.

- styled_default is not a function
	- https://github.com/mui/material-ui/issues/32727
	- https://github.com/vitejs/vite/issues/12423
 

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
