### PR TITLE
Lf 4387 migrate upload public images functions to new reusable function

### DIFF
--- a/packages/api/src/controllers/cropController.js
+++ b/packages/api/src/controllers/cropController.js
@@ -19,14 +19,7 @@ import NominationCrop from '../models/nominationCropModel.js';
 import CropModel from '../models/cropModel.js';
 import CropVarietyModel from '../models/cropVarietyModel.js';
 import objection from 'objection';
-import {
-  getPublicS3BucketName,
-  s3,
-  imaginaryPost,
-  getPublicS3Url,
-} from '../util/digitalOceanSpaces.js';
-import { v4 as uuidv4 } from 'uuid';
-import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { uploadPublicImage } from '../util/imageUpload.js';
 
 const { transaction, Model, UniqueViolationError } = objection;
 
@@ -213,40 +206,7 @@ const cropController = {
 
   uploadCropImage() {
     return async (req, res, next) => {
-      try {
-        const TYPE = 'webp';
-        const fileName = `crop/${uuidv4()}.${TYPE}`;
-
-        const THUMBNAIL_FORMAT = 'webp';
-        const LENGTH = '208';
-
-        const compressedImage = await imaginaryPost(
-          req.file,
-          {
-            width: LENGTH,
-            height: LENGTH,
-            type: THUMBNAIL_FORMAT,
-            aspectratio: '1:1',
-          },
-          { endpoint: 'smartcrop' },
-        );
-
-        await s3.send(
-          new PutObjectCommand({
-            Body: compressedImage.data,
-            Bucket: getPublicS3BucketName(),
-            Key: fileName,
-            ACL: 'public-read',
-          }),
-        );
-
-        return res.status(201).json({
-          url: `${getPublicS3Url()}/${fileName}`,
-        });
-      } catch (error) {
-        console.log(error);
-        return res.status(400).send('Fail to upload image');
-      }
+      await uploadPublicImage('crop')(req, res, next);
     };
   },
 

--- a/packages/api/src/controllers/cropVarietyController.js
+++ b/packages/api/src/controllers/cropVarietyController.js
@@ -1,15 +1,9 @@
 import CropVarietyModel from '../models/cropVarietyModel.js';
 import ManagementPlanModel from '../models/managementPlanModel.js';
 import CropModel from '../models/cropModel.js';
-import {
-  getPublicS3BucketName,
-  s3,
-  imaginaryPost,
-  getPublicS3Url,
-} from '../util/digitalOceanSpaces.js';
-import { v4 as uuidv4 } from 'uuid';
 import baseController from './baseController.js';
-import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { uploadPublicImage } from '../util/imageUpload.js';
+
 const { post } = baseController;
 
 const cropVarietyController = {
@@ -131,40 +125,7 @@ const cropVarietyController = {
   },
   uploadCropImage() {
     return async (req, res, next) => {
-      try {
-        const TYPE = 'webp';
-        const fileName = `crop_variety/${uuidv4()}.${TYPE}`;
-
-        const THUMBNAIL_FORMAT = 'webp';
-        const LENGTH = '208';
-
-        const compressedImage = await imaginaryPost(
-          req.file,
-          {
-            width: LENGTH,
-            height: LENGTH,
-            type: THUMBNAIL_FORMAT,
-            aspectratio: '1:1',
-          },
-          { endpoint: 'smartcrop' },
-        );
-
-        await s3.send(
-          new PutObjectCommand({
-            Body: compressedImage.data,
-            Bucket: getPublicS3BucketName(),
-            Key: fileName,
-            ACL: 'public-read',
-          }),
-        );
-
-        return res.status(201).json({
-          url: `${getPublicS3Url()}/${fileName}`,
-        });
-      } catch (error) {
-        console.log(error);
-        return res.status(400).send('Fail to upload image');
-      }
+      await uploadPublicImage('crop_variety')(req, res, next);
     };
   },
 };


### PR DESCRIPTION
**Description**

-80 lines of reused code

This uses the utility instead of storing the same logic in multiple controllers.

To test: Make sure local image bucket is running

Jira link: [LF-4387](https://lite-farm.atlassian.net/browse/LF-4387)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4387]: https://lite-farm.atlassian.net/browse/LF-4387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ