### PR TITLE
Fix default_type_id type in animal uses API

### DIFF
--- a/packages/api/src/models/animalUseModel.js
+++ b/packages/api/src/models/animalUseModel.js
@@ -57,7 +57,7 @@ class AnimalUse extends baseModel {
     }, {});
 
     const response = Object.entries(usesPerType).map(([defaultTypeId, uses]) => {
-      return { default_type_id: defaultTypeId, uses };
+      return { default_type_id: +defaultTypeId, uses };
     });
 
     const allUses = await AnimalUse.query();

--- a/packages/api/tests/animal_use.test.js
+++ b/packages/api/tests/animal_use.test.js
@@ -131,7 +131,7 @@ describe('Animal Use Tests', () => {
 
         res.body.forEach(({ default_type_id, uses }) => {
           const expectedTypeAndUses = testCase.find(({ defaultType }) => {
-            return default_type_id ? defaultType.id == default_type_id : !defaultType;
+            return default_type_id ? defaultType.id === default_type_id : !defaultType;
           });
 
           expect(uses.map(({ id }) => id).sort()).toEqual(

--- a/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/index.tsx
+++ b/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/index.tsx
@@ -91,8 +91,8 @@ const AddAnimalDetails = () => {
     const watchedCount = watch(`${namePrefix}${DetailsFields.COUNT}`);
 
     const useOptionsForType = useOptions.find(
-      ({ default_type_id }: { default_type_id: string | null }) =>
-        default_type_id === `${parseUniqueDefaultId(field.type.value)}` || default_type_id === null,
+      ({ default_type_id }: { default_type_id: number | null }) =>
+        default_type_id === parseUniqueDefaultId(field.type.value) || default_type_id === null,
     );
 
     const mainContent = (

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -120,7 +120,7 @@ export interface AnimalOrigin {
 }
 
 export interface AnimalUse {
-  default_type_id: string | null;
+  default_type_id: number | null;
   uses: { id: number; key: string }[];
 }
 


### PR DESCRIPTION
**Description**

- Fix `default_type_id` type in animal_uses API to number (it was used as map keys and converted to string)
- Make the test more strict (I shouldn't have used `==`!!!)
- Adjust frontend code

Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
