### PR TITLE
LF-4531: Set up new task abandonment reason for tasks with removed animals

### DIFF
--- a/packages/api/db/migration/20241118191954_add_constraint_to_task_abandonment_reason.js
+++ b/packages/api/db/migration/20241118191954_add_constraint_to_task_abandonment_reason.js
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2024 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  const reasons = [
+    'OTHER',
+    'CROP_FAILURE',
+    'LABOUR_ISSUE',
+    'MARKET_PROBLEM',
+    'WEATHER',
+    'MACHINERY_ISSUE',
+    'SCHEDULING_ISSUE',
+    'NO_ANIMALS_AVAILABLE',
+  ];
+  await knex.raw(`
+    ALTER TABLE task ADD CONSTRAINT abandonment_reason_check 
+    CHECK (abandonment_reason = ANY (ARRAY['${reasons.join(`'::text,'`)}'::text]))
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.raw('ALTER TABLE task DROP CONSTRAINT abandonment_reason_check');
+};

--- a/packages/api/db/migration/20241118191954_add_constraint_to_task_abandonment_reason.js
+++ b/packages/api/db/migration/20241118191954_add_constraint_to_task_abandonment_reason.js
@@ -26,7 +26,7 @@ export const up = async (knex) => {
     'WEATHER',
     'MACHINERY_ISSUE',
     'SCHEDULING_ISSUE',
-    'NO_ANIMALS_AVAILABLE',
+    'NO_ANIMALS',
   ];
   await knex.raw(`
     ALTER TABLE task ADD CONSTRAINT abandonment_reason_check 

--- a/packages/api/src/middleware/validation/checkTask.js
+++ b/packages/api/src/middleware/validation/checkTask.js
@@ -24,6 +24,7 @@ import { checkIsArray, customError } from '../../util/customErrors.js';
 
 const adminRoles = [1, 2, 5];
 const taskTypesRequiringProducts = ['soil_amendment_task'];
+const clientRestrictedReasons = ['NO_ANIMALS'];
 
 export function noReqBodyCheckYet() {
   return async (req, res, next) => {
@@ -60,6 +61,10 @@ export function checkAbandonTask() {
 
       if (abandonment_reason.toUpperCase() === 'OTHER' && !other_abandonment_reason) {
         return res.status(400).send('must have other_abandonment_reason');
+      }
+
+      if (clientRestrictedReasons.includes(abandonment_reason.toUpperCase())) {
+        return res.status(400).send('The provided abandonment_reason is not allowed');
       }
 
       if (!abandon_date) {

--- a/packages/api/src/models/taskModel.js
+++ b/packages/api/src/models/taskModel.js
@@ -80,6 +80,7 @@ class TaskModel extends BaseModel {
             'WEATHER',
             'MACHINERY_ISSUE',
             'SCHEDULING_ISSUE',
+            'NO_ANIMALS',
           ],
         },
         other_abandonment_reason: { type: ['string', 'null'] },

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1922,7 +1922,7 @@
         "LABOUR_ISSUE": "Labour issue",
         "MACHINERY_ISSUE": "Machinery issue",
         "MARKET_PROBLEM": "Market problem",
-        "NO_ANIMALS_AVAILABLE": "No animals available (automatic)",
+        "NO_ANIMALS": "Auto-abandoned: No animals for this task",
         "OTHER": "Other",
         "SCHEDULING_ISSUE": "Scheduling issue",
         "WEATHER": "Weather"

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1922,6 +1922,7 @@
         "LABOUR_ISSUE": "Labour issue",
         "MACHINERY_ISSUE": "Machinery issue",
         "MARKET_PROBLEM": "Market problem",
+        "NO_ANIMALS_AVAILABLE": "No animals available (automatic)",
         "OTHER": "Other",
         "SCHEDULING_ISSUE": "Scheduling issue",
         "WEATHER": "Weather"


### PR DESCRIPTION
**Description**

This PR adds support for the new abandonment reason when all animals are removed from a task. The key will be added as part of delete/remove animals/batches APIs.

- Add a migration to add constraint to validate the `abandonment_reason` in the `task` table. (This wasn't necessary, but I added it to avoid adding a wrong key. Wrong keys don't exist in the prod or beta DB, so it should be safe to add this constraint.)
- Add a translation key for the new reason
- Add the new reason to `TaskModel`
- Add the `checkAbandonTask` middleware not to allow the new key to be added from clients
- Add a test 
 
This task was simpler than expected since the keys are hard-coded in the webapp, and the read-only page and task creation page don't share the same code.

- Creation
   https://github.com/LiteFarmOrg/LiteFarm/blob/aa4be4fbba5419348083870c6046839dbcf26b5f/packages/webapp/src/components/Task/AbandonTask/index.jsx#L164-L178
   
- Read-only

https://github.com/LiteFarmOrg/LiteFarm/blob/aa4be4fbba5419348083870c6046839dbcf26b5f/packages/webapp/src/components/Task/TaskReadOnly/index.jsx#L350-L371


Jira link: https://lite-farm.atlassian.net/browse/LF-4531

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Replaced abandoned task's `abandonment_reason` with `NO_ANIMALS` in the DB and checked the read-only page in the webapp.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files