### PR TITLE
LF-4618 Fix remove error entry when click X on number input

### DIFF
--- a/packages/webapp/src/components/Animals/AddAnimalsFormCard/AddAnimalsFormCard.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsFormCard/AddAnimalsFormCard.tsx
@@ -128,6 +128,7 @@ export default function AddAnimalsFormCard({
           label={t('common:COUNT')}
           className={styles.countInput}
           allowDecimal={false}
+          defaultValue={1}
           showStepper
           rules={{
             required: {

--- a/packages/webapp/src/components/Form/NumberInput/index.tsx
+++ b/packages/webapp/src/components/Form/NumberInput/index.tsx
@@ -60,8 +60,10 @@ export default function NumberInput<T extends FieldValues>({
   ...props
 }: NumberInputProps<T>) {
   const { field, fieldState, formState } = useController({ name, control, rules, defaultValue });
+  console.log(field.value);
+  console.log(defaultValue);
   const { inputProps, reset, numericValue, increment, decrement } = useNumberInput({
-    initialValue: field.value || get(formState.defaultValues, name) || defaultValue,
+    initialValue: defaultValue || field.value || get(formState.defaultValues, name),
     allowDecimal,
     decimalDigits,
     locale,


### PR DESCRIPTION
**Description**

Bug: error value in animals count input not restored to default value when clicking "X". 
Cause: default value not being used and logic of restoring default is wrong.
Fix: Change default value logic to be using prop default value instead of current value in the field and add default value prop to field input

Jira link: https://lite-farm.atlassian.net/browse/LF-4618

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
