### PR TITLE
LF-4609 Reduce touch delay for tooltip going away

### DIFF
--- a/packages/webapp/src/components/Tooltip/index.tsx
+++ b/packages/webapp/src/components/Tooltip/index.tsx
@@ -70,7 +70,7 @@ export default function OverlayTooltip({
       arrow={true}
       classes={{ tooltip: classes.tooltip, arrow: classes.arrow }}
       enterTouchDelay={10}
-      leaveTouchDelay={900000}
+      leaveTouchDelay={5000}
     >
       <span className={classes.childrenContainer}>{icon || children}</span>
     </Tooltip>


### PR DESCRIPTION
**Description**

Reduces the delay to which the popup self removes. It was 900s, I put it to 5s, default is 1.5s.

I have not tested this on all tooltips, presumably there is some with long text -- but the worst case scenario I can see is you click again vs interfering with other elements.

Jira link: [LF-4609](https://lite-farm.atlassian.net/browse/LF-4609)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4609]: https://lite-farm.atlassian.net/browse/LF-4609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ