### PR TITLE
Fix failing animal group API test

### DIFF
--- a/packages/api/tests/animal_group.test.js
+++ b/packages/api/tests/animal_group.test.js
@@ -143,7 +143,10 @@ describe('Animal Group Tests', () => {
         const [secondFarm] = await mocks.farmFactory();
 
         // Create two animals groups and add animals and batches to each of them
-        const groups = await Promise.all([makeAnimalGroup(mainFarm), makeAnimalGroup(mainFarm)]);
+        const groups = await Promise.all([
+          makeAnimalGroup(mainFarm, { name: 'group1' }),
+          makeAnimalGroup(mainFarm, { name: 'group2' }),
+        ]);
         const animalRelationships = await Promise.all(
           groups.map(
             async (group) =>


### PR DESCRIPTION
**Description**

Tests depending on uniqueness of the output from `faker.lorem.word()` don't always pass because the uniqueness of the generated words is not guaranteed.
This PR updates a test to create groups with hard-coded unique names.

Failing test: https://github.com/LiteFarmOrg/LiteFarm/actions/runs/8791645244/job/24126565403?pr=3196

Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

It rarely fails, so I ran the test 100 times by doing `test.each(Array(100).fill(null))`.

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
