### PR TITLE
LF-4309 Complete form breaks when not completed fast enough allowing page to time out or something

### DIFF
--- a/packages/api/src/models/soilAmendmentTaskModel.js
+++ b/packages/api/src/models/soilAmendmentTaskModel.js
@@ -27,6 +27,25 @@ class SoilAmendmentTaskModel extends Model {
     return 'task_id';
   }
 
+  async $beforeUpdate(queryContext) {
+    await super.$beforeUpdate(queryContext);
+
+    const methodKey = await soilAmendmentMethodModel
+      .query(queryContext.transaction)
+      .findById(this.method_id)
+      .select('key')
+      .first();
+
+    if (methodKey !== 'OTHER') {
+      this.other_application_method = null;
+    }
+
+    if (methodKey !== 'FURROW_HOLE') {
+      this.furrow_hole_depth = null;
+      this.furrow_hole_depth_unit = null;
+    }
+  }
+
   // Optional JSON schema. This is not the database schema! Nothing is generated
   // based on this. This is only used for validation. Whenever a model instance
   // is created it is checked against this schema. http://json-schema.org/.

--- a/packages/webapp/src/components/Form/Unit/index.jsx
+++ b/packages/webapp/src/components/Form/Unit/index.jsx
@@ -59,6 +59,7 @@ const Unit = ({
   hasLeaf,
   autoConversion,
   onInputChange,
+  shouldUnregister,
   ...props
 }) => {
   const { t } = useTranslation(['translation', 'common']);
@@ -165,6 +166,7 @@ const Unit = ({
           <Controller
             control={control}
             name={displayUnitName}
+            shouldUnregister={shouldUnregister}
             render={({ field: { onBlur, value, ref } }) => (
               <Select
                 data-cy="unit-select"
@@ -202,6 +204,7 @@ const Unit = ({
           valueAsNumber: true,
           max: { value: getMax(), message: t('UNIT.VALID_VALUE') + max },
           min: { value: 0, message: t('UNIT.VALID_VALUE') + max },
+          shouldUnregister,
         })}
         data-testid={`${testId}-hiddeninput`}
       />
@@ -283,6 +286,8 @@ Unit.propTypes = {
   onBlur: PropTypes.func,
   /** testId used for component testing */
   'data-testid': PropTypes.string,
+  /** react hook form shouldUnregister - unmounting input removes value */
+  shouldUnregister: PropTypes.bool,
 };
 
 export default Unit;

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -182,7 +182,7 @@ const SoilAmendmentProductCard = ({
             label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER_PURPOSE')}
             name={OTHER_PURPOSE}
             disabled={isReadOnly}
-            hookFormRegister={register(OTHER_PURPOSE)}
+            hookFormRegister={register(OTHER_PURPOSE, { shouldUnregister: true })}
             optional
           />
         </>

--- a/packages/webapp/src/components/Task/SoilAmendmentTask/index.tsx
+++ b/packages/webapp/src/components/Task/SoilAmendmentTask/index.tsx
@@ -181,6 +181,7 @@ const PureSoilAmendmentTask = ({
               defaultValue={undefined} // TODO
               system={system}
               placeholder={t('ADD_TASK.SOIL_AMENDMENT_VIEW.FURROW_HOLE_DEPTH_PLACEHOLDER')}
+              shouldUnregister={true}
             />
           </>
         )}

--- a/packages/webapp/src/components/Task/SoilAmendmentTask/index.tsx
+++ b/packages/webapp/src/components/Task/SoilAmendmentTask/index.tsx
@@ -191,7 +191,7 @@ const PureSoilAmendmentTask = ({
               label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER_METHOD')}
               name={OTHER_APPLICATION_METHOD}
               disabled={disabled}
-              hookFormRegister={register(OTHER_APPLICATION_METHOD)}
+              hookFormRegister={register(OTHER_APPLICATION_METHOD, { shouldUnregister: true })}
               optional
               placeholder={t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER_METHOD_PLACEHOLDER')}
             />

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -506,7 +506,6 @@ const getPostTaskReqBody = (
   task_translation_key,
   isCustomTask,
   managementPlanWithCurrentLocationEntities,
-  taskTypeSpecificData,
 ) => {
   if (isCustomTask)
     return getPostTaskBody(data, endpoint, managementPlanWithCurrentLocationEntities);
@@ -514,7 +513,6 @@ const getPostTaskReqBody = (
     data,
     endpoint,
     managementPlanWithCurrentLocationEntities,
-    taskTypeSpecificData,
   );
 };
 
@@ -528,7 +526,6 @@ export function* createTaskSaga({ payload }) {
   const { task_translation_key, farm_id: task_farm_id } = yield select(
     taskTypeSelector(data.task_type_id),
   );
-  const taskTypeSpecificData = {};
   const header = getHeader(user_id, farm_id);
   const isCustomTask = !!task_farm_id;
   const isHarvest = task_translation_key === 'HARVEST_TASK';
@@ -551,7 +548,6 @@ export function* createTaskSaga({ payload }) {
         task_translation_key,
         isCustomTask,
         managementPlanWithCurrentLocationEntities,
-        taskTypeSpecificData,
       ),
       header,
     );
@@ -723,9 +719,8 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
   const { task_translation_key, isCustomTaskType } = data;
   const header = getHeader(user_id, farm_id);
   const endpoint = isCustomTaskType ? 'custom_task' : task_translation_key.toLowerCase();
-  const taskTypeSpecificData = {};
   const taskData = taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key]
-    ? taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key](data, taskTypeSpecificData)
+    ? taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key](data)
     : data.taskData;
 
   try {

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -72,10 +72,7 @@ import {
   onLoadingHarvestUseTypeStart,
 } from '../harvestUseTypeSlice';
 import { managementPlanWithCurrentLocationEntitiesSelector } from './TaskCrops/managementPlansWithLocationSelector';
-import {
-  formatSoilAmendmentTaskToDBStructure,
-  formatSoilAmendmentProductToDBStructure,
-} from '../../util/task';
+import { formatSoilAmendmentProductToDBStructure } from '../../util/task';
 import { api } from '../../store/api/apiSlice';
 
 const taskTypeEndpoint = [
@@ -489,13 +486,10 @@ const getSoilAmendmentTaskBody = (
   data,
   endpoint,
   managementPlanWithCurrentLocationEntities,
-  { purposes, methods },
+  { purposes },
 ) => {
   return {
     ...getPostTaskBody(data, endpoint, managementPlanWithCurrentLocationEntities),
-    soil_amendment_task: formatSoilAmendmentTaskToDBStructure(data.soil_amendment_task, {
-      methods,
-    }),
     soil_amendment_task_products: formatSoilAmendmentProductToDBStructure(
       data.soil_amendment_task_products,
       { purposes },
@@ -549,8 +543,6 @@ export function* createTaskSaga({ payload }) {
       api.endpoints.getSoilAmendmentPurposes.select()(state),
     );
     taskTypeSpecificData.purposes = purposes.data;
-    const methods = yield select((state) => api.endpoints.getSoilAmendmentMethods.select()(state));
-    taskTypeSpecificData.methods = methods.data;
   }
   const header = getHeader(user_id, farm_id);
   const isCustomTask = !!task_farm_id;
@@ -721,17 +713,12 @@ const getCompleteIrrigationTaskBody = (task_translation_key) => (data) => {
 };
 
 const getCompleteSoilAmendmentTaskBody = (data, taskTypeSpecificData) => {
-  const soilAmendmentTask = formatSoilAmendmentTaskToDBStructure(
-    data.soil_amendment_task,
-    taskTypeSpecificData,
-  );
   const soilAmendmentTaskProducts = formatSoilAmendmentProductToDBStructure(
     data.soil_amendment_task_products,
     taskTypeSpecificData,
   );
   return {
     ...data.taskData,
-    soil_amendment_task: soilAmendmentTask,
     soil_amendment_task_products: soilAmendmentTaskProducts,
   };
 };
@@ -760,8 +747,6 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
       api.endpoints.getSoilAmendmentPurposes.select()(state),
     );
     taskTypeSpecificData.purposes = purposes.data;
-    const methods = yield select((state) => api.endpoints.getSoilAmendmentMethods.select()(state));
-    taskTypeSpecificData.methods = methods.data;
   }
   const taskData = taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key]
     ? taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key](data, taskTypeSpecificData)

--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -137,8 +137,11 @@ type RemainingFormSATProductKeys = keyof Omit<
 >;
 
 export const formatSoilAmendmentProductToDBStructure = (
-  soilAmendmentTaskProducts: FormSoilAmendmentTaskProduct[],
-): DBSoilAmendmentTaskProduct[] => {
+  soilAmendmentTaskProducts: FormSoilAmendmentTaskProduct[] | undefined,
+): DBSoilAmendmentTaskProduct[] | undefined => {
+  if (!soilAmendmentTaskProducts) {
+    return undefined;
+  }
   return soilAmendmentTaskProducts.map((formTaskProduct) => {
     const { purposes: purposeIds, other_purpose, is_weight, ...rest } = formTaskProduct;
 

--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -13,8 +13,6 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { SoilAmendmentPurpose } from '../store/api/types';
-
 interface UnitOption {
   label: string;
   value: string;
@@ -127,10 +125,9 @@ export const formatSoilAmendmentTaskToFormStructure = (
 const formatPurposeIdsToRelationships = (
   purposeIds: number[],
   otherPurpose: string | undefined,
-  otherPurposeId: number,
 ): PurposeRelationship[] => {
   return purposeIds.map((purpose_id) => {
-    return { purpose_id, other_purpose: purpose_id === otherPurposeId ? otherPurpose : undefined };
+    return { purpose_id, other_purpose: otherPurpose };
   });
 };
 
@@ -141,12 +138,7 @@ type RemainingFormSATProductKeys = keyof Omit<
 
 export const formatSoilAmendmentProductToDBStructure = (
   soilAmendmentTaskProducts: FormSoilAmendmentTaskProduct[],
-  { purposes }: { purposes: SoilAmendmentPurpose[] },
 ): DBSoilAmendmentTaskProduct[] => {
-  const otherPurposeId = purposes?.find(({ key }) => key === 'OTHER')?.id;
-  if (!otherPurposeId) {
-    throw Error('id for OTHER purpose does not exist');
-  }
   return soilAmendmentTaskProducts.map((formTaskProduct) => {
     const { purposes: purposeIds, other_purpose, is_weight, ...rest } = formTaskProduct;
 
@@ -170,11 +162,7 @@ export const formatSoilAmendmentProductToDBStructure = (
       application_rate_volume_unit: !is_weight
         ? (rest.application_rate_volume_unit as UnitOption)?.value
         : undefined,
-      purpose_relationships: formatPurposeIdsToRelationships(
-        purposeIds,
-        other_purpose,
-        otherPurposeId,
-      ),
+      purpose_relationships: formatPurposeIdsToRelationships(purposeIds, other_purpose),
     };
   });
 };


### PR DESCRIPTION
**Description**

This PR removes the passing of the purpose and method keys from the saga to the task utility functions in favour of using `{ shouldUnregister: true }` on the inputs that need to be nulled when their method_id / purpose_id is not selected

Notes:
- Removing the calls to `api.endpoints.getSoilAmendmentPurposes.select()(state),` fixes the timeout that makes the form unsubmittable after the api cache expires
- `<Unit />` component need a little bit of adjustment to accept `shouldUnregister: true`
- A cleanup before insert was on the model was still needed _on PATCH_, but I feel this is an appropriate place for it because
  - Nothing is wrong with the PATCH request, it is correctly only giving the updated data, which means it doesn't overwrite any old data in the other fields (e.g. `other_application_method`, which triggers the check constraint)
  - There is no longer any ambiguity about what data is correct
  - It is logical + readable on the model where it is defined specifically on PATCH (update) 
- `shouldUnregister: true` resolves the other persistence bugs we saw; I will re-test this momentarily then indicate their tickets below as well
  
Jira link: https://lite-farm.atlassian.net/browse/LF-4309


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Checked on the `soil_amendment_task` product table and the `soil_amendment_task_products_purpose_relationship` table of db.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
