### PR TITLE
LF-4554 Adjust frontend task view to handle tasks with no locations

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1955,7 +1955,8 @@
     "ANIMAL_MOVEMENT_EXPANDING_SUMMARY_TITLE": "See detail list of animals to move",
     "CARD": {
       "MULTIPLE_CROPS": "Multiple crops",
-      "MULTIPLE_LOCATIONS": "Multiple locations"
+      "MULTIPLE_LOCATIONS": "Multiple locations",
+      "NO_LOCATION": "No location"
     },
     "COMPLETE": {
       "DATE": "Completion date",

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -233,7 +233,7 @@ export default function PureTaskReadOnly({
         </div>
       )}
 
-      {task?.locations?.length || task?.pinCoordinates?.length ? (
+      {task.locations?.length || task.pinCoordinates?.length ? (
         <>
           <Semibold style={{ marginBottom: '12px' }}>{t('TASK.LOCATIONS')}</Semibold>
           {isTaskType(taskType, 'TRANSPLANT_TASK') && (

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -233,26 +233,30 @@ export default function PureTaskReadOnly({
         </div>
       )}
 
-      <Semibold style={{ marginBottom: '12px' }}>{t('TASK.LOCATIONS')}</Semibold>
-      {isTaskType(taskType, 'TRANSPLANT_TASK') && (
-        <TransplantLocationLabel
-          locations={task.locations}
-          selectedLocationId={task.selectedLocationIds[0]}
-          pinCoordinate={task.pinCoordinates[0]}
-        />
-      )}
-      <LocationPicker
-        onSelectLocation={() => {
-          //  TODO: fix onSelectLocationRef in LocationPicker
-        }}
-        readOnlyPinCoordinates={task.pinCoordinates}
-        style={{ minHeight: '160px', marginBottom: '40px' }}
-        locations={task.locations}
-        selectedLocationIds={task.selectedLocationIds || []}
-        farmCenterCoordinate={user.grid_points}
-        maxZoomRef={maxZoomRef}
-        getMaxZoom={getMaxZoom}
-      />
+      {task?.locations?.length || task?.pinCoordinates?.length ? (
+        <>
+          <Semibold style={{ marginBottom: '12px' }}>{t('TASK.LOCATIONS')}</Semibold>
+          {isTaskType(taskType, 'TRANSPLANT_TASK') && (
+            <TransplantLocationLabel
+              locations={task.locations}
+              selectedLocationId={task.selectedLocationIds[0]}
+              pinCoordinate={task.pinCoordinates[0]}
+            />
+          )}
+          <LocationPicker
+            onSelectLocation={() => {
+              //  TODO: fix onSelectLocationRef in LocationPicker
+            }}
+            readOnlyPinCoordinates={task.pinCoordinates}
+            style={{ minHeight: '160px', marginBottom: '40px' }}
+            locations={task.locations}
+            selectedLocationIds={task.selectedLocationIds || []}
+            farmCenterCoordinate={user.grid_points}
+            maxZoomRef={maxZoomRef}
+            getMaxZoom={getMaxZoom}
+          />
+        </>
+      ) : null}
 
       {Object.keys(task.managementPlansByLocation).map((location_id) => {
         return (

--- a/packages/webapp/src/containers/Task/taskCardContentSelector.js
+++ b/packages/webapp/src/containers/Task/taskCardContentSelector.js
@@ -119,6 +119,8 @@ const getLocationNameOfTask = (managementPlans, locations, taskType) => {
     if (locationNameSet.size > 1) return i18n.t('TASK.CARD.MULTIPLE_LOCATIONS');
   }
 
+  if (locationNameSet.size == 0) return i18n.t('TASK.CARD.NO_LOCATION');
+
   return locationNameSet.values()?.next()?.value;
 };
 


### PR DESCRIPTION
**Description**

Minor frontend view changes needed to work with tasks with no locations:
1. Task card selector logic should specify "No location" instead of the fallback "Multiple locations"
2. Readonly view should only show the map if pins or locations are associated with the task
3. ~[TBD, code not yet pushed] Filter by location logic should exclude tasks that have no location instead of matching them to every location~ - Will create a fresh ticket to address the nice-to-have filter updates; not included here

Jira link: https://lite-farm.atlassian.net/browse/LF-4554

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

You can view tasks without locations on the branch without GET, or by adding this line to the taskEntitiesSelector to remove locations from custom tasks once they have already been fetched:

```js
if (farm_id) {
  taskEntities[task_id].locations = [];
}
```

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
