### PR TITLE
LF-4251: Add more inputs to AddSoilAmendmentProducts component

### DIFF
--- a/packages/webapp/src/components/Expandable/useExpandableItem.js
+++ b/packages/webapp/src/components/Expandable/useExpandableItem.js
@@ -15,7 +15,7 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 
-export default function useExpandable({ defaultExpandedIds = [], isSingleExpandable }) {
+export default function useExpandable({ defaultExpandedIds = [], isSingleExpandable } = {}) {
   const [expandedIds, setExpandedIds] = useState(defaultExpandedIds);
 
   const expand = (id) => {

--- a/packages/webapp/src/components/Form/CompositionInputs/NumberInputWithSelect.tsx
+++ b/packages/webapp/src/components/Form/CompositionInputs/NumberInputWithSelect.tsx
@@ -38,7 +38,6 @@ export type NumberInputWithSelectProps = {
   onChange: (fieldName: string, value: number | string | null) => void;
   onBlur?: () => void;
   reactSelectWidth?: number;
-  reactSelectJustifyContent?: 'center' | 'flex-start' | 'flex-end';
 };
 
 const REACT_SELECT_WIDTH = 44;
@@ -60,7 +59,6 @@ const NumberInputWithSelect = ({
   unit,
   unitFieldName = '',
   reactSelectWidth = REACT_SELECT_WIDTH,
-  reactSelectJustifyContent = 'center',
 }: NumberInputWithSelectProps) => {
   const { t } = useTranslation();
 
@@ -89,7 +87,7 @@ const NumberInputWithSelect = ({
     width: `${reactSelectWidth - 19}px`,
     display: 'flex',
     background: disabled ? 'var(--inputDisabled)' : 'inherit',
-    justifyContent: reactSelectJustifyContent,
+    justifyContent: disabled ? 'flex-end' : 'center',
   });
 
   const { inputProps, update, clear, numericValue } = useNumberInput({

--- a/packages/webapp/src/components/Form/CompositionInputs/NumberInputWithSelect.tsx
+++ b/packages/webapp/src/components/Form/CompositionInputs/NumberInputWithSelect.tsx
@@ -34,7 +34,7 @@ export type NumberInputWithSelectProps = {
   className?: string;
   value?: number | null;
   unit: string;
-  unitFieldName: string;
+  unitFieldName?: string;
   onChange: (fieldName: string, value: number | string | null) => void;
   onBlur?: () => void;
   reactSelectWidth?: number;
@@ -58,7 +58,7 @@ const NumberInputWithSelect = ({
   onBlur,
   value,
   unit,
-  unitFieldName,
+  unitFieldName = '',
   reactSelectWidth = REACT_SELECT_WIDTH,
   reactSelectJustifyContent = 'center',
 }: NumberInputWithSelectProps) => {

--- a/packages/webapp/src/components/Form/CompositionInputs/index.tsx
+++ b/packages/webapp/src/components/Form/CompositionInputs/index.tsx
@@ -26,6 +26,7 @@ type CompositionInputsProps = Omit<
   inputsInfo: { name: string; label: string }[];
   values: { [key: string]: any };
   unit?: string;
+  shouldShowErrorMessage?: boolean;
 };
 
 /**
@@ -37,6 +38,7 @@ const CompositionInputs = ({
   mainLabel = '',
   inputsInfo,
   error = '',
+  shouldShowErrorMessage = true,
   disabled = false,
   onChange,
   onBlur,
@@ -68,7 +70,7 @@ const CompositionInputs = ({
             );
           })}
         </div>
-        {error && (
+        {shouldShowErrorMessage && error && (
           <div className={styles.error}>
             <BsFillExclamationCircleFill className={styles.errorIcon} />
             <span className={styles.errorMessage}>{error}</span>

--- a/packages/webapp/src/components/Form/CompositionInputs/index.tsx
+++ b/packages/webapp/src/components/Form/CompositionInputs/index.tsx
@@ -29,6 +29,11 @@ type CompositionInputsProps = Omit<
   unitFieldName: string;
 };
 
+/**
+ * Component for inputs that share the same unit.
+ * Changing the unit of one input updates the units of all inputs.
+ * Units that require unit system conversions are not supported.
+ */
 const CompositionInputs = ({
   mainLabel = '',
   inputsInfo,

--- a/packages/webapp/src/components/Form/CompositionInputs/index.tsx
+++ b/packages/webapp/src/components/Form/CompositionInputs/index.tsx
@@ -26,7 +26,6 @@ type CompositionInputsProps = Omit<
   inputsInfo: { name: string; label: string }[];
   values: { [key: string]: any };
   unit?: string;
-  unitFieldName: string;
 };
 
 /**
@@ -43,7 +42,7 @@ const CompositionInputs = ({
   onBlur,
   values,
   unit,
-  unitFieldName,
+  unitFieldName = '',
   reactSelectJustifyContent,
   ...props
 }: CompositionInputsProps) => {

--- a/packages/webapp/src/components/Form/CompositionInputs/index.tsx
+++ b/packages/webapp/src/components/Form/CompositionInputs/index.tsx
@@ -43,7 +43,6 @@ const CompositionInputs = ({
   values,
   unit,
   unitFieldName = '',
-  reactSelectJustifyContent,
   ...props
 }: CompositionInputsProps) => {
   return (
@@ -65,9 +64,6 @@ const CompositionInputs = ({
                 unit={unit || values?.[unitFieldName]}
                 unitFieldName={unitFieldName}
                 value={values?.[name]}
-                reactSelectJustifyContent={
-                  reactSelectJustifyContent || (disabled ? 'flex-end' : 'flex-start')
-                }
               />
             );
           })}

--- a/packages/webapp/src/components/Form/CompositionInputs/styles.module.scss
+++ b/packages/webapp/src/components/Form/CompositionInputs/styles.module.scss
@@ -75,7 +75,7 @@
 }
 
 .selectValue {
-  color: var(--Colors-Neutral-Neutral-300, #98a1b1);
+  color: var(--Colors-Neutral-Neutral-600, #5d697e);
 }
 
 .error {

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -34,6 +34,7 @@ import {
   type Product,
   type ProductId,
 } from '../types';
+import useInputsInfo from './useInputsInfo';
 import { CANADA } from '../../AddProduct/constants';
 import { TASK_TYPES } from '../../../../containers/Task/constants';
 import { roundToTwoDecimal } from '../../../../util';
@@ -161,6 +162,8 @@ const ProductDetails = ({
     unExpand: unExpandAdditionalNutrients,
   } = useExpandable();
 
+  const inputsInfo = useInputsInfo();
+
   const isAdditionalNutrientsExpanded =
     expandedAdditionalNutrientsIds.includes(additionalNutrientsId);
 
@@ -170,7 +173,7 @@ const ProductDetails = ({
     const isAddingNewProduct = !!(productId && !selectedProduct);
     const shouldNotResetFields = wasAddingNewProduct && isAddingNewProduct;
 
-    const dryMatterContent =
+    const newDryMatterContent =
       typeof selectedProduct?.[MOISTURE_CONTENT] === 'number'
         ? subtractFrom100(selectedProduct[MOISTURE_CONTENT] as number)
         : undefined;
@@ -181,7 +184,7 @@ const ProductDetails = ({
         [PERMITTED]: selectedProduct?.[PERMITTED] || undefined,
         [FERTILISER_TYPE]: selectedProduct?.[FERTILISER_TYPE] || undefined,
         [MOISTURE_CONTENT]: selectedProduct?.[MOISTURE_CONTENT] || undefined,
-        [DRY_MATTER_CONTENT]: dryMatterContent,
+        [DRY_MATTER_CONTENT]: newDryMatterContent,
         [COMPOSITION]: {
           [UNIT]: selectedProduct?.[UNIT] || Unit.RATIO,
           [N]: selectedProduct?.[N] ?? NaN,
@@ -194,6 +197,8 @@ const ProductDetails = ({
           [MN]: selectedProduct?.[MN] ?? NaN,
           [B]: selectedProduct?.[B] ?? NaN,
         },
+        [AMMONIUM]: selectedProduct?.[AMMONIUM] ?? NaN,
+        [NITRATE]: selectedProduct?.[NITRATE] ?? NaN,
       });
     }
 
@@ -355,27 +360,14 @@ const ProductDetails = ({
             onChange={(fieldName: string, value: string | number | null): void => {
               handleMoistureDryMatterContentChange(fieldName, value ? +value : undefined);
             }}
-            inputsInfo={[
-              {
-                name: MOISTURE_CONTENT,
-                label: t('ADD_PRODUCT.MOISTURE_CONTENT'),
-              },
-              {
-                name: DRY_MATTER_CONTENT,
-                label: t('ADD_PRODUCT.DRY_MATTER_CONTENT'),
-              },
-            ]}
+            inputsInfo={inputsInfo.moistureDrymatterContents}
             values={{ [MOISTURE_CONTENT]: moistureContent, [DRY_MATTER_CONTENT]: dryMatterContent }}
             unit="%"
           />
 
           {renderCompositionInputsWithController({
             mainLabel: t('ADD_PRODUCT.COMPOSITION'),
-            inputsInfo: [
-              { name: Nutrients.N, label: t('ADD_PRODUCT.NITROGEN') },
-              { name: Nutrients.P, label: t('ADD_PRODUCT.PHOSPHOROUS') },
-              { name: Nutrients.K, label: t('ADD_PRODUCT.POTASSIUM') },
-            ],
+            inputsInfo: inputsInfo.npk,
             shouldShowError: true, // TODO
           })}
 
@@ -408,14 +400,7 @@ const ProductDetails = ({
             >
               <div className={styles.sectionBody}>
                 {renderCompositionInputsWithController({
-                  inputsInfo: [
-                    { name: Nutrients.CA, label: t('ADD_PRODUCT.CALCIUM') },
-                    { name: Nutrients.MG, label: t('ADD_PRODUCT.MAGNESIUM') },
-                    { name: Nutrients.S, label: t('ADD_PRODUCT.SULFUR') },
-                    { name: Nutrients.CU, label: t('ADD_PRODUCT.COPPER') },
-                    { name: Nutrients.MN, label: t('ADD_PRODUCT.MANGANESE') },
-                    { name: Nutrients.B, label: t('ADD_PRODUCT.BORON') },
-                  ],
+                  inputsInfo: inputsInfo.additionalNutrients,
                   shouldShowError: true, // TODO
                 })}
 
@@ -426,16 +411,7 @@ const ProductDetails = ({
                       value ? +value : undefined,
                     );
                   }}
-                  inputsInfo={[
-                    {
-                      name: AMMONIUM,
-                      label: t('ADD_PRODUCT.AMMONIUM'),
-                    },
-                    {
-                      name: NITRATE,
-                      label: t('ADD_PRODUCT.NITRATE'),
-                    },
-                  ]}
+                  inputsInfo={inputsInfo.ammoniumNitrate}
                   values={{ [AMMONIUM]: ammonium, [NITRATE]: nitrate }}
                   unit="ppm"
                 />

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -26,14 +26,8 @@ import RadioGroup from '../../../Form/RadioGroup';
 import CompositionInputs from '../../../Form/CompositionInputs';
 import ReactSelect from '../../../Form/ReactSelect';
 import Buttons from './Buttons';
-import {
-  PRODUCT_FIELD_NAMES,
-  Nutrients,
-  Unit,
-  type ProductFormFields,
-  type Product,
-  type ProductId,
-} from '../types';
+import type { ProductFormFields, Product, ProductId } from '../types';
+import { PRODUCT_FIELD_NAMES, Nutrients, Unit, MolecularCompoundsUnit } from '../types';
 import useInputsInfo from './useInputsInfo';
 import { CANADA } from '../../AddProduct/constants';
 import { TASK_TYPES } from '../../../../containers/Task/constants';
@@ -60,13 +54,19 @@ const {
   B,
   AMMONIUM,
   NITRATE,
+  MOLECULAR_COMPOUNDS_UNIT,
 } = PRODUCT_FIELD_NAMES;
 
-const unitOptions = [
+const elementalUnitOptions = [
   { label: '%', value: Unit.PERCENT },
   { label: Unit.RATIO, value: Unit.RATIO },
   { label: Unit.PPM, value: Unit.PPM },
   { label: Unit['MG/KG'], value: Unit['MG/KG'] },
+];
+
+const molecularCompoundsUnitOptions = [
+  { label: MolecularCompoundsUnit.PPM, value: MolecularCompoundsUnit.PPM },
+  { label: MolecularCompoundsUnit['MG/KG'], value: MolecularCompoundsUnit['MG/KG'] },
 ];
 
 export type ProductDetailsProps = {
@@ -105,6 +105,7 @@ export const defaultValues = {
     [MN]: NaN,
     [B]: NaN,
   },
+  [MOLECULAR_COMPOUNDS_UNIT]: MolecularCompoundsUnit.PPM,
 };
 
 const subtractFrom100 = (value: number) => +(100 * 100 - value * 100) / 100;
@@ -149,12 +150,20 @@ const ProductDetails = ({
     defaultValues,
   });
 
-  const [moistureContent, dryMatterContent, ammonium, nitrate, fertiliserType] = watch([
+  const [
+    moistureContent,
+    dryMatterContent,
+    ammonium,
+    nitrate,
+    fertiliserType,
+    molecularCompoundsUnit,
+  ] = watch([
     MOISTURE_CONTENT,
     DRY_MATTER_CONTENT,
     AMMONIUM,
     NITRATE,
     FERTILISER_TYPE,
+    MOLECULAR_COMPOUNDS_UNIT,
   ]);
 
   const {
@@ -200,6 +209,8 @@ const ProductDetails = ({
         },
         [AMMONIUM]: selectedProduct?.[AMMONIUM] ?? NaN,
         [NITRATE]: selectedProduct?.[NITRATE] ?? NaN,
+        [MOLECULAR_COMPOUNDS_UNIT]:
+          selectedProduct?.[MOLECULAR_COMPOUNDS_UNIT] ?? MolecularCompoundsUnit.PPM,
       });
     }
 
@@ -286,7 +297,7 @@ const ProductDetails = ({
           return (
             <CompositionInputs
               mainLabel={mainLabel}
-              unitOptions={unitOptions}
+              unitOptions={elementalUnitOptions}
               inputsInfo={inputsInfo}
               disabled={isDetailDisabled}
               error={fieldState.error?.message}
@@ -303,6 +314,17 @@ const ProductDetails = ({
         }}
       />
     );
+  };
+
+  const handleMolecularCompoundsChange = (name: string, value: string | number | null): void => {
+    let newValue: MolecularCompoundsUnit | number | undefined;
+    if (value === MolecularCompoundsUnit.PPM || value === MolecularCompoundsUnit['MG/KG']) {
+      newValue = value as MolecularCompoundsUnit;
+    } else {
+      newValue = value ? +value : undefined;
+    }
+
+    setValue(name as typeof AMMONIUM | typeof NITRATE | typeof MOLECULAR_COMPOUNDS_UNIT, newValue);
   };
 
   return (
@@ -409,15 +431,16 @@ const ProductDetails = ({
 
                 <CompositionInputs
                   disabled={isDetailDisabled}
-                  onChange={(fieldName: string, value: string | number | null): void => {
-                    setValue(
-                      fieldName as typeof AMMONIUM | typeof NITRATE,
-                      value ? +value : undefined,
-                    );
-                  }}
+                  onChange={handleMolecularCompoundsChange}
                   inputsInfo={inputsInfo.ammoniumNitrate}
-                  values={{ [AMMONIUM]: ammonium, [NITRATE]: nitrate }}
-                  unit="ppm"
+                  values={{
+                    [AMMONIUM]: ammonium,
+                    [NITRATE]: nitrate,
+                    [MOLECULAR_COMPOUNDS_UNIT]: molecularCompoundsUnit,
+                  }}
+                  unitOptions={molecularCompoundsUnitOptions}
+                  unitFieldName={MOLECULAR_COMPOUNDS_UNIT}
+                  reactSelectWidth={MG_KG_REACT_SELECT_WIDTH}
                 />
               </div>
             </Collapse>

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -271,6 +271,7 @@ const ProductDetails = ({
             render={({ field, fieldState }) => {
               return (
                 <CompositionInputs
+                  mainLabel={t('ADD_PRODUCT.COMPOSITION')}
                   unitOptions={unitOptions}
                   inputsInfo={[
                     { name: NPK.N, label: t('ADD_PRODUCT.NITROGEN') },

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -149,11 +149,12 @@ const ProductDetails = ({
     defaultValues,
   });
 
-  const [moistureContent, dryMatterContent, ammonium, nitrate] = watch([
+  const [moistureContent, dryMatterContent, ammonium, nitrate, fertiliserType] = watch([
     MOISTURE_CONTENT,
     DRY_MATTER_CONTENT,
     AMMONIUM,
     NITRATE,
+    FERTILISER_TYPE,
   ]);
 
   const {
@@ -351,6 +352,7 @@ const ProductDetails = ({
           )}
 
           <ReactSelect
+            value={fertiliserTypeOptions.find(({ value }) => value === fertiliserType) || null}
             isDisabled={isDetailDisabled}
             label={t('ADD_PRODUCT.FERTILISER_TYPE')}
             placeholder={t('ADD_PRODUCT.FERTILISER_TYPE_PLACEHOLDER')}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -260,11 +260,11 @@ const ProductDetails = ({
   const renderCompositionInputsWithController = ({
     mainLabel = '',
     inputsInfo,
-    shouldShowError = false,
+    shouldShowErrorMessage = false,
   }: {
     mainLabel?: string;
     inputsInfo: { name: string; label: string }[];
-    shouldShowError: boolean;
+    shouldShowErrorMessage: boolean;
   }) => {
     return (
       <Controller
@@ -289,7 +289,8 @@ const ProductDetails = ({
               unitOptions={unitOptions}
               inputsInfo={inputsInfo}
               disabled={isDetailDisabled}
-              error={shouldShowError ? fieldState.error?.message : undefined}
+              error={fieldState.error?.message}
+              shouldShowErrorMessage={shouldShowErrorMessage}
               values={field.value || {}}
               onChange={(name, value) => field.onChange({ ...field.value, [name]: value })}
               // onBlur needs to be passed manually
@@ -376,7 +377,7 @@ const ProductDetails = ({
           {renderCompositionInputsWithController({
             mainLabel: t('ADD_PRODUCT.COMPOSITION'),
             inputsInfo: inputsInfo.npk,
-            shouldShowError: true, // TODO
+            shouldShowErrorMessage: !isAdditionalNutrientsExpanded,
           })}
 
           <div className={clsx(styles.additionalNutrients)}>
@@ -403,7 +404,7 @@ const ProductDetails = ({
               <div className={styles.additionalNutrientsBody}>
                 {renderCompositionInputsWithController({
                   inputsInfo: inputsInfo.additionalNutrients,
-                  shouldShowError: true, // TODO
+                  shouldShowErrorMessage: true,
                 })}
 
                 <CompositionInputs

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -25,7 +25,14 @@ import TextButton from '../../../Form/Button/TextButton';
 import RadioGroup from '../../../Form/RadioGroup';
 import CompositionInputs from '../../../Form/CompositionInputs';
 import Buttons from './Buttons';
-import { FIELD_NAMES, NPK, Unit, type FormFields, type Product, type ProductId } from '../types';
+import {
+  PRODUCT_FIELD_NAMES,
+  NPK,
+  Unit,
+  type ProductFormFields,
+  type Product,
+  type ProductId,
+} from '../types';
 import { CANADA } from '../../AddProduct/constants';
 import { TASK_TYPES } from '../../../../containers/Task/constants';
 import styles from '../styles.module.scss';
@@ -47,7 +54,7 @@ export type ProductDetailsProps = {
   clearProduct: () => void;
   setProductId: (id: ProductId) => void;
   onSave: (
-    data: FormFields & { farm_id: string; product_id: ProductId; type: string },
+    data: ProductFormFields & { farm_id: string; product_id: ProductId; type: string },
     callback?: (id: number) => void,
   ) => void;
 };
@@ -55,12 +62,12 @@ export type ProductDetailsProps = {
 const isNewProduct = (productId: ProductId): boolean => typeof productId === 'string';
 
 export const defaultValues = {
-  [FIELD_NAMES.SUPPLIER]: '',
-  [FIELD_NAMES.COMPOSITION]: {
-    [FIELD_NAMES.UNIT]: Unit.RATIO,
-    [FIELD_NAMES.N]: NaN,
-    [FIELD_NAMES.P]: NaN,
-    [FIELD_NAMES.K]: NaN,
+  [PRODUCT_FIELD_NAMES.SUPPLIER]: '',
+  [PRODUCT_FIELD_NAMES.COMPOSITION]: {
+    [PRODUCT_FIELD_NAMES.UNIT]: Unit.RATIO,
+    [PRODUCT_FIELD_NAMES.N]: NaN,
+    [PRODUCT_FIELD_NAMES.P]: NaN,
+    [PRODUCT_FIELD_NAMES.K]: NaN,
   },
 };
 
@@ -94,7 +101,7 @@ const ProductDetails = ({
     trigger,
     register,
     formState: { errors, isValid, isDirty },
-  } = useForm<FormFields>({
+  } = useForm<ProductFormFields>({
     mode: 'onBlur',
     defaultValues,
   });
@@ -109,13 +116,13 @@ const ProductDetails = ({
 
     if (!productId || !shouldNotResetFields) {
       reset({
-        [FIELD_NAMES.SUPPLIER]: supplier || '',
-        [FIELD_NAMES.PERMITTED]: on_permitted_substances_list || undefined,
-        [FIELD_NAMES.COMPOSITION]: {
-          [FIELD_NAMES.UNIT]: npk_unit || Unit.RATIO,
-          [FIELD_NAMES.N]: n ?? NaN,
-          [FIELD_NAMES.P]: p ?? NaN,
-          [FIELD_NAMES.K]: k ?? NaN,
+        [PRODUCT_FIELD_NAMES.SUPPLIER]: supplier || '',
+        [PRODUCT_FIELD_NAMES.PERMITTED]: on_permitted_substances_list || undefined,
+        [PRODUCT_FIELD_NAMES.COMPOSITION]: {
+          [PRODUCT_FIELD_NAMES.UNIT]: npk_unit || Unit.RATIO,
+          [PRODUCT_FIELD_NAMES.N]: n ?? NaN,
+          [PRODUCT_FIELD_NAMES.P]: p ?? NaN,
+          [PRODUCT_FIELD_NAMES.K]: k ?? NaN,
         },
       });
     }
@@ -130,7 +137,7 @@ const ProductDetails = ({
     if (isAddingNewProduct && productId) {
       // Wait for the card to be expaneded
       setTimeout(() => {
-        setFocus(FIELD_NAMES.SUPPLIER);
+        setFocus(PRODUCT_FIELD_NAMES.SUPPLIER);
       }, 0);
     }
     previousProductIdRef.current = productId;
@@ -147,7 +154,7 @@ const ProductDetails = ({
     }
   };
 
-  const onSubmit = (data: FormFields) => {
+  const onSubmit = (data: ProductFormFields) => {
     const callback = isNewProduct(productId) ? setProductId : undefined;
     onSave({ ...data, farm_id, product_id: productId, type: TASK_TYPES.SOIL_AMENDMENT }, callback);
 
@@ -177,15 +184,15 @@ const ProductDetails = ({
         <div className={styles.sectionBody}>
           {/* @ts-ignore */}
           <Input
-            name={FIELD_NAMES.SUPPLIER}
+            name={PRODUCT_FIELD_NAMES.SUPPLIER}
             label={t('ADD_PRODUCT.SUPPLIER_LABEL')}
-            hookFormRegister={register(FIELD_NAMES.SUPPLIER, {
+            hookFormRegister={register(PRODUCT_FIELD_NAMES.SUPPLIER, {
               required: interested,
               maxLength: 255,
             })}
             disabled={isDetailDisabled}
             hasLeaf={true}
-            errors={getInputErrors(errors, FIELD_NAMES.SUPPLIER)}
+            errors={getInputErrors(errors, PRODUCT_FIELD_NAMES.SUPPLIER)}
             optional={!interested}
           />
           {interested && inCanada && (
@@ -194,7 +201,7 @@ const ProductDetails = ({
               {/* @ts-ignore */}
               <RadioGroup
                 hookFormControl={control}
-                name={FIELD_NAMES.PERMITTED}
+                name={PRODUCT_FIELD_NAMES.PERMITTED}
                 required={true}
                 disabled={isDetailDisabled}
                 showNotSure
@@ -203,11 +210,11 @@ const ProductDetails = ({
           )}
 
           <Controller
-            name={FIELD_NAMES.COMPOSITION}
+            name={PRODUCT_FIELD_NAMES.COMPOSITION}
             control={control}
             rules={{
               validate: (value): boolean | string => {
-                if (!value || value[FIELD_NAMES.UNIT] !== Unit.PERCENT) {
+                if (!value || value[PRODUCT_FIELD_NAMES.UNIT] !== Unit.PERCENT) {
                   return true;
                 }
                 return (
@@ -234,7 +241,7 @@ const ProductDetails = ({
                   // onBlur needs to be passed manually
                   // https://stackoverflow.com/questions/61661432/how-to-make-react-hook-form-controller-validation-triggered-on-blur
                   onBlur={field.onBlur}
-                  unitFieldName={FIELD_NAMES.UNIT}
+                  unitFieldName={PRODUCT_FIELD_NAMES.UNIT}
                 />
               );
             }}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -349,7 +349,7 @@ const ProductDetails = ({
           )}
 
           <ReactSelect
-            isDisabled={isReadOnly}
+            isDisabled={isDetailDisabled}
             label={t('ADD_PRODUCT.FERTILISER_TYPE')}
             placeholder={t('ADD_PRODUCT.FERTILISER_TYPE_PLACEHOLDER')}
             options={fertiliserTypeOptions}
@@ -357,6 +357,7 @@ const ProductDetails = ({
           />
 
           <CompositionInputs
+            disabled={isDetailDisabled}
             onChange={(fieldName: string, value: string | number | null): void => {
               handleMoistureDryMatterContentChange(fieldName, value ? +value : undefined);
             }}
@@ -399,6 +400,7 @@ const ProductDetails = ({
                 })}
 
                 <CompositionInputs
+                  disabled={isDetailDisabled}
                   onChange={(fieldName: string, value: string | number | null): void => {
                     setValue(
                       fieldName as typeof AMMONIUM | typeof NITRATE,

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -50,7 +50,6 @@ export type ProductDetailsProps = {
     data: FormFields & { farm_id: string; product_id: ProductId; type: string },
     callback?: (id: number) => void,
   ) => void;
-  setFieldValidity: (isValid: boolean) => void;
 };
 
 const isNewProduct = (productId: ProductId): boolean => typeof productId === 'string';
@@ -77,7 +76,6 @@ const ProductDetails = ({
   clearProduct,
   setProductId,
   onSave,
-  setFieldValidity,
 }: ProductDetailsProps) => {
   const { t } = useTranslation();
   const [isEditingProduct, setIsEditingProduct] = useState(false);
@@ -137,10 +135,6 @@ const ProductDetails = ({
     }
     previousProductIdRef.current = productId;
   }, [productId]);
-
-  useEffect(() => {
-    setFieldValidity(!!(productId && isValid));
-  }, [productId, isValid]);
 
   const onCancel = () => {
     if (isNewProduct(productId)) {

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -100,17 +100,6 @@ export const defaultValues = {
   },
 };
 
-const validateCompositionValues = (value?: ProductFormFields['composition']): boolean | string => {
-  if (!value || value[UNIT] !== Unit.PERCENT) {
-    return true;
-  }
-  const total = Object.keys(Nutrients).reduce((acc: number, key) => {
-    const valueKey = Nutrients[key as keyof typeof Nutrients];
-    return acc + (value[valueKey] || 0);
-  }, 0);
-  return total <= 100 || `t('ADD_PRODUCT.COMPOSITION_ERROR')`;
-};
-
 const subtractFrom100 = (value: number) => +(100 * 100 - value * 100) / 100;
 
 const ProductDetails = ({
@@ -249,6 +238,52 @@ const ProductDetails = ({
     }
   };
 
+  const renderCompositionInputsWithController = ({
+    mainLabel = '',
+    inputsInfo,
+    shouldShowError = false,
+  }: {
+    mainLabel?: string;
+    inputsInfo: { name: string; label: string }[];
+    shouldShowError: boolean;
+  }) => {
+    return (
+      <Controller
+        name={COMPOSITION}
+        control={control}
+        rules={{
+          validate: (value: ProductFormFields['composition']): boolean | string => {
+            if (!value || value[UNIT] !== Unit.PERCENT) {
+              return true;
+            }
+            const total = Object.keys(Nutrients).reduce((acc: number, key) => {
+              const valueKey = Nutrients[key as keyof typeof Nutrients];
+              return acc + (value[valueKey] || 0);
+            }, 0);
+            return total <= 100 || t('ADD_PRODUCT.COMPOSITION_ERROR');
+          },
+        }}
+        render={({ field, fieldState }) => {
+          return (
+            <CompositionInputs
+              mainLabel={mainLabel}
+              unitOptions={unitOptions}
+              inputsInfo={inputsInfo}
+              disabled={isDetailDisabled}
+              error={shouldShowError ? fieldState.error?.message : undefined}
+              values={field.value || {}}
+              onChange={(name, value) => field.onChange({ ...field.value, [name]: value })}
+              // onBlur needs to be passed manually
+              // https://stackoverflow.com/questions/61661432/how-to-make-react-hook-form-controller-validation-triggered-on-blur
+              onBlur={field.onBlur}
+              unitFieldName={UNIT}
+            />
+          );
+        }}
+      />
+    );
+  };
+
   return (
     <div
       className={clsx(
@@ -322,34 +357,15 @@ const ProductDetails = ({
             unit="%"
           />
 
-          <Controller
-            name={COMPOSITION}
-            control={control}
-            rules={{ validate: validateCompositionValues }}
-            render={({ field, fieldState }) => {
-              return (
-                <CompositionInputs
-                  mainLabel={t('ADD_PRODUCT.COMPOSITION')}
-                  unitOptions={unitOptions}
-                  inputsInfo={[
-                    { name: Nutrients.N, label: t('ADD_PRODUCT.NITROGEN') },
-                    { name: Nutrients.P, label: t('ADD_PRODUCT.PHOSPHOROUS') },
-                    { name: Nutrients.K, label: t('ADD_PRODUCT.POTASSIUM') },
-                  ]}
-                  disabled={isDetailDisabled}
-                  error={fieldState.error?.message}
-                  values={field.value || {}}
-                  onChange={(name, value) => {
-                    field.onChange({ ...field.value, [name]: value });
-                  }}
-                  // onBlur needs to be passed manually
-                  // https://stackoverflow.com/questions/61661432/how-to-make-react-hook-form-controller-validation-triggered-on-blur
-                  onBlur={field.onBlur}
-                  unitFieldName={UNIT}
-                />
-              );
-            }}
-          />
+          {renderCompositionInputsWithController({
+            mainLabel: t('ADD_PRODUCT.COMPOSITION'),
+            inputsInfo: [
+              { name: Nutrients.N, label: t('ADD_PRODUCT.NITROGEN') },
+              { name: Nutrients.P, label: t('ADD_PRODUCT.PHOSPHOROUS') },
+              { name: Nutrients.K, label: t('ADD_PRODUCT.POTASSIUM') },
+            ],
+            shouldShowError: true, // TODO
+          })}
 
           <div
             className={clsx(
@@ -379,36 +395,17 @@ const ProductDetails = ({
               unmountOnExit
             >
               <div className={styles.sectionBody}>
-                <Controller
-                  name={COMPOSITION}
-                  control={control}
-                  rules={{ validate: validateCompositionValues }}
-                  render={({ field, fieldState }) => {
-                    return (
-                      <CompositionInputs
-                        unitOptions={unitOptions}
-                        inputsInfo={[
-                          { name: Nutrients.CA, label: t('ADD_PRODUCT.CALCIUM') },
-                          { name: Nutrients.MG, label: t('ADD_PRODUCT.MAGNESIUM') },
-                          { name: Nutrients.S, label: t('ADD_PRODUCT.SULFUR') },
-                          { name: Nutrients.CU, label: t('ADD_PRODUCT.COPPER') },
-                          { name: Nutrients.MN, label: t('ADD_PRODUCT.MANGANESE') },
-                          { name: Nutrients.B, label: t('ADD_PRODUCT.BORON') },
-                        ]}
-                        disabled={isDetailDisabled}
-                        error={fieldState.error?.message}
-                        values={field.value || {}}
-                        onChange={(name, value) => {
-                          field.onChange({ ...field.value, [name]: value });
-                        }}
-                        // onBlur needs to be passed manually
-                        // https://stackoverflow.com/questions/61661432/how-to-make-react-hook-form-controller-validation-triggered-on-blur
-                        onBlur={field.onBlur}
-                        unitFieldName={UNIT}
-                      />
-                    );
-                  }}
-                />
+                {renderCompositionInputsWithController({
+                  inputsInfo: [
+                    { name: Nutrients.CA, label: t('ADD_PRODUCT.CALCIUM') },
+                    { name: Nutrients.MG, label: t('ADD_PRODUCT.MAGNESIUM') },
+                    { name: Nutrients.S, label: t('ADD_PRODUCT.SULFUR') },
+                    { name: Nutrients.CU, label: t('ADD_PRODUCT.COPPER') },
+                    { name: Nutrients.MN, label: t('ADD_PRODUCT.MANGANESE') },
+                    { name: Nutrients.B, label: t('ADD_PRODUCT.BORON') },
+                  ],
+                  shouldShowError: true, // TODO
+                })}
               </div>
             </Collapse>
           </div>

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -143,7 +143,7 @@ const ProductDetails = ({
     setFocus,
     trigger,
     register,
-    formState: { errors, isValid, isDirty },
+    formState: { errors, isValid },
   } = useForm<ProductFormFields>({
     mode: 'onBlur',
     defaultValues,
@@ -426,7 +426,7 @@ const ProductDetails = ({
             <Buttons
               isEditingProduct={isEditingProduct}
               isEditDisabled={!isProductEntered}
-              isSaveDisabled={!isProductEntered || !(isDirty && isValid)}
+              isSaveDisabled={!isProductEntered || !isValid}
               onCancel={onCancel}
               onEdit={() => setIsEditingProduct(true)}
               onSave={handleSubmit(onSubmit)}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -57,6 +57,8 @@ const {
   CU,
   MN,
   B,
+  AMMONIUM,
+  NITRATE,
 } = PRODUCT_FIELD_NAMES;
 
 const unitOptions = [
@@ -146,7 +148,12 @@ const ProductDetails = ({
     defaultValues,
   });
 
-  const [moistureContent, dryMatterContent] = watch([MOISTURE_CONTENT, DRY_MATTER_CONTENT]);
+  const [moistureContent, dryMatterContent, ammonium, nitrate] = watch([
+    MOISTURE_CONTENT,
+    DRY_MATTER_CONTENT,
+    AMMONIUM,
+    NITRATE,
+  ]);
 
   const {
     expandedIds: expandedAdditionalNutrientsIds,
@@ -411,6 +418,27 @@ const ProductDetails = ({
                   ],
                   shouldShowError: true, // TODO
                 })}
+
+                <CompositionInputs
+                  onChange={(fieldName: string, value: string | number | null): void => {
+                    setValue(
+                      fieldName as typeof AMMONIUM | typeof NITRATE,
+                      value ? +value : undefined,
+                    );
+                  }}
+                  inputsInfo={[
+                    {
+                      name: AMMONIUM,
+                      label: t('ADD_PRODUCT.AMMONIUM'),
+                    },
+                    {
+                      name: NITRATE,
+                      label: t('ADD_PRODUCT.NITRATE'),
+                    },
+                  ]}
+                  values={{ [AMMONIUM]: ammonium, [NITRATE]: nitrate }}
+                  unit="ppm"
+                />
               </div>
             </Collapse>
           </div>

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -183,7 +183,7 @@ const ProductDetails = ({
         [SUPPLIER]: selectedProduct?.[SUPPLIER] || '',
         [PERMITTED]: selectedProduct?.[PERMITTED] || undefined,
         [FERTILISER_TYPE]: selectedProduct?.[FERTILISER_TYPE] || undefined,
-        [MOISTURE_CONTENT]: selectedProduct?.[MOISTURE_CONTENT] || undefined,
+        [MOISTURE_CONTENT]: selectedProduct?.[MOISTURE_CONTENT] ?? undefined,
         [DRY_MATTER_CONTENT]: newDryMatterContent,
         [COMPOSITION]: {
           [UNIT]: selectedProduct?.[UNIT] || Unit.RATIO,
@@ -239,8 +239,10 @@ const ProductDetails = ({
 
   const handleMoistureDryMatterContentChange = (fieldName: string, value?: number) => {
     const theOtherField = fieldName === MOISTURE_CONTENT ? DRY_MATTER_CONTENT : MOISTURE_CONTENT;
-    const inputtedFieldValue = Math.min(100, +(value ? roundToTwoDecimal(value) : 0));
-    const theOtherFieldValue = subtractFrom100(inputtedFieldValue);
+    const inputtedFieldValue =
+      typeof value === 'number' ? Math.min(100, roundToTwoDecimal(value)) : undefined;
+    const theOtherFieldValue =
+      typeof inputtedFieldValue === 'number' ? subtractFrom100(inputtedFieldValue) : undefined;
 
     setValue(fieldName as typeof MOISTURE_CONTENT | typeof DRY_MATTER_CONTENT, inputtedFieldValue);
     setValue(theOtherField, theOtherFieldValue);
@@ -359,7 +361,10 @@ const ProductDetails = ({
           <CompositionInputs
             disabled={isDetailDisabled}
             onChange={(fieldName: string, value: string | number | null): void => {
-              handleMoistureDryMatterContentChange(fieldName, value ? +value : undefined);
+              handleMoistureDryMatterContentChange(
+                fieldName,
+                value === null || value === undefined ? undefined : +value,
+              );
             }}
             inputsInfo={inputsInfo.moistureDrymatterContents}
             values={{ [MOISTURE_CONTENT]: moistureContent, [DRY_MATTER_CONTENT]: dryMatterContent }}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -184,7 +184,7 @@ const ProductDetails = ({
         [SUPPLIER]: selectedProduct?.[SUPPLIER] || '',
         [PERMITTED]: selectedProduct?.[PERMITTED] || undefined,
         [FERTILISER_TYPE]: selectedProduct?.[FERTILISER_TYPE] || undefined,
-        [MOISTURE_CONTENT]: selectedProduct?.[MOISTURE_CONTENT] ?? undefined,
+        [MOISTURE_CONTENT]: selectedProduct?.[MOISTURE_CONTENT] ?? NaN,
         [DRY_MATTER_CONTENT]: newDryMatterContent,
         [COMPOSITION]: {
           [UNIT]: selectedProduct?.[UNIT] || Unit.RATIO,

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -62,6 +62,8 @@ const {
 const unitOptions = [
   { label: '%', value: Unit.PERCENT },
   { label: Unit.RATIO, value: Unit.RATIO },
+  { label: Unit.PPM, value: Unit.PPM },
+  { label: Unit['MG/KG'], value: Unit['MG/KG'] },
 ];
 
 export type ProductDetailsProps = {
@@ -83,6 +85,8 @@ export type ProductDetailsProps = {
 };
 
 const isNewProduct = (productId: ProductId): boolean => typeof productId === 'string';
+
+const MG_KG_REACT_SELECT_WIDTH = 76;
 
 export const defaultValues = {
   [SUPPLIER]: '',
@@ -277,6 +281,7 @@ const ProductDetails = ({
               // https://stackoverflow.com/questions/61661432/how-to-make-react-hook-form-controller-validation-triggered-on-blur
               onBlur={field.onBlur}
               unitFieldName={UNIT}
+              reactSelectWidth={MG_KG_REACT_SELECT_WIDTH}
             />
           );
         }}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -320,7 +320,7 @@ const ProductDetails = ({
       </TextButton>
 
       <Collapse id={`product_details-${productId}`} in={isExpanded} timeout="auto" unmountOnExit>
-        <div className={styles.sectionBody}>
+        <div className={styles.productDetailsContent}>
           {/* @ts-ignore */}
           <Input
             name={SUPPLIER}
@@ -371,13 +371,7 @@ const ProductDetails = ({
             shouldShowError: true, // TODO
           })}
 
-          <div
-            className={clsx(
-              styles.border,
-              isAdditionalNutrientsExpanded && styles.expanded,
-              styles.additionalNutrients,
-            )}
-          >
+          <div className={clsx(styles.additionalNutrients)}>
             <TextButton
               disabled={!isProductEntered}
               onClick={() => toggleAdditionalNutrientsExpanded(additionalNutrientsId)}
@@ -398,7 +392,7 @@ const ProductDetails = ({
               timeout="auto"
               unmountOnExit
             >
-              <div className={styles.sectionBody}>
+              <div className={styles.additionalNutrientsBody}>
                 {renderCompositionInputsWithController({
                   inputsInfo: inputsInfo.additionalNutrients,
                   shouldShowError: true, // TODO

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -29,7 +29,6 @@ export type ProductCardProps = Omit<ProductDetailsProps, 'clearProduct'> & {
   system: 'metric' | 'imperial';
   onRemove?: () => void;
   onSaveProduct: ProductDetailsProps['onSave'];
-  totalArea: number;
   purposeOptions: { label: string; value: number }[];
   otherPurposeId?: number;
 };
@@ -70,7 +69,6 @@ const SoilAmendmentProductCard = ({
   onSaveProduct,
   isReadOnly,
   products = [],
-  totalArea,
   purposeOptions,
   otherPurposeId,
   ...props

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -21,7 +21,7 @@ import SmallButton from '../../../Form/Button/SmallButton';
 import ReactSelect, { CreatableSelect } from '../../../Form/ReactSelect';
 import Input from '../../../Form/Input';
 import ProductDetails, { type ProductDetailsProps } from './ProductDetails';
-import { FIELD_NAMES, type Product } from '../types';
+import { PRODUCT_FIELD_NAMES, type Product } from '../types';
 import styles from '../styles.module.scss';
 
 export type ProductCardProps = Omit<ProductDetailsProps, 'clearProduct'> & {
@@ -78,8 +78,8 @@ const SoilAmendmentProductCard = ({
   const { t } = useTranslation();
   const { control, register, watch, setValue } = useFormContext();
 
-  const PRODUCT_ID = `${namePrefix}.${FIELD_NAMES.PRODUCT_ID}`;
-  const PURPOSES = `${namePrefix}.${FIELD_NAMES.PURPOSES}`;
+  const PRODUCT_ID = `${namePrefix}.${PRODUCT_FIELD_NAMES.PRODUCT_ID}`;
+  const PURPOSES = `${namePrefix}.${PRODUCT_FIELD_NAMES.PURPOSES}`;
 
   const purposes = watch(PURPOSES);
 
@@ -119,9 +119,9 @@ const SoilAmendmentProductCard = ({
           {/* @ts-ignore */}
           <Input
             label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER_PURPOSE')}
-            name={FIELD_NAMES.OTHER_PURPOSE}
+            name={PRODUCT_FIELD_NAMES.OTHER_PURPOSE}
             disabled={isReadOnly}
-            hookFormRegister={register(FIELD_NAMES.OTHER_PURPOSE)}
+            hookFormRegister={register(PRODUCT_FIELD_NAMES.OTHER_PURPOSE)}
             optional
           />
         </>

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -130,7 +130,12 @@ const SoilAmendmentProductCard = ({
         <Controller
           control={control}
           name={PRODUCT_ID}
-          rules={{ required: true }}
+          rules={{
+            required: true,
+            validate: (value) => {
+              return typeof value === 'number';
+            },
+          }}
           render={({ field: { value, onChange } }) => (
             <CreatableSelect
               ref={selectRef}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/useInputsInfo.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/useInputsInfo.ts
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { PRODUCT_FIELD_NAMES } from '../types';
+
+const { MOISTURE_CONTENT, DRY_MATTER_CONTENT, N, P, K, CA, MG, S, CU, MN, B, AMMONIUM, NITRATE } =
+  PRODUCT_FIELD_NAMES;
+
+const useInputsInfo = () => {
+  const { t } = useTranslation();
+
+  return {
+    moistureDrymatterContents: [
+      { name: MOISTURE_CONTENT, label: t('ADD_PRODUCT.MOISTURE_CONTENT') },
+      { name: DRY_MATTER_CONTENT, label: t('ADD_PRODUCT.DRY_MATTER_CONTENT') },
+    ],
+    npk: [
+      { name: N, label: t('ADD_PRODUCT.NITROGEN') },
+      { name: P, label: t('ADD_PRODUCT.PHOSPHOROUS') },
+      { name: K, label: t('ADD_PRODUCT.POTASSIUM') },
+    ],
+    additionalNutrients: [
+      { name: CA, label: t('ADD_PRODUCT.CALCIUM') },
+      { name: MG, label: t('ADD_PRODUCT.MAGNESIUM') },
+      { name: S, label: t('ADD_PRODUCT.SULFUR') },
+      { name: CU, label: t('ADD_PRODUCT.COPPER') },
+      { name: MN, label: t('ADD_PRODUCT.MANGANESE') },
+      { name: B, label: t('ADD_PRODUCT.BORON') },
+    ],
+    ammoniumNitrate: [
+      { name: AMMONIUM, label: t('ADD_PRODUCT.AMMONIUM') },
+      { name: NITRATE, label: t('ADD_PRODUCT.NITRATE') },
+    ],
+  };
+};
+
+export default useInputsInfo;

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
@@ -24,7 +24,10 @@ import { defaultValues } from './ProductCard/ProductDetails';
 import { ReactComponent as PlusCircleIcon } from '../../../assets/images/plus-circle.svg';
 import styles from './styles.module.scss';
 
-export type AddSoilAmendmentProductsProps = ProductCardProps & { products: Product[] };
+export type AddSoilAmendmentProductsProps = ProductCardProps & {
+  products: Product[];
+  purposes?: { id: number; key: string }[];
+};
 
 interface ProductFields {
   product_id: ProductId;
@@ -34,6 +37,7 @@ const FIELD_NAME = 'soil_amendment_task_products';
 
 const AddSoilAmendmentProducts = ({
   products,
+  purposes = [],
   isReadOnly,
   ...props
 }: AddSoilAmendmentProductsProps) => {
@@ -87,6 +91,18 @@ const AddSoilAmendmentProducts = ({
     append(defaultValues);
   };
 
+  // t('ADD_TASK.SOIL_AMENDMENT_VIEW.STRUCTURE')
+  // t('ADD_TASK.SOIL_AMENDMENT_VIEW.MOISTURE_RETENTION')
+  // t('ADD_TASK.SOIL_AMENDMENT_VIEW.NUTRIENT_AVAILABILITY')
+  // t('ADD_TASK.SOIL_AMENDMENT_VIEW.PH')
+  // t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER')
+  const purposeOptions = purposes.map(({ id, key }) => ({
+    value: id,
+    label: t(`ADD_TASK.SOIL_AMENDMENT_VIEW.${key}`),
+  }));
+
+  const otherPurposeId = purposes.find(({ key }) => key === 'OTHER')?.id;
+
   return (
     <>
       <div className={styles.products}>
@@ -111,6 +127,8 @@ const AddSoilAmendmentProducts = ({
                 setValue(`${namePrefix}.product_id`, id);
               }}
               setFieldValidity={getInvalidProductsUpdater(field.id)}
+              purposeOptions={purposeOptions}
+              otherPurposeId={otherPurposeId}
             />
           );
         })}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
@@ -23,7 +23,10 @@ import { defaultValues } from './ProductCard/ProductDetails';
 import { ReactComponent as PlusCircleIcon } from '../../../assets/images/plus-circle.svg';
 import styles from './styles.module.scss';
 
-export type AddSoilAmendmentProductsProps = ProductCardProps & {
+export type AddSoilAmendmentProductsProps = Pick<
+  ProductCardProps,
+  'isReadOnly' | 'farm' | 'onSave' | 'system' | 'onSaveProduct'
+> & {
   products: Product[];
   purposes?: { id: number; key: string }[];
   fertiliserTypes?: { id: number; key: string }[];
@@ -47,7 +50,7 @@ const AddSoilAmendmentProducts = ({
     control,
     setValue,
     watch,
-    formState: { isDirty, isValid },
+    formState: { isValid },
   } = useFormContext();
   const { fields, append, remove } = useFieldArray({
     name: FIELD_NAME,

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
@@ -26,6 +26,7 @@ import styles from './styles.module.scss';
 export type AddSoilAmendmentProductsProps = ProductCardProps & {
   products: Product[];
   purposes?: { id: number; key: string }[];
+  fertiliserTypes?: { id: number; key: string }[];
 };
 
 interface ProductFields {
@@ -37,6 +38,7 @@ const FIELD_NAME = 'soil_amendment_task_products';
 const AddSoilAmendmentProducts = ({
   products,
   purposes = [],
+  fertiliserTypes = [],
   isReadOnly,
   ...props
 }: AddSoilAmendmentProductsProps) => {
@@ -82,6 +84,13 @@ const AddSoilAmendmentProducts = ({
     label: t(`ADD_TASK.SOIL_AMENDMENT_VIEW.${key}`),
   }));
 
+  // t('ADD_PRODUCT.DRY_FERTILISER')
+  // t('ADD_PRODUCT.LIQUID_FERTILISER')
+  const fertiliserTypeOptions = fertiliserTypes.map(({ id, key }) => ({
+    value: id,
+    label: t(`ADD_PRODUCT.${key}_FERTILISER`),
+  }));
+
   const otherPurposeId = purposes.find(({ key }) => key === 'OTHER')?.id;
 
   return (
@@ -109,6 +118,7 @@ const AddSoilAmendmentProducts = ({
               }}
               purposeOptions={purposeOptions}
               otherPurposeId={otherPurposeId}
+              fertiliserTypeOptions={fertiliserTypeOptions}
             />
           );
         })}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
@@ -108,6 +108,10 @@
       stroke-width: 2px;
       stroke: var(--Colors-Accent---singles-Blue-full, #0669e1);
     }
+
+    &.expanded {
+      transform: rotate(0deg);
+    }
   }
   .productDetailsTitle {
     padding: 4px 8px;
@@ -136,10 +140,6 @@
   &.expanded {
     @include sectionStyle();
 
-    .expandIcon {
-      transform: rotate(0deg);
-    }
-
     .productDetailsTitle {
       width: 100%;
       background: var(--Colors-Backgrounds-table-row-bg, #f7fbff);
@@ -148,6 +148,21 @@
 
   .permitedSubstance {
     @include flex-column-gap(8px);
+  }
+
+  // Additional nutrients
+  .additionalNutrients {
+    border: solid 1px var(--Colors-Accent---singles-Blue-light, #e9f3ff);
+    border-radius: 4px;
+  }
+  .additionalNutrientsTitle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    width: 100%;
+    height: 40px;
+    color: var(--Colors-Accent---singles-Blue-full, #0669e1);
   }
 }
 

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
@@ -15,27 +15,6 @@
 
 @import '../../../assets/mixin.scss';
 
-@mixin sectionStyle() {
-  overflow: hidden;
-  border-radius: 8px;
-  box-shadow: 0px 2px 1px 0px rgba(0, 0, 0, 0.05);
-
-  &.border {
-    border: 1px solid var(--Colors-Neutral-Neutral-100, #d0d4db);
-  }
-}
-
-.sectionBody {
-  padding: 8px 16px 16px 16px;
-  border-radius: 0 0 8px 8px;
-  @include flex-column-gap();
-
-  &.border {
-    border: 1px solid var(--Colors-Neutral-Neutral-100, #d0d4db);
-    border-top: none;
-  }
-}
-
 /*----------------------------------------
   AddSoilAmendmentProducts
 ----------------------------------------*/
@@ -96,6 +75,11 @@
 .productDetails {
   border: solid 1px transparent;
 
+  .productDetailsContent {
+    padding: 8px 16px 16px 16px;
+    @include flex-column-gap(24px);
+  }
+
   .expandIcon {
     width: 16px;
     height: 16px;
@@ -138,7 +122,10 @@
   }
 
   &.expanded {
-    @include sectionStyle();
+    overflow: hidden;
+    border-radius: 8px;
+    box-shadow: 0px 2px 1px 0px rgba(0, 0, 0, 0.05);
+    border: 1px solid var(--Colors-Neutral-Neutral-100, #d0d4db);
 
     .productDetailsTitle {
       width: 100%;
@@ -154,6 +141,10 @@
   .additionalNutrients {
     border: solid 1px var(--Colors-Accent---singles-Blue-light, #e9f3ff);
     border-radius: 4px;
+  }
+  .additionalNutrientsBody {
+    padding: 24px 16px 16px 16px;
+    @include flex-column-gap(24px);
   }
   .additionalNutrientsTitle {
     display: flex;

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -22,12 +22,6 @@ export enum Unit {
   'MG/KG' = 'mg/kg',
 }
 
-export enum NPK {
-  N = 'n',
-  P = 'p',
-  K = 'k',
-}
-
 export enum Nutrients {
   N = 'n',
   P = 'p',
@@ -67,6 +61,8 @@ export const PRODUCT_FIELD_NAMES = {
   CU: Nutrients.CU,
   MN: Nutrients.MN,
   B: Nutrients.B,
+  AMMONIUM: 'ammonium',
+  NITRATE: 'nitrate',
 } as const;
 
 export type ProductId = number | string | undefined;
@@ -91,6 +87,8 @@ export type ProductFormFields = {
     [PRODUCT_FIELD_NAMES.MN]?: number | null;
     [PRODUCT_FIELD_NAMES.B]?: number | null;
   };
+  [PRODUCT_FIELD_NAMES.AMMONIUM]?: number;
+  [PRODUCT_FIELD_NAMES.NITRATE]?: number;
 };
 
 export type Product = {
@@ -110,6 +108,8 @@ export type Product = {
   [PRODUCT_FIELD_NAMES.MN]?: number | null;
   [PRODUCT_FIELD_NAMES.B]?: number | null;
   [PRODUCT_FIELD_NAMES.UNIT]?: Unit | null;
+  [PRODUCT_FIELD_NAMES.AMMONIUM]?: number;
+  [PRODUCT_FIELD_NAMES.NITRATE]?: number;
   farm_id: string;
   type:
     | typeof TASK_TYPES.SOIL_AMENDMENT

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -26,6 +26,18 @@ export enum NPK {
   K = 'k',
 }
 
+export enum Nutrients {
+  N = 'n',
+  P = 'p',
+  K = 'k',
+  CA = 'calcium',
+  MG = 'magnesium',
+  S = 'sulfur',
+  CU = 'copper',
+  MN = 'manganese',
+  B = 'boron',
+}
+
 export const TASK_PRODUCT_FIELD_NAMES = {
   PRODUCT_ID: 'product_id',
   PURPOSES: 'purposes',
@@ -44,9 +56,15 @@ export const PRODUCT_FIELD_NAMES = {
   DRY_MATTER_CONTENT: 'dry_matter_content',
   COMPOSITION: 'composition',
   UNIT: 'npk_unit',
-  N: NPK.N,
-  P: NPK.P,
-  K: NPK.K,
+  N: Nutrients.N,
+  P: Nutrients.P,
+  K: Nutrients.K,
+  CA: Nutrients.CA,
+  MG: Nutrients.MG,
+  S: Nutrients.S,
+  CU: Nutrients.CU,
+  MN: Nutrients.MN,
+  B: Nutrients.B,
 } as const;
 
 export type ProductId = number | string | undefined;
@@ -64,6 +82,12 @@ export type ProductFormFields = {
     [PRODUCT_FIELD_NAMES.N]?: number | null;
     [PRODUCT_FIELD_NAMES.P]?: number | null;
     [PRODUCT_FIELD_NAMES.K]?: number | null;
+    [PRODUCT_FIELD_NAMES.CA]?: number | null;
+    [PRODUCT_FIELD_NAMES.MG]?: number | null;
+    [PRODUCT_FIELD_NAMES.S]?: number | null;
+    [PRODUCT_FIELD_NAMES.CU]?: number | null;
+    [PRODUCT_FIELD_NAMES.MN]?: number | null;
+    [PRODUCT_FIELD_NAMES.B]?: number | null;
   };
 };
 
@@ -77,6 +101,12 @@ export type Product = {
   [PRODUCT_FIELD_NAMES.N]?: number | null;
   [PRODUCT_FIELD_NAMES.P]?: number | null;
   [PRODUCT_FIELD_NAMES.K]?: number | null;
+  [PRODUCT_FIELD_NAMES.CA]?: number | null;
+  [PRODUCT_FIELD_NAMES.MG]?: number | null;
+  [PRODUCT_FIELD_NAMES.S]?: number | null;
+  [PRODUCT_FIELD_NAMES.CU]?: number | null;
+  [PRODUCT_FIELD_NAMES.MN]?: number | null;
+  [PRODUCT_FIELD_NAMES.B]?: number | null;
   [PRODUCT_FIELD_NAMES.UNIT]?: Unit | null;
   farm_id: string;
   type:

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -28,6 +28,8 @@ export enum NPK {
 
 export const FIELD_NAMES = {
   PRODUCT_ID: 'product_id',
+  PURPOSES: 'purposes',
+  OTHER_PURPOSE: 'other_purpose',
   NAME: 'name',
   SUPPLIER: 'supplier',
   PERMITTED: 'on_permitted_substances_list',

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -22,6 +22,11 @@ export enum Unit {
   'MG/KG' = 'mg/kg',
 }
 
+export enum MolecularCompoundsUnit {
+  PPM = 'ppm',
+  'MG/KG' = 'mg/kg',
+}
+
 export enum Nutrients {
   N = 'n',
   P = 'p',
@@ -63,6 +68,7 @@ export const PRODUCT_FIELD_NAMES = {
   B: Nutrients.B,
   AMMONIUM: 'ammonium',
   NITRATE: 'nitrate',
+  MOLECULAR_COMPOUNDS_UNIT: 'molecular_compounds_unit',
 } as const;
 
 export type ProductId = number | string | undefined;
@@ -89,6 +95,7 @@ export type ProductFormFields = {
   };
   [PRODUCT_FIELD_NAMES.AMMONIUM]?: number;
   [PRODUCT_FIELD_NAMES.NITRATE]?: number;
+  [PRODUCT_FIELD_NAMES.MOLECULAR_COMPOUNDS_UNIT]?: MolecularCompoundsUnit;
 };
 
 export type Product = {
@@ -110,6 +117,7 @@ export type Product = {
   [PRODUCT_FIELD_NAMES.UNIT]?: Unit | null;
   [PRODUCT_FIELD_NAMES.AMMONIUM]?: number;
   [PRODUCT_FIELD_NAMES.NITRATE]?: number;
+  [PRODUCT_FIELD_NAMES.MOLECULAR_COMPOUNDS_UNIT]?: MolecularCompoundsUnit;
   farm_id: string;
   type:
     | typeof TASK_TYPES.SOIL_AMENDMENT

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -18,6 +18,8 @@ import { TASK_TYPES } from '../../../containers/Task/constants';
 export enum Unit {
   RATIO = 'ratio',
   PERCENT = 'percent',
+  PPM = 'ppm',
+  'MG/KG' = 'mg/kg',
 }
 
 export enum NPK {

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -26,6 +26,12 @@ export enum NPK {
   K = 'k',
 }
 
+export const TASK_PRODUCT_FIELD_NAMES = {
+  PRODUCT_ID: 'product_id',
+  PURPOSES: 'purposes',
+  OTHER_PURPOSE: 'other_purpose',
+} as const;
+
 export const PRODUCT_FIELD_NAMES = {
   PRODUCT_ID: 'product_id',
   PURPOSES: 'purposes',
@@ -33,6 +39,9 @@ export const PRODUCT_FIELD_NAMES = {
   NAME: 'name',
   SUPPLIER: 'supplier',
   PERMITTED: 'on_permitted_substances_list',
+  FERTILISER_TYPE: 'fertiliser_type',
+  MOISTURE_CONTENT: 'moisture_content',
+  DRY_MATTER_CONTENT: 'dry_matter_content',
   COMPOSITION: 'composition',
   UNIT: 'npk_unit',
   N: NPK.N,
@@ -47,6 +56,9 @@ export type ProductFormFields = {
   [PRODUCT_FIELD_NAMES.PERMITTED]?: 'YES' | 'NO' | 'NOT_SURE' | null;
   [PRODUCT_FIELD_NAMES.PURPOSES]?: number[];
   [PRODUCT_FIELD_NAMES.OTHER_PURPOSE]?: string;
+  [PRODUCT_FIELD_NAMES.FERTILISER_TYPE]?: number;
+  [PRODUCT_FIELD_NAMES.MOISTURE_CONTENT]?: number;
+  [PRODUCT_FIELD_NAMES.DRY_MATTER_CONTENT]?: number;
   [PRODUCT_FIELD_NAMES.COMPOSITION]?: {
     [PRODUCT_FIELD_NAMES.UNIT]?: Unit;
     [PRODUCT_FIELD_NAMES.N]?: number | null;
@@ -60,6 +72,8 @@ export type Product = {
   [PRODUCT_FIELD_NAMES.NAME]: string;
   [PRODUCT_FIELD_NAMES.SUPPLIER]?: string | null;
   [PRODUCT_FIELD_NAMES.PERMITTED]?: 'YES' | 'NO' | 'NOT_SURE' | null;
+  [PRODUCT_FIELD_NAMES.FERTILISER_TYPE]?: number;
+  [PRODUCT_FIELD_NAMES.MOISTURE_CONTENT]?: number;
   [PRODUCT_FIELD_NAMES.N]?: number | null;
   [PRODUCT_FIELD_NAMES.P]?: number | null;
   [PRODUCT_FIELD_NAMES.K]?: number | null;

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -26,7 +26,7 @@ export enum NPK {
   K = 'k',
 }
 
-export const FIELD_NAMES = {
+export const PRODUCT_FIELD_NAMES = {
   PRODUCT_ID: 'product_id',
   PURPOSES: 'purposes',
   OTHER_PURPOSE: 'other_purpose',
@@ -42,26 +42,28 @@ export const FIELD_NAMES = {
 
 export type ProductId = number | string | undefined;
 
-export type FormFields = {
-  [FIELD_NAMES.SUPPLIER]?: string | null;
-  [FIELD_NAMES.PERMITTED]?: 'YES' | 'NO' | 'NOT_SURE' | null;
-  [FIELD_NAMES.COMPOSITION]?: {
-    [FIELD_NAMES.UNIT]?: Unit;
-    [FIELD_NAMES.N]?: number | null;
-    [FIELD_NAMES.P]?: number | null;
-    [FIELD_NAMES.K]?: number | null;
+export type ProductFormFields = {
+  [PRODUCT_FIELD_NAMES.SUPPLIER]?: string | null;
+  [PRODUCT_FIELD_NAMES.PERMITTED]?: 'YES' | 'NO' | 'NOT_SURE' | null;
+  [PRODUCT_FIELD_NAMES.PURPOSES]?: number[];
+  [PRODUCT_FIELD_NAMES.OTHER_PURPOSE]?: string;
+  [PRODUCT_FIELD_NAMES.COMPOSITION]?: {
+    [PRODUCT_FIELD_NAMES.UNIT]?: Unit;
+    [PRODUCT_FIELD_NAMES.N]?: number | null;
+    [PRODUCT_FIELD_NAMES.P]?: number | null;
+    [PRODUCT_FIELD_NAMES.K]?: number | null;
   };
 };
 
 export type Product = {
-  [FIELD_NAMES.PRODUCT_ID]: number;
-  [FIELD_NAMES.NAME]: string;
-  [FIELD_NAMES.SUPPLIER]?: string | null;
-  [FIELD_NAMES.PERMITTED]?: 'YES' | 'NO' | 'NOT_SURE' | null;
-  [FIELD_NAMES.N]?: number | null;
-  [FIELD_NAMES.P]?: number | null;
-  [FIELD_NAMES.K]?: number | null;
-  [FIELD_NAMES.UNIT]?: Unit | null;
+  [PRODUCT_FIELD_NAMES.PRODUCT_ID]: number;
+  [PRODUCT_FIELD_NAMES.NAME]: string;
+  [PRODUCT_FIELD_NAMES.SUPPLIER]?: string | null;
+  [PRODUCT_FIELD_NAMES.PERMITTED]?: 'YES' | 'NO' | 'NOT_SURE' | null;
+  [PRODUCT_FIELD_NAMES.N]?: number | null;
+  [PRODUCT_FIELD_NAMES.P]?: number | null;
+  [PRODUCT_FIELD_NAMES.K]?: number | null;
+  [PRODUCT_FIELD_NAMES.UNIT]?: Unit | null;
   farm_id: string;
   type:
     | typeof TASK_TYPES.SOIL_AMENDMENT

--- a/packages/webapp/src/stories/Form/CompositionInputs/CompositionInputs.stories.tsx
+++ b/packages/webapp/src/stories/Form/CompositionInputs/CompositionInputs.stories.tsx
@@ -88,7 +88,6 @@ export const Default: Story = {
               onChange={(name, value) => {
                 field.onChange({ ...field.value, [name]: value });
               }}
-              reactSelectJustifyContent="flex-start"
             />
           );
         }}
@@ -256,7 +255,6 @@ export const SixInputs: Story = {
               onChange={(name, value) => {
                 field.onChange({ ...field.value, [name]: value });
               }}
-              reactSelectJustifyContent="flex-start"
             />
           );
         }}

--- a/packages/webapp/src/stories/Pages/Task/AddSoilAmendmentProducts/AddSoilAmendmentProducts.stories.tsx
+++ b/packages/webapp/src/stories/Pages/Task/AddSoilAmendmentProducts/AddSoilAmendmentProducts.stories.tsx
@@ -23,6 +23,14 @@ import { defaultValues } from '../../../../components/Task/AddSoilAmendmentProdu
 import { products } from './products';
 import { FormFields } from '../../../../components/Task/AddSoilAmendmentProducts/types';
 
+const purposes = [
+  { id: 1, key: 'STRUCTURE' },
+  { id: 2, key: 'MOISTURE_RETENTION' },
+  { id: 3, key: 'NUTRIENT_AVAILABILITY' },
+  { id: 4, key: 'PH' },
+  { id: 5, key: 'OTHER' },
+];
+
 type ComponentWithFormMethodsProps = AddSoilAmendmentProductsProps & {
   defaultValues: (FormFields & { product_id?: number })[];
 };
@@ -48,6 +56,7 @@ const meta: Meta<ComponentWithFormMethodsProps> = {
     onSaveProduct: console.log,
     system: 'metric',
     products,
+    purposes,
     defaultValues: [defaultValues],
   },
 };

--- a/packages/webapp/src/stories/Pages/Task/AddSoilAmendmentProducts/AddSoilAmendmentProducts.stories.tsx
+++ b/packages/webapp/src/stories/Pages/Task/AddSoilAmendmentProducts/AddSoilAmendmentProducts.stories.tsx
@@ -31,6 +31,11 @@ const purposes = [
   { id: 5, key: 'OTHER' },
 ];
 
+const fertiliserTypes = [
+  { id: 1, key: 'DRY' },
+  { id: 2, key: 'LIQUID' },
+];
+
 type ComponentWithFormMethodsProps = AddSoilAmendmentProductsProps & {
   defaultValues: (ProductFormFields & { product_id?: number })[];
 };
@@ -57,6 +62,7 @@ const meta: Meta<ComponentWithFormMethodsProps> = {
     system: 'metric',
     products,
     purposes,
+    fertiliserTypes,
     defaultValues: [defaultValues],
   },
 };

--- a/packages/webapp/src/stories/Pages/Task/AddSoilAmendmentProducts/AddSoilAmendmentProducts.stories.tsx
+++ b/packages/webapp/src/stories/Pages/Task/AddSoilAmendmentProducts/AddSoilAmendmentProducts.stories.tsx
@@ -21,7 +21,7 @@ import AddSoilAmendmentProducts, {
 } from '../../../../components/Task/AddSoilAmendmentProducts';
 import { defaultValues } from '../../../../components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails';
 import { products } from './products';
-import { FormFields } from '../../../../components/Task/AddSoilAmendmentProducts/types';
+import { ProductFormFields } from '../../../../components/Task/AddSoilAmendmentProducts/types';
 
 const purposes = [
   { id: 1, key: 'STRUCTURE' },
@@ -32,7 +32,7 @@ const purposes = [
 ];
 
 type ComponentWithFormMethodsProps = AddSoilAmendmentProductsProps & {
-  defaultValues: (FormFields & { product_id?: number })[];
+  defaultValues: (ProductFormFields & { product_id?: number })[];
 };
 
 const ComponentWithFormMethods = ({ defaultValues, ...props }: ComponentWithFormMethodsProps) => {


### PR DESCRIPTION
**Description**

I rebased the branch! ⚠️ 🙏  

- Update `useExpandableItem` to handle empty props.
- Update `CompositionInputs` and `NumberInputWithSelect` to
  - handle single unit. (If there are no unit options, `unit` field will not be registered for `react-hook-form`)
  - update `justifyContent` to centre the selected unit. (It will still be right-aligned when disabled.) 
  - display error message conditionally.
- Add unit options to nutrients. (ppm, mg/kg)
- Add inputs for:
  - purpose
  - fertiliser type
  - moisture/dry matter contents
  - additional nutrients
- Improve the condition to disable "add another product" button
- Update [stories](http://localhost:6006/?path=/docs/page-task-addsoilamendmentproducts--docs)

Jira link: https://lite-farm.atlassian.net/browse/LF-4251

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
