### PR TITLE
LF-4612b Accidental click outside checkbox goes to details view and loses check progress

### DIFF
--- a/packages/webapp/src/components/Table/Cell/styles.module.scss
+++ b/packages/webapp/src/components/Table/Cell/styles.module.scss
@@ -31,6 +31,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-left: -12px;
 }
 
 .photoUrl,

--- a/packages/webapp/src/components/Table/styles.module.scss
+++ b/packages/webapp/src/components/Table/styles.module.scss
@@ -260,7 +260,8 @@
 
 // checkbox
 .checkboxCell {
-  width: 32px;
+  width: 44px;
+  padding-right: 6px;
   text-align: center;
 
   span {


### PR DESCRIPTION
**Description**

Checkbox hitbox was improved in:
- https://github.com/LiteFarmOrg/LiteFarm/pull/3602

by making sure that the onClick handler fills the whole checkbox cell. However, the checkbox cell still needed to be increased to 44px (increased by 12px) in order to meet Loïc's specifications.

I moved the icon left the same amount so the view remains unchanged.

Jira link: https://lite-farm.atlassian.net/browse/LF-4612

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
