### PR TITLE
LF-4141 The animal inventory of the previous farm is shown to the user once he changes the farm without logging out

### DIFF
--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -151,6 +151,7 @@ import {
   onLoadingWatercourseFail,
   onLoadingWatercourseStart,
 } from './watercourseSlice';
+import { api } from '../store/api/apiSlice';
 
 const logUserInfoUrl = () => `${url}/userLog`;
 const getCropsByFarmIdUrl = (farm_id) => `${url}/crop/farm/${farm_id}`;
@@ -618,6 +619,17 @@ export function* fetchAllSaga() {
 
 export function* clearOldFarmStateSaga() {
   yield put(resetTasks());
+
+  yield put(
+    api.util.invalidateTags([
+      'Animals',
+      'AnimalBatches',
+      'AnimalGroups',
+      'CustomAnimalBreeds',
+      'CustomAnimalTypes',
+      'DefaultAnimalTypes', // needs to be cleared for KPI count
+    ]),
+  );
 
   // Reset finance loading state
   yield put(setIsFetchingData(true));


### PR DESCRIPTION
**Description**

This adds RTK Query tag invalidation to `clearOldFarmStateSaga()` which is called during farm switching. For rationale and alternative approaches considered, please see Jira ticket.

Jira link: https://lite-farm.atlassian.net/browse/LF-4141

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
