### PR TITLE
USes the filterDeleted modifier to creat the repeatable graph

### DIFF
--- a/packages/api/src/controllers/managementPlanController.js
+++ b/packages/api/src/controllers/managementPlanController.js
@@ -58,7 +58,7 @@ const managementPlanController = {
         const managementPlanGraph = await ManagementPlanModel.query(trx)
           .where('management_plan_id', management_plan_id)
           .withGraphFetched(
-            'crop_management_plan.[planting_management_plans.[managementTasks.[task.[pest_control_task, irrigation_task, scouting_task, soil_task, soil_amendment_task, soil_amendment_task_products.[purpose_relationships], field_work_task, harvest_task, cleaning_task, locationTasks]], plant_task.[task.[locationTasks]], transplant_task.[task.[locationTasks]], bed_method, container_method, broadcast_method, row_method]]',
+            'crop_management_plan.[planting_management_plans.[managementTasks.[task.[pest_control_task, irrigation_task, scouting_task, soil_task, soil_amendment_task, soil_amendment_task_products(filterDeleted).[purpose_relationships], field_work_task, harvest_task, cleaning_task, locationTasks]], plant_task.[task.[locationTasks]], transplant_task.[task.[locationTasks]], bed_method, container_method, broadcast_method, row_method]]',
           )
           .modifyGraph(
             'crop_management_plan.[planting_management_plans.managementTasks]',


### PR DESCRIPTION
**Description**

Repairs the ability to repeat a management plan where the user created a soil amendment task in which they edited the tasks products a specific way.

- Uses the filterDeleted modifier.

Jira link: [LF-4440](https://lite-farm.atlassian.net/browse/LF-4440)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
