### PR TITLE
LF-4529 update default types count when adding animals

### DIFF
--- a/packages/webapp/src/containers/Animals/Inventory/KPI/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/KPI/index.tsx
@@ -18,6 +18,7 @@ import { useTranslation, TFunction } from 'react-i18next';
 import {
   useGetDefaultAnimalTypesQuery,
   useGetCustomAnimalTypesQuery,
+  useGetDefaultAnimalTypesCountQuery,
 } from '../../../../store/api/apiSlice';
 import { PureTileDashboard, TypeCountTile } from '../../../../components/TileDashboard';
 import useQueries from '../../../../hooks/api/useQueries';
@@ -58,7 +59,7 @@ interface KPIProps {
 function KPI({ selectedTypeIds, onTypeClick }: KPIProps) {
   const { t } = useTranslation(['translation', 'common', 'animal']);
   const { data, isLoading } = useQueries([
-    { label: 'defaultAnimalTypes', hook: useGetDefaultAnimalTypesQuery, params: '?count=true' },
+    { label: 'defaultAnimalTypes', hook: useGetDefaultAnimalTypesCountQuery },
     { label: 'customAnimalTypes', hook: useGetCustomAnimalTypesQuery, params: '?count=true' },
   ]);
 

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -78,6 +78,7 @@ export const api = createApi({
     'CustomAnimalTypes',
     'DefaultAnimalBreeds',
     'DefaultAnimalTypes',
+    'DefaultAnimalTypesCount',
     'AnimalSexes',
     'AnimalIdentifierTypes',
     'AnimalIdentifierColors',
@@ -111,6 +112,10 @@ export const api = createApi({
     getCustomAnimalTypes: build.query<CustomAnimalType[], string | void>({
       query: (param = '') => `${customAnimalTypesUrl}${param}`,
       providesTags: ['CustomAnimalTypes'],
+    }),
+    getDefaultAnimalTypesCount: build.query<DefaultAnimalType[], string | void>({
+      query: () => `${defaultAnimalTypesUrl}?count=true`,
+      providesTags: ['DefaultAnimalTypesCount'],
     }),
     getCustomAnimalBreeds: build.query<CustomAnimalBreed[], void>({
       query: () => `${customAnimalBreedsUrl}`,
@@ -182,7 +187,12 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
-      invalidatesTags: ['Animals', 'CustomAnimalTypes', 'CustomAnimalBreeds'],
+      invalidatesTags: [
+        'Animals',
+        'DefaultAnimalTypesCount',
+        'CustomAnimalTypes',
+        'CustomAnimalBreeds',
+      ],
     }),
     addAnimalBatches: build.mutation<AnimalBatch[], Partial<AnimalBatch>[]>({
       query: (body) => ({
@@ -190,7 +200,12 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
-      invalidatesTags: ['AnimalBatches', 'CustomAnimalTypes', 'CustomAnimalBreeds'],
+      invalidatesTags: [
+        'AnimalBatches',
+        'DefaultAnimalTypesCount',
+        'CustomAnimalTypes',
+        'CustomAnimalBreeds',
+      ],
     }),
     getSoilAmendmentMethods: build.query<SoilAmendmentMethod[], void>({
       query: () => `${soilAmendmentMethodsUrl}`,
@@ -231,6 +246,7 @@ export const {
   useGetCustomAnimalTypesQuery,
   useGetDefaultAnimalBreedsQuery,
   useGetDefaultAnimalTypesQuery,
+  useGetDefaultAnimalTypesCountQuery,
   useGetAnimalSexesQuery,
   useGetAnimalIdentifierTypesQuery,
   useGetAnimalIdentifierColorsQuery,


### PR DESCRIPTION
**Description**

Update KPIs when animals are created. This is slightly different from the approach in #3500 because it only updates the count endpoint for default types, thus preventing having to re-fetch all of the types all the time. This way we keep one of the advantages of separating default and custom types which is considering default types somewhat "static" and not having to re-fetch them after user updates.

Jira link:
https://lite-farm.atlassian.net/browse/LF-4529

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
