### PR TITLE
Discussion - Radio Options

### DIFF
--- a/packages/webapp/src/components/Animals/DetailCards/Origin.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Origin.tsx
@@ -41,15 +41,8 @@ const Origin = ({ t, currency, originOptions, namePrefix = '' }: OriginProps) =>
 
   const watchedOrigin = watch(`${namePrefix}${DetailsFields.ORIGIN}`);
 
-  const getOriginEnum = (watchedOrigin: number): AnimalOrigins => {
-    const originOption = originOptions.find((option) => option.value === watchedOrigin);
-    return AnimalOrigins[originOption?.key as keyof typeof AnimalOrigins];
-  };
-
-  const origin = !watchedOrigin ? undefined : getOriginEnum(watchedOrigin);
-
   const fields = useMemo(() => {
-    return origin === AnimalOrigins.BROUGHT_IN ? (
+    return watchedOrigin?.key === AnimalOrigins.BROUGHT_IN ? (
       <>
         {/* @ts-ignore */}
         <Input
@@ -115,7 +108,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '' }: OriginProps) =>
         />
       </>
     );
-  }, [origin, Object.entries(errors)]);
+  }, [watchedOrigin, Object.entries(errors)]);
 
   return (
     <div className={styles.sectionWrapper}>
@@ -135,7 +128,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '' }: OriginProps) =>
           row
         />
       </div>
-      {origin && fields}
+      {watchedOrigin && fields}
     </div>
   );
 };

--- a/packages/webapp/src/components/Form/RadioGroup/index.jsx
+++ b/packages/webapp/src/components/Form/RadioGroup/index.jsx
@@ -92,24 +92,28 @@ export default function RadioGroup({
         </>
       )}
       {!!radios &&
-        radios.map((radioOptions) => (
-          <Radio
-            name={name}
-            key={radioOptions.value}
-            checked={field.value === radioOptions.value}
-            onChange={(e) => {
-              field?.onChange?.(radioOptions.value);
-              onChange?.({ target: { value: radioOptions.value } });
-            }}
-            onBlur={(e) => {
-              field?.onBlur?.(radioOptions.value);
-              onBlur?.({ target: { value: radioOptions.value } });
-            }}
-            value={field.value}
-            {...props}
-            {...radioOptions}
-          />
-        ))}
+        radios.map((radioOptions) => {
+          return (
+            <Radio
+              name={name}
+              key={radioOptions.value?.id || radioOptions.value}
+              checked={
+                field.value?.id === radioOptions.value?.id || field.value === radioOptions.value
+              }
+              onChange={(e) => {
+                field?.onChange?.(radioOptions.value);
+                onChange?.({ target: { value: radioOptions.value } });
+              }}
+              onBlur={(e) => {
+                field?.onBlur?.(radioOptions.value);
+                onBlur?.({ target: { value: radioOptions.value } });
+              }}
+              value={field.value}
+              {...props}
+              {...radioOptions}
+            />
+          );
+        })}
     </div>
   );
 }
@@ -130,7 +134,12 @@ RadioGroup.propTypes = {
       label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
       pill: PropTypes.string,
       defaultChecked: PropTypes.bool,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.number]),
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.number,
+        PropTypes.object,
+      ]),
     }),
   ),
 };

--- a/packages/webapp/src/containers/Animals/AddAnimals/index.tsx
+++ b/packages/webapp/src/containers/Animals/AddAnimals/index.tsx
@@ -51,24 +51,21 @@ function AddAnimals({ isCompactSideMenu, history }: AddAnimalsProps) {
   const [addAnimals] = useAddAnimalsMutation();
   const [addAnimalBatches] = useAddAnimalBatchesMutation();
 
-  const { data: orgins = [] } = useGetAnimalOriginsQuery();
-
   const onSave = async (
     data: any,
     onGoForward: () => void,
     setFormResultData: (data: any) => void,
   ) => {
     const details = data[STEPS.DETAILS] as AnimalDetailsFormFields[];
-    const broughtInId = orgins.find((origin) => origin.key === 'BROUGHT_IN')?.id;
 
     const formattedAnimals: Partial<Animal>[] = [];
     const formattedBatches: Partial<AnimalBatch>[] = [];
 
     details.forEach((animalOrBatch) => {
       if (animalOrBatch.animal_or_batch === AnimalOrBatchKeys.ANIMAL) {
-        formattedAnimals.push(formatAnimalDetailsToDBStructure(animalOrBatch, broughtInId));
+        formattedAnimals.push(formatAnimalDetailsToDBStructure(animalOrBatch));
       } else {
-        formattedBatches.push(formatBatchDetailsToDBStructure(animalOrBatch, broughtInId));
+        formattedBatches.push(formatBatchDetailsToDBStructure(animalOrBatch));
       }
     });
 

--- a/packages/webapp/src/containers/Animals/AddAnimals/types.ts
+++ b/packages/webapp/src/containers/Animals/AddAnimals/types.ts
@@ -78,7 +78,12 @@ export enum DetailsFields {
   PRICE = 'price',
 }
 
-export type ReactSelectOption<T extends string | number> = {
+export interface OriginValue {
+  id: number;
+  key: string;
+}
+
+export type ReactSelectOption<T extends string | number | OriginValue> = {
   label: string;
   value: T;
   key?: string;
@@ -92,7 +97,7 @@ export type Option = {
   [DetailsFields.TAG_TYPE]: ReactSelectOption<number>;
   [DetailsFields.ORGANIC_STATUS]: ReactSelectOption<OrganicStatus>;
   [DetailsFields.SEX]: ReactSelectOption<number>;
-  [DetailsFields.ORIGIN]: ReactSelectOption<number>;
+  [DetailsFields.ORIGIN]: ReactSelectOption<OriginValue>;
 };
 
 export type AnimalDetailsFormFields = {
@@ -116,7 +121,7 @@ export type AnimalDetailsFormFields = {
   [DetailsFields.ORGANIC_STATUS]?: Option[DetailsFields.ORGANIC_STATUS];
   [DetailsFields.OTHER_DETAILS]?: string;
   [DetailsFields.ANIMAL_IMAGE]?: any;
-  [DetailsFields.ORIGIN]?: number;
+  [DetailsFields.ORIGIN]?: OriginValue;
   [DetailsFields.DAM]?: string;
   [DetailsFields.SIRE]?: string;
   [DetailsFields.BROUGHT_IN_DATE]?: string;

--- a/packages/webapp/src/containers/Animals/AddAnimals/useAnimalOptions.ts
+++ b/packages/webapp/src/containers/Animals/AddAnimals/useAnimalOptions.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../store/api/apiSlice';
 import { useTranslation } from 'react-i18next';
 import { generateUniqueAnimalId } from '../../../util/animal';
-import { ANIMAL_ID_PREFIX } from '../types';
+import { ANIMAL_ID_PREFIX, AnimalOrigins } from '../types';
 
 type OptionType =
   | 'default_types'
@@ -149,9 +149,8 @@ export const useAnimalOptions = (...optionTypes: OptionType[]) => {
 
   if (optionTypes.includes('origin')) {
     options.originOptions = orgins.map(({ id, key }) => ({
-      value: id,
+      value: { id, key: AnimalOrigins[key] },
       label: t(`animal:ORIGIN.${key}`),
-      key: key,
     }));
   }
 

--- a/packages/webapp/src/containers/Animals/AddAnimals/utils.ts
+++ b/packages/webapp/src/containers/Animals/AddAnimals/utils.ts
@@ -30,6 +30,7 @@ import {
   BatchSummary,
 } from '../../../components/Animals/AddAnimalsSummaryCard/types';
 import { chooseAnimalBreedLabel, chooseAnimalTypeLabel } from '../Inventory/useAnimalInventory';
+import { AnimalOrigins } from '../types';
 
 const formatFormTypeOrBreed = (
   typeOrBreed: 'type' | 'breed',
@@ -89,19 +90,16 @@ const convertFormDate = (date?: string): string | undefined => {
   return toLocalISOString(date);
 };
 
-const formatOrigin = (
-  data: AnimalDetailsFormFields,
-  broughtInId?: number,
-): Partial<Animal | AnimalBatch> => {
-  if (!broughtInId && !data[DetailsFields.ORIGIN]) {
+const formatOrigin = (data: AnimalDetailsFormFields): Partial<Animal | AnimalBatch> => {
+  if (!data[DetailsFields.ORIGIN]) {
     return { birth_date: convertFormDate(data[DetailsFields.DATE_OF_BIRTH]) };
   }
 
-  const isBroughtIn = broughtInId === data[DetailsFields.ORIGIN];
+  const isBroughtIn = data[DetailsFields.ORIGIN]?.key === AnimalOrigins.BROUGHT_IN;
 
   return {
     birth_date: convertFormDate(data[DetailsFields.DATE_OF_BIRTH]),
-    origin_id: data[DetailsFields.ORIGIN],
+    origin_id: data[DetailsFields.ORIGIN]?.id,
     ...(isBroughtIn
       ? {
           brought_in_date: convertFormDate(data[DetailsFields.BROUGHT_IN_DATE]),
@@ -118,7 +116,6 @@ const formatOrigin = (
 const formatCommonDetails = (
   isAnimal: boolean,
   data: AnimalDetailsFormFields,
-  broughtInId?: number,
 ): Partial<Animal | AnimalBatch> => {
   return {
     // General
@@ -133,7 +130,7 @@ const formatCommonDetails = (
     photo_url: data[DetailsFields.ANIMAL_IMAGE],
 
     // Origin
-    ...formatOrigin(data, broughtInId),
+    ...formatOrigin(data),
 
     // Unique (animal) | General (batch)
     name: data[DetailsFields.NAME],
@@ -142,10 +139,9 @@ const formatCommonDetails = (
 
 export const formatAnimalDetailsToDBStructure = (
   data: AnimalDetailsFormFields,
-  broughtInId?: number,
 ): Partial<Animal> => {
   return {
-    ...formatCommonDetails(true, data, broughtInId),
+    ...formatCommonDetails(true, data),
 
     // Other
     weaning_date: convertFormDate(data[DetailsFields.WEANING_DATE]),
@@ -160,9 +156,8 @@ export const formatAnimalDetailsToDBStructure = (
 
 export const formatBatchDetailsToDBStructure = (
   data: AnimalDetailsFormFields,
-  broughtInId?: number,
 ): Partial<AnimalBatch> => {
-  return formatCommonDetails(false, data, broughtInId);
+  return formatCommonDetails(false, data);
 };
 
 export const getSexMap = (

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -130,7 +130,7 @@ export interface AnimalIdentifierColor {
 
 export interface AnimalOrigin {
   id: number;
-  key: string;
+  key: 'BROUGHT_IN' | 'BORN_AT_FARM';
 }
 
 export interface AnimalUse {

--- a/packages/webapp/src/stories/Animals/Details/mockData.ts
+++ b/packages/webapp/src/stories/Animals/Details/mockData.ts
@@ -62,8 +62,8 @@ export const organicStatusOptions: ReactSelectOption<OrganicStatus>[] = [
 ];
 
 export const originOptions = [
-  { value: 1, label: 'Brought in', key: 'BROUGHT_IN' },
-  { value: 2, label: 'Born at the farm', key: 'BORN_AT_FARM' },
+  { value: { id: 1, key: 'BROUGHT_IN' }, label: 'Brought in' },
+  { value: { id: 2, key: 'BORN_AT_FARM' }, label: 'Born at the farm' },
 ];
 
 export const defaultValues: Partial<AnimalDetailsFormFields> = {


### PR DESCRIPTION
**Description**

Not for merging, just for discussion, based on the [conversation](https://github.com/LiteFarmOrg/LiteFarm/pull/3397#pullrequestreview-2273420748) in #3397

NOT URGENT, just documenting before I forget.

### Background
A RadioGroup option (unlike a React Select option) is set up to only store a single primitive value (string/number) in React Hook Form. We have a RadioGroup option in the Add Animals (and later Readonly/Edit animals) which stores an Origin id (numeric key) from the AnimalOrigins enum table. But when we want to perform logic on AnimalOrigins (e.g. showing/hiding fields in the component or cleaning up submission data), we need the KEY, which has to be either 1) stored and passed down in some way in data otherwise available to the component and then re-matched to the numeric id (this was done in the component), or 2) re-fetched from the API (which luckily is not a network request though, as it should be cached) and then passed down to where the logic is needed.

To me, it read kind of messily in both places, so the idea was to discuss some alternatives and/or check if this was indeed the way it has to be done.

### Options
1. (Currently pushed to this branch) My first question was how "wrong" is it to make radio values optionally an object with `{ id, key }` and update Radios to accept these values alongside primitives. Personally, I kind of like how this idea reads more than any of the others. We can continue to use the AnimalOrigins enum and the logic is trivial
2. Similarly, a pattern closer to the React Select could be implemented, using a Controller to wrap RadioGroup (see Sayaka's screenshot [here](https://github.com/LiteFarmOrg/LiteFarm/pull/3397#issuecomment-2322343274)). Potentially the update to Radios/RadioGroup would be more substantial. I like this idea but I don't know if we have the bandwidth to implement.
3. More or less equivalently to (1), the key could be stored by using a compound key which is still a primitive value, e.g. `1:BROUGHT_IN` and parsed with split:
```ts
const [originId, originKey] = data[DetailsFields.ORIGIN].split(':')`
```
but Sayaka mentioned not liking compound string keys and I also don't find that split very beautiful so I'm happy to discard that idea.

4. `containers/AddAnimals/utils.ts` could be refactored into a hook in order to call the origins useQuery hook directly, see comment [here](https://github.com/LiteFarmOrg/LiteFarm/pull/3397#issuecomment-2322604249) which would save the passing down of `broughtInId` through so many functions. However, this wouldn't work for the component, if we are keeping it pure (as I think we should).
5. (By default) leave as is. Although it's a little unwieldy to have to re-match up the key and the id like this in two places, it's logical. Maybe it's even the best pattern?

So, just wanted to discuss that. No rush though!

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
