### PR TITLE
LF-4348: The 400 error will be displayed once the user will try to add an other purpose in the list of purposes during the task completion or creation

### DIFF
--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -514,6 +514,7 @@ const getPostTaskReqBody = (
   task_translation_key,
   isCustomTask,
   managementPlanWithCurrentLocationEntities,
+  taskTypeSpecificData,
 ) => {
   if (isCustomTask)
     return getPostTaskBody(data, endpoint, managementPlanWithCurrentLocationEntities);
@@ -521,6 +522,7 @@ const getPostTaskReqBody = (
     data,
     endpoint,
     managementPlanWithCurrentLocationEntities,
+    taskTypeSpecificData,
   );
 };
 
@@ -534,6 +536,7 @@ export function* createTaskSaga({ payload }) {
   const { task_translation_key, farm_id: task_farm_id } = yield select(
     taskTypeSelector(data.task_type_id),
   );
+  const taskTypeSpecificData = {};
   const header = getHeader(user_id, farm_id);
   const isCustomTask = !!task_farm_id;
   const isHarvest = task_translation_key === 'HARVEST_TASK';
@@ -556,6 +559,7 @@ export function* createTaskSaga({ payload }) {
         task_translation_key,
         isCustomTask,
         managementPlanWithCurrentLocationEntities,
+        taskTypeSpecificData,
       ),
       header,
     );
@@ -727,8 +731,9 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
   const { task_translation_key, isCustomTaskType } = data;
   const header = getHeader(user_id, farm_id);
   const endpoint = isCustomTaskType ? 'custom_task' : task_translation_key.toLowerCase();
+  const taskTypeSpecificData = {};
   const taskData = taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key]
-    ? taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key](data)
+    ? taskTypeGetCompleteTaskBodyFunctionMap[task_translation_key](data, taskTypeSpecificData)
     : data.taskData;
 
   try {

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -56,14 +56,17 @@ export const api = createApi({
     getSoilAmendmentMethods: build.query<SoilAmendmentMethod[], void>({
       query: () => `${soilAmendmentMethodsUrl}`,
       providesTags: ['SoilAmendmentMethods'],
+      keepUnusedDataFor: 7 * 24 * 60 * 60, // 1 week in seconds
     }),
     getSoilAmendmentPurposes: build.query<SoilAmendmentPurpose[], void>({
       query: () => `${soilAmendmentPurposesUrl}`,
       providesTags: ['SoilAmendmentPurposes'],
+      keepUnusedDataFor: 7 * 24 * 60 * 60, // 1 week in seconds
     }),
     getSoilAmendmentFertiliserTypes: build.query<SoilAmendmentFertiliserType[], void>({
       query: () => `${soilAmendmentFertiliserTypesUrl}`,
       providesTags: ['SoilAmendmentFertiliserTypes'],
+      keepUnusedDataFor: 7 * 24 * 60 * 60, // 1 week in seconds
     }),
     addSoilAmendmentProduct: build.mutation<SoilAmendmentProduct, Partial<SoilAmendmentProduct>>({
       query: (body) => ({

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -56,17 +56,17 @@ export const api = createApi({
     getSoilAmendmentMethods: build.query<SoilAmendmentMethod[], void>({
       query: () => `${soilAmendmentMethodsUrl}`,
       providesTags: ['SoilAmendmentMethods'],
-      keepUnusedDataFor: 7 * 24 * 60 * 60, // 1 week in seconds
+      keepUnusedDataFor: 24 * 60 * 60, // 1 day in seconds
     }),
     getSoilAmendmentPurposes: build.query<SoilAmendmentPurpose[], void>({
       query: () => `${soilAmendmentPurposesUrl}`,
       providesTags: ['SoilAmendmentPurposes'],
-      keepUnusedDataFor: 7 * 24 * 60 * 60, // 1 week in seconds
+      keepUnusedDataFor: 24 * 60 * 60, // 1 day in seconds
     }),
     getSoilAmendmentFertiliserTypes: build.query<SoilAmendmentFertiliserType[], void>({
       query: () => `${soilAmendmentFertiliserTypesUrl}`,
       providesTags: ['SoilAmendmentFertiliserTypes'],
-      keepUnusedDataFor: 7 * 24 * 60 * 60, // 1 week in seconds
+      keepUnusedDataFor: 24 * 60 * 60, // 1 day in seconds
     }),
     addSoilAmendmentProduct: build.mutation<SoilAmendmentProduct, Partial<SoilAmendmentProduct>>({
       query: (body) => ({


### PR DESCRIPTION
**Description**

 - Revert b697d25f5ee666afcf393f60fb69a5046da89aa1 and 4c69bfa3c6876a0cf78d8a7c5a152e1d64b67791
 - Set `keepUnusedDataFor` (https://redux-toolkit.js.org/rtk-query/api/createApi#keepunuseddatafor-1) for the three GET requests (purposes, fertiliser types, methods) to keep data cached for a week.

I'm not sure what the appropriate `keepUnusedDataFor` is... Was this an expected solution?

Wait, if the user starts the completion flow right before the cache is expired, they will have the same issue, won't they? Let me try to do better...

Jira link: https://lite-farm.atlassian.net/browse/LF-4348

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
