### PR TITLE
Lf 4402 translate sensor csv js into new languages

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -23,6 +23,12 @@ jobs:
               source: packages/webapp/src/containers/Consent/locales/en/*.md,
               translation: packages/webapp/src/containers/Consent/locales/%two_letters_code%/%original_file_name%,
             },
+            # Shared translations
+            {
+              name: shared_locales,
+              source: packages/shared/locales/en/*.json,
+              translation: packages/shared/locales/%two_letters_code%/%original_file_name%,
+            },
             # Backend tranlsations - skipping pdf (crop.json is copied jobs scheduler init during build)
             {
               name: api_job_locales,

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -30,6 +30,11 @@ jobs:
               source: packages/webapp/src/containers/Consent/locales/en/*.md,
               translation: packages/webapp/src/containers/Consent/locales/%two_letters_code%/%original_file_name%,
             },
+            # Shared translations
+            {
+              source: packages/shared/locales/en/*.json,
+              translation: packages/shared/locales/%two_letters_code%/%original_file_name%,
+            },
             # Backend tranlsations - skipping pdf (crop.json is copied jobs scheduler init during build)
             {
               source: packages/api/src/jobs/locales/en/*.json,

--- a/packages/api/src/controllers/sensorController.js
+++ b/packages/api/src/controllers/sensorController.js
@@ -40,6 +40,13 @@ import { sensorErrors, parseSensorCsv } from '../../../shared/validation/sensorC
 import syncAsyncResponse from '../util/syncAsyncResponse.js';
 import knex from '../util/knex.js';
 
+const getSensorTranslations = async (language) => {
+  const translations = await import(`../../../shared/locales/${language}/sensorCSV.json`, {
+    assert: { type: 'json' },
+  });
+  return translations.default;
+};
+
 const sensorController = {
   async getSensorReadingTypes(req, res) {
     const { location_id } = req.params;
@@ -103,7 +110,12 @@ const sensorController = {
 
       const [{ language_preference }] = await baseController.getIndividual(UserModel, user_id);
 
-      const { data, errors } = parseSensorCsv(req.file.buffer.toString(), language_preference);
+      const translations = await getSensorTranslations(language_preference);
+      const { data, errors } = parseSensorCsv(
+        req.file.buffer.toString(),
+        language_preference,
+        translations,
+      );
 
       if (errors.length > 0) {
         return await sendResponse(

--- a/packages/shared/locales/en/sensorCSV.json
+++ b/packages/shared/locales/en/sensorCSV.json
@@ -1,0 +1,17 @@
+{
+  "CSV_HEADER_TRANSLATIONS": {
+    "name": "Name",
+    "latitude": "Latitude",
+    "longitude": "Longitude",
+    "reading_types": "Reading_types",
+    "external_id": "External_ID",
+    "depth": "Depth_cm",
+    "brand": "Brand",
+    "model": "Model"
+  },
+  "READING_TYPE_TRANSLATIONS": {
+    "soil_water_content": "soil_water_content",
+    "soil_water_potential": "soil_water_potential",
+    "temperature": "temperature"
+  }
+}

--- a/packages/shared/locales/es/sensorCSV.json
+++ b/packages/shared/locales/es/sensorCSV.json
@@ -1,0 +1,17 @@
+{
+  "CSV_HEADER_TRANSLATIONS": {
+    "name": "Nombre",
+    "latitude": "Latitud",
+    "longitude": "Longitud",
+    "reading_types": "tipos_de_medición",
+    "external_id": "ID_externo",
+    "depth": "Profundidad_cm",
+    "brand": "Marca",
+    "model": "Modelo"
+  },
+  "READING_TYPE_TRANSLATIONS": {
+    "soil_water_content": "contenido_de_agua_en_el_suelo",
+    "soil_water_potential": "potencial_hídrico_del_suelo",
+    "temperature": "temperatura"
+  }
+}

--- a/packages/shared/locales/fr/sensorCSV.json
+++ b/packages/shared/locales/fr/sensorCSV.json
@@ -1,0 +1,17 @@
+{
+  "CSV_HEADER_TRANSLATIONS": {
+    "name": "Nom",
+    "latitude": "Latitude",
+    "longitude": "Longitude",
+    "reading_types": "Type_de_données_relevées",
+    "external_id": "ID_externe",
+    "depth": "Profondeur_cm",
+    "brand": "Marque",
+    "model": "Modèle"
+  },
+  "READING_TYPE_TRANSLATIONS": {
+    "soil_water_content": "teneur_en_eau_du_sol",
+    "soil_water_potential": "potentiel_hydrique_du_sol",
+    "temperature": "température"
+  }
+}

--- a/packages/shared/locales/pt/sensorCSV.json
+++ b/packages/shared/locales/pt/sensorCSV.json
@@ -1,0 +1,17 @@
+{
+  "CSV_HEADER_TRANSLATIONS": {
+    "name": "Nome",
+    "latitude": "Latitude",
+    "longitude": "Longitude",
+    "reading_types": "tipos_de_medição",
+    "external_id": "ID_externo",
+    "depth": "Profundidade_cm",
+    "brand": "Marca",
+    "model": "Modelo"
+  },
+  "READING_TYPE_TRANSLATIONS": {
+    "soil_water_content": "teor_de_água_no_solo",
+    "soil_water_potential": "potencial_de_água_do_solo",
+    "temperature": "temperatura"
+  }
+}

--- a/packages/shared/validation/csv.js
+++ b/packages/shared/validation/csv.js
@@ -23,10 +23,10 @@
  * @param {Array<Validator>} validators
  * @param {Translation} headerTranslations - translations for each CSV header based on validator keys.
  */
-const getHeaderToValidatorMapping = (lang, validators, headerTranslations) => {
+const getHeaderToValidatorMapping = (validators, headerTranslations) => {
   const mapping = {};
   validators.forEach((validator, index) => {
-    mapping[headerTranslations[lang][validator.key]] = index;
+    mapping[headerTranslations[validator.key]] = index;
   });
   return mapping;
 };
@@ -73,7 +73,7 @@ const parseCsv = (
   const headers = rows[0].split(regex).map((h) => h.trim());
   const requiredHeaders = validators
     .filter((v) => v.required)
-    .map((v) => headerTranslations[lang][v.key]);
+    .map((v) => headerTranslations[v.key]);
   const headerErrors = [];
   requiredHeaders.forEach((header) => {
     if (!headers.includes(header)) {
@@ -84,7 +84,7 @@ const parseCsv = (
     return { data: [], errors: headerErrors };
   }
 
-  const allowedHeaders = validators.map((v) => headerTranslations[lang][v.key]);
+  const allowedHeaders = validators.map((v) => headerTranslations[v.key]);
 
   // get all rows except the header and filter out any empty rows
   const dataRows = rows.slice(1).filter((d) => !/^(,? ?\t?)+$/.test(d));
@@ -106,7 +106,7 @@ const parseCsv = (
   // with a particular key defined by getDataKeyFromRow if duplicates are in the file
   const uniqueDataKeys = new Set();
 
-  const headerMapping = getHeaderToValidatorMapping(lang, validators, headerTranslations);
+  const headerMapping = getHeaderToValidatorMapping(validators, headerTranslations);
 
   const { data, errors } = dataRows.reduce(
     (previous, row, rowIndex) => {

--- a/packages/shared/validation/sensorCSV.js
+++ b/packages/shared/validation/sensorCSV.js
@@ -33,151 +33,87 @@ export const sensorErrors = {
   INTERNAL_ERROR: "FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_CLAIM_ERROR.INTERNAL_ERROR",
 };
 
-const sensorCsvHeaderTranslations = {
-  en: {
-    name: "Name",
-    latitude: "Latitude",
-    longitude: "Longitude",
-    reading_types: "Reading_types",
-    external_id: "External_ID",
-    depth: "Depth_cm",
-    brand: "Brand",
-    model: "Model",
-  },
-  es: {
-    name: "Nombre",
-    latitude: "Latitud",
-    longitude: "Longitud",
-    reading_types: "tipos_de_medición",
-    external_id: "ID_externo",
-    depth: "Profundidad_cm",
-    brand: "Marca",
-    model: "Modelo",
-  },
-  fr: {
-    name: "Nom",
-    latitude: "Latitude",
-    longitude: "Longitude",
-    reading_types: "Type_de_données_relevées",
-    external_id: "ID_externe",
-    depth: "Profondeur_cm",
-    brand: "Marque",
-    model: "Modèle",
-  },
-  pt: {
-    name: "Nome",
-    latitude: "Latitude",
-    longitude: "Longitude",
-    reading_types: "tipos_de_medição",
-    external_id: "ID_externo",
-    depth: "Profundidade_cm",
-    brand: "Marca",
-    model: "Modelo",
-  },
-};
-
-const readingTypeTranslations = {
-  en: {
-    soil_water_content: "soil_water_content",
-    soil_water_potential: "soil_water_potential",
-    temperature: "temperature",
-  },
-  es: {
-    soil_water_content: "contenido_de_agua_en_el_suelo",
-    soil_water_potential: "potencial_hídrico_del_suelo",
-    temperature: "temperatura",
-  },
-  fr: {
-    soil_water_content: "teneur_en_eau_du_sol",
-    soil_water_potential: "potentiel_hydrique_du_sol",
-    temperature: "température",
-  },
-  pt: {
-    soil_water_content: "teor_de_água_no_solo",
-    soil_water_potential: "potencial_de_água_do_solo",
-    temperature: "temperatura",
-  },
-};
-
-const sensorCsvValidators = [
-  {
-    key: "name",
-    parse: (val) => val.trim(),
-    validate: (val) => 1 <= val.length && val.length <= 100,
-    required: true,
-    errorTranslationKey: sensorErrors.SENSOR_NAME,
-    useParsedValForError: true,
-  },
-  {
-    key: "external_id",
-    parse: (val) => val.trim(),
-    validate: (val) => val.length <= 40,
-    required: false,
-    errorTranslationKey: sensorErrors.EXTERNAL_ID,
-    useParsedValForError: true,
-  },
-  {
-    key: "latitude",
-    parse: (val) => parseFloat(val),
-    validate: (val) => -85 <= val && val <= 85,
-    required: true,
-    errorTranslationKey: sensorErrors.SENSOR_LATITUDE,
-    useParsedValForError: true,
-  },
-  {
-    key: "longitude",
-    parse: (val) => parseFloat(val),
-    validate: (val) => -180 <= val && val <= 180,
-    required: true,
-    errorTranslationKey: sensorErrors.SENSOR_LONGITUDE,
-    useParsedValForError: true,
-  },
-  {
-    key: "reading_types",
-    parse: (val, lang) => {
-      const rawReadingTypes = val.replaceAll(" ", "").split(",");
-      return getReadableValuesForReadingTypes(lang, rawReadingTypes);
+const sensorCsvValidators = (translations) => {
+  return [
+    {
+      key: "name",
+      parse: (val) => val.trim(),
+      validate: (val) => 1 <= val.length && val.length <= 100,
+      required: true,
+      errorTranslationKey: sensorErrors.SENSOR_NAME,
+      useParsedValForError: true,
     },
-    validate: (val) => {
-      if (!val.length || (val.length === 1 && val[0] === "")) {
-        return false;
-      }
-      const allowedReadingTypes = ["soil_water_potential", "soil_water_content", "temperature"];
-      return val.every((readingType) => allowedReadingTypes.includes(readingType));
+    {
+      key: "external_id",
+      parse: (val) => val.trim(),
+      validate: (val) => val.length <= 40,
+      required: false,
+      errorTranslationKey: sensorErrors.EXTERNAL_ID,
+      useParsedValForError: true,
     },
-    required: true,
-    errorTranslationKey: sensorErrors.SENSOR_READING_TYPES,
-    useParsedValForError: false,
-  },
-  {
-    key: "depth",
-    parse: (val) => parseFloat(val) / 100, // val is in cm, so divide by 100 to get val in m,
-    validate: (val) => 0 <= val && val <= 10,
-    required: false,
-    errorTranslationKey: sensorErrors.SENSOR_DEPTH,
-    useParsedValForError: true,
-  },
-  {
-    key: "brand",
-    parse: (val) => val.trim(),
-    validate: (val) => val.length <= 100,
-    required: false,
-    errorTranslationKey: sensorErrors.SENSOR_BRAND,
-    useParsedValForError: true,
-  },
-  {
-    key: "model",
-    parse: (val) => val.trim(),
-    validate: (val) => val.length <= 100,
-    required: false,
-    errorTranslationKey: sensorErrors.SENSOR_MODEL,
-    useParsedValForError: true,
-  },
-];
+    {
+      key: "latitude",
+      parse: (val) => parseFloat(val),
+      validate: (val) => -85 <= val && val <= 85,
+      required: true,
+      errorTranslationKey: sensorErrors.SENSOR_LATITUDE,
+      useParsedValForError: true,
+    },
+    {
+      key: "longitude",
+      parse: (val) => parseFloat(val),
+      validate: (val) => -180 <= val && val <= 180,
+      required: true,
+      errorTranslationKey: sensorErrors.SENSOR_LONGITUDE,
+      useParsedValForError: true,
+    },
+    {
+      key: "reading_types",
+      parse: (val, lang) => {
+        const rawReadingTypes = val.replaceAll(" ", "").split(",");
+        return getReadableValuesForReadingTypes(lang, rawReadingTypes, translations);
+      },
+      validate: (val) => {
+        if (!val.length || (val.length === 1 && val[0] === "")) {
+          return false;
+        }
+        const allowedReadingTypes = ["soil_water_potential", "soil_water_content", "temperature"];
+        return val.every((readingType) => allowedReadingTypes.includes(readingType));
+      },
+      required: true,
+      errorTranslationKey: sensorErrors.SENSOR_READING_TYPES,
+      useParsedValForError: false,
+    },
+    {
+      key: "depth",
+      parse: (val) => parseFloat(val) / 100, // val is in cm, so divide by 100 to get val in m,
+      validate: (val) => 0 <= val && val <= 10,
+      required: false,
+      errorTranslationKey: sensorErrors.SENSOR_DEPTH,
+      useParsedValForError: true,
+    },
+    {
+      key: "brand",
+      parse: (val) => val.trim(),
+      validate: (val) => val.length <= 100,
+      required: false,
+      errorTranslationKey: sensorErrors.SENSOR_BRAND,
+      useParsedValForError: true,
+    },
+    {
+      key: "model",
+      parse: (val) => val.trim(),
+      validate: (val) => val.length <= 100,
+      required: false,
+      errorTranslationKey: sensorErrors.SENSOR_MODEL,
+      useParsedValForError: true,
+    },
+  ];
+};
 
 // Returns the readable values to save in the database based on the given translated reading types
-const getReadableValuesForReadingTypes = (lang, readingTypes) => {
-  const translationEntries = Object.entries(readingTypeTranslations[lang]);
+const getReadableValuesForReadingTypes = (lang, readingTypes, translations) => {
+  const translationEntries = Object.entries(translations.READING_TYPE_TRANSLATIONS);
   return readingTypes.map((rt) => {
     const entryWithReadableValue = translationEntries.find((e) => e[1] === rt);
     return entryWithReadableValue ? entryWithReadableValue[0] : null;
@@ -192,12 +128,12 @@ const generateSensorKey = (sensor) => {
   }
 };
 
-export const parseSensorCsv = (csvString, lang) => {
+export const parseSensorCsv = (csvString, lang, translations) => {
   return parseCsv(
     csvString,
     lang,
-    sensorCsvValidators,
-    sensorCsvHeaderTranslations,
+    sensorCsvValidators(translations),
+    translations.CSV_HEADER_TRANSLATIONS,
     sensorErrors.MISSING_COLUMNS,
     true,
     generateSensorKey,

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -18,8 +18,17 @@ import { useSelector } from 'react-redux';
 import { bulkSensorsUploadSliceSelector } from '../../../../containers/bulkSensorUploadSlice';
 import { createSensorErrorDownload } from '../../../../util/sensor';
 import { ErrorTypes } from './constants';
-import parseSensorCsv from '../../../../../../shared/validation/sensorCSV.js';
+import parseSensorCsv from '@shared/validation/sensorCSV.js';
 import { getLanguageFromLocalStorage } from '../../../../util/getLanguageFromLocalStorage';
+import { languageCodes } from '../../../../hooks/useLanguageOptions';
+
+const getSensorTranslations = async (language) => {
+  // return english if language not supported
+  if (!languageCodes.includes(language)) {
+    return await import('../../../../../../shared/locales/en/sensorCSV.json');
+  }
+  return await import(`../../../../../../shared/locales/${language}/sensorCSV.json`);
+};
 
 export function useValidateBulkSensorData(onUpload, t) {
   const bulkSensorsUploadResponse = useSelector(bulkSensorsUploadSliceSelector);
@@ -96,7 +105,6 @@ export function useValidateBulkSensorData(onUpload, t) {
   };
 
   useEffect(() => {
-    // console.log(bulkSensorsUploadResponse)
     if (bulkSensorsUploadResponse?.defaultFailure) {
       setErrorCount(1);
       setErrorTypeCode(ErrorTypes.INVALID_CSV);
@@ -121,8 +129,8 @@ export function useValidateBulkSensorData(onUpload, t) {
       setSelectedFile(file);
 
       const fileString = await readFile(file);
-
-      const { data, errors } = parseSensorCsv(fileString, lang);
+      const translations = await getSensorTranslations(lang);
+      const { data, errors } = parseSensorCsv(fileString, lang, translations);
 
       const translatedErrors = translateErrors(errors);
 

--- a/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
+++ b/packages/webapp/src/components/Map/Modals/BulkSensorUploadModal/useValidateBulkSensorData.js
@@ -43,27 +43,6 @@ export function useValidateBulkSensorData(onUpload, t) {
   const [errorTypeCode, setErrorTypeCode] = useState(ErrorTypes.DEFAULT);
   const lang = getLanguageFromLocalStorage();
 
-  // Required Fields
-  const SENSOR_NAME = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.NAME');
-  const SENSOR_LATITUDE = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.LATITUDE');
-  const SENSOR_LONGITUDE = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.LONGITUDE');
-  const SENSOR_READING_TYPES = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.READING_TYPES');
-
-  // Optional Fields
-  const SENSOR_EXTERNAL_ID = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.SENSOR_EXTERNAL_ID');
-  const SENSOR_DEPTH = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.DEPTH');
-  const SENSOR_BRAND = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.BRAND');
-  const SENSOR_MODEL = t('FARM_MAP.BULK_UPLOAD_SENSORS.SENSOR_FIELDS.MODEL');
-
-  const requiredFields = [SENSOR_NAME, SENSOR_LATITUDE, SENSOR_LONGITUDE, SENSOR_READING_TYPES];
-  const templateFields = [
-    ...requiredFields,
-    SENSOR_EXTERNAL_ID,
-    SENSOR_DEPTH,
-    SENSOR_BRAND,
-    SENSOR_MODEL,
-  ];
-
   useEffect(() => {
     if (!disabled) setDisabled(0);
     else setDisabled(bulkSensorsUploadResponse.loading ? -1 : 1);
@@ -163,9 +142,9 @@ export function useValidateBulkSensorData(onUpload, t) {
     }
   };
 
-  const onShowErrorClick = (errorCode) => {
+  const onShowErrorClick = async (errorCode) => {
     if (errorCode === 2) {
-      onTemplateDownloadClick();
+      await onTemplateDownloadClick();
       return;
     }
     if (sheetErrors.length) {
@@ -186,9 +165,10 @@ export function useValidateBulkSensorData(onUpload, t) {
     }
   };
 
-  const onTemplateDownloadClick = () => {
+  const onTemplateDownloadClick = async () => {
     const element = document.createElement('a');
-    const file = new Blob([`${'\ufeff'}${templateFields.join(',')}`], {
+    const { CSV_HEADER_TRANSLATIONS } = await getSensorTranslations(lang);
+    const file = new Blob([`${'\ufeff'}${Object.values(CSV_HEADER_TRANSLATIONS).join(',')}`], {
       type: 'text/plain',
     });
     element.href = URL.createObjectURL(file);

--- a/packages/webapp/src/components/Modals/BulkSensorUploadModal/FileUploader.jsx
+++ b/packages/webapp/src/components/Modals/BulkSensorUploadModal/FileUploader.jsx
@@ -46,12 +46,18 @@ export default function FileUploader({
           <label>
             {uploadErrorMessage}{' '}
             {!errorTypeCode && (
-              <span className={styles.errorMessage} onClick={() => onShowErrorClick(errorTypeCode)}>
+              <span
+                className={styles.errorMessage}
+                onClick={async () => await onShowErrorClick(errorTypeCode)}
+              >
                 {uploadErrorLink}
               </span>
             )}
             {errorTypeCode === 2 && (
-              <span className={styles.errorMessage} onClick={() => onShowErrorClick(errorTypeCode)}>
+              <span
+                className={styles.errorMessage}
+                onClick={async () => await onShowErrorClick(errorTypeCode)}
+              >
                 {invalidFileTypeErrorLink}
               </span>
             )}


### PR DESCRIPTION
**Description**

This adds the sensors translations to a locales directory to be translated in crowdin and resolves the historical BUG of a mismatch between the template csv and the parsed csv.

Notes:
- the main challenge was around the dynamic import, import syntax is different on the frontend from back due to vite + typescript compiler with no such thing on the backend. Therefore this one function was split up between the frontend and backend or else would have also been placed in the shared utility script.

Jira link: [LF-4402](https://lite-farm.atlassian.net/browse/LF-4402)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4402]: https://lite-farm.atlassian.net/browse/LF-4402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ