### PR TITLE
LF-4579: Recording a movement task in the past messes up animals location

### DIFF
--- a/packages/api/src/models/animalBatchModel.js
+++ b/packages/api/src/models/animalBatchModel.js
@@ -243,7 +243,7 @@ class AnimalBatchModel extends baseModel {
 
   static async getBatchesWithNewerCompletedTasks(batchIds, taskTypeId, completedDate) {
     return AnimalBatchModel.query()
-      .select('id', 'location_id')
+      .select('id')
       .withGraphFetched('tasks')
       .modifyGraph('tasks', (builder) => {
         builder.select('task.task_id', 'task.complete_date');

--- a/packages/api/src/models/animalBatchModel.js
+++ b/packages/api/src/models/animalBatchModel.js
@@ -241,6 +241,20 @@ class AnimalBatchModel extends baseModel {
     );
   }
 
+  static async getBatchesWithNewerCompletedTasks(batchIds, taskTypeId, completedDate) {
+    return AnimalBatchModel.query()
+      .select('id', 'location_id')
+      .withGraphFetched('tasks')
+      .modifyGraph('tasks', (builder) => {
+        builder.select('task.task_id', 'task.complete_date');
+        builder
+          .where('deleted', false)
+          .where('complete_date', '>', completedDate)
+          .where('task_type_id', taskTypeId);
+      })
+      .whereIn('id', batchIds);
+  }
+
   static async unrelateIncompleteTasksForBatches(trx, batchIds) {
     let unrelatedTaskIds = [];
     const batches = await AnimalBatchModel.getBatchIdsWithIncompleteTasks(trx, batchIds);

--- a/packages/api/src/models/animalModel.js
+++ b/packages/api/src/models/animalModel.js
@@ -238,7 +238,7 @@ class Animal extends baseModel {
 
   static async getAnimalsWithNewerCompletedTasks(animalIds, taskTypeId, completedDate) {
     return Animal.query()
-      .select('id', 'location_id')
+      .select('id')
       .withGraphFetched('tasks')
       .modifyGraph('tasks', (builder) => {
         builder.select('task.task_id', 'task.complete_date');

--- a/packages/api/src/models/animalModel.js
+++ b/packages/api/src/models/animalModel.js
@@ -236,6 +236,20 @@ class Animal extends baseModel {
     );
   }
 
+  static async getAnimalsWithNewerCompletedTasks(animalIds, taskTypeId, completedDate) {
+    return Animal.query()
+      .select('id', 'location_id')
+      .withGraphFetched('tasks')
+      .modifyGraph('tasks', (builder) => {
+        builder.select('task.task_id', 'task.complete_date');
+        builder
+          .where('deleted', false)
+          .where('complete_date', '>', completedDate)
+          .where('task_type_id', taskTypeId);
+      })
+      .whereIn('id', animalIds);
+  }
+
   static async unrelateIncompleteTasksForAnimals(trx, animalIds) {
     let unrelatedTaskIds = [];
     const animals = await Animal.getAnimalIdsWithIncompleteTasks(trx, animalIds);

--- a/packages/api/tests/animalTask.test.js
+++ b/packages/api/tests/animalTask.test.js
@@ -101,6 +101,14 @@ const checkMovementPurposeRelationships = (expectedRelationships, actualRelation
   );
 };
 
+const getAnimalLocations = async (animalOrBatch, ids) => {
+  return knex(animalOrBatch === 'animal' ? 'animal' : 'animal_batch')
+    .select('id', 'location_id')
+    .whereIn('id', ids);
+};
+
+const getAnimalOrBatchIds = (animalsOrBatches) => animalsOrBatches.map(({ id }) => id);
+
 describe('Animal task tests', () => {
   let user_id, farm_id, location_id, task_type_id, planting_management_plan_id;
   let animal1, animal2, animal3, animal4, batch1, batch2, batch3, batch4;
@@ -841,6 +849,43 @@ describe('Animal task tests', () => {
           }
         };
 
+        const checkAnimalMovementWithSpecificCompleteDate = async ({
+          locationId,
+          animals = [],
+          batches = [],
+          completeDate,
+          expectedAnimalLocations = {},
+          expectedBatchLocations = {},
+        }) => {
+          const { task_id } = await animalTaskFactory({
+            locations: [{ location_id: locationId }],
+            animals: animals.map(({ id }) => ({ id })),
+            animal_batches: batches.map(({ id }) => ({ id })),
+            ...createFakeMovementTask(),
+          });
+
+          await completeMovementTaskReq(
+            {
+              ...fakeCompletionData,
+              complete_date: completeDate,
+              ...createMovementTaskForReqBody(),
+            },
+            task_id,
+          );
+
+          const [updatedAnimals, updatedBatches] = await Promise.all([
+            getAnimalLocations('animal', getAnimalOrBatchIds(animals)),
+            getAnimalLocations('batch', getAnimalOrBatchIds(batches)),
+          ]);
+
+          updatedAnimals.forEach(({ id, location_id }) => {
+            expect(location_id).toBe(expectedAnimalLocations[id]);
+          });
+          updatedBatches.forEach(({ id, location_id }) => {
+            expect(location_id).toBe(expectedBatchLocations[id]);
+          });
+        };
+
         test('should complete an animal task without purpose relations and no updates', async () => {
           await checkCompletedMovementTask(null, null, null, null);
         });
@@ -889,6 +934,88 @@ describe('Animal task tests', () => {
 
         test('should complete a movement task with deleting other_purpose', async () => {
           await checkCompletedMovementTask([otherPurpose], faker.lorem.word(), [otherPurpose], '');
+        });
+
+        test(`should complete a movement task without updating animals' location if there's newer completed task`, async () => {
+          const [[animalA], [animalB], [animalC]] = await Promise.all(
+            new Array(4).fill().map(() => mocks.animalFactory({ promisedFarm: [{ farm_id }] })),
+          );
+          const [[batchA], [batchB]] = await Promise.all(
+            new Array(4)
+              .fill()
+              .map(() => mocks.animal_batchFactory({ promisedFarm: [{ farm_id }] })),
+          );
+
+          // Record a task completed a week ago
+          const dateWeekAgo = new Date();
+          dateWeekAgo.setDate(dateWeekAgo.getDate() - 7);
+          await checkAnimalMovementWithSpecificCompleteDate({
+            locationId: location_id,
+            animals: [animalA, animalB],
+            completeDate: toLocal8601Extended(dateWeekAgo),
+            expectedAnimalLocations: { [animalA.id]: location_id, [animalB.id]: location_id },
+          });
+
+          // Record a task completed a month ago
+          const dateMonthAgo = new Date();
+          dateMonthAgo.setMonth(dateMonthAgo.getMonth() - 1);
+          await checkAnimalMovementWithSpecificCompleteDate({
+            locationId: location2Id,
+            animals: [animalA, animalB],
+            batches: [batchA, batchB],
+            completeDate: toLocal8601Extended(dateMonthAgo),
+            expectedAnimalLocations: { [animalA.id]: location_id, [animalB.id]: location_id },
+            expectedBatchLocations: { [batchA.id]: location2Id, [batchB.id]: location2Id },
+          });
+
+          // Move some animals today
+          const [{ location_id: location3Id }] = await mocks.locationFactory({
+            promisedFarm: [{ farm_id }],
+          });
+          await checkAnimalMovementWithSpecificCompleteDate({
+            locationId: location3Id,
+            animals: [animalA],
+            batches: [batchA],
+            completeDate: toLocal8601Extended(new Date()),
+            expectedAnimalLocations: { [animalA.id]: location3Id },
+            expectedBatchLocations: { [batchA.id]: location3Id },
+          });
+
+          // Record yesterday's movement
+          const dateYesterday = new Date();
+          dateYesterday.setDate(dateYesterday.getDate() - 1);
+          const [{ location_id: location4Id }] = await mocks.locationFactory({
+            promisedFarm: [{ farm_id }],
+          });
+          await checkAnimalMovementWithSpecificCompleteDate({
+            locationId: location4Id,
+            animals: [animalA, animalB, animalC],
+            batches: [batchA, batchB],
+            completeDate: toLocal8601Extended(dateYesterday),
+            expectedAnimalLocations: {
+              [animalA.id]: location3Id,
+              [animalB.id]: location4Id,
+              [animalC.id]: location4Id,
+            },
+            expectedBatchLocations: { [batchA.id]: location3Id, [batchB.id]: location4Id },
+          });
+
+          // Move animals again today
+          const [{ location_id: location5Id }] = await mocks.locationFactory({
+            promisedFarm: [{ farm_id }],
+          });
+          await checkAnimalMovementWithSpecificCompleteDate({
+            locationId: location5Id,
+            animals: [animalA, animalB, animalC],
+            batches: [batchA, batchB],
+            completeDate: toLocal8601Extended(new Date()),
+            expectedAnimalLocations: {
+              [animalA.id]: location5Id,
+              [animalB.id]: location5Id,
+              [animalC.id]: location5Id,
+            },
+            expectedBatchLocations: { [batchA.id]: location5Id, [batchB.id]: location5Id },
+          });
         });
 
         test('should not complete a movement task with an invalid purpose id', async () => {

--- a/packages/api/tests/animalTask.test.js
+++ b/packages/api/tests/animalTask.test.js
@@ -938,10 +938,10 @@ describe('Animal task tests', () => {
 
         test(`should complete a movement task without updating animals' location if there's newer completed task`, async () => {
           const [[animalA], [animalB], [animalC]] = await Promise.all(
-            new Array(4).fill().map(() => mocks.animalFactory({ promisedFarm: [{ farm_id }] })),
+            new Array(3).fill().map(() => mocks.animalFactory({ promisedFarm: [{ farm_id }] })),
           );
           const [[batchA], [batchB]] = await Promise.all(
-            new Array(4)
+            new Array(2)
               .fill()
               .map(() => mocks.animal_batchFactory({ promisedFarm: [{ farm_id }] })),
           );


### PR DESCRIPTION
**Description**

- Conditionally update animals' location when a movement task is completed.
   - Retrieve completed movement tasks newer than the task about to be completed, and if there are, keep the existing location.
- Add tests (`npm run test animalTask`)

Jira link: https://lite-farm.atlassian.net/browse/LF-4579

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
