### PR TITLE
bump formatjs version

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.11.0",
-    "@formatjs/intl-datetimeformat": "^6.12.5",
+    "@formatjs/intl-datetimeformat": "^6.15.0",
     "@googlemaps/markerclusterer": "^2.0.14",
     "@mui/base": "5.0.0-beta.26",
     "@mui/icons-material": "^5.11.16",

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -17,8 +17,8 @@ dependencies:
     specifier: ^11.11.0
     version: 11.11.0(@emotion/react@11.10.5)(@types/react@18.0.25)(react@18.2.0)
   '@formatjs/intl-datetimeformat':
-    specifier: ^6.12.5
-    version: 6.12.5
+    specifier: ^6.15.0
+    version: 6.15.0
   '@googlemaps/markerclusterer':
     specifier: ^2.0.14
     version: 2.0.14
@@ -5769,25 +5769,32 @@ packages:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@formatjs/ecma402-abstract@2.0.0:
-    resolution: {integrity: sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==}
+  /@formatjs/ecma402-abstract@2.2.0:
+    resolution: {integrity: sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==}
     dependencies:
-      '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.0
+      '@formatjs/fast-memoize': 2.2.1
+      '@formatjs/intl-localematcher': 0.5.5
+      tslib: 2.8.0
     dev: false
 
-  /@formatjs/intl-datetimeformat@6.12.5:
-    resolution: {integrity: sha512-RYVlgQjUWUKZWMPl7Id8iSETXxHYLbHbii1hrDA/LpWtmFqWKFnF8esMXaHxpysDHviEpJbyGIqrYsABWjrFTw==}
+  /@formatjs/fast-memoize@2.2.1:
+    resolution: {integrity: sha512-XS2RcOSyWxmUB7BUjj3mlPH0exsUzlf6QfhhijgI941WaJhVxXQ6mEWkdUFIdnKi3TuTYxRdelsgv3mjieIGIA==}
     dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.0
+      tslib: 2.8.0
     dev: false
 
-  /@formatjs/intl-localematcher@0.5.4:
-    resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+  /@formatjs/intl-datetimeformat@6.15.0:
+    resolution: {integrity: sha512-rlCAGenAXqqi0og6vRW+2zOpCEy+YslSwhHFckv1JcfRSaIWjLsj0qtByTXJQQCyaefzPtcwhjXKXmfQFq02JQ==}
     dependencies:
-      tslib: 2.6.0
+      '@formatjs/ecma402-abstract': 2.2.0
+      '@formatjs/intl-localematcher': 0.5.5
+      tslib: 2.8.0
+    dev: false
+
+  /@formatjs/intl-localematcher@0.5.5:
+    resolution: {integrity: sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==}
+    dependencies:
+      tslib: 2.8.0
     dev: false
 
   /@googlemaps/js-api-loader@1.16.2:
@@ -7535,10 +7542,10 @@ packages:
       '@storybook/global': 5.0.0
     dev: true
 
-  /@storybook/client-logger@8.4.0-alpha.0(storybook@7.0.27):
-    resolution: {integrity: sha512-OhiFmFAEo0f0EbpXqVuLN78gXB14hD177RDH7kXGiQyMq1CB78et34Qs6boPKfscHUXpRTa375aaGrNbNM6E4Q==}
+  /@storybook/client-logger@8.4.0-alpha.8(storybook@7.0.27):
+    resolution: {integrity: sha512-oUoz0Cs6gM1Ye5EkwuR/Bq4uxhKu0NIrfepe0NbvDHg0Hy9tFYp9XQvtGxmzouAEhfmii7IaSHyoMX7QmrzA6g==}
     peerDependencies:
-      storybook: ^8.4.0-alpha.0
+      storybook: ^8.4.0-alpha.8
     dependencies:
       storybook: 7.0.27
     dev: true
@@ -7864,15 +7871,14 @@ packages:
       '@storybook/preview-api': 7.0.27
     dev: true
 
-  /@storybook/instrumenter@8.4.0-alpha.0(storybook@7.0.27):
-    resolution: {integrity: sha512-JOuez6W6rwTaFLJiQrT6Bk3Xj9KpWWH718GcN7brUb5qq2SWtNuk7yoPQ1JNQw1H3KNbA7jL54+Vwr3nzEZdQQ==}
+  /@storybook/instrumenter@8.4.0-alpha.8(storybook@7.0.27):
+    resolution: {integrity: sha512-mbGy+Z0KBdmeIYfX4gemhomZMuI3Tdb8kUAjV1tBZU5RYBM/HWUGOHGBXdc+yvYdyqoXWN+RqaP7PU7R7p8Fgg==}
     peerDependencies:
-      storybook: ^8.4.0-alpha.0
+      storybook: ^8.4.0-alpha.8
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.1
       storybook: 7.0.27
-      util: 0.12.5
     dev: true
 
   /@storybook/jest@0.2.3(jest@28.1.3)(vitest@0.34.5):
@@ -8197,8 +8203,8 @@ packages:
   /@storybook/testing-library@0.0.14-next.1(storybook@7.0.27):
     resolution: {integrity: sha512-1CAl40IKIhcPaCC4pYCG0b9IiYNymktfV/jTrX7ctquRY3akaN7f4A1SippVHosksft0M+rQTFE0ccfWW581fw==}
     dependencies:
-      '@storybook/client-logger': 8.4.0-alpha.0(storybook@7.0.27)
-      '@storybook/instrumenter': 8.4.0-alpha.0(storybook@7.0.27)
+      '@storybook/client-logger': 8.4.0-alpha.8(storybook@7.0.27)
+      '@storybook/instrumenter': 8.4.0-alpha.8(storybook@7.0.27)
       '@testing-library/dom': 8.20.1
       '@testing-library/user-event': 13.5.0(@testing-library/dom@8.20.1)
       ts-dedent: 2.2.0
@@ -20374,6 +20380,10 @@ packages:
 
   /tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
+
+  /tslib@2.8.0:
+    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
+    dev: false
 
   /tsutils@3.21.0(typescript@4.9.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}


### PR DESCRIPTION
**Description**

@formatjs released a new version of the datetimeformat package including the fix discussed in #3462. Bumping the package version so we get the fix in for the release.

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Forced an undefined date on the WeatherBoard container and checked that an "Invalid Date" string is displayed instead of the app crashing.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
