### PR TITLE
LF-4272 trim sign-up name whitespace

### DIFF
--- a/packages/api/src/models/userModel.js
+++ b/packages/api/src/models/userModel.js
@@ -37,6 +37,8 @@ class User extends Model {
   async $beforeInsert(context) {
     await super.$beforeInsert(context);
     this.email && (this.email = this.email.toLowerCase());
+    this.first_name && (this.first_name = this.first_name.trim());
+    this.last_name && (this.last_name = this.last_name.trim());
   }
 
   static async beforeFind(args) {

--- a/packages/webapp/src/components/CreateUserAccount/index.jsx
+++ b/packages/webapp/src/components/CreateUserAccount/index.jsx
@@ -105,6 +105,9 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNot
         label={t('CREATE_USER.FULL_NAME')}
         placeholder={'e.g. Juan Perez'}
         hookFormRegister={register(NAME, { required: true })}
+        onBlur={(e) => {
+          e.target.value = e.target.value.trimStart();
+        }}
       />
       <Controller
         control={control}

--- a/packages/webapp/src/components/CreateUserAccount/index.jsx
+++ b/packages/webapp/src/components/CreateUserAccount/index.jsx
@@ -106,7 +106,7 @@ export default function PureCreateUserAccount({ onSignUp, email, onGoBack, isNot
         placeholder={'e.g. Juan Perez'}
         hookFormRegister={register(NAME, { required: true })}
         onBlur={(e) => {
-          e.target.value = e.target.value.trimStart();
+          e.target.value = e.target.value.trim();
         }}
       />
       <Controller

--- a/packages/webapp/src/components/InviteUser/index.jsx
+++ b/packages/webapp/src/components/InviteUser/index.jsx
@@ -79,6 +79,9 @@ export default function PureInviteUser({ onInvite, onGoBack, userFarmEmails, rol
         label={t('INVITE_USER.FULL_NAME')}
         hookFormRegister={register(NAME, { required: true, validate: isValidName })}
         errors={getInputErrors(errors, NAME)}
+        onBlur={(e) => {
+          e.target.value = e.target.value.trim();
+        }}
       />
       <Controller
         data-cy="invite-roleSelect"


### PR DESCRIPTION
**Description**

Previously, when the user tries to create an account with leading spaces in the name field it would cause an error on creation. The issue has been fixed by trimming any leading spaces in the field on blur. 

[Jira link](https://lite-farm.atlassian.net/browse/LF-4272)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**


- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
