### PR TITLE
LF-4219: Create component for weight application rate tabs

### DIFF
--- a/packages/webapp/src/assets/images/check-in-circle.svg
+++ b/packages/webapp/src/assets/images/check-in-circle.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <g clip-path="url(#clip0_13662_6687)">
+    <path d="M6.24996 10.0001L8.74996 12.5001L13.75 7.50008M18.3333 10.0001C18.3333 14.6025 14.6023 18.3334 9.99996 18.3334C5.39759 18.3334 1.66663 14.6025 1.66663 10.0001C1.66663 5.39771 5.39759 1.66675 9.99996 1.66675C14.6023 1.66675 18.3333 5.39771 18.3333 10.0001Z" stroke="#5D697E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_13662_6687">
+      <rect width="20" height="20" fill="white"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/packages/webapp/src/components/RouterTab/StateTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/StateTab/index.jsx
@@ -18,7 +18,7 @@ import { Semibold } from '../../Typography';
 import styles from '../styles.module.scss';
 import clsx from 'clsx';
 
-const KIND = {
+const VARIANT = {
   PILL: 'pill',
   PLANE: 'plane',
 };
@@ -34,21 +34,27 @@ const KIND = {
  * @param {string} props.state - The key corresponding to the currently selected tab.
  * @param {function} props.setState - A function to update the selected tab
  * @param {string} props.className - Optional CSS styling to applied to the tab container
- * @param {('pill'|'plane')} props.kind - Determines the style of the tabs.
+ * @param {('pill'|'plane')} props.variant - Determines the style of the tabs.
  *
  * @returns {React.Component} The rendered StateTab component.
  */
 
-export default function StateTab({ tabs, state, setState, className = '', kind = KIND.PILL }) {
+export default function StateTab({
+  tabs,
+  state,
+  setState,
+  className = '',
+  variant = VARIANT.PILL,
+}) {
   const isSelected = (key) => state === key;
-  const kindClassName = styles[kind];
+  const variantClassName = styles[variant];
 
   return (
-    <div className={clsx(styles.container, className, kindClassName)}>
+    <div className={clsx(styles.container, className, variantClassName)}>
       {tabs.map((tab, index) => (
         <Semibold
           key={index}
-          className={clsx(styles.tab, isSelected(tab.key) && styles.selected, kindClassName)}
+          className={clsx(styles.tab, isSelected(tab.key) && styles.selected, variantClassName)}
           onClick={() => !isSelected(tab.key) && setState(tab.key)}
           id={tab.label + index}
         >
@@ -69,5 +75,5 @@ StateTab.propTypes = {
   state: PropTypes.string.isRequired,
   setState: PropTypes.func.isRequired,
   className: PropTypes.string,
-  kind: PropTypes.oneOf(['pill', 'plane']),
+  variant: PropTypes.oneOf(['pill', 'plane']),
 };

--- a/packages/webapp/src/components/RouterTab/StateTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/StateTab/index.jsx
@@ -19,7 +19,7 @@ import clsx from 'clsx';
 
 const VARIANTS = {
   PILL: 'pill',
-  PLANE: 'plane',
+  PLAIN: 'plain',
 };
 
 /**
@@ -33,7 +33,7 @@ const VARIANTS = {
  * @param {string} props.state - The key corresponding to the currently selected tab.
  * @param {function} props.setState - A function to update the selected tab
  * @param {string} props.className - Optional CSS styling to applied to the tab container
- * @param {('pill'|'plane')} props.variant - Determines the style of the tabs.
+ * @param {('pill'|'plain')} props.variant - Determines the style of the tabs.
  *
  * @returns {React.Component} The rendered StateTab component.
  */

--- a/packages/webapp/src/components/RouterTab/StateTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/StateTab/index.jsx
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
 import styles from '../styles.module.scss';
 import clsx from 'clsx';
 
-const VARIANT = {
+const VARIANTS = {
   PILL: 'pill',
   PLANE: 'plane',
 };
@@ -43,7 +43,7 @@ export default function StateTab({
   state,
   setState,
   className = '',
-  variant = VARIANT.PILL,
+  variant = VARIANTS.PILL,
 }) {
   const isSelected = (key) => state === key;
   const variantClassName = styles[variant];
@@ -74,5 +74,5 @@ StateTab.propTypes = {
   state: PropTypes.string.isRequired,
   setState: PropTypes.func.isRequired,
   className: PropTypes.string,
-  variant: PropTypes.oneOf(['pill', 'plane']),
+  variant: PropTypes.oneOf(Object.values(VARIANTS)),
 };

--- a/packages/webapp/src/components/RouterTab/StateTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/StateTab/index.jsx
@@ -1,7 +1,27 @@
+/*
+ *  Copyright 2021-2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
 import PropTypes from 'prop-types';
 import { Semibold } from '../../Typography';
 import styles from '../styles.module.scss';
 import clsx from 'clsx';
+
+const KIND = {
+  PILL: 'pill',
+  PLANE: 'plane',
+};
 
 /**
  * A version of RouterTab that toggles an active tab held in parent state, rather than using path changes.
@@ -14,22 +34,25 @@ import clsx from 'clsx';
  * @param {string} props.state - The key corresponding to the currently selected tab.
  * @param {function} props.setState - A function to update the selected tab
  * @param {string} props.className - Optional CSS styling to applied to the tab container
+ * @param {('pill'|'plane')} props.kind - Determines the style of the tabs.
  *
  * @returns {React.Component} The rendered StateTab component.
  */
 
-export default function StateTab({ tabs, state, setState, className = '' }) {
+export default function StateTab({ tabs, state, setState, className = '', kind = KIND.PILL }) {
   const isSelected = (key) => state === key;
+  const kindClassName = styles[kind];
+
   return (
-    <div className={clsx(styles.container, className)}>
+    <div className={clsx(styles.container, className, kindClassName)}>
       {tabs.map((tab, index) => (
         <Semibold
           key={index}
-          className={clsx(styles.pill, isSelected(tab.key) && styles.selected)}
+          className={clsx(styles.tab, isSelected(tab.key) && styles.selected, kindClassName)}
           onClick={() => !isSelected(tab.key) && setState(tab.key)}
           id={tab.label + index}
         >
-          {tab.label}
+          <span className={styles.tabText}>{tab.label}</span>
         </Semibold>
       ))}
     </div>
@@ -46,4 +69,5 @@ StateTab.propTypes = {
   state: PropTypes.string.isRequired,
   setState: PropTypes.func.isRequired,
   className: PropTypes.string,
+  kind: PropTypes.oneOf(['pill', 'plane']),
 };

--- a/packages/webapp/src/components/RouterTab/StateTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/StateTab/index.jsx
@@ -14,7 +14,6 @@
  */
 
 import PropTypes from 'prop-types';
-import { Semibold } from '../../Typography';
 import styles from '../styles.module.scss';
 import clsx from 'clsx';
 
@@ -52,14 +51,14 @@ export default function StateTab({
   return (
     <div className={clsx(styles.container, className, variantClassName)}>
       {tabs.map((tab, index) => (
-        <Semibold
+        <button
           key={index}
           className={clsx(styles.tab, isSelected(tab.key) && styles.selected, variantClassName)}
           onClick={() => !isSelected(tab.key) && setState(tab.key)}
           id={tab.label + index}
         >
           <span className={styles.tabText}>{tab.label}</span>
-        </Semibold>
+        </button>
       ))}
     </div>
   );

--- a/packages/webapp/src/components/RouterTab/index.jsx
+++ b/packages/webapp/src/components/RouterTab/index.jsx
@@ -6,11 +6,11 @@ import clsx from 'clsx';
 export default function RouterTab({ tabs, history, classes }) {
   const isSelected = (path) => history.location.pathname?.toLowerCase().includes(path);
   return (
-    <div className={styles.container} style={classes?.container}>
+    <div className={clsx(styles.container, styles.pill)} style={classes?.container}>
       {tabs.map((tab, index) => (
         <Semibold
           key={index}
-          className={clsx(styles.pill, isSelected(tab.path) && styles.selected)}
+          className={clsx(styles.pill, isSelected(tab.path) && styles.selected, styles.tab)}
           onClick={() => !isSelected(tab.path) && history.replace(tab.path, tab.state)}
           id={tab.label + index}
         >

--- a/packages/webapp/src/components/RouterTab/styles.module.scss
+++ b/packages/webapp/src/components/RouterTab/styles.module.scss
@@ -27,7 +27,7 @@
     border-radius: 18px;
   }
 
-  &.plane {
+  &.plain {
     height: 40px;
     border-radius: 8px 8px 0 0;
     background: var(--Colors-Neutral-Neutral-50);
@@ -66,7 +66,7 @@
     }
   }
 
-  &.plane {
+  &.plain {
     font-weight: 400;
     color: var(--Colors-Neutral-Neutral-300);
     border: solid 1px var(--Colors-Neutral-Neutral-50);
@@ -92,7 +92,7 @@
     height: 38px;
   }
 
-  &.plane {
+  &.plain {
     border-radius: 0;
     border: 1px solid var(--Colors-Neutral-Neutral-100);
     border-bottom: none;

--- a/packages/webapp/src/components/RouterTab/styles.module.scss
+++ b/packages/webapp/src/components/RouterTab/styles.module.scss
@@ -53,6 +53,8 @@
 
   &.pill {
     justify-content: center;
+    height: 36px;
+    padding: 8px;
 
     &:not(.selected) {
       &:first-child {

--- a/packages/webapp/src/components/RouterTab/styles.module.scss
+++ b/packages/webapp/src/components/RouterTab/styles.module.scss
@@ -1,28 +1,94 @@
-.default {
-}
-
-.selected {
-  color: var(--teal700);
-  border: 1px solid var(--teal700);
-  border-radius: 19px;
-  height: 38px;
-  background: white;
-}
+/*
+ *  Copyright 2021-2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
 
 .container {
   display: flex;
   flex-direction: row;
   justify-content: space-around;
   background-color: var(--grey400);
-  height: 36px;
-  align-items: center;
-  border-radius: 18px;
+
+  &.pill {
+    height: 36px;
+    align-items: center;
+    border-radius: 18px;
+  }
+
+  &.plane {
+    height: 40px;
+    border-radius: 8px 8px 0 0;
+    background: var(--Colors-Neutral-Neutral-50);
+  }
 }
 
-.pill {
-  flex-grow: 1;
-  justify-content: center;
+.tab {
+  flex: 1;
   align-items: center;
   display: flex;
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &.pill {
+    justify-content: center;
+  }
+
+  &.plane {
+    font-weight: 400;
+    color: var(--Colors-Neutral-Neutral-300);
+    border: solid 1px var(--Colors-Neutral-Neutral-50);
+    border-bottom: none;
+    padding: 0 16px;
+
+    &:first-child {
+      border-radius: 8px 0 0 0;
+    }
+    &:last-child {
+      border-radius: 0 8px 0 0;
+    }
+  }
+}
+
+.selected {
+  background: white;
+
+  &.pill {
+    color: var(--teal700);
+    border: 1px solid var(--teal700);
+    border-radius: 19px;
+    height: 38px;
+  }
+
+  &.plane {
+    border-radius: 0;
+    border: 1px solid var(--Colors-Neutral-Neutral-100);
+    border-bottom: none;
+    color: var(--Colors-Neutral-Neutral-900);
+    overflow: hidden;
+
+    &:after {
+      content: url('../../assets/images/check-in-circle.svg');
+      width: 24px;
+      height: 20px;
+      padding-left: 4px;
+    }
+  }
+}
+
+.tabText {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/packages/webapp/src/components/RouterTab/styles.module.scss
+++ b/packages/webapp/src/components/RouterTab/styles.module.scss
@@ -13,6 +13,8 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+@import '../../assets/mixin.scss';
+
 .container {
   display: flex;
   flex-direction: row;
@@ -37,9 +39,6 @@
   align-items: center;
   display: flex;
   cursor: pointer;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   border: solid 1px var(--grey400);
   background-color: inherit;
   height: 100%;
@@ -107,8 +106,7 @@
   }
 }
 
+.tab,
 .tabText {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  @include truncateText();
 }

--- a/packages/webapp/src/components/RouterTab/styles.module.scss
+++ b/packages/webapp/src/components/RouterTab/styles.module.scss
@@ -40,9 +40,29 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border: solid 1px var(--grey400);
+  background-color: inherit;
+  height: 100%;
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--fontColor);
+  font-family: 'Open Sans', 'SansSerif', serif;
+
+  &:focus-visible {
+    outline: none;
+  }
 
   &.pill {
     justify-content: center;
+
+    &:not(.selected) {
+      &:first-child {
+        border-radius: 18px 0 0 18px;
+      }
+      &:last-child {
+        border-radius: 0 18px 18px 0;
+      }
+    }
   }
 
   &.plane {

--- a/packages/webapp/src/stories/StateTabs/StateTabs.stories.jsx
+++ b/packages/webapp/src/stories/StateTabs/StateTabs.stories.jsx
@@ -17,7 +17,18 @@ import { useState } from 'react';
 import StateTabs from '../../components/RouterTab/StateTab';
 import { componentDecorators } from '../Pages/config/Decorators';
 
-const meta = {
+const twoTabs = [
+  { key: 'WEIGHT', label: 'Weight' },
+  { key: 'APPLICATION_RATE', label: 'Application rate' },
+];
+
+const threeTabs = [
+  { key: 'WEIGHT', label: 'Weight' },
+  { key: 'APPLICATION_RATE', label: 'Application rate' },
+  { key: 'OTHER', label: 'Other' },
+];
+
+export default {
   title: 'Components/RouterTab/StateTabs',
   component: StateTabs,
   decorators: [
@@ -28,54 +39,22 @@ const meta = {
       return <Story state={state} setState={setState} />;
     },
   ],
-  args: {
-    state: 'WEIGHT',
-    tabs: [
-      { key: 'WEIGHT', label: 'Weight' },
-      { key: 'APPLICATION_RATE', label: 'Application rate' },
-    ],
+  args: { state: 'WEIGHT', tabs: twoTabs },
+  render: (args, context) => {
+    return <StateTabs {...args} {...context} />;
   },
 };
 
-export const Pill = {
-  render: (args, context) => {
-    return <StateTabs {...args} {...context} kind="pill" />;
-  },
-};
+export const Pill = {};
 
 export const PillThreeTabs = {
-  render: (args, context) => {
-    return (
-      <StateTabs
-        {...args}
-        {...context}
-        kind="pill"
-        tabs={[
-          { key: 'WEIGHT', label: 'Weight' },
-          { key: 'APPLICATION_RATE', label: 'Application rate' },
-          { key: 'OTHER', label: 'Other' },
-        ]}
-      />
-    );
-  },
+  args: { tabs: threeTabs },
 };
 
 export const Plane = {
-  render: (args, context) => {
-    return (
-      <>
-        <StateTabs {...args} {...context} kind="plane" />
-        <div
-          style={{
-            height: '100px',
-            border: '1px solid #d0d4db',
-            borderTop: 'none',
-            backgroundColor: '#fff',
-          }}
-        ></div>
-      </>
-    );
-  },
+  args: { variant: 'plane' },
 };
 
-export default meta;
+export const PlaneThreeTabs = {
+  args: { variant: 'plane', tabs: threeTabs },
+};

--- a/packages/webapp/src/stories/StateTabs/StateTabs.stories.jsx
+++ b/packages/webapp/src/stories/StateTabs/StateTabs.stories.jsx
@@ -51,10 +51,10 @@ export const PillThreeTabs = {
   args: { tabs: threeTabs },
 };
 
-export const Plane = {
-  args: { variant: 'plane' },
+export const Plain = {
+  args: { variant: 'plain' },
 };
 
-export const PlaneThreeTabs = {
-  args: { variant: 'plane', tabs: threeTabs },
+export const PlainThreeTabs = {
+  args: { variant: 'plain', tabs: threeTabs },
 };

--- a/packages/webapp/src/stories/StateTabs/StateTabs.stories.jsx
+++ b/packages/webapp/src/stories/StateTabs/StateTabs.stories.jsx
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+import StateTabs from '../../components/RouterTab/StateTab';
+import { componentDecorators } from '../Pages/config/Decorators';
+
+const meta = {
+  title: 'Components/RouterTab/StateTabs',
+  component: StateTabs,
+  decorators: [
+    ...componentDecorators,
+    (Story) => {
+      const [state, setState] = useState('WEIGHT');
+
+      return <Story state={state} setState={setState} />;
+    },
+  ],
+  args: {
+    state: 'WEIGHT',
+    tabs: [
+      { key: 'WEIGHT', label: 'Weight' },
+      { key: 'APPLICATION_RATE', label: 'Application rate' },
+    ],
+  },
+};
+
+export const Pill = {
+  render: (args, context) => {
+    return <StateTabs {...args} {...context} kind="pill" />;
+  },
+};
+
+export const PillThreeTabs = {
+  render: (args, context) => {
+    return (
+      <StateTabs
+        {...args}
+        {...context}
+        kind="pill"
+        tabs={[
+          { key: 'WEIGHT', label: 'Weight' },
+          { key: 'APPLICATION_RATE', label: 'Application rate' },
+          { key: 'OTHER', label: 'Other' },
+        ]}
+      />
+    );
+  },
+};
+
+export const Plane = {
+  render: (args, context) => {
+    return (
+      <>
+        <StateTabs {...args} {...context} kind="plane" />
+        <div
+          style={{
+            height: '100px',
+            border: '1px solid #d0d4db',
+            borderTop: 'none',
+            backgroundColor: '#fff',
+          }}
+        ></div>
+      </>
+    );
+  },
+};
+
+export default meta;


### PR DESCRIPTION
**Description**

- Update `StateTab` component to
  - take `variant`.
  - replace `Semibold` with `button` so that tabs become focusable. (I plan to use `:focus-within` to style cards when focused, which will require this change. The outline is "none" for now.)
- Update `RoterTab` to be compatible with the new CSS.
- [Stories](http://localhost:6006/?path=/docs/components-routertab-statetabs--docs)

Jira link: https://lite-farm.atlassian.net/browse/LF-4219

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
