### PR TITLE
Patch 3.6.5 Translations Delete

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -985,7 +985,6 @@
       "REVENUE_TYPE": "Revenue types",
       "TITLE": "Filter transactions"
     },
-    "MANAGE_CUSTOM_TYPE": "Manage custom type",
     "REPORT": {
       "DATES": "Dates",
       "FILE_TITLE": "Financial Report",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -502,7 +502,6 @@
     "MANAGEMENT_PLANS": "Crop Plans",
     "MANAGEMENT_TAB": "Management",
     "ORGANIC": "Is the seed or crop certified organic?",
-    "ORGANIC_COMPLIANCE": "Organic Compliance",
     "PERENNIAL": "Perennial",
     "TREATED": "Have the seeds for this crop been treated?"
   },


### PR DESCRIPTION
**Description**

Deletion of unused keys from the `en` translation file, identified via crowdin normalization in #3274

- one belonged to the previous expense/revenue view: https://github.com/LiteFarmOrg/LiteFarm/pull/2851
- other looks like belongs on the view for adding an organic crop but has been missing in two languages for [> 3 years](https://github.com/LiteFarmOrg/LiteFarm/pull/926/files#diff-d7c3637e6dcddb5e0a7e3f3f60baf2ebecd3f59685bccb84d26517ea89c4f817)

Jira link: none

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
