### PR TITLE
LF-4549: Sex-Detail Field Not Editable on Edit Animal Details Page

### DIFF
--- a/packages/webapp/src/components/Form/SexDetails/index.tsx
+++ b/packages/webapp/src/components/Form/SexDetails/index.tsx
@@ -96,7 +96,7 @@ export default function SexDetails({
         }
       />
     ),
-    [isPopoverOpen, maxCount],
+    [isPopoverOpen, maxCount, isDisabled],
   );
 
   return (


### PR DESCRIPTION
**Description**

Add missing dependency to `SexDetails` `useMemo`.
(This addresses the [comment](https://github.com/LiteFarmOrg/LiteFarm/pull/3534#pullrequestreview-2465801603) in https://github.com/LiteFarmOrg/LiteFarm/pull/3534)

Jira link: https://lite-farm.atlassian.net/browse/LF-4549
 
**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
