### PR TITLE
LF-4346 The user is not able to complete a task any task for a farm worker account without an email

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -41,7 +41,7 @@ async function getTaskAssigneeAndFinalWage(farm_id, user_id, task_id) {
     wage_at_moment,
     override_hourly_wage,
   } = await TaskModel.getTaskAssignee(task_id, farm_id);
-  const { role_id } = await UserFarmModel.getUserRoleId(user_id);
+  const { role_id } = await UserFarmModel.getUserRoleId(user_id, farm_id);
   if (!canCompleteTask(assignee_user_id, assignee_role_id, user_id, role_id)) {
     throw new Error("Not authorized to complete other people's task");
   }

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -40,7 +40,7 @@ async function getTaskAssigneeAndFinalWage(farm_id, user_id, task_id) {
     assignee_role_id,
     wage_at_moment,
     override_hourly_wage,
-  } = await TaskModel.getTaskAssignee(task_id);
+  } = await TaskModel.getTaskAssignee(task_id, farm_id);
   const { role_id } = await UserFarmModel.getUserRoleId(user_id);
   if (!canCompleteTask(assignee_user_id, assignee_role_id, user_id, role_id)) {
     throw new Error("Not authorized to complete other people's task");

--- a/packages/api/src/models/taskModel.js
+++ b/packages/api/src/models/taskModel.js
@@ -278,7 +278,7 @@ class TaskModel extends BaseModel {
    * @async
    * @returns {Object} - Object {assignee_user_id, assignee_role_id, wage_at_moment, override_hourly_wage}
    */
-  static async getTaskAssignee(taskId) {
+  static async getTaskAssignee(taskId, farmId) {
     return await TaskModel.query()
       .whereNotDeleted()
       .join('users', 'task.assignee_user_id', 'users.user_id')
@@ -289,7 +289,7 @@ class TaskModel extends BaseModel {
           'users.user_id as assignee_user_id, role.role_id as assignee_role_id, task.wage_at_moment, task.override_hourly_wage',
         ),
       )
-      .where('task.task_id', taskId)
+      .where({ 'task.task_id': taskId, 'uf.farm_id': farmId })
       .first();
   }
 

--- a/packages/api/src/models/userFarmModel.js
+++ b/packages/api/src/models/userFarmModel.js
@@ -147,12 +147,12 @@ class userFarm extends Model {
    * @async
    * @returns {number} Number corresponding to role_id.
    */
-  static async getUserRoleId(userId) {
+  static async getUserRoleId(userId, farmId) {
     return userFarm
       .query()
       .join('role', 'userFarm.role_id', 'role.role_id')
       .select('role.role_id')
-      .where('userFarm.user_id', userId)
+      .where({ 'userFarm.user_id': userId, 'userFarm.farm_id': farmId })
       .first();
   }
 


### PR DESCRIPTION
**Description**

To summarize our discussion (please also see Jira ticket for details):
- This is not a regression; the bug is about 2 years old
- It would only be triggered in the situation Denis showed us today (completing a task assigned to a worker without an account), ONLY IF
- The managing account has multiple userFarms and the first one returned by the query in `getUserRoleId()` (see PR) happens to be non-admin. This is highly unlikely in a non-QA context, but the fix is straightforward so it has been applied
- The neighbouring function had the same bug so it was fixed at the same time

Jira link: https://lite-farm.atlassian.net/browse/LF-4346

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

To set up the situation that would cause the issue, I used a user account whose first userFarm entry (first invite) was as worker role. I verified that the original (buggy) query would return a `role_id` of 3 by running the SQL version against my database:

```sql
SELECT role.role_id
FROM "userFarm"
JOIN role ON "userFarm".role_id = role.role_id
WHERE "userFarm".user_id = <user_id here>
LIMIT 1;
```

Note: a minor remaining mystery is that running this query against Denis' user_id on beta doesn't return a `role_id` of 3, but there are something like 76 userFarm records on that ID, and I don't think there is any particular reason to trust that `.first()` will return the same one each time. It so happens that the top record (visually inspecting the records) does have `role_id` 3, for what it's worth 🙂  (Update: inspected the query and `.first()` is actually not adding a `LIMIT 1` to the SQL, interesting! So it may be grabbing the top record / first index some other way.)

I then invited this user as a manager to a different farm where I also created a user without an account and completed a task assigned to that worker, as described in the original bug documentation.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
