### PR TITLE
LF-3951: Show water calculator with wild crops

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -157,6 +157,7 @@
     "IRRIGATION_VIEW": {
       "BRAND_TOOLTIP": "This task is for watering your location. If you want to install irrigation, create a field work task instead.",
       "CALCULATE_WATER_USAGE": "Calculate Water Usage",
+      "CALCULATE_WATER_USAGE_WARNING": "For wild crops, estimation of water usage by depth is not available.",
       "DEFAULT_APPLICATION_DEPTH": "Set as default application depth for this location",
       "DEFAULT_LOCATION_FLOW_RATE": "Set as default flow rate for this location",
       "DEPTH": "Depth",

--- a/packages/webapp/public/locales/es/translation.json
+++ b/packages/webapp/public/locales/es/translation.json
@@ -162,6 +162,7 @@
     "IRRIGATION_VIEW": {
       "BRAND_TOOLTIP": "Esta tarea es para regar su ubicación. Si desea instalar riego, cree una tarea de trabajo de campo en su lugar.",
       "CALCULATE_WATER_USAGE": "Calcular el consumo de agua",
+      "CALCULATE_WATER_USAGE_WARNING": "MISSING",
       "DEFAULT_APPLICATION_DEPTH": "Establecer como profundidad de aplicación predeterminada para esta ubicación",
       "DEFAULT_LOCATION_FLOW_RATE": "Establecer como índice de flujo predeterminado para esta ubicación",
       "DEPTH": "Profundidad",

--- a/packages/webapp/public/locales/fr/translation.json
+++ b/packages/webapp/public/locales/fr/translation.json
@@ -162,6 +162,7 @@
     "IRRIGATION_VIEW": {
       "BRAND_TOOLTIP": "Cette tâche est d'arroser votre emplacement. Pour configuer l'irrigation, créez plutôt une tâche de terrain.",
       "CALCULATE_WATER_USAGE": "Calculer la consommation d'eau",
+      "CALCULATE_WATER_USAGE_WARNING": "MISSING",
       "DEFAULT_APPLICATION_DEPTH": "Sélectionner cette profondeur d'application par défaut pour cet emplacement",
       "DEFAULT_LOCATION_FLOW_RATE": "Sélectionner ce débit par défaut pour cet emplacement",
       "DEPTH": "Profondeur",

--- a/packages/webapp/public/locales/pt/translation.json
+++ b/packages/webapp/public/locales/pt/translation.json
@@ -162,6 +162,7 @@
     "IRRIGATION_VIEW": {
       "BRAND_TOOLTIP": "Esta tarefa é para regar seu cultivo. Se você deseja instalar a irrigação, crie uma tarefa de trabalho de campo.",
       "CALCULATE_WATER_USAGE": "Calcular uso de água",
+      "CALCULATE_WATER_USAGE_WARNING": "MISSING",
       "DEFAULT_APPLICATION_DEPTH": "Definir como profundidade de aplicação padrão para esta área",
       "DEFAULT_LOCATION_FLOW_RATE": "Definir como vazão padrão para esta área",
       "DEPTH": "Profundidade",

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -197,7 +197,7 @@ export default function PureIrrigationTask({
   const waterCalculatorDisabled =
     !showWaterUseCalculatorModal ||
     !measurement_type ||
-    (measurement_type === 'DEPTH' && !(location || getValues().show_wild_crop));
+    (measurement_type === 'DEPTH' && !location);
 
   return (
     <>

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -16,6 +16,7 @@ import { getIrrigationTaskTypes } from '../../../containers/Task/IrrigationTaskT
 import { useDispatch, useSelector } from 'react-redux';
 import { irrigationTaskTypesSliceSelector } from '../../../containers/irrigationTaskTypesSlice';
 import { cropLocationsSelector } from '../../../containers/locationSlice';
+import { BsFillExclamationCircleFill } from 'react-icons/bs';
 
 export default function PureIrrigationTask({
   system,
@@ -199,6 +200,7 @@ export default function PureIrrigationTask({
     !measurement_type ||
     (measurement_type === 'DEPTH' && !location);
 
+  const calculatorLinkIsDisabled = measurement_type === 'DEPTH' && !location;
   return (
     <>
       <Controller
@@ -303,16 +305,51 @@ export default function PureIrrigationTask({
         onKeyDown={numberOnKeyDown}
         onChangeUnitOption={() => setEstimatedWaterUsageComputed(true)}
       />
-      {!disabled && (
-        <>
-          <Label style={{ marginTop: '4px', marginBottom: `${disabled ? 36 : 0}px` }}>
-            {t('ADD_TASK.IRRIGATION_VIEW.NOT_SURE')}{' '}
-            <Underlined onClick={() => !disabled && setShowWaterUseCalculatorModal(true)}>
-              {t('ADD_TASK.IRRIGATION_VIEW.CALCULATE_WATER_USAGE')}
-            </Underlined>
-          </Label>
-        </>
-      )}
+      {!disabled &&
+        (!calculatorLinkIsDisabled ? (
+          <>
+            <Label style={{ marginTop: '4px', marginBottom: `${disabled ? 36 : 0}px` }}>
+              {t('ADD_TASK.IRRIGATION_VIEW.NOT_SURE')}{' '}
+              <Underlined onClick={() => !disabled && setShowWaterUseCalculatorModal(true)}>
+                {t('ADD_TASK.IRRIGATION_VIEW.CALCULATE_WATER_USAGE')}
+              </Underlined>
+            </Label>
+          </>
+        ) : (
+          <>
+            <div style={{ display: 'flex', gap: '10px' }}>
+              <Label
+                style={{
+                  marginTop: '4px',
+                  marginBottom: `${disabled ? 36 : 0}px`,
+                  color: 'var(--Colors-Neutral-Neutral-300)',
+                }}
+              >
+                {t('ADD_TASK.IRRIGATION_VIEW.NOT_SURE')}{' '}
+                {t('ADD_TASK.IRRIGATION_VIEW.CALCULATE_WATER_USAGE')}
+              </Label>
+              <div
+                style={{
+                  color: 'var(--Colors-Accent---singles-Red-full)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '5px',
+                }}
+              >
+                <BsFillExclamationCircleFill />
+                <Label
+                  style={{
+                    marginTop: '4px',
+                    marginBottom: `${disabled ? 36 : 0}px`,
+                    color: 'var(--Colors-Accent---singles-Red-full)',
+                  }}
+                >
+                  For wild crops, estimation of water usage by depth is not available.
+                </Label>
+              </div>
+            </div>
+          </>
+        ))}
 
       {!waterCalculatorDisabled && (
         <WaterUsageCalculatorModal

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -336,7 +336,7 @@ export default function PureIrrigationTask({
                     color: 'var(--Colors-Accent---singles-Red-full)',
                   }}
                 >
-                  For wild crops, estimation of water usage by depth is not available.
+                  {t('ADD_TASK.IRRIGATION_VIEW.CALCULATE_WATER_USAGE_WARNING')}
                 </Label>
               </div>
             </div>

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -6,7 +6,7 @@ import ReactSelect from '../../Form/ReactSelect';
 import Checkbox from '../../Form/Checkbox';
 import RadioGroup from '../../Form/RadioGroup';
 import typographyStyles from '../../Typography/typography.module.scss';
-import styles from '../../Typography/typography.module.scss';
+import styles from './styles.module.scss';
 import Input, { getInputErrors, numberOnKeyDown } from '../../Form/Input';
 import Unit from '../../Form/Unit';
 import { getUnitOptionMap } from '../../../util/convert-units/getUnitOptionMap';
@@ -318,7 +318,7 @@ export default function PureIrrigationTask({
           </>
         ) : (
           <>
-            <div style={{ display: 'flex', gap: '10px', marginTop: '4px' }}>
+            <div className={styles.waterCalculatorWrapper}>
               <Label
                 style={{
                   marginBottom: `${disabled ? 36 : 0}px`,
@@ -328,14 +328,7 @@ export default function PureIrrigationTask({
                 {t('ADD_TASK.IRRIGATION_VIEW.NOT_SURE')}{' '}
                 {t('ADD_TASK.IRRIGATION_VIEW.CALCULATE_WATER_USAGE')}
               </Label>
-              <div
-                style={{
-                  color: 'var(--Colors-Accent---singles-Red-full)',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '5px',
-                }}
-              >
+              <div className={styles.waterCalculatorWarningWrapper}>
                 <BsFillExclamationCircleFill />
                 <Label
                   style={{

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -5,6 +5,7 @@ import { Controller } from 'react-hook-form';
 import ReactSelect from '../../Form/ReactSelect';
 import Checkbox from '../../Form/Checkbox';
 import RadioGroup from '../../Form/RadioGroup';
+import typographyStyles from '../../Typography/typography.module.scss';
 import styles from '../../Typography/typography.module.scss';
 import Input, { getInputErrors, numberOnKeyDown } from '../../Form/Input';
 import Unit from '../../Form/Unit';
@@ -253,7 +254,7 @@ export default function PureIrrigationTask({
       />
       <div style={{ paddingBlock: '10px' }} />
 
-      <Label className={styles.label} style={{ marginBottom: '24px', fontSize: '16px' }}>
+      <Label className={typographyStyles.label} style={{ marginBottom: '24px', fontSize: '16px' }}>
         {t('ADD_TASK.IRRIGATION_VIEW.HOW_DO_YOU_MEASURE_WATER_USE_FOR_THIS_IRRIGATION_TYPE')}
       </Label>
 

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -197,7 +197,7 @@ export default function PureIrrigationTask({
   const waterCalculatorDisabled =
     !showWaterUseCalculatorModal ||
     !measurement_type ||
-    (measurement_type === 'DEPTH' && !location);
+    (measurement_type === 'DEPTH' && !(location || getValues().show_wild_crop));
 
   return (
     <>

--- a/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/index.jsx
@@ -317,10 +317,9 @@ export default function PureIrrigationTask({
           </>
         ) : (
           <>
-            <div style={{ display: 'flex', gap: '10px' }}>
+            <div style={{ display: 'flex', gap: '10px', marginTop: '4px' }}>
               <Label
                 style={{
-                  marginTop: '4px',
                   marginBottom: `${disabled ? 36 : 0}px`,
                   color: 'var(--Colors-Neutral-Neutral-300)',
                 }}
@@ -339,7 +338,6 @@ export default function PureIrrigationTask({
                 <BsFillExclamationCircleFill />
                 <Label
                   style={{
-                    marginTop: '4px',
                     marginBottom: `${disabled ? 36 : 0}px`,
                     color: 'var(--Colors-Accent---singles-Red-full)',
                   }}

--- a/packages/webapp/src/components/Task/PureIrrigationTask/styles.module.scss
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/styles.module.scss
@@ -20,7 +20,7 @@
   gap: 10px;
   margin-top: 4px;
 
-  @include xs-breakpoint {
+  @include md-breakpoint {
     flex-direction: column;
   }
 }

--- a/packages/webapp/src/components/Task/PureIrrigationTask/styles.module.scss
+++ b/packages/webapp/src/components/Task/PureIrrigationTask/styles.module.scss
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+@import '../../../assets/mixin.scss';
+
+.waterCalculatorWrapper {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+
+  @include xs-breakpoint {
+    flex-direction: column;
+  }
+}
+
+.waterCalculatorWarningWrapper {
+  color: var(--Colors-Accent---singles-Red-full);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}


### PR DESCRIPTION
**Description**

Users were not able to open the "Water calculator" (_Create a task_ > _Irrigation task_)  if the water measurement method was "Depth".

It is expected that the **Calculate Water Usage** link will be disabled (+ a warning) for wild crops if the measure of water use is set to **Depth**:

![image](https://github.com/user-attachments/assets/2253e8b7-21cb-4ff5-9f0b-7519657d6f93)

![image](https://github.com/user-attachments/assets/1393f644-8bea-4949-a811-7ad4f2692747)


Jira link: https://lite-farm.atlassian.net/browse/LF-3951

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
