### PR TITLE
LF-4092 - update animal controllers to use handle objection error

### DIFF
--- a/packages/api/src/controllers/animalBatchController.js
+++ b/packages/api/src/controllers/animalBatchController.js
@@ -78,6 +78,11 @@ const animalBatchController = {
             }
           }
 
+          if (animalBatch.default_breed_id && animalBatch.custom_type_id) {
+            await trx.rollback();
+            return res.status(400).send('Default breed does not use custom type');
+          }
+
           if (animalBatch.custom_breed_id) {
             const customBreed = await CustomAnimalBreedModel.query()
               .whereNotDeleted()

--- a/packages/api/src/controllers/animalBatchController.js
+++ b/packages/api/src/controllers/animalBatchController.js
@@ -19,7 +19,7 @@ import baseController from './baseController.js';
 import DefaultAnimalBreedModel from '../models/defaultAnimalBreedModel.js';
 import CustomAnimalBreedModel from '../models/customAnimalBreedModel.js';
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
-import { handleObjectionError } from '../util/errorCodes.js';
+import { handleDBError } from '../util/errorCodes.js';
 import { assignInternalIdentifiers } from '../util/animal.js';
 
 const animalBatchController = {
@@ -150,7 +150,7 @@ const animalBatchController = {
         await assignInternalIdentifiers(result, 'batch');
         return res.status(201).send(result);
       } catch (error) {
-        await handleObjectionError(error, res, trx);
+        await handleDBError(error, res, trx);
       }
     };
   },
@@ -215,7 +215,7 @@ const animalBatchController = {
         await trx.commit();
         return res.status(204).send();
       } catch (error) {
-        handleObjectionError(error, res, trx);
+        handleDBError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalBatchController.js
+++ b/packages/api/src/controllers/animalBatchController.js
@@ -19,7 +19,7 @@ import baseController from './baseController.js';
 import DefaultAnimalBreedModel from '../models/defaultAnimalBreedModel.js';
 import CustomAnimalBreedModel from '../models/customAnimalBreedModel.js';
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
-import { handleDBError } from '../util/errorCodes.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 import { assignInternalIdentifiers } from '../util/animal.js';
 
 const animalBatchController = {
@@ -150,7 +150,7 @@ const animalBatchController = {
         await assignInternalIdentifiers(result, 'batch');
         return res.status(201).send(result);
       } catch (error) {
-        await handleDBError(error, res, trx);
+        await handleObjectionError(error, res, trx);
       }
     };
   },
@@ -215,7 +215,7 @@ const animalBatchController = {
         await trx.commit();
         return res.status(204).send();
       } catch (error) {
-        handleDBError(error, res, trx);
+        handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalController.js
+++ b/packages/api/src/controllers/animalController.js
@@ -20,7 +20,7 @@ import DefaultAnimalBreedModel from '../models/defaultAnimalBreedModel.js';
 import CustomAnimalBreedModel from '../models/customAnimalBreedModel.js';
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { assignInternalIdentifiers } from '../util/animal.js';
-import { handleDBError } from '../util/errorCodes.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 
 const animalController = {
   getFarmAnimals() {
@@ -121,7 +121,7 @@ const animalController = {
         await assignInternalIdentifiers(result, 'animal');
         return res.status(201).send(result);
       } catch (error) {
-        await handleDBError(error, res, trx);
+        await handleObjectionError(error, res, trx);
       }
     };
   },
@@ -186,7 +186,7 @@ const animalController = {
         await trx.commit();
         return res.status(204).send();
       } catch (error) {
-        handleDBError(error, res, trx);
+        handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalController.js
+++ b/packages/api/src/controllers/animalController.js
@@ -18,7 +18,6 @@ import AnimalModel from '../models/animalModel.js';
 import baseController from './baseController.js';
 import DefaultAnimalBreedModel from '../models/defaultAnimalBreedModel.js';
 import CustomAnimalBreedModel from '../models/customAnimalBreedModel.js';
-import DefaultAnimalTypeModel from '../models/defaultAnimalTypeModel.js';
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { assignInternalIdentifiers } from '../util/animal.js';
 import { handleObjectionError } from '../util/errorCodes.js';
@@ -51,60 +50,30 @@ const animalController = {
         const { farm_id } = req.headers;
         const result = [];
 
-        if (!Array.isArray(req.body)) {
-          await trx.rollback();
-          return res.status(400).send('Request body should be an array');
-        }
-
         for (const animal of req.body) {
-          if (!animal.default_type_id && !animal.custom_type_id) {
-            await trx.rollback();
-            return res.status(400).send('Should send either default_type_id or custom_type_id');
-          }
-
-          if (animal.default_type_id && animal.custom_type_id) {
-            await trx.rollback();
-            return res
-              .status(400)
-              .send('Should only send either default_type_id or custom_type_id');
-          }
-
-          if (animal.default_breed_id && animal.custom_breed_id) {
-            await trx.rollback();
-            return res
-              .status(400)
-              .send('Should only send either default_breed_id or custom_breed_id');
-          }
-
-          if (animal.default_type_id) {
-            const defaultType = await DefaultAnimalTypeModel.query().findById(
-              animal.default_type_id,
-            );
-
-            if (!defaultType) {
-              await trx.rollback();
-              return res.status(400).send('default_type_id has invalid value');
-            }
-          }
-
           if (animal.custom_type_id) {
             const customType = await CustomAnimalTypeModel.query().findById(animal.custom_type_id);
 
-            if (!customType || customType.farm_id !== farm_id) {
+            if (customType && customType.farm_id !== farm_id) {
               await trx.rollback();
-              return res.status(400).send('custom_type_id has invalid value');
+              return res.status(403).send('Forbidden custom type does not belong to this farm');
             }
           }
 
-          if (animal.default_breed_id) {
+          if (animal.default_breed_id && animal.default_type_id) {
             const defaultBreed = await DefaultAnimalBreedModel.query().findById(
               animal.default_breed_id,
             );
 
-            if (!defaultBreed || defaultBreed.default_type_id !== animal.default_type_id) {
+            if (defaultBreed && defaultBreed.default_type_id !== animal.default_type_id) {
               await trx.rollback();
-              return res.status(400).send('default_breed_id has invalid value');
+              return res.status(400).send('Breed does not match type');
             }
+          }
+
+          if (animal.default_breed_id && animal.custom_type_id) {
+            await trx.rollback();
+            return res.status(400).send('Default breed does not use custom type');
           }
 
           if (animal.custom_breed_id) {
@@ -112,9 +81,9 @@ const animalController = {
               .whereNotDeleted()
               .findById(animal.custom_breed_id);
 
-            if (!customBreed || customBreed.farm_id !== farm_id) {
+            if (customBreed && customBreed.farm_id !== farm_id) {
               await trx.rollback();
-              return res.status(400).send('custom_breed_id has invalid value');
+              return res.status(403).send('Forbidden custom breed does not belong to this farm');
             }
 
             if (
@@ -122,7 +91,7 @@ const animalController = {
               customBreed.default_type_id !== animal.default_type_id
             ) {
               await trx.rollback();
-              return res.status(400).send('custom_breed_id has invalid value');
+              return res.status(400).send('Breed does not match type');
             }
 
             if (
@@ -130,7 +99,7 @@ const animalController = {
               customBreed.custom_type_id !== animal.custom_type_id
             ) {
               await trx.rollback();
-              return res.status(400).send('custom_breed_id has invalid value');
+              return res.status(400).send('Breed does not match type');
             }
           }
 
@@ -152,11 +121,7 @@ const animalController = {
         await assignInternalIdentifiers(result, 'animal');
         return res.status(201).send(result);
       } catch (error) {
-        console.error(error);
-        await trx.rollback();
-        return res.status(500).json({
-          error,
-        });
+        await handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalController.js
+++ b/packages/api/src/controllers/animalController.js
@@ -20,7 +20,7 @@ import DefaultAnimalBreedModel from '../models/defaultAnimalBreedModel.js';
 import CustomAnimalBreedModel from '../models/customAnimalBreedModel.js';
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { assignInternalIdentifiers } from '../util/animal.js';
-import { handleObjectionError } from '../util/errorCodes.js';
+import { handleDBError } from '../util/errorCodes.js';
 
 const animalController = {
   getFarmAnimals() {
@@ -121,7 +121,7 @@ const animalController = {
         await assignInternalIdentifiers(result, 'animal');
         return res.status(201).send(result);
       } catch (error) {
-        await handleObjectionError(error, res, trx);
+        await handleDBError(error, res, trx);
       }
     };
   },
@@ -186,7 +186,7 @@ const animalController = {
         await trx.commit();
         return res.status(204).send();
       } catch (error) {
-        handleObjectionError(error, res, trx);
+        handleDBError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalGroupController.js
+++ b/packages/api/src/controllers/animalGroupController.js
@@ -21,7 +21,7 @@ import AnimalBatchGroupRelationshipModel from '../models/animalBatchGroupRelatio
 import AnimalModel from '../models/animalModel.js';
 import AnimalBatchModel from '../models/animalBatchModel.js';
 import { checkAndTrimString } from '../util/util.js';
-import { handleObjectionError } from '../util/errorCodes.js';
+import { handleDBError } from '../util/errorCodes.js';
 
 const animalGroupController = {
   getFarmAnimalGroups() {
@@ -138,7 +138,7 @@ const animalGroupController = {
         await trx.commit();
         return res.status(201).send(result);
       } catch (error) {
-        await handleObjectionError(error, res, trx);
+        await handleDBError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalGroupController.js
+++ b/packages/api/src/controllers/animalGroupController.js
@@ -21,6 +21,7 @@ import AnimalBatchGroupRelationshipModel from '../models/animalBatchGroupRelatio
 import AnimalModel from '../models/animalModel.js';
 import AnimalBatchModel from '../models/animalBatchModel.js';
 import { checkAndTrimString } from '../util/util.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 
 const animalGroupController = {
   getFarmAnimalGroups() {
@@ -56,16 +57,6 @@ const animalGroupController = {
         let { name, notes } = req.body;
         name = checkAndTrimString(name);
         notes = checkAndTrimString(notes);
-
-        if (!name) {
-          await trx.rollback();
-          return res.status(400).send('Group name is required');
-        }
-
-        if (!Array.isArray(related_animal_ids) || !Array.isArray(related_batch_ids)) {
-          await trx.rollback();
-          return res.status(400).send('Animal ids and batch ids must be arrays');
-        }
 
         const relatedAnimalIdSet = new Set(related_animal_ids);
         const relatedBatchIdSet = new Set(related_batch_ids);
@@ -147,9 +138,7 @@ const animalGroupController = {
         await trx.commit();
         return res.status(201).send(result);
       } catch (error) {
-        await trx.rollback();
-        console.error(error);
-        return res.status(500).json({ error });
+        await handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/animalGroupController.js
+++ b/packages/api/src/controllers/animalGroupController.js
@@ -21,7 +21,7 @@ import AnimalBatchGroupRelationshipModel from '../models/animalBatchGroupRelatio
 import AnimalModel from '../models/animalModel.js';
 import AnimalBatchModel from '../models/animalBatchModel.js';
 import { checkAndTrimString } from '../util/util.js';
-import { handleDBError } from '../util/errorCodes.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 
 const animalGroupController = {
   getFarmAnimalGroups() {
@@ -138,7 +138,7 @@ const animalGroupController = {
         await trx.commit();
         return res.status(201).send(result);
       } catch (error) {
-        await handleDBError(error, res, trx);
+        await handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/customAnimalBreedController.js
+++ b/packages/api/src/controllers/customAnimalBreedController.js
@@ -18,7 +18,7 @@ import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { transaction, Model } from 'objection';
 import baseController from './baseController.js';
 import { checkAndTrimString } from '../util/util.js';
-import { handleObjectionError } from '../util/errorCodes.js';
+import { handleDBError } from '../util/errorCodes.js';
 
 const customAnimalBreedController = {
   getCustomAnimalBreeds() {
@@ -99,7 +99,7 @@ const customAnimalBreedController = {
           return res.status(201).send(result);
         }
       } catch (error) {
-        await handleObjectionError(error, res, trx);
+        await handleDBError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/customAnimalBreedController.js
+++ b/packages/api/src/controllers/customAnimalBreedController.js
@@ -18,7 +18,7 @@ import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { transaction, Model } from 'objection';
 import baseController from './baseController.js';
 import { checkAndTrimString } from '../util/util.js';
-import { handleDBError } from '../util/errorCodes.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 
 const customAnimalBreedController = {
   getCustomAnimalBreeds() {
@@ -99,7 +99,7 @@ const customAnimalBreedController = {
           return res.status(201).send(result);
         }
       } catch (error) {
-        await handleDBError(error, res, trx);
+        await handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/customAnimalBreedController.js
+++ b/packages/api/src/controllers/customAnimalBreedController.js
@@ -59,18 +59,6 @@ const customAnimalBreedController = {
         const { default_type_id, custom_type_id } = req.body;
         breed = checkAndTrimString(breed);
 
-        // if (default_type_id && custom_type_id) {
-        //   await trx.rollback();
-        //   return res.status(400).send('Only default_type_id or custom_type_id should be specified');
-        // }
-
-        // if (!default_type_id && !custom_type_id) {
-        //   await trx.rollback();
-        //   return res
-        //     .status(400)
-        //     .send('One of default_type_id or custom_type_id should be specified');
-        // }
-
         const breedDetails = { breed };
 
         if (custom_type_id) {

--- a/packages/api/src/controllers/customAnimalTypeController.js
+++ b/packages/api/src/controllers/customAnimalTypeController.js
@@ -18,7 +18,7 @@ import baseController from './baseController.js';
 
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { checkAndTrimString } from '../util/util.js';
-import { handleDBError } from '../util/errorCodes.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 
 const customAnimalTypeController = {
   getCustomAnimalTypes() {
@@ -71,7 +71,7 @@ const customAnimalTypeController = {
         await trx.commit();
         return res.status(201).send(result);
       } catch (error) {
-        await handleDBError(error, res, trx);
+        await handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/customAnimalTypeController.js
+++ b/packages/api/src/controllers/customAnimalTypeController.js
@@ -18,6 +18,7 @@ import baseController from './baseController.js';
 
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { checkAndTrimString } from '../util/util.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 
 const customAnimalTypeController = {
   getCustomAnimalTypes() {
@@ -47,11 +48,6 @@ const customAnimalTypeController = {
         let { type } = req.body;
         type = checkAndTrimString(type);
 
-        if (!type) {
-          await trx.rollback();
-          return res.status(400).send('Animal type must be provided');
-        }
-
         const record = await baseController.existsInTable(trx, CustomAnimalTypeModel, {
           type,
           farm_id,
@@ -75,9 +71,7 @@ const customAnimalTypeController = {
         await trx.commit();
         return res.status(201).send(result);
       } catch (error) {
-        await trx.rollback();
-        console.error(error);
-        return res.status(500).json({ error });
+        await handleObjectionError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/controllers/customAnimalTypeController.js
+++ b/packages/api/src/controllers/customAnimalTypeController.js
@@ -18,7 +18,7 @@ import baseController from './baseController.js';
 
 import CustomAnimalTypeModel from '../models/customAnimalTypeModel.js';
 import { checkAndTrimString } from '../util/util.js';
-import { handleObjectionError } from '../util/errorCodes.js';
+import { handleDBError } from '../util/errorCodes.js';
 
 const customAnimalTypeController = {
   getCustomAnimalTypes() {
@@ -71,7 +71,7 @@ const customAnimalTypeController = {
         await trx.commit();
         return res.status(201).send(result);
       } catch (error) {
-        await handleObjectionError(error, res, trx);
+        await handleDBError(error, res, trx);
       }
     };
   },

--- a/packages/api/src/util/errorCodes.js
+++ b/packages/api/src/util/errorCodes.js
@@ -16,27 +16,6 @@
 // See https://github.com/Vincit/objection.js/issues/2023#issuecomment-806059039
 import objection from 'objection';
 
-export async function handleDBError(err, res, trx) {
-  console.error(err); // also reports to Sentry
-  try {
-    // Check that response has not been sent
-    if (!res.writableFinished) {
-      await handleObjectionError(err, res, trx);
-    }
-    // Check that response has not been sent
-    if (!res.writableFinished) {
-      await handleCustomError(err, res, trx);
-    }
-  } catch {
-    await trx.rollback();
-    res.status(500).send({
-      message: err.message,
-      type: 'UnknownError',
-      data: {},
-    });
-  }
-}
-
 /**
  * Handles objection.js errors and sends appropriate responses based on the error type.
  * Augmented from: https://vincit.github.io/objection.js/recipes/error-handling.html#examples
@@ -53,7 +32,8 @@ export async function handleDBError(err, res, trx) {
  *   await handleObjectionError(error, res, trx);
  * }
  */
-async function handleObjectionError(err, res, trx) {
+export async function handleObjectionError(err, res, trx) {
+  console.error(err); // also reports to Sentry
   if (err instanceof objection.ValidationError) {
     switch (err.type) {
       case 'ModelValidation':
@@ -164,33 +144,6 @@ async function handleObjectionError(err, res, trx) {
     res.status(500).send({
       message: err.message,
       type: 'UnknownDatabaseError',
-      data: {},
-    });
-  }
-}
-
-// Objection response
-const isNotIterable = 'is not iterable';
-// Plain knex response for tests
-const isNotIterableTests =
-  'Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.';
-
-const captureAllBefore = (searchString) => `^.*(?=( ${searchString}))`;
-
-async function handleCustomError(err, res, trx) {
-  if (err.message?.includes(isNotIterable)) {
-    const badData = err.message?.match(captureAllBefore(isNotIterable));
-    await trx.rollback();
-    res.status(400).send({
-      message: 'Data should be formatted in an array',
-      type: 'RequestFormatError',
-      data: badData[0],
-    });
-  } else if (err.message?.includes(isNotIterableTests)) {
-    await trx.rollback();
-    res.status(400).send({
-      message: 'Data should be formatted in an array',
-      type: 'RequestFormatError',
       data: {},
     });
   } else {

--- a/packages/api/tests/animal.test.js
+++ b/packages/api/tests/animal.test.js
@@ -242,7 +242,7 @@ describe('Animal Tests', () => {
         animal,
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(500);
     });
 
     test('Unique internal_identifier should be added within the same farm_id between animals and animalBatches', async () => {
@@ -303,7 +303,7 @@ describe('Animal Tests', () => {
         [animal],
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(403);
     });
 
     test('Should not be able to create an animal with a breed belonging to a different farm', async () => {
@@ -328,7 +328,7 @@ describe('Animal Tests', () => {
         [animal],
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(403);
     });
 
     test('Should not be able to create an animal where type and breed do not match', async () => {

--- a/packages/api/tests/animal.test.js
+++ b/packages/api/tests/animal.test.js
@@ -242,7 +242,7 @@ describe('Animal Tests', () => {
         animal,
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(500);
     });
 
     test('Unique internal_identifier should be added within the same farm_id between animals and animalBatches', async () => {

--- a/packages/api/tests/animal.test.js
+++ b/packages/api/tests/animal.test.js
@@ -242,7 +242,7 @@ describe('Animal Tests', () => {
         animal,
       );
 
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(400);
     });
 
     test('Unique internal_identifier should be added within the same farm_id between animals and animalBatches', async () => {

--- a/packages/api/tests/animal_batch.test.js
+++ b/packages/api/tests/animal_batch.test.js
@@ -222,7 +222,7 @@ describe('Animal Batch Tests', () => {
         });
         const secondAnimalBatch = mocks.fakeAnimalBatch({
           default_breed_id: defaultBreedId,
-          custom_type_id: animalType.id,
+          default_type_id: defaultTypeId,
         });
         const thirdAnimalBatch = mocks.fakeAnimalBatch({
           custom_type_id: animalBreed.custom_type_id,

--- a/packages/api/tests/animal_group.test.js
+++ b/packages/api/tests/animal_group.test.js
@@ -172,15 +172,19 @@ describe('Animal Group Tests', () => {
         expect(res.status).toBe(200);
         // Should return first two animal groups
         expect(res.body.length).toBe(2);
+        // Sometimes response is returned in different order than created
+        const idMap = res.body.map((group) => groups.findIndex(({ name }) => name === group.name));
         res.body.forEach((group, index) => {
           expect(group.farm_id).toBe(mainFarm.farm_id);
-          expect(group.name).toBe(groups[index].name);
+          expect(group.name).toBe(groups[idMap[index]].name);
           // Match relationships in any order
           expect(group.related_animal_ids.sort()).toEqual(
-            animalRelationships[index].map((relationship) => relationship.animal_id).sort(),
+            animalRelationships[idMap[index]].map((relationship) => relationship.animal_id).sort(),
           );
           expect(group.related_batch_ids.sort()).toEqual(
-            batchRelationships[index].map((relationship) => relationship.animal_batch_id).sort(),
+            batchRelationships[idMap[index]]
+              .map((relationship) => relationship.animal_batch_id)
+              .sort(),
           );
         });
       }

--- a/packages/api/tests/animal_group.test.js
+++ b/packages/api/tests/animal_group.test.js
@@ -172,19 +172,15 @@ describe('Animal Group Tests', () => {
         expect(res.status).toBe(200);
         // Should return first two animal groups
         expect(res.body.length).toBe(2);
-        // Sometimes response is returned in different order than created
-        const idMap = res.body.map((group) => groups.findIndex(({ name }) => name === group.name));
         res.body.forEach((group, index) => {
           expect(group.farm_id).toBe(mainFarm.farm_id);
-          expect(group.name).toBe(groups[idMap[index]].name);
+          expect(group.name).toBe(groups[index].name);
           // Match relationships in any order
           expect(group.related_animal_ids.sort()).toEqual(
-            animalRelationships[idMap[index]].map((relationship) => relationship.animal_id).sort(),
+            animalRelationships[index].map((relationship) => relationship.animal_id).sort(),
           );
           expect(group.related_batch_ids.sort()).toEqual(
-            batchRelationships[idMap[index]]
-              .map((relationship) => relationship.animal_batch_id)
-              .sort(),
+            batchRelationships[index].map((relationship) => relationship.animal_batch_id).sort(),
           );
         });
       }

--- a/packages/api/tests/animal_group.test.js
+++ b/packages/api/tests/animal_group.test.js
@@ -172,17 +172,24 @@ describe('Animal Group Tests', () => {
         expect(res.status).toBe(200);
         // Should return first two animal groups
         expect(res.body.length).toBe(2);
+
         // Sometimes response is returned in different order than created
-        const idMap = res.body.map((group) => groups.findIndex(({ name }) => name === group.name));
+        // TODO: Find a better solution to this:
+        const orderedMockGroupIds = res.body.map((group) =>
+          groups.findIndex(({ name }) => name === group.name),
+        );
+
         res.body.forEach((group, index) => {
           expect(group.farm_id).toBe(mainFarm.farm_id);
-          expect(group.name).toBe(groups[idMap[index]].name);
+          expect(group.name).toBe(groups[orderedMockGroupIds[index]].name);
           // Match relationships in any order
           expect(group.related_animal_ids.sort()).toEqual(
-            animalRelationships[idMap[index]].map((relationship) => relationship.animal_id).sort(),
+            animalRelationships[orderedMockGroupIds[index]]
+              .map((relationship) => relationship.animal_id)
+              .sort(),
           );
           expect(group.related_batch_ids.sort()).toEqual(
-            batchRelationships[idMap[index]]
+            batchRelationships[orderedMockGroupIds[index]]
               .map((relationship) => relationship.animal_batch_id)
               .sort(),
           );

--- a/packages/api/tests/animal_group.test.js
+++ b/packages/api/tests/animal_group.test.js
@@ -172,24 +172,17 @@ describe('Animal Group Tests', () => {
         expect(res.status).toBe(200);
         // Should return first two animal groups
         expect(res.body.length).toBe(2);
-
         // Sometimes response is returned in different order than created
-        // TODO: Find a better solution to this:
-        const orderedMockGroupIds = res.body.map((group) =>
-          groups.findIndex(({ name }) => name === group.name),
-        );
-
+        const idMap = res.body.map((group) => groups.findIndex(({ name }) => name === group.name));
         res.body.forEach((group, index) => {
           expect(group.farm_id).toBe(mainFarm.farm_id);
-          expect(group.name).toBe(groups[orderedMockGroupIds[index]].name);
+          expect(group.name).toBe(groups[idMap[index]].name);
           // Match relationships in any order
           expect(group.related_animal_ids.sort()).toEqual(
-            animalRelationships[orderedMockGroupIds[index]]
-              .map((relationship) => relationship.animal_id)
-              .sort(),
+            animalRelationships[idMap[index]].map((relationship) => relationship.animal_id).sort(),
           );
           expect(group.related_batch_ids.sort()).toEqual(
-            batchRelationships[orderedMockGroupIds[index]]
+            batchRelationships[idMap[index]]
               .map((relationship) => relationship.animal_batch_id)
               .sort(),
           );

--- a/packages/api/tests/animal_group.test.js
+++ b/packages/api/tests/animal_group.test.js
@@ -172,15 +172,25 @@ describe('Animal Group Tests', () => {
         expect(res.status).toBe(200);
         // Should return first two animal groups
         expect(res.body.length).toBe(2);
+        // Sometimes response is returned in different order than created
+        // TODO: Find a better solution to this:
+        const orderedMockGroupIds = res.body.map((group) =>
+          groups.findIndex(({ name }) => name === group.name),
+        );
+
         res.body.forEach((group, index) => {
           expect(group.farm_id).toBe(mainFarm.farm_id);
-          expect(group.name).toBe(groups[index].name);
+          expect(group.name).toBe(groups[orderedMockGroupIds[index]].name);
           // Match relationships in any order
           expect(group.related_animal_ids.sort()).toEqual(
-            animalRelationships[index].map((relationship) => relationship.animal_id).sort(),
+            animalRelationships[orderedMockGroupIds[index]]
+              .map((relationship) => relationship.animal_id)
+              .sort(),
           );
           expect(group.related_batch_ids.sort()).toEqual(
-            batchRelationships[index].map((relationship) => relationship.animal_batch_id).sort(),
+            batchRelationships[orderedMockGroupIds[index]]
+              .map((relationship) => relationship.animal_batch_id)
+              .sort(),
           );
         });
       }


### PR DESCRIPTION
**Description**

On creation of the objection error handler it was mentioned by @SayakaOno that we should update all animal controllers to be consistent. (and a modest -50 lines of code ;) )

Now every endpoint in animals with a trx and excess checks should be covered.

Also added in a test that was missing from batch and controller -- should not be able to add a default breed with a custom type.

To test: For exhaustive testing remove one check at a time and check that it is still handled.

Jira link: [LF-4092](https://lite-farm.atlassian.net/jira/software/c/projects/LF/issues/LF-4092)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4092]: https://lite-farm.atlassian.net/browse/LF-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ