### PR TITLE
LF-4256 (2): Old consent version is shown after setting has consent to false

### DIFF
--- a/packages/webapp/src/containers/userFarmSlice.ts
+++ b/packages/webapp/src/containers/userFarmSlice.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import type { RootState } from '../store/store';
 import { AxiosError } from 'axios';
+import { CONSENT_VERSION } from '../util/constants';
 
 export interface Units {
   currency: string;
@@ -253,6 +254,9 @@ export const userFarmSelector = createSelector(
       ? {
           is_admin: adminRoles.includes(byFarmIdUserId[farm_id][user_id].role_id),
           ...byFarmIdUserId[farm_id][user_id],
+          has_consent:
+            byFarmIdUserId[farm_id][user_id].has_consent &&
+            byFarmIdUserId[farm_id][user_id].consent_version === CONSENT_VERSION,
         }
       : {};
   },

--- a/packages/webapp/src/containers/userFarmSlice.ts
+++ b/packages/webapp/src/containers/userFarmSlice.ts
@@ -3,7 +3,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import type { RootState } from '../store/store';
 import { AxiosError } from 'axios';
-import { CONSENT_VERSION } from '../util/constants';
 
 export interface Units {
   currency: string;
@@ -123,10 +122,6 @@ const userFarmSlice = createSlice({
         const prevUserFarms = state.byFarmIdUserId[farm_id] || {};
         state.byFarmIdUserId[farm_id] = prevUserFarms;
         state.byFarmIdUserId[farm_id][user_id] = prevUserFarms[user_id] || {};
-
-        const { has_consent, consent_version } = userFarm;
-        userFarm.has_consent = has_consent && consent_version === CONSENT_VERSION;
-
         Object.assign(state.byFarmIdUserId[farm_id][user_id], userFarm);
         delete state.byFarmIdUserId[farm_id][user_id].role;
       });


### PR DESCRIPTION
**Description**

Updates `userFarmSelector` to override `has_consent`.

(https://github.com/LiteFarmOrg/LiteFarm/pull/3222 didn't work for farm worker accounts because the API returns different responses between admin and farm worker accounts)


Jira link: https://lite-farm.atlassian.net/browse/LF-4256

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update