### PR TITLE
LF-4348 Demo branch -- Pass other_purpose_id as a form field

### DIFF
--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -107,6 +107,7 @@ const SoilAmendmentProductCard = ({
   const PRODUCT_ID = `${namePrefix}.${PRODUCT_FIELD_NAMES.PRODUCT_ID}`;
   const PURPOSES = `${namePrefix}.${PRODUCT_FIELD_NAMES.PURPOSES}`;
   const OTHER_PURPOSE = `${namePrefix}.${PRODUCT_FIELD_NAMES.OTHER_PURPOSE}`;
+  const OTHER_PURPOSE_ID = `${namePrefix}.${PRODUCT_FIELD_NAMES.OTHER_PURPOSE_ID}`;
 
   const purposes = watch(PURPOSES);
 
@@ -184,6 +185,8 @@ const SoilAmendmentProductCard = ({
           />
         )}
       />
+      <input type="hidden" value={otherPurposeId} {...register(OTHER_PURPOSE_ID)} />
+
       {purposes?.includes(otherPurposeId) && (
         <>
           {/* @ts-ignore */}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -185,7 +185,12 @@ const SoilAmendmentProductCard = ({
           />
         )}
       />
-      <input type="hidden" value={otherPurposeId} {...register(OTHER_PURPOSE_ID)} />
+      <input
+        type="hidden"
+        value={otherPurposeId}
+        defaultValue={otherPurposeId}
+        {...register(OTHER_PURPOSE_ID)}
+      />
 
       {purposes?.includes(otherPurposeId) && (
         <>

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/types.ts
@@ -62,6 +62,7 @@ export const PRODUCT_FIELD_NAMES = {
   PRODUCT_ID: 'product_id',
   PURPOSES: 'purposes',
   OTHER_PURPOSE: 'other_purpose',
+  OTHER_PURPOSE_ID: 'other_purpose_id',
   NAME: 'name',
   SUPPLIER: 'supplier',
   PERMITTED: 'on_permitted_substances_list',

--- a/packages/webapp/src/util/task.ts
+++ b/packages/webapp/src/util/task.ts
@@ -121,9 +121,10 @@ export const formatSoilAmendmentTaskToFormStructure = (
 const formatPurposeIdsToRelationships = (
   purposeIds: number[],
   otherPurpose: string | undefined,
+  otherPurposeId: number,
 ): PurposeRelationship[] => {
   return purposeIds.map((purpose_id) => {
-    return { purpose_id, other_purpose: otherPurpose };
+    return { purpose_id, other_purpose: purpose_id == otherPurposeId ? otherPurpose : undefined };
   });
 };
 
@@ -139,7 +140,13 @@ export const formatSoilAmendmentProductToDBStructure = (
     return undefined;
   }
   return soilAmendmentTaskProducts.map((formTaskProduct) => {
-    const { purposes: purposeIds, other_purpose, is_weight, ...rest } = formTaskProduct;
+    const {
+      purposes: purposeIds,
+      other_purpose,
+      other_purpose_id,
+      is_weight,
+      ...rest
+    } = formTaskProduct;
 
     const propertiesToDelete: RemainingFormSATProductKeys[] = [
       'application_rate_weight',
@@ -161,7 +168,11 @@ export const formatSoilAmendmentProductToDBStructure = (
       application_rate_volume_unit: !is_weight
         ? (rest.application_rate_volume_unit as UnitOption)?.value
         : null,
-      purpose_relationships: formatPurposeIdsToRelationships(purposeIds, other_purpose),
+      purpose_relationships: formatPurposeIdsToRelationships(
+        purposeIds,
+        other_purpose,
+        other_purpose_id,
+      ),
     };
   });
 };


### PR DESCRIPTION
**Description**

@SayakaOno I was thinking like this! But I didn't mean for you to have to close the other one...!

... it got closed! 😢 But this method was based on trying to avoid cache due to the complications described in original PR here
- #3338 

and thinking of the most quick and dirty way to get the OTHER value into `formatPurposeIdsToRelationships`, where it needed to be, and from which I had removed it in #3324, causing this bug.

Jira link: https://lite-farm.atlassian.net/browse/LF-4348

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

This was the faulty API request situation that had to be fixed:

```js
[
  {
    purpose_id: 4,
    other_purpose: 'Other purpose text field', // should not be sent here
  },
  {
    purpose_id: 5,
    other_purpose: 'Other purpose text field', // this one is correct
  },
]
```


**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
