### PR TITLE
LF-4221 Fix soil_amendment_task_products defaultValues

### DIFF
--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/index.tsx
@@ -41,7 +41,7 @@ interface ProductFields {
 
 const FIELD_NAME = 'soil_amendment_task_products';
 
-const defaultValues = {
+export const defaultValues = {
   [TASK_PRODUCT_FIELD_NAMES.PRODUCT_ID]: undefined,
   [TASK_PRODUCT_FIELD_NAMES.PURPOSES]: [],
   [TASK_PRODUCT_FIELD_NAMES.IS_WEIGHT]: true,

--- a/packages/webapp/src/components/Task/PureTaskDetails/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskDetails/index.jsx
@@ -13,6 +13,7 @@ import PureHarvestingTask from '../HarvestingTask';
 import PurePestControlTask from '../PestControlTask';
 import PureIrrigationTask from '../PureIrrigationTask';
 import PureSoilAmendmentTask from '../SoilAmendmentTask';
+import { defaultValues as soilAmendmentProductDefaultValues } from '../AddSoilAmendmentProducts';
 
 export default function PureTaskDetails({
   handleGoBack,
@@ -38,7 +39,7 @@ export default function PureTaskDetails({
   const defaults = {
     CLEANING_TASK: { cleaning_task: { agent_used: false } },
     SOIL_AMENDMENT_TASK: {
-      soil_amendment_task_products: [{}],
+      soil_amendment_task_products: [soilAmendmentProductDefaultValues],
     },
   };
 


### PR DESCRIPTION
**Description**

Fix for https://github.com/LiteFarmOrg/LiteFarm/pull/3299#discussion_r1681600368
Use the soil_amendment_task_products `defaultValues` (currently used for `append()`) for the first product.
