### PR TITLE
Lf 4192 animal inventory table columns not showing the correct width

### DIFF
--- a/packages/webapp/src/assets/colors.scss
+++ b/packages/webapp/src/assets/colors.scss
@@ -67,6 +67,7 @@
   --mainBackground: #fafcfb;
   --tableAlternateRowBackground: #f7fbff;
   --tableSortPill: #f4f5f7;
+  --tableV2Header: white;
 
   // New design system colours
   --White: #fff;

--- a/packages/webapp/src/components/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/components/Animals/Inventory/index.tsx
@@ -130,7 +130,7 @@ const PureAnimalInventory = ({
             stickyHeader={isDesktop}
             maxHeight={tableMaxHeight}
             spacerRowHeight={isDesktop ? 96 : 120}
-            headerBackgroundColor={'#fff'}
+            headerClass={styles.headerClass}
           />
         ) : (
           <NoSearchResults

--- a/packages/webapp/src/components/Animals/Inventory/styles.module.scss
+++ b/packages/webapp/src/components/Animals/Inventory/styles.module.scss
@@ -76,3 +76,7 @@
 .tableWrapperCommon {
   flex: 1;
 }
+
+.headerClass {
+  background-color: var(--tableV2Header);
+}

--- a/packages/webapp/src/components/Table/Header/TableHead.jsx
+++ b/packages/webapp/src/components/Table/Header/TableHead.jsx
@@ -33,7 +33,7 @@ export default function EnhancedTableHead({
   onSelectAllClick,
   numSelected,
   rowCount,
-  backgroundColor,
+  headerClass,
 }) {
   const createSortHandler = (property) => (event) => {
     onRequestSort(event, property);
@@ -43,7 +43,7 @@ export default function EnhancedTableHead({
     <TableHead className={styles.headerRow}>
       <TableRow>
         {shouldShowCheckbox && (
-          <TableCell padding="checkbox" className={styles.checkboxCell}>
+          <TableCell padding="checkbox" className={clsx(headerClass, styles.checkboxCell)}>
             <Checkbox
               color="primary"
               indeterminate={numSelected > 0 && numSelected < rowCount}
@@ -62,9 +62,13 @@ export default function EnhancedTableHead({
               key={id}
               align={align || 'left'}
               sortDirection={active ? order : false}
-              className={clsx(styles.tableCell, styles.tableHead, dense && styles.dense)}
+              className={clsx(
+                headerClass,
+                styles.tableCell,
+                styles.tableHead,
+                dense && styles.dense,
+              )}
               {...columnProps}
-              style={{ backgroundColor }}
             >
               <TableSortLabel
                 active={active}
@@ -107,6 +111,4 @@ EnhancedTableHead.propTypes = {
   onSelectAllClick: PropTypes.func,
   numSelected: PropTypes.number,
   rowCount: PropTypes.number,
-  /** Mui adds grey background color to sticky header by default */
-  backgroundColor: PropTypes.string,
 };

--- a/packages/webapp/src/components/Table/TableV2.jsx
+++ b/packages/webapp/src/components/Table/TableV2.jsx
@@ -330,7 +330,8 @@ TableV2.propTypes = {
   maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** adds an empty row at the end of the table to create spacing */
   spacerRowHeight: PropTypes.number,
-  headerClass: ClassValue,
+  /** Cheating here  using any since it is not meshing well with ts type */
+  headerClass: PropTypes.any,
 };
 
 TableV2.defaultProps = {

--- a/packages/webapp/src/components/Table/TableV2.jsx
+++ b/packages/webapp/src/components/Table/TableV2.jsx
@@ -24,7 +24,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import { BsThreeDots } from 'react-icons/bs';
-import clsx from 'clsx';
+import clsx, { ClassValue } from 'clsx';
 import EnhancedTableHead from './Header/TableHead';
 import Button from '../Form/Button';
 import { getComparator } from '../../util/sort';
@@ -330,7 +330,7 @@ TableV2.propTypes = {
   maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** adds an empty row at the end of the table to create spacing */
   spacerRowHeight: PropTypes.number,
-  headerClass: PropTypes.any,
+  headerClass: ClassValue,
 };
 
 TableV2.defaultProps = {

--- a/packages/webapp/src/components/Table/TableV2.jsx
+++ b/packages/webapp/src/components/Table/TableV2.jsx
@@ -100,7 +100,7 @@ export default function TableV2(props) {
     stickyHeader,
     maxHeight,
     spacerRowHeight,
-    headerBackgroundColor,
+    headerClass,
   } = props;
 
   const [order, setOrder] = useState('asc');
@@ -182,7 +182,8 @@ export default function TableV2(props) {
               onSelectAllClick={handleSelectAllClick}
               numSelected={selectedIds?.length}
               rowCount={data.length}
-              backgroundColor={headerBackgroundColor}
+              // backgroundColor={headerBackgroundColor}
+              headerClass={headerClass}
             />
           )}
           <TableBody className={styles.tableBody}>
@@ -329,7 +330,7 @@ TableV2.propTypes = {
   maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** adds an empty row at the end of the table to create spacing */
   spacerRowHeight: PropTypes.number,
-  headerBackgroundColor: PropTypes.string,
+  headerClass: PropTypes.any,
 };
 
 TableV2.defaultProps = {

--- a/packages/webapp/src/components/Table/types.ts
+++ b/packages/webapp/src/components/Table/types.ts
@@ -16,6 +16,7 @@
 import type { ReactElement, ReactNode, ChangeEvent } from 'react';
 import type { ColumnInstance } from 'react-table';
 import { ReactComponentLike } from 'prop-types';
+import { ClassValue } from 'clsx';
 
 export enum TableKind {
   V1 = 'v1',
@@ -83,5 +84,5 @@ export type TableV2Props<RowData extends TableRowData> = {
   stickyHeader?: boolean;
   maxHeight?: number | string;
   spacerRowHeight?: number;
-  headerBackgroundColor?: string;
+  headerClass?: ClassValue;
 };


### PR DESCRIPTION
**Description**

The inline style property was overriding the column prop on the header.

Converted it from inline style to passed class.

Did not see any gap issue shown in picture from [LF-4072](https://lite-farm.atlassian.net/browse/LF-4072)

Jira link: [LF-4192](https://lite-farm.atlassian.net/browse/LF-4192 )

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
