### PR TITLE
Fix failing animal test

### DIFF
--- a/packages/api/tests/animal.test.js
+++ b/packages/api/tests/animal.test.js
@@ -531,11 +531,27 @@ describe('Animal Tests', () => {
       });
 
       test('Should be able to create animals with various types and breeds at once', async () => {
-        const [customAnimalType1] = await mocks.custom_animal_typeFactory({ promisedFarm: [farm] });
-        const [customAnimalType2] = await mocks.custom_animal_typeFactory({ promisedFarm: [farm] });
-        const [typeName1, typeName2, breedName1, breedName2, breedName3, breedName4, breedName5] = [
-          ...Array(7),
-        ].map(() => faker.lorem.word());
+        const [
+          customTypeName1,
+          customTypeName2,
+          typeName1,
+          typeName2,
+          breedName1,
+          breedName2,
+          breedName3,
+          breedName4,
+          breedName5,
+        ] = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((num) => {
+          return `${faker.lorem.word() + num}`;
+        });
+        const [customAnimalType1] = await mocks.custom_animal_typeFactory({
+          promisedFarm: [farm],
+          properties: { type: customTypeName1 },
+        });
+        const [customAnimalType2] = await mocks.custom_animal_typeFactory({
+          promisedFarm: [farm],
+          properties: { type: customTypeName2 },
+        });
         const animal1 = mocks.fakeAnimal({ type_name: typeName1 });
         const animal2 = mocks.fakeAnimal({ type_name: typeName2 });
         const animal3 = mocks.fakeAnimal({

--- a/packages/api/tests/animal_batch.test.js
+++ b/packages/api/tests/animal_batch.test.js
@@ -648,8 +648,8 @@ describe('Animal Batch Tests', () => {
       });
 
       test('Should be able to create animal batches with various types and breeds at once', async () => {
-        const [typeName1, typeName2, breedName1, breedName2] = [...Array(4)].map(() =>
-          faker.lorem.word(),
+        const [typeName1, typeName2, breedName1, breedName2] = [1, 2, 3, 4].map(
+          (num) => faker.lorem.word() + num,
         );
         const animalBatch1 = mocks.fakeAnimalBatch({ type_name: typeName1 });
         const animalBatch2 = mocks.fakeAnimalBatch({ type_name: typeName2 });


### PR DESCRIPTION
**Description**

`faker.lorem.word()` returns non-unique strings, which causes unexpected `409 conflict` in animal types. (I believe that was the cause of the test failure: https://github.com/LiteFarmOrg/LiteFarm/actions/runs/8573143951/job/23497247488?pr=3180)
I made some changes to append a number to a generated string.

It rarely happens, so I tested using `.each()` (`test.each(Array(100).fill(null))('xxx', async () => {})`)
