### PR TITLE
LF-4354: Get cypress tests passing on integration after recent patch changes

### DIFF
--- a/packages/end-to-end/cypress/support/commands.js
+++ b/packages/end-to-end/cypress/support/commands.js
@@ -138,8 +138,8 @@ const onboardCompleteQuestions = (role) => {
 
   cy.url().should('include', '/certification/selection');
   cy.get(Selectors.CERTIFICATION_SELECTION_CONTINUE).should('exist').and('be.disabled');
-  cy.get(Selectors.CERTIFICATION_SELECTION_TYPE).should('exist');
-  cy.get(Selectors.RADIO).first().check();
+  cy.get(Selectors.CERTIFICATION_ORGANIC_OPTION).should('exist');
+  cy.get(Selectors.CERTIFICATION_ORGANIC_OPTION).check();
   cy.get(Selectors.CERTIFICATION_SELECTION_CONTINUE).should('not.be.disabled').click();
 
   // Select certifier

--- a/packages/end-to-end/cypress/support/selectorConstants.ts
+++ b/packages/end-to-end/cypress/support/selectorConstants.ts
@@ -40,7 +40,7 @@ export const ROLE_SELECTION_CONTINUE = '[data-cy=roleSelection-continue]';
 export const ROLE_SELECTION_ROLE = '[data-cy=roleSelection-role]';
 
 export const CERTIFICATION_SELECTION_CONTINUE = '[data-cy=certificationSelection-continue]';
-export const CERTIFICATION_SELECTION_TYPE = '[data-cy=certificationSelection-type]';
+export const CERTIFICATION_ORGANIC_OPTION = '[data-cy=certification_id-1]';
 export const CERTIFICATION_SUMMARY_CONTINUE = '[data-cy=certificationSummary-continue]';
 export const CERTIFICATION_SELECTION_ITEM = '[data-cy=certifierSelection-item]';
 export const CERTIFIER_SELECTION_PROCEED = '[data-cy=certifierSelection-proceed]';

--- a/packages/webapp/src/components/OrganicCertifierSurvey/CertificationSelection/PureCertificationSelection.jsx
+++ b/packages/webapp/src/components/OrganicCertifierSurvey/CertificationSelection/PureCertificationSelection.jsx
@@ -50,6 +50,7 @@ export function PureCertificationSelection({
     const certificationRadioOptions = certifications.map((certification) => ({
       label: t(`certifications:${certification.certification_translation_key}`),
       value: certification.certification_id,
+      'data-cy': `${CERTIFICATION_ID}-${certification.certification_id}`,
     }));
     return [
       ...certificationRadioOptions,
@@ -68,7 +69,12 @@ export function PureCertificationSelection({
       onSubmit={handleSubmit(onSubmit)}
       buttonGroup={
         <>
-          <Button data-cy='certificationSelection-continue' type={'submit'} fullLength disabled={disabled}>
+          <Button
+            data-cy="certificationSelection-continue"
+            type={'submit'}
+            fullLength
+            disabled={disabled}
+          >
             {t('common:CONTINUE')}
           </Button>
         </>
@@ -80,7 +86,6 @@ export function PureCertificationSelection({
         style={{ marginBottom: '20px' }}
       />
       <RadioGroup
-        data-cy='certificationSelection-type'
         name={CERTIFICATION_ID}
         hookFormControl={control}
         radios={radioOptions}


### PR DESCRIPTION
**Description**

Before the name of Organic type selection was updated in https://github.com/LiteFarmOrg/LiteFarm/pull/3302, the order of the certification types was:
<img width="533" alt="Screenshot 2024-07-30 at 3 01 14 PM" src="https://github.com/user-attachments/assets/127ad55c-46b8-4d0f-8173-e870d9c7e02b">

and the first option of the radio group was being checked for the cypress test.
```
cy.get(Selectors.RADIO).first().check();
```

After the change, the order of the radio buttons was changed because the API now returns `PGS` first. (I have no idea how this happens)
![Screenshot 2024-07-30 at 3 11 26 PM](https://github.com/user-attachments/assets/dbcf0bb3-fd4f-4d34-b8f6-a6d0fd28e6fa)

The organic option is no longer selected, causing the test to fail.


***Solution***
Instead of selecting the first item of the radio buttons, select the radio button with `data-cy=certification_id-1`, which is the organic option.

Jira link: https://lite-farm.atlassian.net/browse/LF-4354

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Ran `npm run cypress` in `packages/end-to-end`.

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
