### PR TITLE
LF-4341: The text overlaps the borders of the save button on mobile device

### DIFF
--- a/packages/webapp/src/components/Form/InFormButtons/index.tsx
+++ b/packages/webapp/src/components/Form/InFormButtons/index.tsx
@@ -27,6 +27,7 @@ export interface InFormButtonsProps {
   onCancel: () => void;
   onConfirm?: () => void;
   confirmButtonType?: 'button' | 'submit';
+  className?: string;
 }
 
 const InFormButtons = ({
@@ -37,11 +38,12 @@ const InFormButtons = ({
   onCancel,
   onConfirm,
   confirmButtonType = 'button',
+  className,
 }: InFormButtonsProps) => {
   const { t } = useTranslation();
 
   return (
-    <div className={styles.container}>
+    <div className={clsx(styles.container, className)}>
       <div className={styles.buttons}>
         {statusText && <span className={styles.statusText}>{statusText}</span>}
         <Button type="button" color="secondary-cta" className={styles.button} onClick={onCancel}>

--- a/packages/webapp/src/components/Form/InFormButtons/styles.module.scss
+++ b/packages/webapp/src/components/Form/InFormButtons/styles.module.scss
@@ -25,6 +25,10 @@
 .statusText {
   font-size: 16px;
   color: var(--Colors-Neutral-Neutral-300);
+
+  @include xs-breakpoint {
+    display: none;
+  }
 }
 
 .informationalText {

--- a/packages/webapp/src/components/Form/InFormButtons/styles.module.scss
+++ b/packages/webapp/src/components/Form/InFormButtons/styles.module.scss
@@ -13,6 +13,8 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+@import '../../../assets/mixin';
+
 .container {
   display: flex;
   flex-direction: column;
@@ -43,10 +45,12 @@
   min-height: 32px;
   height: 32px;
   font-size: 14px;
+  display: inline-block;
+
+  @include truncateText();
 }
 
 .confirmButton {
-  padding: 8px 12px;
   color: var(--Colors-Neutral-Neutral-900);
   border: 1px solid var(--Colors-Neutral-Neutral-900);
 

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/Buttons.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/Buttons.tsx
@@ -41,6 +41,7 @@ const Buttons = ({
   if (isEditingProduct) {
     return (
       <InFormButtons
+        className={styles.inFormButtons}
         statusText={t('common:EDITING')}
         confirmText={t('ADD_PRODUCT.SAVE_PRODUCT')}
         onCancel={onCancel}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
@@ -164,6 +164,14 @@
 /*----------------------------------------
   Buttons
 ----------------------------------------*/
+.inFormButtons {
+  button {
+    @include xs-breakpoint {
+      max-width: 80px;
+    }
+  }
+}
+
 .editButton {
   width: fit-content;
   align-self: center;

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/styles.module.scss
@@ -167,7 +167,7 @@
 .inFormButtons {
   button {
     @include xs-breakpoint {
-      max-width: 80px;
+      max-width: 150px;
     }
   }
 }


### PR DESCRIPTION
**Description**

- Truncate text in InFormButtons
   - Remove padding
   - Set display to `inline-block` 
- Update InFormButtons to take `className`
- Add max-width to the buttons in `InFormButtons`. Without max-width, the container width extends to accommodate the buttons' width.

I can't do better than this now 😣😣😣😣😣🤮 If you have any suggestions, please let me know!

Jira link: https://lite-farm.atlassian.net/browse/LF-4341

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
