### PR TITLE
LF-4164 Import from and install types for lodash-es instead of lodash

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -92,7 +92,7 @@
     "@storybook/test": "^8.2.8",
     "@storybook/test-runner": "^0.19.1",
     "@types/d3": "^7.4.0",
-    "@types/lodash": "^4.17.7",
+    "@types/lodash-es": "^4.17.12",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -231,9 +231,9 @@ devDependencies:
   '@types/d3':
     specifier: ^7.4.0
     version: 7.4.0
-  '@types/lodash':
-    specifier: ^4.17.7
-    version: 4.17.7
+  '@types/lodash-es':
+    specifier: ^4.17.12
+    version: 4.17.12
   '@types/prop-types':
     specifier: ^15.7.5
     version: 15.7.5
@@ -5027,6 +5027,12 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.3.2
+    dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.17.7
     dev: true
 
   /@types/lodash@4.17.7:

--- a/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/usePopulateDetails.ts
+++ b/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/usePopulateDetails.ts
@@ -14,7 +14,7 @@
  */
 import { UseFieldArrayReplace, useFormContext } from 'react-hook-form';
 import { useEffect } from 'react';
-import { groupBy } from 'lodash';
+import groupBy from 'lodash-es/groupBy';
 import { STEPS } from '..';
 import {
   AddAnimalsFormFields,


### PR DESCRIPTION
**Description**

[Deploy](https://github.com/LiteFarmOrg/LiteFarm/actions/runs/10565072484) and [Cypress](https://github.com/LiteFarmOrg/LiteFarm/actions/runs/10565068112) failed on `pnpm install` due to the import of `groupBy` from lodash. Why does build not fail here but not locally? I don't know!

But the other `groupBy` was imported from `lodash-es` (es for ES modules, not for Spanish) so I'll try the same here.

Also uninstalled the lodash types and installed lodash-es types, so that the type error might, in the future, be a reminder to use lodash-es 🤷 

Jira link: https://lite-farm.atlassian.net/browse/LF-4164

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
