### PR TITLE
Lf 4367 the view on the mobile device will be broken once the user enters the crop which name contains of more than 7 characters

### DIFF
--- a/packages/webapp/src/components/Crop/styles.module.scss
+++ b/packages/webapp/src/components/Crop/styles.module.scss
@@ -3,6 +3,7 @@
   margin: -24px -24px 0;
   background-color: var(--grey200);
   width: auto;
+  max-width: 100vw;
   height: var(--header-height);
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
**Description**

This PR adds a max width property to the header as max 100vw. Please see video of After and Before below.


https://github.com/user-attachments/assets/465409fc-e98e-4c3b-88ba-7708502e93ed



Other components are not responsive so they get squished at very tiny widths, before it would make horizontal scroll (. 

I don't think this is the root cause, overall I wonder if we need a better "content" component that defines the boundaries of the content according to our new menu breakpoints. There some styling here like negative margins to compensate for Layout and it probably shouldn't be that way. Also I think there might be a way to do the image clipping better that is translated 25% off screen. and is contributing to this specific issue

This PR does not address:
- classic awkward screen sizes on tablet that disrupt the menu placement

Jira link: [LF-4367](https://lite-farm.atlassian.net/browse/LF-4367)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4367]: https://lite-farm.atlassian.net/browse/LF-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ