### PR TITLE
LF-4619 Added validation to throw error when animal type or breed name exceeds 255 characters

### DIFF
--- a/packages/webapp/src/components/Animals/AddAnimalsFormCard/AnimalSelect.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsFormCard/AnimalSelect.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { RefObject } from 'react';
 import { GroupBase, SelectInstance, OptionsOrGroups } from 'react-select';
 import { Error } from '../../Typography';
+import { hookFormSelectOptionMaxLength } from '../../Form/hookformValidationUtils';
 
 export type Option = {
   label: string;
@@ -49,6 +50,7 @@ export function AnimalTypeSelect<T extends FieldValues>({
         control={control}
         rules={{
           required: { value: true, message: t('common:REQUIRED') },
+          validate: hookFormSelectOptionMaxLength,
         }}
         render={({ field: { onChange, value } }) => (
           <CreatableSelect
@@ -94,6 +96,9 @@ export function AnimalBreedSelect<T extends FieldValues>({
       <Controller
         name={name}
         control={control}
+        rules={{
+          validate: hookFormSelectOptionMaxLength,
+        }}
         render={({ field: { onChange, value } }) => (
           <CreatableSelect
             ref={breedSelectRef}

--- a/packages/webapp/src/components/Animals/DetailCards/General.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/General.tsx
@@ -201,6 +201,10 @@ const GeneralDetails = ({
         control={control}
         breedOptions={filteredBreeds}
         isTypeSelected={!!watchAnimalType}
+        onBreedChange={(option) => {
+          trigger(`${namePrefix}${DetailsFields.BREED}`);
+        }}
+        error={get(errors, `${namePrefix}${DetailsFields.BREED}`)}
         isDisabled={mode !== 'edit'}
       />
       {sexInputs}

--- a/packages/webapp/src/components/Form/hookformValidationUtils.js
+++ b/packages/webapp/src/components/Form/hookformValidationUtils.js
@@ -87,3 +87,18 @@ export const hookFormUniquePropertyWithStatusValidation = ({
     return true;
   };
 };
+
+/**
+ * Validates whether the length of the selected option's label exceeds the specified maximum.
+ * Returns an error message if the length is greater than the allowed limit; otherwise, returns true.
+ *
+ * @param {string} Option - The option whose label length is being validated.
+ * @param {number} length - The maximum allowed length for the label.
+ * @returns {string | boolean} A validation function that checks the label's length
+ * and returns either an error message or `true` if the validation passes.
+ */
+export const hookFormSelectOptionMaxLength = (selectedOption, length = 255) => {
+  return (
+    selectedOption?.label.length <= length || i18n.t('common:CHAR_LIMIT_ERROR', { value: length })
+  );
+};


### PR DESCRIPTION
**Description**

User was able to create an animal type or breed with more that 255 characters. This PR resolves this and throws an error to show the limitation to the user while creating animal.

Jira link: https://lite-farm.atlassian.net/browse/LF-4619

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Try to create animal type or breed with more that 255 characters, it will throw an error and restricts user from moving forward with creation of animal.

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
