### PR TITLE
LF-4601 Fixed: KPI needs to be higher than table header

### DIFF
--- a/packages/webapp/src/components/TileDashboard/MoreComponent/styles.module.scss
+++ b/packages/webapp/src/components/TileDashboard/MoreComponent/styles.module.scss
@@ -16,7 +16,7 @@
 .moreContainer {
   position: relative;
   overflow-x: visible;
-  z-index: 2;
+  z-index: 3;
 }
 
 .moreButton.moreButton {


### PR DESCRIPTION
**Description**

If you have lots of animal type and click on overflow button(more), the box showing remaining animal types goes under the table header. Which is fixed in this PR.

Jira link: https://lite-farm.atlassian.net/browse/LF-4601

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Add lots of animal type if not there. Click on the more button. The popup now is above the table header.

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
