### PR TITLE
LF-4567 Allow custom tasks with animals to be editable on complete

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -165,28 +165,26 @@ export default function PureCompleteStepOne({
         </div>
       ) : null}
 
-      {taskType && taskComponents[taskType] ? (
-        taskComponents[taskType]({
-          setValue,
-          getValues,
-          watch,
-          control,
-          register,
-          reset,
-          getFieldState,
-          formState: { errors, isValid },
-          errors,
-          system,
-          products,
-          farm,
-          task: selectedTask,
-          disabled: !changesRequired,
-          isModified: changesRequired,
-          locations: selectedTask.locations,
-        })
-      ) : (
-        <></>
-      )}
+      {taskType && taskComponents[taskType]
+        ? taskComponents[taskType]({
+            setValue,
+            getValues,
+            watch,
+            control,
+            register,
+            reset,
+            getFieldState,
+            formState: { errors, isValid },
+            errors,
+            system,
+            products,
+            farm,
+            task: selectedTask,
+            disabled: !changesRequired,
+            isModified: changesRequired,
+            locations: selectedTask.locations,
+          })
+        : null}
     </Form>
   );
 }

--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -165,7 +165,7 @@ export default function PureCompleteStepOne({
         </div>
       ) : null}
 
-      {taskType &&
+      {taskType && taskComponents[taskType] ? (
         taskComponents[taskType]({
           setValue,
           getValues,
@@ -183,7 +183,10 @@ export default function PureCompleteStepOne({
           disabled: !changesRequired,
           isModified: changesRequired,
           locations: selectedTask.locations,
-        })}
+        })
+      ) : (
+        <></>
+      )}
     </Form>
   );
 }

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -111,7 +111,7 @@ export default function PureTaskComplete({
       isFieldWork && persistedFormData?.field_work_task?.field_work_task_type.value === 'OTHER';
 
     // Won't send task type details if need_changes is false
-    if (persistedFormData?.need_changes && !isOtherFieldWork) {
+    if (!data.isCustomTaskType && persistedFormData?.need_changes && !isOtherFieldWork) {
       data.taskData[task_type_name] = getObjectInnerValues(persistedFormData[task_type_name]);
     } else if (isOtherFieldWork) {
       data.taskData[task_type_name] = { ...persistedFormData[task_type_name] };

--- a/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
@@ -56,6 +56,7 @@ function TaskReadOnly({ history, match, location }) {
   const [isTaskTypeCustom, setIsTaskTypeCustom] = useState(false);
   const [isHarvest, setIsHarvest] = useState(undefined);
   const [wageAtMoment, setWageAtMoment] = useState(undefined);
+  const [hasAnimals, setHasAnimals] = useState(false);
 
   useEffect(() => {
     if (task === undefined) {
@@ -64,6 +65,7 @@ function TaskReadOnly({ history, match, location }) {
       setIsTaskTypeCustom(!!task.taskType.farm_id);
       setIsHarvest(isTaskType(task.taskType, 'HARVEST_TASK'));
       setWageAtMoment(task.wage_at_moment);
+      setHasAnimals(task.animals?.length || task.animal_batches?.length);
     }
   }, [task, history]);
 
@@ -74,7 +76,7 @@ function TaskReadOnly({ history, match, location }) {
   const onComplete = () => {
     if (isHarvest) {
       history.push(`/tasks/${task_id}/complete_harvest_quantity`, location?.state);
-    } else if (isTaskTypeCustom) {
+    } else if (isTaskTypeCustom && !hasAnimals) {
       dispatch(setFormData({ task_id, taskType: task.taskType }));
       history.push(`/tasks/${task_id}/complete`, location?.state);
     } else {


### PR DESCRIPTION
**Description**

In testing the new custom task type flow end-to-end, I noticed the custom task types were not offering the ability to edit the associated animals, and realized that was because StepOne (before complete) is not shown at all for custom tasks, which lack a Details component (previously the only part of the task that could be editable, until Animals were added).

This adds that step so animals can be added or removed on complete.

Jira link: https://lite-farm.atlassian.net/browse/LF-4567

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I used Duncan's frontend branch, the middleware adjust, and the other pieces now in integration to test end to end flow of tasks with animals with and without locations.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
