### PR TITLE
LF-4595 The app crashes when trying to access deleted animal’s details page

### DIFF
--- a/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
+++ b/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
@@ -175,6 +175,10 @@ function SingleAnimalView({ isCompactSideMenu, history, match, location }: AddAn
   };
 
   const getInventoryId = () => {
+    if (!selectedAnimal && !selectedBatch) {
+      return '';
+    }
+
     const animalOrBatch = AnimalOrBatchKeys[selectedAnimal ? 'ANIMAL' : 'BATCH'];
     return generateInventoryId(animalOrBatch, (selectedAnimal || selectedBatch)!);
   };


### PR DESCRIPTION
**Description**

The `generateInventoryId` function was crashing before the useEffect redirect ran.

Incidentally if you remove the useEffect and redirect in the function body (or the hook), you can get both crash AND redirect!  (I.e. type error crash in console but won't notice because the redirect masks it immediately). I thought that was kind of fun 😁  It's not a good solution though.

Jira link: https://lite-farm.atlassian.net/browse/LF-4595

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
