### PR TITLE
LF-4411: Hide add animals button when user is worker

### DIFF
--- a/packages/webapp/src/components/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/components/Animals/Inventory/index.tsx
@@ -58,6 +58,7 @@ const PureAnimalInventory = ({
   clearFilters,
   isLoading,
   containerHeight,
+  isWorker,
   history,
 }: {
   filteredInventory: AnimalInventory[];
@@ -73,6 +74,7 @@ const PureAnimalInventory = ({
   clearFilters: () => void;
   isLoading: boolean;
   containerHeight?: number;
+  isWorker: boolean;
   history: History;
 }) => {
   const { t } = useTranslation();
@@ -148,15 +150,17 @@ const PureAnimalInventory = ({
           />
         )}
       </div>
-      <FloatingButtonMenu
-        type={'add'}
-        options={[
-          {
-            label: t('ADD_ANIMAL.ADD_ANIMALS'),
-            onClick: () => history.push(ADD_ANIMALS_URL),
-          },
-        ]}
-      />
+      {!isWorker && (
+        <FloatingButtonMenu
+          type={'add'}
+          options={[
+            {
+              label: t('ADD_ANIMAL.ADD_ANIMALS'),
+              onClick: () => history.push(ADD_ANIMALS_URL),
+            },
+          ]}
+        />
+      )}
     </>
   );
 };

--- a/packages/webapp/src/containers/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/index.tsx
@@ -37,6 +37,7 @@ import {
   isFilterCurrentlyActiveSelector,
   resetAnimalsFilter,
 } from '../../../containers/filterSlice';
+import { userFarmSelector } from '../../userFarmSlice';
 import { useAnimalsFilterReduxState } from './KPI/useAnimalsFilterReduxState';
 import FloatingContainer from '../../../components/FloatingContainer';
 
@@ -63,6 +64,10 @@ function AnimalInventory({ isCompactSideMenu, history }: AnimalInventoryProps) {
   const { t } = useTranslation(['translation', 'animal', 'common', 'message']);
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
+
+  const role = useSelector(userFarmSelector);
+  const isWorker = 'role_id' in role ? role.role_id === 3 : false;
+
   const zIndexBase = theme.zIndex.drawer;
 
   const { inventory, isLoading } = useAnimalInventory();
@@ -234,6 +239,7 @@ function AnimalInventory({ isCompactSideMenu, history }: AnimalInventoryProps) {
         isFilterActive={isFilterActive}
         clearFilters={clearFilters}
         isLoading={isLoading}
+        isWorker={isWorker}
         history={history}
       />
       {selectedInventoryIds.length ? (


### PR DESCRIPTION
**Description**

When user is a worker, they should not be able to add animals, so hiding this button when user role is worker.

Jira link: https://lite-farm.atlassian.net/browse/LF-4411

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
