### PR TITLE
LF-4555: Update getTasksForFarm to return all custom tasks in GET API response

### DIFF
--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -918,6 +918,20 @@ describe('Task tests', () => {
       });
     });
 
+    test(`should get custom tasks that don't have locations, managementPlans, or animals`, async (done) => {
+      const [{ user_id, farm_id }] = await mocks.userFarmFactory({}, fakeUserFarm(1));
+      const [{ task_type_id }] = await mocks.task_typeFactory({ promisedFarm: [{ farm_id }] });
+      await mocks.taskFactory({
+        promisedUser: [{ user_id }],
+        promisedTaskType: [{ task_type_id }],
+      });
+      getTasksRequest({ farm_id, user_id }, (err, res) => {
+        expect(res.status).toBe(200);
+        expect(res.body.length).toBe(1);
+        done();
+      });
+    });
+
     xtest('should get all tasks related to a farm, but not from different farms of that user', async (done) => {
       const [firstUserFarm] = await mocks.userFarmFactory({}, fakeUserFarm(1));
       const [secondUserFarmWithSameUser] = await mocks.userFarmFactory(
@@ -1619,6 +1633,19 @@ describe('Task tests', () => {
           expect(isTaskRelatedToManagementPlans.length).toBe(3);
           const specificProduct = await knex('product').where({ product_id }).first();
           expect(specificProduct.name).toBe('pestProduct2');
+          done();
+        });
+      });
+
+      test('should create a custom task without locations, managementPlans or animals', async (done) => {
+        const [{ user_id, farm_id }] = await mocks.userFarmFactory({}, fakeUserFarm(1));
+        const [{ task_type_id }] = await mocks.task_typeFactory({ promisedFarm: [{ farm_id }] });
+        const data = { ...mocks.fakeTask({ task_type_id }) };
+
+        postTaskRequest({ user_id, farm_id }, 'custom_task', data, async (err, res) => {
+          expect(res.status).toBe(201);
+          const createdTask = await knex('task').where({ task_id: res.body.task_id }).first();
+          expect(createdTask).toBeDefined();
           done();
         });
       });


### PR DESCRIPTION
**Description**

- Update `getTasksForFarm` to retrieve custom tasks for the farm.
- Add tests for GET and POST task(s) requests.

Jira link: https://lite-farm.atlassian.net/browse/LF-4555

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
