### PR TITLE
LF-4437 Remove incomplete languages from dropdown before German release

### DIFF
--- a/packages/api/src/jobs/locales/i18n.js
+++ b/packages/api/src/jobs/locales/i18n.js
@@ -4,7 +4,14 @@ import Backend from 'i18next-fs-backend';
 i18n.use(Backend).init(
   {
     fallbackLng: 'en',
-    preload: ['en', 'es', 'pt', 'fr', 'de', 'hi', 'pa', 'ml'],
+    preload: [
+      'en',
+      'es',
+      'pt',
+      'fr',
+      'de',
+      // 'hi', 'pa', 'ml'
+    ],
     ns: ['translation', 'crop'],
     defaultNS: 'translation',
     nsSeparator: ':',

--- a/packages/api/src/jobs/locales/i18next-parser.config.js
+++ b/packages/api/src/jobs/locales/i18next-parser.config.js
@@ -2,5 +2,12 @@ export default {
   output: 'src/jobs/locales/$LOCALE/$NAMESPACE.json',
   sort: true,
   defaultValue: 'MISSING',
-  locales: ['en', 'es', 'pt', 'fr', 'de', 'hi', 'pa', 'ml'],
+  locales: [
+    'en',
+    'es',
+    'pt',
+    'fr',
+    'de',
+    // 'hi', 'pa', 'ml'
+  ],
 };

--- a/packages/api/src/templates/sendEmailTemplate.js
+++ b/packages/api/src/templates/sendEmailTemplate.js
@@ -71,7 +71,14 @@ const emailTransporter = new EmailTemplates({
     root: path.join(dir, 'emails'),
   },
   i18n: {
-    locales: ['en', 'es', 'fr', 'pt', 'de', 'hi', 'pa', 'ml'],
+    locales: [
+      'en',
+      'es',
+      'fr',
+      'pt',
+      'de',
+      // 'hi', 'pa', 'ml'
+    ],
     directory: path.join(dir, 'locales'),
     objectNotation: true,
   },

--- a/packages/webapp/src/components/WelcomeScreen/index.jsx
+++ b/packages/webapp/src/components/WelcomeScreen/index.jsx
@@ -19,8 +19,8 @@ export default function PureWelcomeScreen({ onClick }) {
     pt: <SignupPortuguese />,
     fr: <SignupFrench />,
     de: <SignupGerman />,
-    hi: <SignupHindi />,
-    pa: <SignupPunjabi />,
+    // hi: <SignupHindi />,
+    // pa: <SignupPunjabi />,
   };
   const language = getLanguageFromLocalStorage();
   return (

--- a/packages/webapp/src/containers/Consent/index.jsx
+++ b/packages/webapp/src/containers/Consent/index.jsx
@@ -30,9 +30,9 @@ const languageConsent = {
   es: { worker: <SpanishWorkerConsent />, owner: <SpanishOwnerConsent /> },
   pt: { worker: <PortugueseWorkerConsent />, owner: <PortugueseOwnerConsent /> },
   de: { worker: <GermanWorkerConsent />, owner: <GermanOwnerConsent /> },
-  hi: { worker: <HindiWorkerConsent />, owner: <HindiOwnerConsent /> },
-  pa: { worker: <PunjabiWorkerConsent />, owner: <PunjabiOwnerConsent /> },
-  ml: { worker: <MalayalamWorkerConsent />, owner: <MalayalamOwnerConsent /> },
+  // hi: { worker: <HindiWorkerConsent />, owner: <HindiOwnerConsent /> },
+  // pa: { worker: <PunjabiWorkerConsent />, owner: <PunjabiOwnerConsent /> },
+  // ml: { worker: <MalayalamWorkerConsent />, owner: <MalayalamOwnerConsent /> },
 };
 
 const getLanguageConsent = (language) => languageConsent[language] || languageConsent.en;

--- a/packages/webapp/src/hooks/useLanguageOptions.ts
+++ b/packages/webapp/src/hooks/useLanguageOptions.ts
@@ -19,9 +19,9 @@ const supportedLanguages = [
   ['de', 'Deutsch'],
   ['fr', 'Français'],
   ['pt', 'Português'],
-  ['hi', 'हिंदी'],
-  ['ml', 'മലയാളം'],
-  ['pa', 'ਪੰਜਾਬੀ'],
+  // ['hi', 'हिंदी'],
+  // ['ml', 'മലയാളം'],
+  // ['pa', 'ਪੰਜਾਬੀ'],
 ];
 
 const useLanguageOptions = () => {

--- a/packages/webapp/src/locales/i18n.js
+++ b/packages/webapp/src/locales/i18n.js
@@ -12,7 +12,15 @@ i18n
     defaultNS: 'translation',
     nsSeparator: ':',
     fallbackLng: 'en',
-    locales: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml'],
+    supportedLngs: ['en', 'pt', 'es', 'fr', 'de'],
+    locales: [
+      'en',
+      'pt',
+      'es',
+      'fr',
+      'de',
+      // 'hi', 'pa', 'ml'
+    ],
     debug: false,
     detection: {
       order: ['localStorage', 'navigator', 'querystring'],

--- a/packages/webapp/src/locales/i18next-parser.config.cjs
+++ b/packages/webapp/src/locales/i18next-parser.config.cjs
@@ -4,5 +4,12 @@ module.exports = {
   output: 'public/locales/$LOCALE/$NAMESPACE.json',
   sort: true,
   defaultValue: 'MISSING',
-  locales: ['en', 'es', 'pt', 'fr', 'de', 'hi', 'pa', 'ml'],
+  locales: [
+    'en',
+    'es',
+    'pt',
+    'fr',
+    'de',
+    //  'hi', 'pa', 'ml'
+  ],
 };


### PR DESCRIPTION
**Description**

This PR comments out the WIP languages from the app before the German release. This includes:

1. removing from the language dropdown
2. removing (via the allowlist, called `supportedLngs`) from the i18n configuration
3. commenting out a few other places that used places that used the local storage language directly (e.g. the welcome message and the consent forms)

Note: 2 & 3 are necessary because local storage languagge has always been set from from `navigator.language` -- meaning that the browser being set to one of the new languages was enough to show translated content, regardless of whether it was selectable in the language options dropdown.

Jira link: https://lite-farm.atlassian.net/browse/LF-4437

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
