### PR TITLE
LF-4558 Give second argument to getSupportedTaskTypes

### DIFF
--- a/packages/webapp/src/containers/Filter/Tasks/index.jsx
+++ b/packages/webapp/src/containers/Filter/Tasks/index.jsx
@@ -62,7 +62,7 @@ const TasksFilterPage = ({ onGoBack }) => {
   }, []);
 
   const taskTypes = useMemo(() => {
-    const supportedTaskTypes = getSupportedTaskTypesSet(true);
+    const supportedTaskTypes = getSupportedTaskTypesSet(true, true);
     let taskTypes = {};
     for (const type of defaultTaskTypes) {
       if (type.deleted === false && supportedTaskTypes.has(type.task_translation_key)) {

--- a/packages/webapp/src/containers/Task/index.jsx
+++ b/packages/webapp/src/containers/Task/index.jsx
@@ -90,7 +90,7 @@ export default function TaskPage({ history }) {
   };
 
   const taskTypes = useMemo(() => {
-    const supportedTaskTypes = getSupportedTaskTypesSet(true);
+    const supportedTaskTypes = getSupportedTaskTypesSet(true, true);
     const taskTypes = [];
     for (const type of defaultTaskTypes) {
       if (type.deleted === false && supportedTaskTypes.has(type.task_translation_key)) {


### PR DESCRIPTION
**Description**

A quick fix to restore movement tasks to the task list 🙂 

Since `getSupportedTaskTypesSet()` expects two arguments now:
- https://github.com/LiteFarmOrg/LiteFarm/pull/3574/

The previous calls that were meant to return all tasks types were written `getSupportedTaskTypes(true)` so they need updating! No sweat! 😅 

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
