### PR TITLE
LF 4232: Fix 400 error when the user goes back during the task creation process

### DIFF
--- a/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
@@ -110,10 +110,10 @@ export default function TaskManagement({ history, match, location }) {
       returnPath: location.state ? location.state.pathname : null,
     };
     // delete data(HOURLY_WAGE_ACTION, SELECT_ALL etc) that should not be included in API request
+    delete postData[ALREADY_COMPLETED];
     Object.keys(data).forEach((key) => {
       if (assignTaskFields.includes(key)) {
         delete postData[key];
-        delete postData[ALREADY_COMPLETED];
       }
     });
     dispatch(

--- a/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
@@ -113,7 +113,7 @@ export default function TaskManagement({ history, match, location }) {
     Object.keys(data).forEach((key) => {
       if (assignTaskFields.includes(key)) {
         delete postData[key];
-        delete postData['already_completed'];
+        delete postData[ALREADY_COMPLETED];
       }
     });
     dispatch(

--- a/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
@@ -113,7 +113,7 @@ export default function TaskManagement({ history, match, location }) {
     Object.keys(data).forEach((key) => {
       if (assignTaskFields.includes(key)) {
         delete postData[key];
-        delete postData[already_completed];
+        delete postData['already_completed'];
       }
     });
     dispatch(


### PR DESCRIPTION
**Description**

The 400 error message is displayed once the user goes back during creating the task( any type of the task ) and then forth.

The reason was just a syntax error that prevented the application from deleting the `already_completed` property from the POST request payload.

Jira link: https://lite-farm.atlassian.net/browse/LF-4232

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
