### PR TITLE
LF-4056b Fix for language selector dropdown

### DIFF
--- a/packages/webapp/src/components/Profile/Account/index.jsx
+++ b/packages/webapp/src/components/Profile/Account/index.jsx
@@ -11,12 +11,11 @@ import useGenderOptions from '../../../hooks/useGenderOptions';
 import useLanguageOptionsMap from '../../../hooks/useLanguageOptions';
 
 const useLanguageOptions = (language_preference) => {
-  const languageOptionMap = useLanguageOptionsMap();
-  const languageOptions = Object.values(languageOptionMap);
+  const languageOptions = useLanguageOptionsMap();
   const languagePreferenceOptionRef = useRef();
   languagePreferenceOptionRef.current =
-    languageOptionMap[language_preference] || language_preference;
-  return { languageOptionMap, languageOptions, languagePreferenceOptionRef };
+    languageOptions.find(({ value }) => value === language_preference) || language_preference;
+  return { languageOptions, languagePreferenceOptionRef };
 };
 
 export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {

--- a/packages/webapp/src/components/Profile/Account/index.jsx
+++ b/packages/webapp/src/components/Profile/Account/index.jsx
@@ -41,14 +41,10 @@ export default function PureAccount({ userFarm, onSubmit, history, isAdmin }) {
     shouldUnregister: true,
   });
   useEffect(() => {
-    // get proper translations for the selected options right after language preference is updated
-    setValue(userFarmEnum.language_preference, null, { shouldValidate: false, shouldDirty: false });
-    setTimeout(() => {
-      setValue(userFarmEnum.language_preference, languagePreferenceOptionRef.current, {
-        shouldValidate: false,
-        shouldDirty: false,
-      });
-    }, 100);
+    setValue(userFarmEnum.language_preference, languagePreferenceOptionRef.current, {
+      shouldValidate: false,
+      shouldDirty: false,
+    });
   }, [userFarm.language_preference]);
   const disabled = !isDirty || !isValid;
   return (

--- a/packages/webapp/src/hooks/useLanguageOptions.ts
+++ b/packages/webapp/src/hooks/useLanguageOptions.ts
@@ -12,7 +12,6 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
-import { useTranslation } from 'react-i18next';
 
 const supportedLanguages = [
   ['en', 'English'],
@@ -26,11 +25,9 @@ const supportedLanguages = [
 ];
 
 const useLanguageOptions = () => {
-  const { t } = useTranslation();
-
   return supportedLanguages.map(([value, text]) => ({
     value,
-    label: t(text),
+    label: text,
   }));
 };
 


### PR DESCRIPTION
**Description**

When I migrated to the new `useLanguageOptions` hook in this PR:
- #3409 

I completely missed that [`components/Profile/Account`](https://github.com/LiteFarmOrg/LiteFarm/pull/3409/files#diff-adc43217d2139fe8fc72c8096103eca677b9a891e0d4782e3bad58cdf024a94a) expected to see the options in a map format, not in the React Select Options array format expected by [`components/InviteUser`](https://github.com/LiteFarmOrg/LiteFarm/pull/3409/files#diff-c131ae3ffab7c7735734d33b70fedf20c1b6eeb7adb947f8f86bb3665d0dca87) and [`components/Profile/EditUser`](https://github.com/LiteFarmOrg/LiteFarm/pull/3409/files#diff-0781e5e695603bdc7fdfbddfe0fa6c13483cce035b1924cbd5bc6801483c24ff).

The hook only returns the array shape, so the code that sets the `languagePreferenceOptionRef` no longer created the correct React Select option shape, and as a result the language became unselected when you saved a new `language_preference`.
 
I also considered updating the hook to return either map or array depending on the calling component (i.e. to accept a parameter like `returnType = 'map' | 'array'`, but I thought it seemed cleaner to update the account code to work with the options array as the other two components do.

Also in this PR:
- There was a 100ms `null`ing of the selected language upon change which flashes the unselected state (you can still see it on app) -- maybe this had a purpose at some point (giving translations time to load or such maybe, according to comment?) but I certainly didn't see such a purpose now so I have deleted it. Therefore no more flash.
- I forgot to delete the `t()` function from the `useLanguageOptions` hook when I updated the language dropdown options in #3416 (at which point they are no longer sent through i18n)

Jira link: https://lite-farm.atlassian.net/browse/LF-4056?focusedCommentId=17638 (linking to comment describing the bug)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
