### PR TITLE
LF-4351: Other purpose text is not saved

### DIFF
--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { ReactNode, useRef } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { GroupBase, SelectInstance } from 'react-select';
@@ -101,6 +101,7 @@ const SoilAmendmentProductCard = ({
     register,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useFormContext();
 
@@ -119,6 +120,12 @@ const SoilAmendmentProductCard = ({
   const clearProduct = () => {
     selectRef?.current?.clearValue();
   };
+
+  useEffect(() => {
+    if (otherPurposeId && !getValues(OTHER_PURPOSE_ID)) {
+      setValue(OTHER_PURPOSE_ID, otherPurposeId);
+    }
+  }, [otherPurposeId]);
 
   return (
     <div className={styles.productCard}>
@@ -185,12 +192,7 @@ const SoilAmendmentProductCard = ({
           />
         )}
       />
-      <input
-        type="hidden"
-        value={otherPurposeId}
-        defaultValue={otherPurposeId}
-        {...register(OTHER_PURPOSE_ID)}
-      />
+      <input type="hidden" {...register(OTHER_PURPOSE_ID)} />
 
       {purposes?.includes(otherPurposeId) && (
         <>

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -188,7 +188,7 @@ const SoilAmendmentProductCard = ({
               const newPurposes = e.map(({ value }) => value);
               setValue(PURPOSES, newPurposes, { shouldValidate: true });
             }}
-            style={{ paddingBottom: '12px' }} // TODO: remove after adding <QuantityApplicationRate />
+            style={{ paddingBottom: '12px' }}
           />
         )}
       />


### PR DESCRIPTION
**Description**

- Set ``OTHER_PURPOSE_ID` in useEffect.
- Remove `value` and `defaultValue` from the input to avoid the controlled/uncontrolled warning.
- Remove out-dated comment.

Jira link: https://lite-farm.atlassian.net/browse/LF-4351

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
