### PR TITLE
LF-4482 support creating task from animal inventory (nice to have)

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -124,6 +124,7 @@ export const PureTaskTypeSelection = ({
       }
       return true;
     }
+    return false;
   };
 
   return (

--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -61,7 +61,6 @@ export const PureTaskTypeSelection = ({
   persistedFormData,
   useHookFormPersist,
   onContinue,
-  onError,
   taskTypes,
   customTasks,
   isAdmin,
@@ -80,7 +79,11 @@ export const PureTaskTypeSelection = ({
   register(TASK_TYPE_ID);
   const selected_task_type = watch(TASK_TYPE_ID);
 
+  console.log(location.state);
+
   const isMakingCropTask = !!location?.state?.management_plan_id;
+  const isMakingAnimalTask = !!location?.state?.animal_ids;
+  console.log(isMakingCropTask);
 
   const onSelectTask = (task_type_id) => {
     setValue(TASK_TYPE_ID, task_type_id);
@@ -127,13 +130,15 @@ export const PureTaskTypeSelection = ({
             ?.filter(({ farm_id, task_translation_key }) => {
               const supportedTaskTypes = getSupportedTaskTypesSet(isAdmin);
               // If trying to make a task through the crop management plan 'Add Task' link -- exclude animal tasks from selection for now
-              const isNotAnimalTaskWhileCreatingCropTask = !(
-                ANIMAL_TASKS.includes(task_translation_key) && isMakingCropTask
-              );
+              const isNotAnimalTaskWhileCreatingCropTask =
+                isMakingCropTask && !ANIMAL_TASKS.includes(task_translation_key);
+              // If trying to make a task through the animal inventory 'Create a task' action -- exclude crop tasks from selection
+              const isAnimalTaskWhileCreatingAnimalTask =
+                isMakingAnimalTask && ANIMAL_TASKS.includes(task_translation_key);
               const shouldDisplayTaskType =
                 farm_id === null &&
                 supportedTaskTypes.has(task_translation_key) &&
-                isNotAnimalTaskWhileCreatingCropTask;
+                (isNotAnimalTaskWhileCreatingCropTask || isAnimalTaskWhileCreatingAnimalTask);
 
               return shouldDisplayTaskType;
             })
@@ -143,7 +148,7 @@ export const PureTaskTypeSelection = ({
               ),
             )
             .map((taskType) => {
-              const { task_translation_key, task_type_id, farm_id } = taskType;
+              const { task_translation_key, task_type_id } = taskType;
               return (
                 <div
                   data-cy="task-selection"
@@ -167,7 +172,7 @@ export const PureTaskTypeSelection = ({
             ?.sort((firstTaskType, secondTaskType) =>
               firstTaskType.task_name.localeCompare(secondTaskType.task_name),
             )
-            .map(({ task_translation_key, task_type_id, task_name }) => {
+            .map(({ task_type_id, task_name }) => {
               return (
                 <div
                   onClick={() => {

--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -79,11 +79,8 @@ export const PureTaskTypeSelection = ({
   register(TASK_TYPE_ID);
   const selected_task_type = watch(TASK_TYPE_ID);
 
-  console.log(location.state);
-
   const isMakingCropTask = !!location?.state?.management_plan_id;
   const isMakingAnimalTask = !!location?.state?.animal_ids;
-  console.log(isMakingCropTask);
 
   const onSelectTask = (task_type_id) => {
     setValue(TASK_TYPE_ID, task_type_id);

--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -108,6 +108,24 @@ export const PureTaskTypeSelection = ({
     }
     return onSelectTask(taskType.task_type_id);
   };
+
+  const shouldDisplayTaskType = (taskType) => {
+    const supportedTaskTypes = getSupportedTaskTypesSet(isAdmin);
+    const { farm_id, task_translation_key } = taskType;
+
+    if (farm_id === null && supportedTaskTypes.has(task_translation_key)) {
+      // If trying to make a task through the crop management plan 'Add Task' link -- exclude animal tasks from selection for now
+      if (isMakingCropTask) {
+        return !ANIMAL_TASKS.includes(task_translation_key);
+      }
+      // If trying to make a task through the animal inventory 'Create a task' action -- only include animal tasks in selection
+      if (isMakingAnimalTask) {
+        return ANIMAL_TASKS.includes(task_translation_key);
+      }
+      return true;
+    }
+  };
+
   return (
     <>
       <Form>
@@ -124,21 +142,7 @@ export const PureTaskTypeSelection = ({
 
         <div style={{ paddingBottom: '20px' }} className={styles.matrixContainer}>
           {taskTypes
-            ?.filter(({ farm_id, task_translation_key }) => {
-              const supportedTaskTypes = getSupportedTaskTypesSet(isAdmin);
-              // If trying to make a task through the crop management plan 'Add Task' link -- exclude animal tasks from selection for now
-              const isNotAnimalTaskWhileCreatingCropTask =
-                isMakingCropTask && !ANIMAL_TASKS.includes(task_translation_key);
-              // If trying to make a task through the animal inventory 'Create a task' action -- exclude crop tasks from selection
-              const isAnimalTaskWhileCreatingAnimalTask =
-                isMakingAnimalTask && ANIMAL_TASKS.includes(task_translation_key);
-              const shouldDisplayTaskType =
-                farm_id === null &&
-                supportedTaskTypes.has(task_translation_key) &&
-                (isNotAnimalTaskWhileCreatingCropTask || isAnimalTaskWhileCreatingAnimalTask);
-
-              return shouldDisplayTaskType;
-            })
+            ?.filter(shouldDisplayTaskType)
             .sort((firstTaskType, secondTaskType) =>
               t(`task:${firstTaskType.task_translation_key}`).localeCompare(
                 t(`task:${secondTaskType.task_translation_key}`),

--- a/packages/webapp/src/components/Task/TaskAnimalInventory/index.jsx
+++ b/packages/webapp/src/components/Task/TaskAnimalInventory/index.jsx
@@ -34,20 +34,14 @@ export default function PureTaskAnimalInventory({
 }) {
   const { t } = useTranslation();
   const ANIMAL_IDS = 'animalIds';
+  const preSelectedIds = persistedFormData.animalIds || history.location?.state?.animal_ids;
 
-  const {
-    register,
-    handleSubmit,
-    getValues,
-    watch,
-    setValue,
-    formState: { isValid },
-  } = useForm({
+  const { register, handleSubmit, getValues, watch, setValue } = useForm({
     mode: 'onChange',
     shouldUnregister: false,
     defaultValues: {
       ...persistedFormData,
-      [ANIMAL_IDS]: persistedFormData.animalIds || [],
+      [ANIMAL_IDS]: preSelectedIds || [],
     },
   });
 
@@ -107,7 +101,7 @@ export default function PureTaskAnimalInventory({
           onSelect={onSelect}
           view={View.TASK}
           history={history}
-          preSelectedIds={persistedFormData?.animalIds}
+          preSelectedIds={preSelectedIds}
           showLinks={false}
         />
       </Form>

--- a/packages/webapp/src/containers/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/index.tsx
@@ -49,6 +49,7 @@ import clsx from 'clsx';
 import AnimalsBetaSpotlight from './AnimalsBetaSpotlight';
 import { sumObjectValues } from '../../../util';
 import Icon from '../../../components/Icons';
+import { onAddTask } from '../../Task/onAddTask';
 
 const HEIGHTS = {
   filterAndSearch: 64,
@@ -420,9 +421,11 @@ export default function AnimalInventory({
   };
 
   const iconActions: iconAction[] = [
-    { label: t(`common:ADD_TO_GROUP`), iconName: 'ADD_ANIMAL', onClick: () => ({}) },
-    { label: t(`common:CREATE_A_TASK`), iconName: 'TASK_CREATION', onClick: () => ({}) },
-    { label: t(`common:CLONE`), iconName: 'CLONE', onClick: () => ({}) },
+    {
+      label: t(`common:CREATE_A_TASK`),
+      iconName: 'TASK_CREATION',
+      onClick: () => onAddTask(dispatch, history, { animal_ids: selectedInventoryIds })(),
+    },
     {
       label: t(`ANIMAL.REMOVE_ANIMAL`),
       iconName: 'REMOVE_ANIMAL',


### PR DESCRIPTION
**Description**

Adds capability to create a task from the animal inventory action menu. Should only show animal related tasks (movement / custom tasks).

Jira link:
https://lite-farm.atlassian.net/browse/LF-4482

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
