### PR TITLE
LF-4345 PT displaying escaped characters in area application summary text

### DIFF
--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/AreaApplicationSummary.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/AreaApplicationSummary.tsx
@@ -43,6 +43,7 @@ export const AreaApplicationSummary = ({
             locationAreaUnit,
             locationType,
           }}
+          shouldUnescape
         >
           Applied to <b>{{ percentOfArea } as any}%</b> of your{' '}
           <em>


### PR DESCRIPTION
**Description**

How did this get through bug bash when we had testers using Portuguese? 😅 

The PT translation of field is `campo/parcela`
![Screenshot 2024-07-23 at 3 25 23 PM](https://github.com/user-attachments/assets/4056d2fa-2d30-4259-9549-d6903b2c0ac6)


 If someone knows off the top of their head why `shouldUnescape: true` is necessary here and not in the AreaDetails (where the same string is sent to the `label` of `<Input />`, I'd love to know! But for now, just pushing the fix 🙂 

Jira link: https://lite-farm.atlassian.net/browse/LF-4345

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
