### PR TITLE
LF-4221 and LF-4249 Adjustments

### DIFF
--- a/packages/webapp/src/components/Form/NumberInput/index.tsx
+++ b/packages/webapp/src/components/Form/NumberInput/index.tsx
@@ -17,7 +17,7 @@ import { ReactNode } from 'react';
 import InputBase, { type InputBaseSharedProps } from '../InputBase';
 import NumberInputStepper from './NumberInputStepper';
 import useNumberInput, { NumberInputOptions } from './useNumberInput';
-import { FieldValues, UseControllerProps, useController } from 'react-hook-form';
+import { FieldValues, UseControllerProps, useController, get } from 'react-hook-form';
 
 export type NumberInputProps<T extends FieldValues> = UseControllerProps<T> &
   InputBaseSharedProps &
@@ -60,7 +60,7 @@ export default function NumberInput<T extends FieldValues>({
 }: NumberInputProps<T>) {
   const { field, fieldState, formState } = useController({ name, control, rules, defaultValue });
   const { inputProps, reset, numericValue, increment, decrement } = useNumberInput({
-    initialValue: defaultValue || formState.defaultValues?.[name],
+    initialValue: get(formState.defaultValues, name) || defaultValue,
     allowDecimal,
     decimalDigits,
     locale,

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -188,7 +188,6 @@ const SoilAmendmentProductCard = ({
         </>
       )}
       <QuantityApplicationRate
-        productId={PRODUCT_ID}
         system={system}
         locations={locations}
         isReadOnly={isReadOnly}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
@@ -86,11 +86,6 @@ const QuantityApplicationRate = ({
   const APPLICATION_RATE_WEIGHT_UNIT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.APPLICATION_RATE_WEIGHT_UNIT}`;
   const APPLICATION_RATE_VOLUME_UNIT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.APPLICATION_RATE_VOLUME_UNIT}`;
   const IS_WEIGHT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.IS_WEIGHT}`;
-
-  // New task products should default to weight
-  useEffect(() => {
-    setValue(IS_WEIGHT, getValues(IS_WEIGHT) ?? true);
-  }, []);
 
   const isWeight = getValues(IS_WEIGHT);
 

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
@@ -72,7 +72,7 @@ const QuantityApplicationRate = ({
 }: QuantityApplicationRateProps) => {
   const { t } = useTranslation();
 
-  const { control, getValues, setValue, register, watch, formState } = useFormContext();
+  const { control, getValues, setValue, register, watch } = useFormContext();
 
   const WEIGHT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.WEIGHT}`;
   const VOLUME = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.VOLUME}`;
@@ -190,7 +190,7 @@ const QuantityApplicationRate = ({
                   rules={{ required: t('common:REQUIRED') }}
                   onChange={updateTotalArea}
                   disabled={isReadOnly}
-                  defaultValue={formState.defaultValues?.[PERCENT_OF_LOCATION_AMENDED] || 100}
+                  defaultValue={100}
                 />
                 <SwapIcon />
                 {/* @ts-ignore */}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
@@ -104,7 +104,7 @@ const QuantityApplicationRate = ({
   const {
     updateApplicationRate,
     updateQuantity,
-    onPercentLocationChange,
+    updateTotalArea,
     previewStringValue,
     previewStringUnit,
   } = useQuantityApplicationRate({
@@ -188,7 +188,7 @@ const QuantityApplicationRate = ({
                   min={0.0001}
                   max={100}
                   rules={{ required: t('common:REQUIRED') }}
-                  onChange={onPercentLocationChange}
+                  onChange={updateTotalArea}
                   disabled={isReadOnly}
                   defaultValue={formState.defaultValues?.[PERCENT_OF_LOCATION_AMENDED] || 100}
                 />
@@ -206,7 +206,6 @@ const QuantityApplicationRate = ({
                   hookFromWatch={watch}
                   control={control}
                   mode={'onChange'}
-                  defaultValue={formState.defaultValues?.[TOTAL_AREA_AMENDED] || total_area}
                   disabled
                   required
                 />

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
@@ -86,6 +86,11 @@ const QuantityApplicationRate = ({
   const APPLICATION_RATE_WEIGHT_UNIT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.APPLICATION_RATE_WEIGHT_UNIT}`;
   const APPLICATION_RATE_VOLUME_UNIT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.APPLICATION_RATE_VOLUME_UNIT}`;
   const IS_WEIGHT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.IS_WEIGHT}`;
+
+  // New task products should default to weight
+  useEffect(() => {
+    setValue(IS_WEIGHT, getValues(IS_WEIGHT) ?? true);
+  }, []);
 
   const isWeight = getValues(IS_WEIGHT);
 

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
@@ -58,7 +58,6 @@ export interface Location {
 }
 
 export type QuantityApplicationRateProps = {
-  productId: number | string;
   isReadOnly: boolean;
   system: 'metric' | 'imperial';
   locations: Location[];
@@ -66,7 +65,6 @@ export type QuantityApplicationRateProps = {
 };
 
 const QuantityApplicationRate = ({
-  productId,
   isReadOnly,
   system, // measurementSelector
   locations,
@@ -180,7 +178,7 @@ const QuantityApplicationRate = ({
             <KeyboardArrowDownIcon className={styles.expandIcon} />
           </TextButton>
 
-          <Collapse id={`application_rate-${productId}`} in={isExpanded} timeout="auto">
+          <Collapse id={'application_rate'} in={isExpanded} timeout="auto">
             <div className={styles.sectionBody}>
               <div className={styles.locationSection}>
                 <NumberInput

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
@@ -132,7 +132,7 @@ export const useQuantityApplicationRate = ({
     updateQuantity();
   }, [application_rate_weight_unit, application_rate_volume_unit]);
 
-  /* For the preview string, replicate the conversion the unit component would do if the value had been displayed in a <Unit /> rather than a string. However, don't update upon changes to application_area_unit beyond the initial undefined > defined change */
+  /* For the preview string, replicate the conversion the unit component would do if the value had been displayed in a <Unit /> rather than a string */
   const previewStrings = useMemo(() => {
     let previewStringUnit;
     let previewStringValue;

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
@@ -63,8 +63,12 @@ export const useQuantityApplicationRate = ({
     APPLICATION_RATE_VOLUME_UNIT,
   ]);
 
+  useEffect(() => {
+    updateTotalArea(100);
+  }, []);
+
   /* Update application area + rate based on percent of location */
-  const onPercentLocationChange = (percent_of_location: number) => {
+  const updateTotalArea = (percent_of_location: number) => {
     const calculatedArea = (total_area * Math.min(percent_of_location || 100, 100)) / 100;
     setValue(TOTAL_AREA_AMENDED, calculatedArea);
 
@@ -170,6 +174,6 @@ export const useQuantityApplicationRate = ({
     previewStringUnit: previewStrings.previewStringUnit,
     updateApplicationRate,
     updateQuantity,
-    onPercentLocationChange,
+    updateTotalArea,
   };
 };

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
@@ -50,19 +50,8 @@ export const useQuantityApplicationRate = ({
 
   const { setValue, getValues, watch } = useFormContext();
 
-  const [
-    application_area_unit,
-    weight_unit,
-    volume_unit,
-    application_rate_weight_unit,
-    application_rate_volume_unit,
-  ] = watch([
-    TOTAL_AREA_AMENDED_UNIT,
-    WEIGHT_UNIT,
-    VOLUME_UNIT,
-    APPLICATION_RATE_WEIGHT_UNIT,
-    APPLICATION_RATE_VOLUME_UNIT,
-  ]);
+  const [weight_unit, volume_unit, application_rate_weight_unit, application_rate_volume_unit] =
+    watch([WEIGHT_UNIT, VOLUME_UNIT, APPLICATION_RATE_WEIGHT_UNIT, APPLICATION_RATE_VOLUME_UNIT]);
 
   useEffect(() => {
     updateTotalArea(getValues(PERCENT_OF_LOCATION_AMENDED));
@@ -148,11 +137,12 @@ export const useQuantityApplicationRate = ({
     let previewStringUnit;
     let previewStringValue;
 
-    if (application_area_unit) {
+    if (total_area) {
       previewStringUnit =
         total_area_unit && location_area[system].units.includes(total_area_unit)
           ? getUnitOptionMap()[total_area_unit]
-          : application_area_unit;
+          : /* @ts-ignore */
+            getUnitOptionMap()[getDefaultUnit(location_area, total_area, system).displayUnit];
 
       previewStringValue =
         total_area &&
@@ -168,7 +158,7 @@ export const useQuantityApplicationRate = ({
     }
 
     return { previewStringUnit, previewStringValue };
-  }, [!!application_area_unit, total_area]);
+  }, [total_area]);
 
   return {
     previewStringValue: previewStrings.previewStringValue,

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
@@ -36,6 +36,7 @@ export const useQuantityApplicationRate = ({
   isWeight,
   namePrefix,
 }: UseQuantityApplicationRate) => {
+  const PERCENT_OF_LOCATION_AMENDED = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.PERCENT_OF_LOCATION_AMENDED}`;
   const TOTAL_AREA_AMENDED = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.TOTAL_AREA_AMENDED}`;
   const TOTAL_AREA_AMENDED_UNIT = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.TOTAL_AREA_AMENDED_UNIT}`;
   const VOLUME = `${namePrefix}.${TASK_PRODUCT_FIELD_NAMES.VOLUME}`;
@@ -64,7 +65,7 @@ export const useQuantityApplicationRate = ({
   ]);
 
   useEffect(() => {
-    updateTotalArea(100);
+    updateTotalArea(getValues(PERCENT_OF_LOCATION_AMENDED));
   }, []);
 
   /* Update application area + rate based on percent of location */

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
@@ -44,6 +44,7 @@ const FIELD_NAME = 'soil_amendment_task_products';
 const defaultValues = {
   [TASK_PRODUCT_FIELD_NAMES.PRODUCT_ID]: undefined,
   [TASK_PRODUCT_FIELD_NAMES.PURPOSES]: [],
+  [TASK_PRODUCT_FIELD_NAMES.IS_WEIGHT]: true,
 };
 
 const AddSoilAmendmentProducts = ({

--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -46,16 +46,16 @@ type FormSoilAmendmentTaskProduct = {
   purposes: number[];
   other_purpose?: string;
   weight?: number;
-  weight_unit?: UnitOption;
+  weight_unit?: UnitOption | string;
   volume?: number;
-  volume_unit?: UnitOption;
+  volume_unit?: UnitOption | string;
   percent_of_location_amended: number;
   total_area_amended: number;
-  total_area_amended_unit?: UnitOption;
+  total_area_amended_unit?: UnitOption | string;
   application_rate_weight?: number;
-  application_rate_weight_unit?: UnitOption;
+  application_rate_weight_unit?: UnitOption | string;
   application_rate_volume?: number;
-  application_rate_volume_unit?: UnitOption;
+  application_rate_volume_unit?: UnitOption | string;
   is_weight: boolean;
   [key: string]: any;
 };
@@ -93,23 +93,17 @@ export const formatSoilAmendmentTaskToFormStructure = (
         formattedTaskProduct.purposes.push(purpose_id);
       });
 
-      const unitOptions: { [key: string]: UnitOption } = getUnitOptionMap();
-
       return {
         ...formattedTaskProduct,
-        weight_unit: isWeight && rest.weight_unit ? unitOptions[rest.weight_unit] : undefined,
-        volume_unit: !isWeight && rest.volume_unit ? unitOptions[rest.volume_unit] : undefined,
-        total_area_amended_unit: rest.total_area_amended_unit
-          ? unitOptions[rest.total_area_amended_unit]
+        weight_unit: isWeight ? rest.weight_unit : undefined,
+        volume_unit: !isWeight ? rest.volume_unit : undefined,
+        total_area_amended_unit: rest.total_area_amended_unit || undefined,
+        application_rate_weight_unit: rest.application_rate_weight
+          ? rest.application_rate_weight_unit
           : undefined,
-        application_rate_weight_unit:
-          rest.application_rate_weight && rest.application_rate_weight_unit
-            ? unitOptions[rest.application_rate_weight_unit]
-            : undefined,
-        application_rate_volume_unit:
-          rest.application_rate_volume && rest.application_rate_volume_unit
-            ? unitOptions[rest.application_rate_volume_unit]
-            : undefined,
+        application_rate_volume_unit: rest.application_rate_volume
+          ? rest.application_rate_volume_unit
+          : undefined,
       };
     },
   );
@@ -154,14 +148,14 @@ export const formatSoilAmendmentProductToDBStructure = (
     return {
       ...rest,
       weight: is_weight ? rest.weight : undefined,
-      weight_unit: is_weight ? rest.weight_unit?.value : undefined,
+      weight_unit: is_weight ? (rest.weight_unit as UnitOption)?.value : undefined,
       application_rate_weight_unit: is_weight
-        ? rest.application_rate_weight_unit?.value
+        ? (rest.application_rate_weight_unit as UnitOption)?.value
         : undefined,
       volume: !is_weight ? rest.volume : undefined,
-      volume_unit: !is_weight ? rest.volume_unit?.value : undefined,
+      volume_unit: !is_weight ? (rest.volume_unit as UnitOption)?.value : undefined,
       application_rate_volume_unit: !is_weight
-        ? rest.application_rate_volume_unit?.value
+        ? (rest.application_rate_volume_unit as UnitOption)?.value
         : undefined,
       purpose_relationships: formatPurposeIdsToRelationships(
         purposeIds,


### PR DESCRIPTION
**Description**

These are adjustments pertaining to the QuantityApplicationRate PR #3289 and the full form integration PR #3294

Summary of changes:
1. set `is_weight` using the `defaultValues` structure appended to new field array entries
2. pass the same `defaultValues` to useForm to populate the first field array entry (thank you @SayakaOno)
3. fix total_area persistence (non-update on location selection changes) by removing the defaultValue prop on `<Unit />` and restoring the useEffect in the QuantityApplicationRate hook
4. Fix percent location non-persistence (incorrect resetting to 100 on location selection changes) by fixing `<NumberInput />` initialValue logic
5. Pass current percent location location to useEffect calculation that should run on location changes
6. Define form `<Unit />` values with strings instead of with `UnitOption` objects; this restores the correct between-system transformation when the farm measurement system does not match the database saved unit value
7. (from LF-4249 PR comments) remove non-functional `productId` prop
8. (from LF-4249 PR comments) remove `useState()` and implement `useMemo()` to calculate and freeze the summary string content

Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
