### PR TITLE
Fix layout

### DIFF
--- a/packages/webapp/src/components/Navigation/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/styles.module.scss
@@ -21,4 +21,5 @@
   min-height: 100vh;
   min-height: -webkit-fill-available;
   overflow: clip;
+  min-width: 0;
 }


### PR DESCRIPTION
**Description**

This PR makes the `mainColumn` fully responsive to the browser size, preventing it from pushing the side menu.

Here’s the problem:

https://github.com/user-attachments/assets/99af173a-b018-4cec-82a2-fb88689de4a1


I learned about the solution while struggling with truncating text properly for the animal header ([LF-4381](https://lite-farm.atlassian.net/browse/LF-4381)). (It took me a few days to realize that `mainColumn` was the element that needed this fix 😭)

This article was very helpful for understanding the purpose of `min-width: 0`!
https://css-tricks.com/flexbox-truncated-text/#aa-the-solution-is-min-width-0-on-the-flex-child


Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4381]: https://lite-farm.atlassian.net/browse/LF-4381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ