### PR TITLE
LF-4187b Fix Crop Sale icon import

### DIFF
--- a/packages/webapp/src/components/Icons/icons.jsx
+++ b/packages/webapp/src/components/Icons/icons.jsx
@@ -19,7 +19,7 @@ import { ReactComponent as CropIcon } from '../../assets/images/finance/Crop-icn
 import { ReactComponent as ProfitLossIcon } from '../../assets/images/finance/Profit-loss-icn.svg';
 
 // Revenue types
-import { ReactComponent as CropSaleIcon } from '../../assets/images/finance/Crop-Sale-icn.svg';
+import { ReactComponent as CropSaleIcon } from '../../assets/images/finance/Crop-sale-icn.svg';
 import { ReactComponent as CustomTypeIcon } from '../../assets/images/finance/Custom-revenue.svg';
 
 // Expense types


### PR DESCRIPTION
**Description**

PR #3180 fails to build on merge due to a case-mismatch between the import and filename. Builds locally, so I assume MacOS is more forgiving of this than Linux/Docker.

Jira link: https://github.com/LiteFarmOrg/LiteFarm/pull/3180

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Should be tested on build

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
