### PR TITLE
LF-4221 Update `formatSoilAmendmentTaskToFormStructure` to handle `FormSoilAmendmentTask type`

### DIFF
--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -70,9 +70,20 @@ type FormSoilAmendmentTask = {
   [key: string]: any;
 };
 
+// Type guard
+function isFormSoilAmendmentTask(
+  task: DBSoilAmendmentTask | FormSoilAmendmentTask,
+): task is FormSoilAmendmentTask {
+  return 'purposes' in task.soil_amendment_task_products[0];
+}
+
 export const formatSoilAmendmentTaskToFormStructure = (
-  task: DBSoilAmendmentTask,
+  task: DBSoilAmendmentTask | FormSoilAmendmentTask,
 ): FormSoilAmendmentTask => {
+  if (isFormSoilAmendmentTask(task)) {
+    return task as FormSoilAmendmentTask;
+  }
+
   const taskClone = structuredClone(task);
 
   const formattedTaskProducts = task.soil_amendment_task_products.map(


### PR DESCRIPTION
**Description**

In the task completion flow, the `formatSoilAmendmentTaskToFormStructure function` is now updated to handle cases where it runs against already formatted data. This ensures proper handling when users navigate back from the last page to the previous page.

- Added a type guard to check if the task is already formatted.
- Updated the `formatSoilAmendmentTaskToFormStructure function` to handle both `DBSoilAmendmentTask` and `FormSoilAmendmentTask` types appropriately.

Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
