### PR TITLE
LF-4575 fix custom tasks not attached to crop plans

### DIFF
--- a/packages/webapp/src/containers/Task/TaskLocations/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskLocations/index.jsx
@@ -183,7 +183,7 @@ function TaskCustomLocations({ history, location }) {
     );
     const hasWildManagementPlans = formData.show_wild_crop && wildManagementPlanTiles.length;
     const hasManagementPlans = hasLocationManagementPlans || hasWildManagementPlans;
-    if (!readOnlyPinCoordinates?.length || !hasManagementPlans) {
+    if (!hasManagementPlans) {
       dispatch(setManagementPlansData([]));
       if (animalsExistOnFarm) {
         return history.push('/add_task/task_animal_selection', location?.state);


### PR DESCRIPTION
**Description**

There was a condition originally on the`TaskAllLocations` component (which was previously used by custom tasks too) that read

```js
if (
      (taskTypesBypassCrops.includes(persistedFormData.task_type_id) &&
        !readOnlyPinCoordinates?.length) ||
      !hasManagementPlans
    ) {
```

When `TaskCustomLocations` was split up from `TaskAllLocations`, this condition was refactored to

```js
if (
      !readOnlyPinCoordinates?.length) ||
      !hasManagementPlans
    ) {
```

However the check for read only pin coordinates was only meant to apply if the task type matched one that should bypass the crops screen. After the refactor, it was applying for custom tasks too and was causing the skipping of the crop selection screen and the linking of the task to the management plan.

Jira link:
https://lite-farm.atlassian.net/browse/LF-4575

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
