### PR TITLE
LF-4256 Old consent version is shown after setting `has_consent` to false

### DIFF
--- a/packages/webapp/src/containers/Consent/index.jsx
+++ b/packages/webapp/src/containers/Consent/index.jsx
@@ -42,7 +42,7 @@ function ConsentForm({
 
     formState: { errors },
   } = useForm();
-  const [consentVersion] = useState('5.0');
+  const [consentVersion] = useState('6.0');
   const consent =
     role.role_id === 3 ? getLanguageConsent(language).worker : getLanguageConsent(language).owner;
   const checkboxName = 'consentCheckbox';

--- a/packages/webapp/src/containers/Consent/index.jsx
+++ b/packages/webapp/src/containers/Consent/index.jsx
@@ -15,6 +15,7 @@ import PortugueseWorkerConsent from './locales/pt/Worker.Consent.md';
 import SpanishOwnerConsent from './locales/es/Owner.Consent.md';
 import SpanishWorkerConsent from './locales/es/Worker.Consent.md';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
+import { CONSENT_VERSION } from '../../util/constants';
 
 const languageConsent = {
   en: { worker: <EnglishWorkerConsent />, owner: <EnglishOwnerConsent /> },
@@ -42,7 +43,6 @@ function ConsentForm({
 
     formState: { errors },
   } = useForm();
-  const [consentVersion] = useState('6.0');
   const consent =
     role.role_id === 3 ? getLanguageConsent(language).worker : getLanguageConsent(language).owner;
   const checkboxName = 'consentCheckbox';
@@ -58,7 +58,7 @@ function ConsentForm({
   };
 
   const updateConsent = (data) => {
-    dispatch(patchConsent({ has_consent: true, consent_version: consentVersion, goForwardTo }));
+    dispatch(patchConsent({ has_consent: true, consent_version: CONSENT_VERSION, goForwardTo }));
   };
 
   return (

--- a/packages/webapp/src/containers/Consent/index.jsx
+++ b/packages/webapp/src/containers/Consent/index.jsx
@@ -1,5 +1,4 @@
 import { useForm } from 'react-hook-form';
-import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PureConsent from '../../components/Consent';
 import { userFarmSelector } from '../userFarmSlice';

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -152,6 +152,7 @@ import {
   onLoadingWatercourseStart,
 } from './watercourseSlice';
 import { api } from '../store/api/apiSlice';
+import { CONSENT_VERSION } from '../util/constants';
 
 const logUserInfoUrl = () => `${url}/userLog`;
 const getCropsByFarmIdUrl = (farm_id) => `${url}/crop/farm/${farm_id}`;
@@ -588,8 +589,8 @@ export function* checkAppVersionSaga() {
 }
 
 export function* fetchAllSaga() {
-  const { has_consent, user_id, farm_id } = yield select(userFarmSelector);
-  if (!has_consent) return history.push('/consent');
+  const { has_consent, consent_version, user_id, farm_id } = yield select(userFarmSelector);
+  if (!has_consent || consent_version !== CONSENT_VERSION) return history.push('/consent');
 
   const isAdmin = yield select(isAdminSelector);
   const adminTasks = [

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -16,6 +16,7 @@
 import React, { Suspense } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import Spinner from '../components/Spinner';
+import { CONSENT_VERSION } from '../util/constants';
 
 // Components that have already been set up with code splitting
 import OnboardingFlow from './Onboarding';
@@ -298,8 +299,17 @@ const Routes = ({ isCompactSideMenu }) => {
     chooseFarmFlowSelector,
     (pre, next) => pre.isInvitationFlow === next.isInvitationFlow,
   );
-  let { step_five, has_consent, role_id, status, step_one, farm_id, step_three, step_four } =
-    userFarm;
+  let {
+    step_five,
+    has_consent,
+    consent_version,
+    role_id,
+    status,
+    step_one,
+    farm_id,
+    step_three,
+    step_four,
+  } = userFarm;
   const hasSelectedFarm = !!farm_id;
   const hasFinishedOnBoardingFlow = step_one && step_four && step_five;
   if (isAuthenticated()) {
@@ -316,13 +326,13 @@ const Routes = ({ isCompactSideMenu }) => {
               component={() => <ConsentForm goForwardTo={'/outro'} goBackTo={null} />}
             />
             <Route path="/outro" exact component={JoinFarmSuccessScreen} />
-            {!has_consent && <Redirect to={'/consent'} />}
+            {(!has_consent || consent_version !== CONSENT_VERSION) && <Redirect to={'/consent'} />}
           </Switch>
         </Suspense>
       );
     } else if (!hasSelectedFarm || !hasFinishedOnBoardingFlow) {
       return <OnboardingFlow {...userFarm} />;
-    } else if (!has_consent) {
+    } else if (!has_consent || consent_version !== CONSENT_VERSION) {
       return (
         <Suspense fallback={<Spinner />}>
           <Switch>
@@ -332,7 +342,7 @@ const Routes = ({ isCompactSideMenu }) => {
               exact
               component={() => <ConsentForm goForwardTo={'/'} goBackTo={null} />}
             />
-            {!has_consent && <Redirect to={'/consent'} />}
+            {(!has_consent || consent_version !== CONSENT_VERSION) && <Redirect to={'/consent'} />}
           </Switch>
         </Suspense>
       );

--- a/packages/webapp/src/util/constants.js
+++ b/packages/webapp/src/util/constants.js
@@ -10,3 +10,5 @@ export const SUPPORT_EMAIL = 'support@litefarm.org';
 // Changing this forces logout and updates the new release card
 export const APP_VERSION = '3.6.0';
 export const VERSION_RELEASE_NOTES_LINK = 'https://www.litefarm.org/post/a-new-look-for-a-new-year';
+
+export const CONSENT_VERSION = '6.0';


### PR DESCRIPTION
**Description**

This PR:
- Cherry-picks @SayakaOno's commits from #3217 that created and used the new consent version constant
- Uses that constant to check against the database stored consent version and treats a mismatch as equivalent to `!has_consent`(this is actually fundamentally how the release badge works as well 🙂) in the fetchAll saga and in routes

Notes:
- It is the routes file change that had been triggering the need to re-consent upon route change. fetchAllSaga would be more relevant to initial login I think and might not be necessary, but included for completeness
- We could instead `logout()` instead of routing to `/consent`; I left it as is and I don't think the user experience is that bad, but that is an option since `.env` key logout would no longer help us here
- In the future the only change necessary will be updating the consent version in the constants file along side the updated text

Jira link: https://lite-farm.atlassian.net/browse/LF-4256

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

This demonstrates how the re-consenting is required. It should be merged together with the changes to the consent text (as will happen in the patch PR) for the timing to be correct.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
