### PR TITLE
LF-4564 unnest tasks from animals

### DIFF
--- a/packages/api/src/controllers/animalBatchController.js
+++ b/packages/api/src/controllers/animalBatchController.js
@@ -37,7 +37,6 @@ const animalBatchController = {
             animal_union_batch: true,
             sex_detail: true,
             animal_batch_use_relationships: true,
-            tasks: true,
           });
         return res.status(200).send(
           rows.map(({ animal_union_batch, ...rest }) => ({

--- a/packages/api/src/controllers/animalController.js
+++ b/packages/api/src/controllers/animalController.js
@@ -36,7 +36,6 @@ const animalController = {
           .withGraphFetched({
             animal_union_batch: true,
             animal_use_relationships: true,
-            tasks: true,
           });
         return res.status(200).send(
           rows.map(({ animal_union_batch, ...rest }) => ({

--- a/packages/api/tests/animal.test.js
+++ b/packages/api/tests/animal.test.js
@@ -163,13 +163,11 @@ describe('Animal Tests', () => {
           ...firstAnimal,
           internal_identifier: res.body[0].internal_identifier,
           animal_use_relationships: [],
-          tasks: [],
         }).toMatchObject(res.body[0]);
         expect({
           ...secondAnimal,
           internal_identifier: res.body[1].internal_identifier,
           animal_use_relationships: [],
-          tasks: [],
         }).toMatchObject(res.body[1]);
       }
     });

--- a/packages/api/tests/animal_batch.test.js
+++ b/packages/api/tests/animal_batch.test.js
@@ -186,13 +186,11 @@ describe('Animal Batch Tests', () => {
           ...firstAnimalBatch,
           internal_identifier: 1,
           animal_batch_use_relationships: [],
-          tasks: [],
         }).toMatchObject(res.body[0]);
         expect({
           ...secondAnimalBatch,
           internal_identifier: 2,
           animal_batch_use_relationships: [],
-          tasks: [],
         }).toMatchObject(res.body[1]);
       }
     });


### PR DESCRIPTION
**Description**

This was initially suggested here https://github.com/LiteFarmOrg/LiteFarm/pull/3554#issuecomment-2515869484
Updates logic in the UI that verifies if animals/batches have finalized tasks to check the tasks themselves instead of relying on tasks being nested within animals.
Eliminates nested tasks from animals in API.
Removes need to invalidate animal/batch tags on task creation/deletion.

Jira link:
https://lite-farm.atlassian.net/browse/LF-4564

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
