### PR TITLE
Patch/3.6.5 add uniqueness check on task product

### DIFF
--- a/packages/api/db/migration/20240719095056_add_uniqueness_check_on_task_product.js
+++ b/packages/api/db/migration/20240719095056_add_uniqueness_check_on_task_product.js
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export const up = async function (knex) {
+  /*----------------------------------------
+   Add uniqueness check for (task_id, product_id) composite - data deletion for local + beta only
+  ----------------------------------------*/
+  const taskProductsWithDuplicates = await knex
+    .select('task_id', 'product_id')
+    .count('*', { as: 'cnt' })
+    .from('soil_amendment_task_products')
+    .groupBy('task_id', 'product_id')
+    .havingRaw('COUNT(*) > 1')
+    .orderBy('task_id', 'asc');
+  for (const taskProduct of taskProductsWithDuplicates) {
+    const duplicates = await knex
+      .select('*')
+      .table('soil_amendment_task_products')
+      .where({ task_id: taskProduct.task_id, product_id: taskProduct.product_id })
+      .orderBy('created_at', 'asc');
+    const countOfNotDeleted = duplicates.filter((dupe) => !dupe.deleted);
+    let keep;
+    let hardDelete;
+    if (countOfNotDeleted.length === 0) {
+      keep = duplicates.pop();
+      await knex('soil_amendment_task_products').where('id', keep.id).update({ deleted: false });
+      hardDelete = duplicates;
+    } else if (countOfNotDeleted.length >= 1) {
+      //Choose only or latest task_product with deleted false
+      keep = countOfNotDeleted.pop();
+      hardDelete = duplicates.filter((dupe) => dupe.id !== keep.id);
+    }
+    for (const deleteable of hardDelete) {
+      await knex('soil_amendment_task_products_purpose_relationship')
+        .where('task_products_id', deleteable.id)
+        .del();
+      await knex('soil_amendment_task_products').where('id', deleteable.id).del();
+    }
+  }
+
+  await knex.schema.alterTable('soil_amendment_task_products', (table) => {
+    table.unique(['task_id', 'product_id'], {
+      indexName: 'task_product_uniqueness_composite',
+    });
+  });
+};
+
+export const down = async function (knex) {
+  /*----------------------------------------
+   Add uniqueness check for (task_id, product_id) composite
+  ----------------------------------------*/
+  await knex.schema.alterTable('soil_amendment_task_products', (table) => {
+    table.dropChecks(['task_product_uniqueness_composite']);
+  });
+};

--- a/packages/api/db/migration/20240719095056_add_uniqueness_check_on_task_product.js
+++ b/packages/api/db/migration/20240719095056_add_uniqueness_check_on_task_product.js
@@ -43,10 +43,9 @@ export const up = async function (knex) {
       softDelete = duplicates.filter((dupe) => dupe.id !== keep.id);
     }
     for (const deleteable of softDelete) {
-      await knex('soil_amendment_task_products_purpose_relationship')
-        .where('task_products_id', deleteable.id)
-        .del();
-      await knex('soil_amendment_task_products').where('id', deleteable.id).del();
+      await knex('soil_amendment_task_products')
+        .update({ deleted: true })
+        .where('id', deleteable.id);
     }
   }
 

--- a/packages/api/db/migration/20240719095056_add_uniqueness_check_on_task_product.js
+++ b/packages/api/db/migration/20240719095056_add_uniqueness_check_on_task_product.js
@@ -30,16 +30,16 @@ export const up = async function (knex) {
       .table('soil_amendment_task_products')
       .where({ task_id: taskProduct.task_id, product_id: taskProduct.product_id })
       .orderBy('created_at', 'asc');
-    const countOfNotDeleted = duplicates.filter((dupe) => !dupe.deleted);
+    const notDeletedDuplicates = duplicates.filter((dupe) => !dupe.deleted);
     let keep;
     let softDelete;
-    if (countOfNotDeleted.length === 0) {
+    if (notDeletedDuplicates.length === 0) {
       keep = duplicates.pop();
       await knex('soil_amendment_task_products').where('id', keep.id).update({ deleted: false });
       softDelete = duplicates;
-    } else if (countOfNotDeleted.length >= 1) {
+    } else if (notDeletedDuplicates.length >= 1) {
       //Choose only or latest task_product with deleted false
-      keep = countOfNotDeleted.pop();
+      keep = notDeletedDuplicates.pop();
       softDelete = duplicates.filter((dupe) => dupe.id !== keep.id);
     }
     for (const deleteable of softDelete) {

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -68,7 +68,7 @@ async function updateTaskWithCompletedData(
 ) {
   if (typeOfTask === 'soil_amendment_task') {
     // Allows the insertion of missing data if no id present
-    // Soft deletes tables with soft delete option and hard deletes ones without
+    // Soft deletes table rows with soft delete option and hard deletes ones without
     const task = await TaskModel.query(trx)
       .context({ user_id })
       .upsertGraph(


### PR DESCRIPTION
**Description**
Changes from original PR:
- prevents only duplicates of `(task_id, product_id) where deleted:false`
- hardDelete => softDelete extra taskproducts
- different constraint
- no controller needed if allowing unlimited `(task_id, product_id) where deleted:true`

Using raw knex because **_partial index_** in Knex not working as expected for `unique()` or `index()`:

```
await knex.schema.alterTable('soil_amendment_task_products', (table) => {
   table.unique(['task_id', 'product_id'], 'task_product_uniqueness_composite',{
     predicate: knex.where("deleted", "=", false),
   });
    });
```
Answer:
https://dba.stackexchange.com/questions/95327/enforce-a-column-as-unique-based-on-another-column-value

Knex adds partial index (we are using this version):
[#2.4.0 Jan 2023](https://knexjs.org/changelog.html#_2-4-0-6-january-2023)

ChatGPT says partial indexes aren't working. And I had problems with it too.

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

@kathyavini  - comment here: https://github.com/LiteFarmOrg/LiteFarm/pull/3307#pullrequestreview-2186999063

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
