### PR TITLE
LF-3884 check if location exists in request body

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -319,13 +319,14 @@ const taskController = {
     return async (req, res, next) => {
       try {
         // Do not allow to create a task if location is deleted
+        const locations = req.body.locations;
         if (
-          await baseController.isDeleted(null, Location, {
-            [Location.idColumn]: req.body.locations[0]?.location_id,
-          })
-        ) {
+          locations?.length &&
+          (await baseController.isDeleted(null, Location, {
+            [Location.idColumn]: locations[0].location_id,
+          }))
+        )
           return res.status(409).send('location deleted');
-        }
 
         // OC: the "noInsert" rule will not fail if a relationship is present in the graph.
         // it will just ignore the insert on it. This is just a 2nd layer of protection


### PR DESCRIPTION
**Description**

Unable to create a task when selecting a wild crop in the task creation flow.

**Issue:**
A 400 error was being returned from api due to a postgres error when quering the db to check for a deleted location before creating a task. When creating a task that targets a wild crop, the wild crop doesn't have a location associated to it so the request body has an empty locations property of `[]`, which means `req.body.locations[0]` is undefined and sending undefined to postgres results in an internal error that is caught in the catch block, sending a 400 response.

**Fix:**
To fix this I made a simple check to ensure that locations is not empty before checking if the location is deleted.

**Question:**
As a user on the app, I don't think its possible to create a task (that is not for a wild crop) without selecting a location first on the map. But isn't it possible for someone to bypass that and send a post request to create a task without a location? I tried and was able to do it, I got a success response and I see the record created in db, but it doesn't show up in the app. Just wondering if that might be a problem or if its intended to be this way?


Jira link: https://lite-farm.atlassian.net/browse/LF-3884

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
