### PR TITLE
LF-3416: Fix "Delete task" button clickable area

### DIFF
--- a/packages/webapp/src/components/Finances/AddExpense/styles.module.scss
+++ b/packages/webapp/src/components/Finances/AddExpense/styles.module.scss
@@ -27,7 +27,7 @@
   font-size: 14px;
 }
 
-p.iconLink {
+button.iconLink {
   display: flex;
   align-items: start;
   height: 16px;

--- a/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
+++ b/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
@@ -34,8 +34,7 @@
 }
 
 .deleteText {
-  width: fit-content;
-  margin-bottom: 16px;
+  padding-bottom: 16px;
 
   span {
     text-decoration: none;
@@ -76,7 +75,7 @@
 
   svg {
     transform: translate(0px, 3px);
-    margin-right: 8px;
+    margin-right: 8px,
   }
 }
 

--- a/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
+++ b/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
@@ -34,7 +34,8 @@
 }
 
 .deleteText {
-  padding-bottom: 16px;
+  width: fit-content;
+  margin-bottom: 16px;
 
   span {
     text-decoration: none;
@@ -75,7 +76,7 @@
 
   svg {
     transform: translate(0px, 3px);
-    margin-right: 8px,
+    margin-right: 8px;
   }
 }
 

--- a/packages/webapp/src/components/Typography/index.tsx
+++ b/packages/webapp/src/components/Typography/index.tsx
@@ -32,6 +32,7 @@ type IconLinkProps = TypographyProps & {
   icon?: ReactNode;
   isIconClickable?: boolean;
   underlined?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 export const IconLink = ({
   children = 'IconLink',
@@ -44,10 +45,11 @@ export const IconLink = ({
   ...props
 }: IconLinkProps) => {
   return (
-    <p
+    <button
       style={style}
       className={clsx(styles.addLinkContainer, className, isIconClickable && styles.clickable)}
       onClick={isIconClickable ? onClick : undefined}
+      type="button"
       {...props}
     >
       {icon}{' '}
@@ -57,8 +59,12 @@ export const IconLink = ({
       >
         {children}
       </span>
-    </p>
+    </button>
   );
+};
+
+type AddLinkProps = TypographyProps & {
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const AddLink = ({
@@ -67,7 +73,7 @@ export const AddLink = ({
   style,
   onClick,
   ...props
-}: TypographyProps) => {
+}: AddLinkProps) => {
   return (
     <IconLink className={className} style={style} onClick={onClick} icon={'+'} {...props}>
       {children}
@@ -77,6 +83,7 @@ export const AddLink = ({
 
 type SubtractLinkProps = TypographyProps & {
   color?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 export const SubtractLink = ({
   children = 'SubtractLink',

--- a/packages/webapp/src/components/Typography/typography.module.scss
+++ b/packages/webapp/src/components/Typography/typography.module.scss
@@ -20,6 +20,9 @@
   font-family: 'Open Sans', 'SansSerif', serif;
   margin: 0;
   display: inline-block;
+  border: none;
+  background-color: transparent;
+  align-self: flex-start;
 }
 
 .editLinkContainer {


### PR DESCRIPTION
**Description**

The **Delete task** button clickable area was taking the full width of its container + the set padding. This PR limits the size of the button (and therefore its clickable area) to just its content width.

Jira link: https://lite-farm.atlassian.net/browse/LF-3416

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
