### PR TITLE
update allow origin header

### DIFF
--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -253,6 +253,18 @@ const rejectBodyInGetAndDelete = (req, res, next) => {
   next();
 };
 
+const getAllowedOrigin = () => {
+  switch (environment) {
+    case 'development':
+      return 'http://localhost:3000';
+    case 'integration':
+      return 'https://beta.litefarm.org';
+    case 'production':
+      return 'https://app.litefarm.org';
+    default:
+      return 'https://app.litefarm.org';
+  }
+};
 app
   .use(applyExpressJSON)
   .use(express.urlencoded({ extended: true }))
@@ -261,7 +273,8 @@ app
   // prevent CORS errors
   .use(cors())
   .use((req, res, next) => {
-    res.header('Access-Control-Allow-Origin', '*');
+    const origin = getAllowedOrigin();
+    res.header('Access-Control-Allow-Origin', origin);
     res.header(
       'Access-Control-Allow-Headers',
       'Origin, X-Requested-With, Content-Type, Accept, Authorization',

--- a/packages/webapp/nginx.conf
+++ b/packages/webapp/nginx.conf
@@ -93,7 +93,7 @@ http {
 
           proxy_set_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
           proxy_pass_request_headers      on;
-          proxy_set_header 'Access-Control-Allow-Origin' '*';
+          proxy_set_header 'Access-Control-Allow-Origin' 'https://beta.litefarm.org';
           proxy_pass http://backend:5000/;
         }
         listen 443 ssl; # managed by Certbot


### PR DESCRIPTION
**Description**

Update allow-origin header on the BE so that only requests coming from a browser are only allowed to come from LiteFarm domains (or localhost).

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
