### PR TITLE
LF-4221: Fix soil amendment completion flow

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -17,7 +17,7 @@ import { getDateInputFormat } from '../../../util/moment';
 import { isNotInFuture } from '../../Form/Input/utils';
 import { useIsTaskType } from '../../../containers/Task/useIsTaskType';
 import { ORIGINAL_DUE_DATE, TODAY_DUE_DATE, ANOTHER_DUE_DATE } from '../AbandonTask/constants';
-import { TASKTYPE_PRODUCT_MAP } from '../../../containers/Task/constants';
+import { TASK_TYPE_PRODUCT_MAP } from '../../../containers/Task/constants';
 
 export default function PureTaskComplete({
   onSave,
@@ -122,8 +122,8 @@ export default function PureTaskComplete({
       if (isIrrigationLocation && persistedFormData.locations?.length) {
         data.location_id = persistedFormData.locations[0].location_id;
       }
-      if (TASKTYPE_PRODUCT_MAP[data.task_translation_key]) {
-        const taskProductKey = TASKTYPE_PRODUCT_MAP[data.task_translation_key];
+      if (TASK_TYPE_PRODUCT_MAP[data.task_translation_key]) {
+        const taskProductKey = TASK_TYPE_PRODUCT_MAP[data.task_translation_key];
         data[taskProductKey] = persistedFormData?.[taskProductKey];
       }
 

--- a/packages/webapp/src/containers/Task/constants.js
+++ b/packages/webapp/src/containers/Task/constants.js
@@ -26,6 +26,6 @@ export const TASK_TYPES = {
   IRRIGATION: 'irrigation_task',
 };
 
-export const TASKTYPE_PRODUCT_MAP = {
+export const TASK_TYPE_PRODUCT_MAP = {
   SOIL_AMENDMENT_TASK: 'soil_amendment_task_products',
 };

--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -151,9 +151,12 @@ type RemainingFormSATProductKeys = keyof Omit<
 >;
 
 export const formatSoilAmendmentProductToDBStructure = (
-  soilAmendmentTaskProducts: FormSoilAmendmentTaskProduct[],
+  soilAmendmentTaskProducts: FormSoilAmendmentTaskProduct[] | undefined,
   { purposes }: { purposes: SoilAmendmentPurpose[] },
-): DBSoilAmendmentTaskProduct[] => {
+): DBSoilAmendmentTaskProduct[] | undefined => {
+  if (!soilAmendmentTaskProducts) {
+    return undefined;
+  }
   const otherPurposeId = purposes?.find(({ key }) => key === 'OTHER')?.id;
   if (!otherPurposeId) {
     throw Error('id for OTHER purpose does not exist');
@@ -191,9 +194,12 @@ export const formatSoilAmendmentProductToDBStructure = (
 };
 
 export const formatSoilAmendmentTaskToDBStructure = (
-  soilAmendmentTask: FormSoilAmendmentTask,
+  soilAmendmentTask: FormSoilAmendmentTask | undefined,
   { methods }: { methods: SoilAmendmentMethod[] },
-): DBSoilAmendmentTask => {
+): DBSoilAmendmentTask | undefined => {
+  if (!soilAmendmentTask) {
+    return undefined;
+  }
   const {
     method_id,
     furrow_hole_depth,


### PR DESCRIPTION
**Description**

As Duncan mentioned, the cause was that `soil_amendment_task` is not sent to the saga when the user completes the task without any changes.

- Update `formatSoilAmendmentProductToDBStructure` and `formatSoilAmendmentTaskToDBStructure` to handle `undefined`.
- Update `format` function in `TaskComplete` not to send `soil_amendment_products` to the `saga` when `need_changes` is `false` to keep it consistent with task type details (e.g. `soil_amendment_task`). I also refactored the function for better readability.
- Fix the constant `TASK_TYPE_PRODUCT_MAP`

Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
