### PR TITLE
[Not urgent!] LF-4384(b): Refactor useAnimalOrBatchRemoval

### DIFF
--- a/packages/webapp/src/containers/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/index.tsx
@@ -41,6 +41,9 @@ import { isAdminSelector } from '../../userFarmSlice';
 import { useAnimalsFilterReduxState } from './KPI/useAnimalsFilterReduxState';
 import FloatingContainer from '../../../components/FloatingContainer';
 import AnimalsBetaSpotlight from './AnimalsBetaSpotlight';
+import { parseInventoryId } from '../../../util/animal';
+import { AnimalOrBatchKeys } from '../types';
+import { Animal } from '../../../store/api/types';
 
 export enum View {
   DEFAULT = 'default',
@@ -102,9 +105,18 @@ function AnimalInventory({
     [updateSelectedTypeIds],
   );
 
+  const onRemovalSuccess = (animalOrBatchKey: AnimalOrBatchKeys, ids: Animal['id'][]) => {
+    setSelectedInventoryIds((selectedInventoryIds) => {
+      return selectedInventoryIds.filter((i) => {
+        const { kind, id } = parseInventoryId(i);
+        return kind === animalOrBatchKey && ids.includes(id);
+      });
+    });
+  };
+
   const { onConfirmRemoveAnimals, removalModalOpen, setRemovalModalOpen } = useAnimalOrBatchRemoval(
-    selectedInventoryIds,
-    setSelectedInventoryIds,
+    selectedInventoryIds.map(parseInventoryId),
+    onRemovalSuccess,
   );
 
   const animalsColumns = useMemo(

--- a/packages/webapp/src/containers/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/index.tsx
@@ -109,7 +109,7 @@ function AnimalInventory({
     setSelectedInventoryIds((selectedInventoryIds) => {
       return selectedInventoryIds.filter((i) => {
         const { kind, id } = parseInventoryId(i);
-        return kind === animalOrBatchKey && ids.includes(id);
+        return !(kind === animalOrBatchKey && ids.includes(id));
       });
     });
   };

--- a/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
+++ b/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
@@ -43,7 +43,6 @@ import { AnimalOrBatchKeys } from '../types';
 import { AnimalDetailsFormFields } from '../AddAnimals/types';
 import RemoveAnimalsModal, { FormFields } from '../../../components/Animals/RemoveAnimalsModal';
 import useAnimalOrBatchRemoval from '../Inventory/useAnimalOrBatchRemoval';
-import { generateInventoryId } from '../../../util/animal';
 import { CustomRouteComponentProps } from '../../../types';
 import { isAdminSelector } from '../../userFarmSlice';
 
@@ -169,13 +168,13 @@ function SingleAnimalView({ isCompactSideMenu, history, match, location }: AddAn
     }
   };
 
-  const getInventoryId = () => {
-    const animalOrBatch = AnimalOrBatchKeys[selectedAnimal ? 'ANIMAL' : 'BATCH'];
-    return generateInventoryId(animalOrBatch, (selectedAnimal || selectedBatch)!);
-  };
-
   const { onConfirmRemoveAnimals, removalModalOpen, setRemovalModalOpen } = useAnimalOrBatchRemoval(
-    [getInventoryId()],
+    [
+      {
+        kind: AnimalOrBatchKeys[selectedAnimal ? 'ANIMAL' : 'BATCH'],
+        id: (selectedAnimal || selectedBatch)!.id,
+      },
+    ],
   );
 
   const onConfirmRemoval = async (formData: FormFields) => {


### PR DESCRIPTION
**Description**

Currently the `useAnimalOrBatchRemoval` hook accepts inventory IDs and parses them. This parsing is redundant for the `SingleAnimalView`, which already has a parsed ID. This PR makes the hook more generic by:

- Updating `useAnimalOrBatchRemoval` to accept:
   - `id`s with `kind` (animal or batch key) instead of inventory IDs
   - `onSuccess` instead of `setSelectedInventoryIds`
- Move the inventory ID parsing and `setSelectedInventoryIds` logic to the `Inventory` component.

(This PR addresses the [comment](https://github.com/LiteFarmOrg/LiteFarm/pull/3534#discussion_r1856718064) on https://github.com/LiteFarmOrg/LiteFarm/pull/3534)


