### PR TITLE
Remove server.js CORS for development environment

### DIFF
--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -255,7 +255,7 @@ const rejectBodyInGetAndDelete = (req, res, next) => {
 const getAllowedOrigin = () => {
   switch (environment) {
     case 'development':
-      return 'http://localhost:3000';
+      return '*';
     case 'integration':
       return 'https://beta.litefarm.org';
     case 'production':


### PR DESCRIPTION
**Description**

We added server-side CORS in this PR:

- https://github.com/LiteFarmOrg/LiteFarm/pull/3551

But limiting development environment domain to localhost was overly restrictive; it produces CORS errors when connecting to the server from e.g. a mobile device connecting over the local network. We do have an `.env` variable in webapp where we can point to the local network name, but no such variable in api.

Restricting domain is not necessary for dev environment so I have just lifted the restriction.

Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Ran into the issue testing something on mobile; tested the fix the same way.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
