### PR TITLE
LF-4221: Fix soil amendment task completion flow

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -14,6 +14,13 @@ import { PurePlantingTask } from '../PlantingTask';
 import PureIrrigationTask from '../PureIrrigationTask';
 import { formatTaskReadOnlyDefaultValues } from '../../../util/task';
 
+const soilAmendmentContinueDisabled = (needsChange, isValid) => {
+  if (!needsChange) {
+    return false;
+  }
+  return !isValid;
+};
+
 export default function PureCompleteStepOne({
   persistedFormData,
   onContinue,
@@ -51,10 +58,20 @@ export default function PureCompleteStepOne({
   const changesRequired = watch(CHANGES_NEEDED);
   const taskType = selectedTaskType?.task_translation_key;
 
+  const continueDisabled =
+    taskType === 'SOIL_AMENDMENT_TASK'
+      ? soilAmendmentContinueDisabled(getValues(CHANGES_NEEDED), isValid)
+      : !isValid;
+
   return (
     <Form
       buttonGroup={
-        <Button data-cy="beforeComplete-submit" type={'submit'} disabled={!isValid} fullLength>
+        <Button
+          data-cy="beforeComplete-submit"
+          type={'submit'}
+          disabled={continueDisabled}
+          fullLength
+        >
           {t('common:CONTINUE')}
         </Button>
       }

--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -63,6 +63,19 @@ export default function PureCompleteStepOne({
       ? soilAmendmentContinueDisabled(getValues(CHANGES_NEEDED), isValid)
       : !isValid;
 
+  const onSubmit = (event) => {
+    event.preventDefault();
+
+    if (
+      taskType === 'SOIL_AMENDMENT_TASK' &&
+      soilAmendmentContinueDisabled(getValues(CHANGES_NEEDED)) === false
+    ) {
+      onContinue();
+    } else {
+      handleSubmit(onContinue)();
+    }
+  };
+
   return (
     <Form
       buttonGroup={
@@ -75,7 +88,7 @@ export default function PureCompleteStepOne({
           {t('common:CONTINUE')}
         </Button>
       }
-      onSubmit={handleSubmit(onContinue)}
+      onSubmit={onSubmit}
     >
       <MultiStepPageTitle
         style={{ marginBottom: '24px' }}

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -72,6 +72,71 @@ export default function PureTaskComplete({
   const disabled = !isValid || (!happiness && !prefer_not_to_say);
 
   const isIrrigationLocation = useIsTaskType('IRRIGATION_TASK');
+  const onSubmit = (event) => {
+    event.preventDefault();
+
+    let task_type_name = persistedFormData?.taskType.task_translation_key.toLowerCase();
+
+    const format = (formData) => {
+      let completeDate = '';
+      switch (formData[DATE_CHOICE]) {
+        case TODAY_DUE_DATE:
+          completeDate = date_today;
+          break;
+        case ANOTHER_DUE_DATE:
+          completeDate = formData[ANOTHER_DATE];
+          break;
+        case ORIGINAL_DUE_DATE:
+        default:
+          completeDate = date_due;
+          break;
+      }
+
+      let data = {
+        taskData: {
+          duration: duration,
+          happiness: prefer_not_to_say ? null : happiness,
+          completion_notes: notes,
+          complete_date: completeDate,
+        },
+        task_translation_key: persistedFormData?.taskType.task_translation_key,
+        isCustomTaskType: !!persistedFormData?.taskType.farm_id,
+      };
+      const isFieldWork = task_type_name === 'field_work_task';
+      const isOtherFieldWork =
+        isFieldWork && persistedFormData?.field_work_task?.field_work_task_type.value === 'OTHER';
+      if (persistedFormData?.need_changes && !isOtherFieldWork) {
+        data.taskData[task_type_name] = getObjectInnerValues(persistedFormData[task_type_name]);
+      } else if (isOtherFieldWork) {
+        data.taskData[task_type_name] = { ...persistedFormData[task_type_name] };
+      }
+      //TODO: replace with useIsTaskType
+      if (task_type_name === 'harvest_task') {
+        data.harvest_uses = persistedFormData?.harvest_uses;
+        data.taskData[task_type_name] = {
+          ...persistedFormData?.harvest_task,
+          actual_quantity: persistedFormData?.actual_quantity,
+          actual_quantity_unit: persistedFormData?.actual_quantity_unit.value,
+        };
+      }
+      if (isIrrigationLocation && persistedFormData.locations?.length) {
+        data.location_id = persistedFormData.locations[0].location_id;
+      }
+      if (TASKTYPE_PRODUCT_MAP[data.task_translation_key]) {
+        const taskProductKey = TASKTYPE_PRODUCT_MAP[data.task_translation_key];
+        data[taskProductKey] = persistedFormData?.[taskProductKey];
+      }
+
+      return data;
+    };
+
+    if (task_type_name === 'soil_amendment_task' && getValues('need_changes') === false) {
+      const formData = getValues();
+      onSave(format(formData));
+    } else {
+      handleSubmit((data) => onSave(format(data)))();
+    }
+  };
 
   return (
     <Form
@@ -80,58 +145,7 @@ export default function PureTaskComplete({
           {t('common:SAVE')}
         </Button>
       }
-      onSubmit={handleSubmit((formData) => {
-        let completeDate = '';
-        switch (formData[DATE_CHOICE]) {
-          case TODAY_DUE_DATE:
-            completeDate = date_today;
-            break;
-          case ANOTHER_DUE_DATE:
-            completeDate = formData[ANOTHER_DATE];
-            break;
-          case ORIGINAL_DUE_DATE:
-          default:
-            completeDate = date_due;
-            break;
-        }
-
-        let data = {
-          taskData: {
-            duration: duration,
-            happiness: prefer_not_to_say ? null : happiness,
-            completion_notes: notes,
-            complete_date: completeDate,
-          },
-          task_translation_key: persistedFormData?.taskType.task_translation_key,
-          isCustomTaskType: !!persistedFormData?.taskType.farm_id,
-        };
-        let task_type_name = persistedFormData?.taskType.task_translation_key.toLowerCase();
-        const isFieldWork = task_type_name === 'field_work_task';
-        const isOtherFieldWork =
-          isFieldWork && persistedFormData?.field_work_task?.field_work_task_type.value === 'OTHER';
-        if (persistedFormData?.need_changes && !isOtherFieldWork) {
-          data.taskData[task_type_name] = getObjectInnerValues(persistedFormData[task_type_name]);
-        } else if (isOtherFieldWork) {
-          data.taskData[task_type_name] = { ...persistedFormData[task_type_name] };
-        }
-        //TODO: replace with useIsTaskType
-        if (task_type_name === 'harvest_task') {
-          data.harvest_uses = persistedFormData?.harvest_uses;
-          data.taskData[task_type_name] = {
-            ...persistedFormData?.harvest_task,
-            actual_quantity: persistedFormData?.actual_quantity,
-            actual_quantity_unit: persistedFormData?.actual_quantity_unit.value,
-          };
-        }
-        if (isIrrigationLocation && persistedFormData.locations?.length) {
-          data.location_id = persistedFormData.locations[0].location_id;
-        }
-        if (TASKTYPE_PRODUCT_MAP[data.task_translation_key]) {
-          const taskProductKey = TASKTYPE_PRODUCT_MAP[data.task_translation_key];
-          data[taskProductKey] = persistedFormData?.[taskProductKey];
-        }
-        onSave(data);
-      })}
+      onSubmit={onSubmit}
     >
       <MultiStepPageTitle
         style={{ marginBottom: '24px' }}

--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -33,7 +33,7 @@ type DBSoilAmendmentTaskProduct = {
   weight_unit?: string;
   volume?: number;
   volume_unit?: string;
-  percent_of_location_amended: number;
+  percent_of_location_amended?: number;
   total_area_amended: number;
   application_rate_weight?: number;
   application_rate_weight_unit?: string;
@@ -74,7 +74,9 @@ type FormSoilAmendmentTask = {
 function isFormSoilAmendmentTask(
   task: DBSoilAmendmentTask | FormSoilAmendmentTask,
 ): task is FormSoilAmendmentTask {
-  return 'purposes' in task.soil_amendment_task_products[0];
+  return (
+    task.soil_amendment_task_products?.[0] && 'purposes' in task.soil_amendment_task_products[0]
+  );
 }
 
 export const formatSoilAmendmentTaskToFormStructure = (
@@ -88,13 +90,14 @@ export const formatSoilAmendmentTaskToFormStructure = (
 
   const formattedTaskProducts = task.soil_amendment_task_products.map(
     (dbTaskProduct: DBSoilAmendmentTaskProduct): FormSoilAmendmentTaskProduct => {
-      const { purpose_relationships, ...rest } = dbTaskProduct;
+      const { purpose_relationships, percent_of_location_amended, ...rest } = dbTaskProduct;
       const isWeight = !!(rest.weight || rest.weight === 0);
 
       const formattedTaskProduct = {
         ...rest,
         purposes: [],
         is_weight: isWeight,
+        percent_of_location_amended: percent_of_location_amended ?? 100,
       } as FormSoilAmendmentTaskProduct;
 
       dbTaskProduct.purpose_relationships.forEach(({ purpose_id, other_purpose }) => {


### PR DESCRIPTION
**Description**

- Allow the user to complete old soil amendment tasks without `method_id`, which is required for task creation.
- Add default value 100 for old soil amendment tasks' `percent_of_location_amended`

Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
