### PR TITLE
LF-4226 broken clear filters button

### DIFF
--- a/packages/webapp/src/components/Filter/FilterDate/index.jsx
+++ b/packages/webapp/src/components/Filter/FilterDate/index.jsx
@@ -21,9 +21,9 @@ export function FilterDate({ defaultValue, onChange, subject, shouldReset, props
   const [date, setDate] = useState(defaultValue ?? '');
 
   useEffect(() => {
-    if (shouldReset) {
+    if (shouldReset && date) {
       setDate('');
-      onChange('');
+      onChange(undefined);
     }
   }, [shouldReset]);
 

--- a/packages/webapp/src/components/Filter/FilterDateRange/index.jsx
+++ b/packages/webapp/src/components/Filter/FilterDateRange/index.jsx
@@ -39,6 +39,7 @@ export function FilterDateRange({
     if (shouldReset) {
       setFromDate('');
       setToDate('');
+      onChange({ fromDate: undefined, toDate: undefined });
     }
   }, [shouldReset]);
 

--- a/packages/webapp/src/components/Filter/FilterDateRange/index.jsx
+++ b/packages/webapp/src/components/Filter/FilterDateRange/index.jsx
@@ -36,7 +36,7 @@ export function FilterDateRange({
   const [toDate, setToDate] = useState(defaultToDate ?? '');
 
   useEffect(() => {
-    if (shouldReset) {
+    if (shouldReset && (fromDate || toDate)) {
       setFromDate('');
       setToDate('');
       onChange({ fromDate: undefined, toDate: undefined });

--- a/packages/webapp/src/components/Filter/FilterMultiSelectV2/index.tsx
+++ b/packages/webapp/src/components/Filter/FilterMultiSelectV2/index.tsx
@@ -115,7 +115,7 @@ export const FilterMultiSelectV2 = ({
   const hiddenCountRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    if (shouldReset) {
+    if (shouldReset && value.length) {
       handleChange([]);
     }
   }, [shouldReset]);

--- a/packages/webapp/src/components/Filter/FilterMultiSelectV2/index.tsx
+++ b/packages/webapp/src/components/Filter/FilterMultiSelectV2/index.tsx
@@ -116,7 +116,7 @@ export const FilterMultiSelectV2 = ({
 
   useEffect(() => {
     if (shouldReset) {
-      setValue(options.filter((option) => option.default));
+      handleChange([]);
     }
   }, [shouldReset]);
 

--- a/packages/webapp/src/components/FilterPage/index.tsx
+++ b/packages/webapp/src/components/FilterPage/index.tsx
@@ -29,8 +29,7 @@ interface PureFilterPageProps {
   title?: string;
   onApply: () => void /* The handler for Redux state update in this flow, e.g.
     () => dispatch(setCropCatalogueFilter(tempFilter)) */;
-  tempFilter: ReduxFilterEntity;
-  setTempFilter: (filter: ReduxFilterEntity) => void;
+  setTempFilter: (filter: (prevFilter: ReduxFilterEntity) => ReduxFilterEntity) => void;
   onGoBack?: () => void;
   children?: React.ReactNode;
 }
@@ -39,7 +38,6 @@ const PureFilterPage = ({
   title,
   filters,
   onApply,
-  tempFilter,
   setTempFilter,
   onGoBack,
   children,
@@ -74,17 +72,19 @@ const PureFilterPage = ({
       <FilterGroup
         filters={filters}
         onChange={(filterKey, filterState) => {
+          console.log(filterKey, 'filterKey');
+          console.log(filterState, 'filterState');
           if (filterKey === 'DATE_RANGE') {
-            setTempFilter({
-              ...tempFilter,
+            setTempFilter((prevTempFilter) => ({
+              ...prevTempFilter,
               ...(filterState.fromDate && { FROM_DATE: filterState.fromDate }),
               ...(filterState.toDate && { TO_DATE: filterState.toDate }),
-            });
+            }));
           } else {
-            setTempFilter({
-              ...tempFilter,
+            setTempFilter((prevTempFilter) => ({
+              ...prevTempFilter,
               [filterKey]: filterState,
-            });
+            }));
           }
           setDirty();
         }}

--- a/packages/webapp/src/components/FilterPage/index.tsx
+++ b/packages/webapp/src/components/FilterPage/index.tsx
@@ -75,8 +75,8 @@ const PureFilterPage = ({
           if (filterKey === 'DATE_RANGE') {
             setTempFilter((prevTempFilter) => ({
               ...prevTempFilter,
-              ...(filterState.fromDate && { FROM_DATE: filterState.fromDate }),
-              ...(filterState.toDate && { TO_DATE: filterState.toDate }),
+              ...{ FROM_DATE: filterState.fromDate },
+              ...{ TO_DATE: filterState.toDate },
             }));
           } else {
             setTempFilter((prevTempFilter) => ({

--- a/packages/webapp/src/components/FilterPage/index.tsx
+++ b/packages/webapp/src/components/FilterPage/index.tsx
@@ -72,8 +72,6 @@ const PureFilterPage = ({
       <FilterGroup
         filters={filters}
         onChange={(filterKey, filterState) => {
-          console.log(filterKey, 'filterKey');
-          console.log(filterState, 'filterState');
           if (filterKey === 'DATE_RANGE') {
             setTempFilter((prevTempFilter) => ({
               ...prevTempFilter,

--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -178,7 +178,6 @@ const TasksFilterPage = ({ onGoBack }) => {
       filters={filters}
       onApply={handleApply}
       onGoBack={onGoBack}
-      tempFilter={tempFilter}
       setTempFilter={setTempFilter}
     />
   );


### PR DESCRIPTION
Still work in progress

**Description**

Previously, when the user clicks the "Clear all filters" button in a filter modal it would not change the applied filters in any way. With the proposed changes the button will remove all filters and show all items.

The bug was fixed by updating the `tempFilter` state which contains the values of changed filters. On button click, we set the fields that have active filters to all be inactive.

Jira link: [LF-4226](https://lite-farm.atlassian.net/browse/LF-4226?atlOrigin=eyJpIjoiZGFjMzQ2YjQ4YjczNDBjMWE3ZmM1MzRlZGJmNDEzYTQiLCJwIjoiaiJ9)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4226]: https://lite-farm.atlassian.net/browse/LF-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ