### PR TITLE
LF-4209 Bump node version to 18.16.1 in Cypress GitHub action workflow

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -35,7 +35,7 @@ jobs:
           - postgres-data:/var/lib/postgresql/data
     strategy:
       matrix:
-        node-version: [16.15.0]
+        node-version: [18.16.1]
     env:
       JWT_SECRET: This_will_(really)_work
       JWT_INVITE_SECRET: Any_arbitrary_string_will_do


### PR DESCRIPTION
**Description**

Bump Cypress node version to the same one used across app. I think we just missed this when implementing the new test suite, and not that Cypress requires Node 16 in some way (it runs locally on Node 18).

Jira link: https://lite-farm.atlassian.net/browse/LF-4209

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Test on GitHub actions workflow please.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
