### PR TITLE
LF-4408 fix language delay string handling

### DIFF
--- a/packages/api/src/templates/emails/export_email/html.pug
+++ b/packages/api/src/templates/emails/export_email/html.pug
@@ -2,11 +2,13 @@ extends ../template
 block content
     p
         span=`${t('EXPORT.SEASON')} `
-        strong #{farm_name}!
+        strong #{farm_name}!HHAHAHHAHH
         span=` ${t('EXPORT.CERTIFICATION')}`
     p
         span=`${t('EXPORT.PRIVACY')}`
     p
-        span=`${t('EXPORT.LANGUAGE_DELAY')}`
+        - var delay = `${t('EXPORT.LANGUAGE_DELAY')}`
+        if delay != 'N/A'
+            span=delay
     a#email-button(href=`${buttonLink}` target='_blank')
         button.button=`${t('EXPORT.GET_YOUR_EXPORT')}`

--- a/packages/api/src/templates/emails/export_email/html.pug
+++ b/packages/api/src/templates/emails/export_email/html.pug
@@ -2,7 +2,7 @@ extends ../template
 block content
     p
         span=`${t('EXPORT.SEASON')} `
-        strong #{farm_name}!HHAHAHHAHH
+        strong #{farm_name}!
         span=` ${t('EXPORT.CERTIFICATION')}`
     p
         span=`${t('EXPORT.PRIVACY')}`

--- a/packages/api/src/templates/locales/en.json
+++ b/packages/api/src/templates/locales/en.json
@@ -92,7 +92,7 @@
     "SUBJECT": "Your certification documents export from LiteFarm",
     "HI": "Hi",
     "GET_YOUR_EXPORT": "Get documents",
-    "LANGUAGE_DELAY": ""
+    "LANGUAGE_DELAY": "N/A"
   },
   "COMMON": {
     "JOIN": "Join",


### PR DESCRIPTION
**Description**

LANGUAGE_DELAY for english locale is empty string, changing this to be 'N/A' and also the pug template to not display the string if in English.

Jira link: https://lite-farm.atlassian.net/browse/LF-4408

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [X] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
