### PR TITLE
LF-4418 Fixed: checkbox label taking more space than the text

### DIFF
--- a/packages/webapp/src/components/Form/Checkbox/checkbox.module.scss
+++ b/packages/webapp/src/components/Form/Checkbox/checkbox.module.scss
@@ -24,6 +24,7 @@
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  width: fit-content;
 
   &:hover input:not(:checked):not(:disabled) {
     ~ .label {


### PR DESCRIPTION
**Description**

Checkbox get selected even if we click outside of the text. This PR resolves this bug. Now if we click outside the text, the checkbox will not be selected.

Jira link: https://lite-farm.atlassian.net/browse/LF-4418

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
- Navigate to the Animals page.
- Click on the “+” button > Add animals.
- Click outside the field “Create individual animal profiles”

Now, checkbox will not get selected.

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
