### PR TITLE
LF-4570: Farm image preview is broken on beta

### DIFF
--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -146,12 +146,12 @@ export default function ImagePicker({
                 accept="image/*"
                 disabled={isDisabled}
               >
-                <TextButton type="button">
+                <TextButton type="button" className={styles.editButton}>
                   <EditIcon />
                   {t('UPLOADER.CHANGE_IMAGE')}
                 </TextButton>
               </PureFilePickerWrapper>
-              <TextButton type="button" onClick={removeImage}>
+              <TextButton type="button" onClick={removeImage} className={styles.editButton}>
                 <TrashIcon />
                 {t('UPLOADER.REMOVE_IMAGE')}
               </TextButton>

--- a/packages/webapp/src/components/ImagePicker/styles.module.scss
+++ b/packages/webapp/src/components/ImagePicker/styles.module.scss
@@ -104,3 +104,9 @@
   background-color: var(--teal100);
   border: 1px solid var(--teal500);
 }
+
+.editButton {
+  svg {
+    width: 22px;
+  }
+}

--- a/packages/webapp/src/components/Profile/Farm/index.jsx
+++ b/packages/webapp/src/components/Profile/Farm/index.jsx
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
 import ProfileLayout from '../ProfileLayout';
 import { Label } from '../../Typography';
 import ImagePicker from '../../ImagePicker';
+import useMediaWithAuthentication from '../../../containers/hooks/useMediaWithAuthentication';
 
 export default function PureFarm({ userFarm, onSubmit, history, isAdmin }) {
   const MEASUREMENT = 'units.measurement';
@@ -56,6 +57,9 @@ export default function PureFarm({ userFarm, onSubmit, history, isAdmin }) {
 
   const { farm_image_thumbnail_url: thumbnailUrl } = userFarm;
   const { field: imageFileField } = useController({ control, name: IMAGE_FILE });
+  const { mediaUrl: authenticatedImageUrl, isLoading } = useMediaWithAuthentication({
+    fileUrls: [thumbnailUrl],
+  });
 
   const disabled = !isDirty || !isValid;
 
@@ -129,11 +133,13 @@ export default function PureFarm({ userFarm, onSubmit, history, isAdmin }) {
       <div>
         <input type="checkbox" style={{ display: 'none' }} {...register(SHOULD_REMOVE_IMAGE)} />
         <Label>{t('PROFILE.FARM.FARM_IMAGE')}</Label>
-        <ImagePicker
-          defaultUrl={thumbnailUrl}
-          onSelectImage={handleSelectImage}
-          onRemoveImage={handleRemoveImage}
-        />
+        {!isLoading && (
+          <ImagePicker
+            defaultUrl={authenticatedImageUrl}
+            onSelectImage={handleSelectImage}
+            onRemoveImage={handleRemoveImage}
+          />
+        )}
       </div>
     </ProfileLayout>
   );


### PR DESCRIPTION
**Description**

This bug seems to have introduced when `FarmImagePicker` was replaced with `ImagePicker` in https://github.com/LiteFarmOrg/LiteFarm/pull/3390. Since farm images are private, we need to generate a URL using `useMediaWithAuthentication` as Navdeep mentioned [here](https://github.com/LiteFarmOrg/LiteFarm/pull/3192#discussion_r1586391467).

I'm not sure how to test this locally, so we can merge if we're comfortable with this change.

Jira link: https://lite-farm.atlassian.net/browse/LF-4570

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
