### PR TITLE
LF-4553 Allow completing custom tasks with no associated locations

### DIFF
--- a/packages/api/src/middleware/acl/hasFarmAccess.js
+++ b/packages/api/src/middleware/acl/hasFarmAccess.js
@@ -30,6 +30,7 @@ const entitiesGetters = {
   nomination_id: fromNomination,
   transplant_task: fromTransPlantTask,
   product_id: fromProduct,
+  taskIdTaskType: fromTaskIdTaskType,
 };
 import userFarmModel from '../../models/userFarmModel.js';
 
@@ -199,6 +200,28 @@ async function fromLocations(locations) {
       .distinct('location.farm_id');
     if (userFarms.length !== 1) return {};
     return userFarms[0];
+  } catch (e) {
+    return {};
+  }
+}
+
+async function fromTaskIdTaskType(req) {
+  if (!req.params || !req.params.task_id) {
+    return {};
+  }
+
+  try {
+    const task_id = req.params.task_id;
+
+    const task = await knex('task').where({ task_id }).first();
+
+    if (!task) return {};
+
+    const taskType = await knex('task_type').where({ task_type_id: task.task_type_id }).first();
+
+    if (!taskType) return {};
+
+    return { farm_id: taskType.farm_id };
   } catch (e) {
     return {};
   }

--- a/packages/api/src/routes/taskRoute.js
+++ b/packages/api/src/routes/taskRoute.js
@@ -273,7 +273,7 @@ router.patch(
 router.patch(
   '/complete/custom_task/:task_id',
   modelMapping['custom_task'],
-  hasFarmAccess({ params: 'task_id' }),
+  hasFarmAccess({ mixed: 'taskIdTaskType' }),
   checkScope(['edit:task']),
   taskController.completeTask('custom_task'),
 );


### PR DESCRIPTION
**Description**

Custom tasks without locations could not previously be completed because they would fail on the hasFarmAccess middleware check, causing 403 and logout. This PR adds a function to hasFarmAccess to pull the farm_id from the task_type, and replaces the previous check, which used location_tasks, with this new check on the custom task complete route.

Jira link: https://lite-farm.atlassian.net/browse/LF-4553

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

You can observe the middleware behaviour by removing the `location_tasks` entry for a custom task (you need to be on the readonly or complete view because will lose it from the task list -- unless you're on Sayaka's modified GET branch!), and completing it.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
