### PR TITLE
Image picker update

### DIFF
--- a/packages/webapp/src/components/Animals/DetailCards/Other.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Other.tsx
@@ -103,6 +103,7 @@ const OtherDetails = ({
         onFileUpload={onFileUpload}
         onRemoveImage={handleRemoveImage}
         shouldGetImageUrl={true}
+        defaultUrl={field.value}
       />
     </div>
   );

--- a/packages/webapp/src/components/Animals/DetailCards/Other.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Other.tsx
@@ -18,6 +18,7 @@ import ReactSelect from '../../Form/ReactSelect';
 import Input from '../../Form/Input';
 import InputAutoSize from '../../Form/InputAutoSize';
 import ImagePicker from '../../ImagePicker';
+import { GetOnFileUpload } from '../../ImagePicker/useImagePickerUpload';
 import { AnimalOrBatchKeys } from '../../../containers/Animals/types';
 import styles from './styles.module.scss';
 import {
@@ -29,6 +30,8 @@ import {
 export type OtherDetailsProps = CommonDetailsProps & {
   organicStatusOptions: Option[DetailsFields.ORGANIC_STATUS][];
   animalOrBatch: AnimalOrBatchKeys;
+  imageUploadTargetRoute: string;
+  getOnFileUpload: GetOnFileUpload;
 };
 
 const OtherDetails = ({
@@ -36,6 +39,8 @@ const OtherDetails = ({
   organicStatusOptions,
   animalOrBatch,
   namePrefix = '',
+  imageUploadTargetRoute,
+  getOnFileUpload,
 }: OtherDetailsProps) => {
   const {
     control,
@@ -46,13 +51,15 @@ const OtherDetails = ({
 
   const { field } = useController({ control, name: `${namePrefix}${DetailsFields.ANIMAL_IMAGE}` });
 
-  const handleSelectImage = (imageFile: any) => {
-    field.onChange(imageFile);
+  const handleSelectImage = (imageUrl: string) => {
+    field.onChange(imageUrl);
   };
 
   const handleRemoveImage = () => {
     resetField(`${namePrefix}${DetailsFields.ANIMAL_IMAGE}`);
   };
+
+  const onFileUpload = getOnFileUpload(imageUploadTargetRoute, handleSelectImage);
 
   return (
     <div className={styles.sectionWrapper}>
@@ -93,8 +100,9 @@ const OtherDetails = ({
       />
       <ImagePicker
         label={t(`ANIMAL.ATTRIBUTE.${animalOrBatch.toUpperCase()}_IMAGE`)}
-        onSelectImage={handleSelectImage}
+        onFileUpload={onFileUpload}
         onRemoveImage={handleRemoveImage}
+        shouldGetImageUrl={true}
       />
     </div>
   );

--- a/packages/webapp/src/components/Animals/DetailCards/Other.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Other.tsx
@@ -102,7 +102,6 @@ const OtherDetails = ({
         label={t(`ANIMAL.ATTRIBUTE.${animalOrBatch.toUpperCase()}_IMAGE`)}
         onFileUpload={onFileUpload}
         onRemoveImage={handleRemoveImage}
-        shouldGetImageUrl={true}
         defaultUrl={field.value}
       />
     </div>

--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -37,15 +37,26 @@ export type OnFileUpload = (
   event: FileEvent,
 ) => Promise<void>;
 
-export type ImagePickerProps = {
-  onSelectImage?: (file: File) => void; // Required if `shouldGetImageUrl` is false or falsy.
+type CommonProps = {
   onRemoveImage: () => void;
   label?: string;
   optional?: boolean;
   defaultUrl?: string;
-  shouldGetImageUrl?: boolean;
-  onFileUpload?: OnFileUpload; // Required if `shouldGetImageUrl` is true.
 };
+
+type ImageUrlUpload = CommonProps & {
+  shouldGetImageUrl: true;
+  onSelectImage?: never;
+  onFileUpload: OnFileUpload;
+};
+
+type DirectImageUpload = CommonProps & {
+  shouldGetImageUrl?: false;
+  onSelectImage: (file: File) => void;
+  onFileUpload?: never;
+};
+
+export type ImagePickerProps = ImageUrlUpload | DirectImageUpload;
 
 export default function ImagePicker({
   onRemoveImage,

--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, DragEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AddLink } from '../Typography';
 import PureFilePickerWrapper from '../Form/FilePickerWrapper';
@@ -25,12 +25,25 @@ import { ReactComponent as EditIcon } from '../../assets/images/farm-profile/edi
 import styles from './styles.module.scss';
 import FileSizeExceedModal from '../Modals/FileSizeExceedModal';
 
+export enum FileEvent {
+  CHANGE = 'change',
+  DRAG = 'drag',
+}
+
+export type OnFileUpload = (
+  e: ChangeEvent<HTMLInputElement> | DragEvent,
+  setPreviewUrl: (url: string) => void,
+  event: FileEvent,
+) => Promise<void>;
+
 export type ImagePickerProps = {
-  onSelectImage: (file: File) => void;
+  onSelectImage?: (file: File) => void; // Required if `shouldGetImageUrl` is false or falsy.
   onRemoveImage: () => void;
   label?: string;
   optional?: boolean;
   defaultUrl?: string;
+  shouldGetImageUrl?: boolean;
+  onFileUpload?: OnFileUpload; // Required if `shouldGetImageUrl` is true.
 };
 
 export default function ImagePicker({
@@ -39,6 +52,8 @@ export default function ImagePicker({
   defaultUrl = '',
   label,
   optional = true, // false is not yet supported
+  shouldGetImageUrl = false,
+  onFileUpload,
 }: ImagePickerProps) {
   const [previewUrl, setPreviewUrl] = useState(defaultUrl);
   const [showFileSizeExceedsModal, setShowFileSizeExceedsModal] = useState(false);
@@ -57,23 +72,33 @@ export default function ImagePicker({
     }
     const url = URL.createObjectURL(file);
     setPreviewUrl(url);
-    onSelectImage(file);
+    onSelectImage?.(file);
   };
 
   const handleFileInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (shouldGetImageUrl) {
+      onFileUpload?.(e, setPreviewUrl, FileEvent.CHANGE);
+      return;
+    }
+
     if (!e.target.files) return;
     const file = e.target.files[0];
     showImage(file);
     e.target.value = '';
   };
 
-  const handleDragEvent = (e: React.DragEvent) => {
+  const handleDragEvent = (e: DragEvent) => {
     e.preventDefault();
     if (e.type === 'dragover') return;
 
     if (e.type === 'dragenter' || e.type === 'dragleave') {
       dropContainerRef.current?.classList.toggle(styles.dropContainerActive);
     } else if (e.type === 'drop') {
+      if (shouldGetImageUrl) {
+        onFileUpload?.(e, setPreviewUrl, FileEvent.DRAG);
+        return;
+      }
+
       const file = e.dataTransfer?.files[0];
       showImage(file);
     }

--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -44,19 +44,17 @@ type CommonProps = {
   defaultUrl?: string;
 };
 
-type ImageUrlUpload = CommonProps & {
-  shouldGetImageUrl: true;
+type CustomFileUpload = CommonProps & {
   onSelectImage?: never;
   onFileUpload: OnFileUpload;
 };
 
 type DirectImageUpload = CommonProps & {
-  shouldGetImageUrl?: false;
   onSelectImage: (file: File) => void;
   onFileUpload?: never;
 };
 
-export type ImagePickerProps = ImageUrlUpload | DirectImageUpload;
+export type ImagePickerProps = CustomFileUpload | DirectImageUpload;
 
 export default function ImagePicker({
   onRemoveImage,
@@ -64,7 +62,6 @@ export default function ImagePicker({
   defaultUrl = '',
   label,
   optional = true, // false is not yet supported
-  shouldGetImageUrl = false,
   onFileUpload,
 }: ImagePickerProps) {
   const [previewUrl, setPreviewUrl] = useState(defaultUrl);
@@ -88,8 +85,8 @@ export default function ImagePicker({
   };
 
   const handleFileInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (shouldGetImageUrl) {
-      onFileUpload?.(e, setPreviewUrl, setShowFileSizeExceedsModal, FileEvent.CHANGE);
+    if (onFileUpload) {
+      onFileUpload(e, setPreviewUrl, setShowFileSizeExceedsModal, FileEvent.CHANGE);
       return;
     }
 
@@ -106,8 +103,8 @@ export default function ImagePicker({
     if (e.type === 'dragenter' || e.type === 'dragleave') {
       dropContainerRef.current?.classList.toggle(styles.dropContainerActive);
     } else if (e.type === 'drop') {
-      if (shouldGetImageUrl) {
-        onFileUpload?.(e, setPreviewUrl, setShowFileSizeExceedsModal, FileEvent.DRAG);
+      if (onFileUpload) {
+        onFileUpload(e, setPreviewUrl, setShowFileSizeExceedsModal, FileEvent.DRAG);
         return;
       }
 

--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -31,10 +31,10 @@ export enum FileEvent {
 }
 
 export type OnFileUpload = (
-  e: ChangeEvent<HTMLInputElement> | DragEvent,
+  event: ChangeEvent<HTMLInputElement> | DragEvent,
   setPreviewUrl: (url: string) => void,
   setFileSizeExceeded: (exceeded: boolean) => void,
-  event: FileEvent,
+  eventType: FileEvent,
 ) => Promise<void>;
 
 type CommonProps = {

--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -33,6 +33,7 @@ export enum FileEvent {
 export type OnFileUpload = (
   e: ChangeEvent<HTMLInputElement> | DragEvent,
   setPreviewUrl: (url: string) => void,
+  setFileSizeExceeded: (exceeded: boolean) => void,
   event: FileEvent,
 ) => Promise<void>;
 
@@ -77,7 +78,7 @@ export default function ImagePicker({
 
   const handleFileInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (shouldGetImageUrl) {
-      onFileUpload?.(e, setPreviewUrl, FileEvent.CHANGE);
+      onFileUpload?.(e, setPreviewUrl, setShowFileSizeExceedsModal, FileEvent.CHANGE);
       return;
     }
 
@@ -95,7 +96,7 @@ export default function ImagePicker({
       dropContainerRef.current?.classList.toggle(styles.dropContainerActive);
     } else if (e.type === 'drop') {
       if (shouldGetImageUrl) {
-        onFileUpload?.(e, setPreviewUrl, FileEvent.DRAG);
+        onFileUpload?.(e, setPreviewUrl, setShowFileSizeExceedsModal, FileEvent.DRAG);
         return;
       }
 

--- a/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
+++ b/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ChangeEvent, DragEvent } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { enqueueErrorSnackbar } from '../../containers/Snackbar/snackbarSlice';
+import { uploadImage } from '../../containers/ImagePickerWrapper/saga';
+import { FileEvent } from '.';
+
+type GetOnFileUpload = (
+  targetRoute: string,
+  onSelectImage: (imageUrl: string) => void,
+  onLoading?: (loading: boolean) => void,
+) => (
+  e: ChangeEvent<HTMLInputElement> | DragEvent,
+  setPreviewUrl: (url: string) => void,
+  event: FileEvent,
+) => Promise<void>;
+
+/**
+ * Custom hook designed to be used as a helper for the `ImagePicker` component to save the image URL
+ * rather than the file itself. (Created by extracting the logic from `ImagePickerWrapper`.)
+ *
+ * This hook could be simplified by directly taking `targetRoute`, `onSelectImage`, and `onLoading`
+ * as parameters rather than passing these to the returned `getOnFileUpload` function. However, the
+ * current structure allows for more flexibility. (Call the hook in a container and delegate the
+ * detailed implementation in its child component - this keeps components pure and prevent stories
+ * from being broken.)
+ *
+ * @example
+ * const { getOnFileUpload } = useImagePickerUpload();
+ * const onFileUpload = getOnFileUpload('/upload-endpoint', onSelectImage, onLoading);
+ *
+ * <ImagePicker
+ *   label={"label"}
+ *   shouldGetImageUrl={true}
+ *   onFileUpload={onFileUpload}
+ *   onRemoveImage={() => console.log('remove')}
+ * />
+ */
+export default function useImagePickerUpload(): { getOnFileUpload: GetOnFileUpload } {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  const getOnUploadSuccess =
+    (setPreviewUrl: (url: string) => void, onSelectImage: (imageUrl: string) => void) =>
+    (url: string, onLoading?: (loading: boolean) => void) => {
+      setPreviewUrl(url);
+      onSelectImage(url);
+      onLoading?.(false);
+    };
+
+  const getOnUploadFail = (onLoading?: (loading: boolean) => void) => (error: string) => {
+    if (error) console.log(error);
+    onLoading?.(false);
+  };
+
+  const getOnFileUpload: GetOnFileUpload =
+    (targetRoute, onSelectImage, onLoading) => async (e, setPreviewUrl, event) => {
+      onLoading?.(true);
+
+      const blob =
+        event === FileEvent.CHANGE
+          ? (e as ChangeEvent<HTMLInputElement>)?.target?.files?.[0]
+          : (e as DragEvent).dataTransfer?.files?.[0];
+
+      if (blob) {
+        const onUploadFail = getOnUploadFail(onLoading);
+        const onUploadSuccess = getOnUploadSuccess(setPreviewUrl, onSelectImage);
+
+        const isNotImage = !/^image\/.*/.test(blob.type);
+        if (isNotImage) {
+          dispatch(enqueueErrorSnackbar(t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
+          onUploadFail('Not an image file');
+        } else if (blob.size < 200000) {
+          dispatch(
+            // @ts-ignore
+            uploadImage({
+              file: blob,
+              onUploadSuccess,
+              onUploadFail,
+              targetRoute,
+            }),
+          );
+        } else {
+          const Compressor = await import('compressorjs').then((Compressor) => Compressor.default);
+          new Compressor(blob, {
+            quality: blob.size > 1000000 ? 0.6 : 0.8,
+            convertSize: 200000,
+            success(compressedBlob) {
+              dispatch(
+                // @ts-ignore
+                uploadImage({
+                  file: compressedBlob,
+                  onUploadSuccess,
+                  onUploadFail,
+                  targetRoute,
+                }),
+              );
+            },
+            error(err) {
+              onUploadFail(err.message);
+            },
+          });
+        }
+      } else {
+        // E.g. file picker is cancelled so no files are present
+        onLoading?.(false);
+      }
+    };
+
+  return { getOnFileUpload };
+}

--- a/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
+++ b/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
@@ -30,11 +30,9 @@ export type GetOnFileUpload = (
  * Custom hook designed to be used as a helper for the `ImagePicker` component to save the image URL
  * rather than the file itself. (Created by extracting the logic from `ImagePickerWrapper`.)
  *
- * This hook could be simplified by directly taking `targetRoute`, `onSelectImage`, and `onLoading`
- * as parameters rather than passing these to the returned `getOnFileUpload` function. However, the
- * current structure allows for more flexibility. (Call the hook in a container and delegate the
- * detailed implementation in its child component - this keeps components pure and prevent stories
- * from being broken.)
+ * While the hook could be simplified by directly taking `targetRoute`, `onSelectImage`, and `onLoading`
+ * as parameters, the current structure provides greater flexibility. It allows parent containers to call
+ * the hook and delegate the specifics of these parameters to child components.
  *
  * @example
  * const { getOnFileUpload } = useImagePickerUpload();
@@ -66,13 +64,13 @@ export default function useImagePickerUpload(): { getOnFileUpload: GetOnFileUplo
 
   const getOnFileUpload: GetOnFileUpload =
     (targetRoute, onSelectImage, onLoading) =>
-    async (e, setPreviewUrl, setFileSizeExceeded, event) => {
+    async (event, setPreviewUrl, setFileSizeExceeded, eventType) => {
       onLoading?.(true);
 
       const blob =
-        event === FileEvent.CHANGE
-          ? (e as ChangeEvent<HTMLInputElement>)?.target?.files?.[0]
-          : (e as DragEvent).dataTransfer?.files?.[0];
+        eventType === FileEvent.CHANGE
+          ? (event as ChangeEvent<HTMLInputElement>)?.target?.files?.[0]
+          : (event as DragEvent).dataTransfer?.files?.[0];
 
       if (blob) {
         const onUploadFail = getOnUploadFail(onLoading);

--- a/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
+++ b/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
@@ -18,17 +18,13 @@ import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { enqueueErrorSnackbar } from '../../containers/Snackbar/snackbarSlice';
 import { uploadImage } from '../../containers/ImagePickerWrapper/saga';
-import { FileEvent } from '.';
+import { FileEvent, OnFileUpload } from '.';
 
-type GetOnFileUpload = (
+export type GetOnFileUpload = (
   targetRoute: string,
   onSelectImage: (imageUrl: string) => void,
   onLoading?: (loading: boolean) => void,
-) => (
-  e: ChangeEvent<HTMLInputElement> | DragEvent,
-  setPreviewUrl: (url: string) => void,
-  event: FileEvent,
-) => Promise<void>;
+) => OnFileUpload;
 
 /**
  * Custom hook designed to be used as a helper for the `ImagePicker` component to save the image URL

--- a/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
+++ b/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
@@ -40,7 +40,6 @@ export type GetOnFileUpload = (
  *
  * <ImagePicker
  *   label={"label"}
- *   shouldGetImageUrl={true}
  *   onFileUpload={onFileUpload}
  *   onRemoveImage={() => console.log('remove')}
  * />

--- a/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/index.tsx
+++ b/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/index.tsx
@@ -31,6 +31,7 @@ import { AnimalOrBatchKeys } from '../../types';
 import { parseUniqueDefaultId } from '../../../../util/animal';
 import { getDefaultAnimalIconName } from '../../Inventory/useAnimalInventory';
 import usePopulateDetails from './usePopulateDetails';
+import useImagePickerUpload from '../../../../components/ImagePicker/useImagePickerUpload';
 
 type AnimalDetailsField = FieldArrayWithId<AddAnimalsFormFields, 'details'>;
 
@@ -43,6 +44,8 @@ const AddAnimalDetails = () => {
     name: STEPS.DETAILS,
     control,
   });
+
+  const { getOnFileUpload } = useImagePickerUpload();
 
   const onRemoveCard = (index: number): void => {
     remove(index);
@@ -119,7 +122,11 @@ const AddAnimalDetails = () => {
         sexDetailsOptions,
         useOptions: useOptionsForType.uses,
       },
-      otherDetailsProps: { organicStatusOptions },
+      otherDetailsProps: {
+        organicStatusOptions,
+        getOnFileUpload,
+        imageUploadTargetRoute: isAnimal ? 'animal' : 'animalBatch',
+      },
       originProps: {
         currency: currency,
         originOptions,

--- a/packages/webapp/src/containers/ImagePickerWrapper/saga.js
+++ b/packages/webapp/src/containers/ImagePickerWrapper/saga.js
@@ -6,10 +6,12 @@ import { axios, getHeader } from '../saga';
 import i18n from '../../locales/i18n';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
 
-const { cropVarietyURL, cropURL } = apiConfig;
+const { cropVarietyURL, cropURL, animalBatchesUrl, animalsUrl } = apiConfig;
 const imageRouteURL = {
   crop_variety: cropVarietyURL,
   crop: cropURL,
+  animal: animalsUrl,
+  animalBatch: animalBatchesUrl,
   //deprecated
   'storybook/': cropVarietyURL,
 };

--- a/packages/webapp/src/stories/Animals/Details/AnimalDetails.stories.tsx
+++ b/packages/webapp/src/stories/Animals/Details/AnimalDetails.stories.tsx
@@ -29,6 +29,7 @@ import {
   organicStatusOptions,
   originOptions,
   defaultValues,
+  getOnFileUpload,
 } from './mockData';
 
 // https://storybook.js.org/docs/writing-stories/typescript
@@ -61,6 +62,8 @@ export const Default: Story = {
               }}
               otherDetailsProps={{
                 organicStatusOptions,
+                getOnFileUpload,
+                imageUploadTargetRoute: 'test',
               }}
               originProps={{
                 currency: '$',

--- a/packages/webapp/src/stories/Animals/Details/BatchDetails.stories.tsx
+++ b/packages/webapp/src/stories/Animals/Details/BatchDetails.stories.tsx
@@ -28,6 +28,7 @@ import {
   organicStatusOptions,
   originOptions,
   defaultValues,
+  getOnFileUpload,
 } from './mockData';
 
 // https://storybook.js.org/docs/writing-stories/typescript
@@ -57,6 +58,8 @@ export const Default: Story = {
               }}
               otherDetailsProps={{
                 organicStatusOptions,
+                getOnFileUpload,
+                imageUploadTargetRoute: 'test',
               }}
               originProps={{
                 currency: '$',

--- a/packages/webapp/src/stories/Animals/Details/Other.stories.tsx
+++ b/packages/webapp/src/stories/Animals/Details/Other.stories.tsx
@@ -20,7 +20,7 @@ import { componentDecorators } from '../../Pages/config/Decorators';
 import Other, { OtherDetailsProps } from '../../../components/Animals/DetailCards/Other';
 import { AnimalOrBatchKeys } from '../../../containers/Animals/types';
 import { FormMethods } from '../../../containers/Animals/AddAnimals/types';
-import { organicStatusOptions } from './mockData';
+import { organicStatusOptions, getOnFileUpload } from './mockData';
 
 // https://storybook.js.org/docs/writing-stories/typescript
 const meta: Meta<OtherDetailsProps> = {
@@ -50,6 +50,7 @@ export const Animal: Story = {
   args: {
     organicStatusOptions,
     animalOrBatch: AnimalOrBatchKeys.ANIMAL,
+    getOnFileUpload,
   },
   render: (args, context) => <Other {...args} {...context} />,
 };
@@ -58,6 +59,7 @@ export const Batch: Story = {
   args: {
     organicStatusOptions,
     animalOrBatch: AnimalOrBatchKeys.BATCH,
+    getOnFileUpload,
   },
   render: (args, context) => <Other {...args} {...context} />,
 };

--- a/packages/webapp/src/stories/Animals/Details/mockData.ts
+++ b/packages/webapp/src/stories/Animals/Details/mockData.ts
@@ -13,10 +13,13 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { ChangeEvent, DragEvent } from 'react';
 import {
   DetailsFields,
   AnimalDetailsFormFields,
 } from '../../../containers/Animals/AddAnimals/types';
+import { FileEvent } from '../../../components/ImagePicker';
+import { GetOnFileUpload } from '../../../components/ImagePicker/useImagePickerUpload';
 
 export const sexOptions = [
   { value: 0, label: `I don't know` },
@@ -65,3 +68,18 @@ export const defaultValues: Partial<AnimalDetailsFormFields> = {
   [DetailsFields.TYPE]: { value: 'default_1', label: 'Cattle' },
   [DetailsFields.BREED]: { value: 'default_2', label: 'Angus' },
 };
+
+export const getOnFileUpload: GetOnFileUpload =
+  (targetRoute, onSelectImage) => async (e, setPreviewUrl, event) => {
+    const file =
+      event === FileEvent.CHANGE
+        ? (e as ChangeEvent<HTMLInputElement>)?.target?.files?.[0]
+        : (e as DragEvent).dataTransfer?.files?.[0];
+
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setPreviewUrl(url);
+      onSelectImage(url);
+      console.log(targetRoute);
+    }
+  };

--- a/packages/webapp/src/stories/Animals/Details/mockData.ts
+++ b/packages/webapp/src/stories/Animals/Details/mockData.ts
@@ -70,13 +70,18 @@ export const defaultValues: Partial<AnimalDetailsFormFields> = {
 };
 
 export const getOnFileUpload: GetOnFileUpload =
-  (targetRoute, onSelectImage) => async (e, setPreviewUrl, event) => {
+  (targetRoute, onSelectImage) => async (e, setPreviewUrl, setFileSizeExceeded, event) => {
     const file =
       event === FileEvent.CHANGE
         ? (e as ChangeEvent<HTMLInputElement>)?.target?.files?.[0]
         : (e as DragEvent).dataTransfer?.files?.[0];
 
     if (file) {
+      if (file.size > 5e6) {
+        setFileSizeExceeded(true);
+        return;
+      }
+
       const url = URL.createObjectURL(file);
       setPreviewUrl(url);
       onSelectImage(url);


### PR DESCRIPTION
**Description**

The current `ImagePicker` is designed to save the file itself rather than the image URL. This PR introduces a hook and updates the `ImagePicker` to support saving the image URL instead.

- Create `useImagePickerUpload` hook, with logic extracted from `ImagePickerWrapper`. (Instead of compressing the file when the file size exceeds, `FileSizeExceedModal` is displayed as Navdeep implemented it)
- Update `ImagePicker` to use the function returned from the `useImagePickerUpload` hook.
- Add animals URLs to imageRouteURL for `uploadImageSaga`.
- Integrate `useImagePickerUpload` hook in `AnimalDetails`.
- Update stories
  - [animals](http://localhost:6006/?path=/docs/components-addanimalsdetails--docs)
  - [batches](http://localhost:6006/?path=/docs/components-addbatchdetails--docs)

Jira link: N/A

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
