### PR TITLE
LF-4409 disallow decimals in animals sex number input

### DIFF
--- a/packages/webapp/src/components/Form/SexDetails/SexDetailsCountInput/index.tsx
+++ b/packages/webapp/src/components/Form/SexDetails/SexDetailsCountInput/index.tsx
@@ -38,6 +38,7 @@ export default function SexDetailsCountInput({
     max,
     clampOnBlur: false,
     useGrouping: false,
+    allowDecimal: false,
     onChange: (num) => onCountChange?.(isNaN(num) ? 0 : num),
   });
 


### PR DESCRIPTION
**Description**

Previously, when a user tries to specify sex when adding animals, the UI field will accept a decimal input. This was caused by the hook `useNumberInput` which creates the input props and has a default `allowDecimal` value of true. By passing a `allowDecimal` value of false it sets the input `pattern` regex to not permit decimal values. 

Jira link: [LF-4409](https://lite-farm.atlassian.net/browse/LF-4409)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4409]: https://lite-farm.atlassian.net/browse/LF-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ