### PR TITLE
LF-4405: floating menu button looks different from what is designed

### DIFF
--- a/packages/webapp/src/assets/colors.scss
+++ b/packages/webapp/src/assets/colors.scss
@@ -14,6 +14,7 @@
   --secondaryGreen800: #495c51;
   --secondaryGreen200: #c1e6d2;
   --secondaryGreen50: #f2faf5;
+  --yellow900: #6b4d00;
   --yellow700: #ffb800;
   --yellow400: #fed450;
   --yellow300: #fce38d;

--- a/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
+++ b/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
@@ -17,11 +17,11 @@
   position: relative;
 
   &[aria-expanded='true'] {
-    background-color: #e3b000;
+    background-color: var(--Btn-primary-hover);
   }
   @media (hover: hover) {
     &:hover {
-      background-color: #e3b000;
+      background-color: var(--Btn-primary-hover);
     }
   }
 

--- a/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
+++ b/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
@@ -16,13 +16,13 @@
 .floatingActionButton {
   position: relative;
 
-  &[aria-expanded='true'] {
-    background-color: var(--Btn-primary-hover);
-  }
   @media (hover: hover) {
     &:hover {
       background-color: var(--Btn-primary-hover);
     }
+  }
+  &[aria-expanded='true'] {
+    background-color: var(--yellow700);
   }
 
   &.add {
@@ -30,7 +30,7 @@
     &::after {
       content: '';
       position: absolute;
-      background-color: #634d00;
+      background-color: var(--yellow900);
       transition: 0.5s;
     }
 
@@ -48,18 +48,19 @@
       height: 4px;
     }
 
-    &[aria-expanded='true'] {
-      &::before,
-      &::after {
-        background-color: #fff;
-      }
-    }
     @media (hover: hover) {
       &:hover {
         &::before,
         &::after {
           background-color: #fff;
         }
+      }
+    }
+
+    &[aria-expanded='true'] {
+      &::before,
+      &::after {
+        background-color: var(--yellow900);
       }
     }
   }

--- a/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
+++ b/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
@@ -58,6 +58,8 @@
     }
 
     &[aria-expanded='true'] {
+      box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.25);
+
       &::before,
       &::after {
         background-color: var(--yellow900);

--- a/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
+++ b/packages/webapp/src/components/Button/FloatingActionButton/styles.module.scss
@@ -16,20 +16,21 @@
 .floatingActionButton {
   position: relative;
 
-  &[aria-expanded="true"] {
-    background-color: #E3B000;
+  &[aria-expanded='true'] {
+    background-color: #e3b000;
   }
   @media (hover: hover) {
     &:hover {
-      background-color: #E3B000;
+      background-color: #e3b000;
     }
   }
 
   &.add {
-    &::before, &::after {
-      content: "";
+    &::before,
+    &::after {
+      content: '';
       position: absolute;
-      background-color: #634D00;
+      background-color: #634d00;
       transition: 0.5s;
     }
 
@@ -47,14 +48,16 @@
       height: 4px;
     }
 
-    &[aria-expanded="true"] {
-      &::before, &::after {
+    &[aria-expanded='true'] {
+      &::before,
+      &::after {
         background-color: #fff;
       }
     }
     @media (hover: hover) {
       &:hover {
-        &::before, &::after {
+        &::before,
+        &::after {
           background-color: #fff;
         }
       }

--- a/packages/webapp/src/components/Menu/FloatingButtonMenu/index.jsx
+++ b/packages/webapp/src/components/Menu/FloatingButtonMenu/index.jsx
@@ -72,9 +72,8 @@ export default function FloatingButtonMenu({
   };
 
   return (
-    <div className={clsx(styles.buttonWrapper, classes.button)}>
+    <div ref={anchorRef} className={clsx(styles.buttonWrapper, classes.button)}>
       <FloatingActionButton
-        ref={anchorRef}
         id="composition-button"
         aria-controls={open ? 'composition-menu' : undefined}
         aria-expanded={open ? 'true' : undefined}

--- a/packages/webapp/src/components/Menu/FloatingButtonMenu/styles.module.scss
+++ b/packages/webapp/src/components/Menu/FloatingButtonMenu/styles.module.scss
@@ -20,17 +20,18 @@
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 8px;
   margin-bottom: 4px;
 }
 
 .menuItem {
   height: 48px;
   padding: 8px 16px;
-  color: #996E00;
+  border-radius: 8px;
+  color: #996e00;
   background-color: var(--yellow100);
   font-size: 16px;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 24px;
   text-align: center;
 


### PR DESCRIPTION
**Description**

![Screenshot 2024-08-29 at 3 22 24 PM](https://github.com/user-attachments/assets/802c52a2-63d4-485a-ad74-32f18b4a4493)

- Fix the position of the floating menu by adjusting the `anchorRef`.
- Implement the active state of the button as designed.
   - replace hex with `var`.
   - switch CSS for hover style and active style so that hover style won't override the active state CSS. 
   - sorry for the formatting!

![Screenshot 2024-08-30 at 13 28 00](https://github.com/user-attachments/assets/870dcc21-f700-48b2-86eb-ff2d3a7d427a)


Jira link: https://lite-farm.atlassian.net/browse/LF-4405

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
