### PR TITLE
LF-4279 Fix logout on OpenWeather API 401

### DIFF
--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -166,7 +166,7 @@ axiosWithoutInterceptors.interceptors.response.use(
       if (localStorage.getItem('id_token')) {
         logout();
       }
-    } else if (error?.response?.status === 403 && error?.config?.url.startsWith(url)) {
+    } else if (error?.response?.status === 403 && error?.config?.url?.startsWith(url)) {
       store?.dispatch(handle403());
     }
     return Promise.reject(error);

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -162,11 +162,11 @@ axiosWithoutInterceptors.interceptors.response.use(
     return response;
   },
   function (error) {
-    if (error?.response?.status === 401) {
+    if (error?.response?.status === 401 && error?.config?.url.startsWith(url)) {
       if (localStorage.getItem('id_token')) {
         logout();
       }
-    } else if (error?.response?.status === 403) {
+    } else if (error?.response?.status === 403 && error?.config?.url.startsWith(url)) {
       store?.dispatch(handle403());
     }
     return Promise.reject(error);

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -162,7 +162,7 @@ axiosWithoutInterceptors.interceptors.response.use(
     return response;
   },
   function (error) {
-    if (error?.response?.status === 401 && error?.config?.url.startsWith(url)) {
+    if (error?.response?.status === 401 && error?.config?.url?.startsWith(url)) {
       if (localStorage.getItem('id_token')) {
         logout();
       }


### PR DESCRIPTION
**Description**

Please see [Jira ticket](https://lite-farm.atlassian.net/browse/LF-4279) and [this Slack thread](https://litefarm.slack.com/archives/C014931NRFY/p1719341970251249) for details.

If for any reason Open Weather rejects our API key on July 1st (extremely extremely unlikely, but might want to stay prepared given that we received an erroneous deprecation notice in the first place), this code change means that the weather dashboard on the homepage will not load, _instead of LiteFarm becoming unusable_.

Logout on API key failure happens because we have an axios interceptor that triggers logout whenever it receives a 401 error. I'm about 99.9% sure that it was never the intention of this interceptor to log us out of the application if any external API returns a 401, because that is absurd. The LiteFarm documentation trail from this era isn't superb, but you can see in the PR that added the interceptor:
- https://github.com/LiteFarmOrg/LiteFarm/pull/471/

references a branch with a Jira ticket number called "logout on 401" (which I won't link in order to not trigger the Jira automations), that has no content beyond this:

> When id_token expires, id_token and redux store should be purged

Therefore, I'm pretty sure it was added to the application to handle our 401s only.

**This PR updates the check to enforce that.** In the case of the worst (Open Weather API key failure in a few days) it will be an easy and quick fix -- not counting the whole arduous process of release 😅 --  to put this on production. We may also want to put it on production prophylactically. I'll bring this up in tech daily tomorrow.

Jira link: https://lite-farm.atlassian.net/browse/LF-4279

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

To test API key error behaviour, open your webapp `.env` file and corrupt your Open Weather API key. You can see the effect on the homepage and/or a temperature sensor (console error + that part of the webapp won't load)

To test preserved 401 logout when triggered by our API, you can edit the `id_token` in local storage or change the `JWT_SECRET` `.env` variable on the API and restart the backend (the same method we once used to log users out upon application update). In both cases you should see immediate logout


**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
