### PR TITLE
LF-4438 Language dropdown ruins layout of page

### DIFF
--- a/packages/webapp/src/components/Form/ReactSelect/Select.tsx
+++ b/packages/webapp/src/components/Form/ReactSelect/Select.tsx
@@ -88,6 +88,7 @@ const Select = React.forwardRef((props, ref) => {
         ref={ref}
         defaultValue={defaultValue}
         isDisabled={isDisabled}
+        menuPlacement="auto"
         {...restProps}
       />
     </div>


### PR DESCRIPTION
**Description**

I didn't realize (sorry I think it was mentioned but I wasn't looking at the right part of the screen!) how badly the side menu jumps when the language dropdown is opened! Even with just German added, the effect is unpleasant enough I would recommend trying to fix this for release.

Luckily what @antsgar suggested as ideal behaviour is already an [available prop](https://react-select.com/props#select-props) on the ReactSelect. I think the only question would be whether we want to add it to language in particular or the base Select across the board. I vote for across the board, not including the Unit or CreatableSelect, but am happy to discuss on Monday.

Jira link: https://lite-farm.atlassian.net/browse/LF-4438

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
