### PR TITLE
LF-4413 The white screen is displayed once the user tries to complete the creation of the new animal type

### DIFF
--- a/packages/webapp/src/containers/Animals/AddAnimals/utils.ts
+++ b/packages/webapp/src/containers/Animals/AddAnimals/utils.ts
@@ -213,7 +213,7 @@ export const formatDBAnimalsToSummary = (data: Animal[], config: Config): Animal
         type: typeString,
         breed: breedString,
         sexDetails: {},
-        iconKey: typeString.toUpperCase(),
+        iconKey: typeString?.toUpperCase(),
         count: 0,
       } as AnimalSummary;
     }

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -182,7 +182,7 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
-      invalidatesTags: ['Animals'],
+      invalidatesTags: ['Animals', 'CustomAnimalTypes', 'CustomAnimalBreeds'],
     }),
     addAnimalBatches: build.mutation<AnimalBatch[], Partial<AnimalBatch>[]>({
       query: (body) => ({
@@ -190,7 +190,7 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
-      invalidatesTags: ['AnimalBatches'],
+      invalidatesTags: ['AnimalBatches', 'CustomAnimalTypes', 'CustomAnimalBreeds'],
     }),
     getSoilAmendmentMethods: build.query<SoilAmendmentMethod[], void>({
       query: () => `${soilAmendmentMethodsUrl}`,


### PR DESCRIPTION
**Description**

Ooooh animals again 😁 

This PR makes sure that adding a new animal/batch also re-fetches custom types and breeds (in case one was added), and also adds optional chaining to cover the initial `null` value and resultant crash until the re-fetch is completed.

Jira link: https://lite-farm.atlassian.net/browse/LF-4413

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Checked the values around the crashing `iconKey: typeString.toUpperCase(),` Tag invalidation does produce the right `typeString`, but not before that code is called once with a `null` value and crashes.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
