### PR TITLE
LF-4606  “Click to upload link” should not display or should “look” disabled if not in editing mode [Duplicate - See Usability section]

### DIFF
--- a/packages/webapp/src/components/Animals/DetailCards/Other.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Other.tsx
@@ -113,13 +113,15 @@ const OtherDetails = ({
         errors={errors?.[`${namePrefix}${DetailsFields.OTHER_DETAILS}`]?.message}
         disabled={mode === 'readonly'}
       />
-      <ImagePicker
-        label={t(`ANIMAL.ATTRIBUTE.${animalOrBatch.toUpperCase()}_IMAGE`)}
-        onFileUpload={onFileUpload}
-        onRemoveImage={handleRemoveImage}
-        defaultUrl={field.value}
-        isDisabled={mode === 'readonly'}
-      />
+      {(!!field.value || mode !== 'readonly') && (
+        <ImagePicker
+          label={t(`ANIMAL.ATTRIBUTE.${animalOrBatch.toUpperCase()}_IMAGE`)}
+          onFileUpload={onFileUpload}
+          onRemoveImage={handleRemoveImage}
+          defaultUrl={field.value}
+          isDisabled={mode === 'readonly'}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
**Description**

Was never a blocker but it came up twice in bug bash, and was a trivial fix on the way to tackling the animal inventory image ticket. It is also part of the spec I just forgot to implement:

- Image upload component should have been hidden entirely in readonly animal details view if no image has been added

Jira link: https://lite-farm.atlassian.net/browse/LF-4606

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
