### PR TITLE
TypeScript cleanup -- hookFormValidationUtils.ts and ts-expect-error

### DIFF
--- a/packages/webapp/src/components/Animals/AddAnimalsDetails/index.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsDetails/index.tsx
@@ -46,10 +46,7 @@ const AnimalDetails = ({
   originProps,
   namePrefix,
 }: AnimalDetailsProps) => {
-  const { expandedIds, toggleExpanded } = useExpandable(
-    // @ts-ignore
-    { isSingleExpandable: true },
-  );
+  const { expandedIds, toggleExpanded } = useExpandable({ isSingleExpandable: true });
   const { t } = useTranslation(['translation', 'common', 'animal']);
   const commonProps = { t, namePrefix };
 

--- a/packages/webapp/src/components/Animals/AddAnimalsFormCard/AddAnimalsFormCard.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsFormCard/AddAnimalsFormCard.tsx
@@ -173,7 +173,7 @@ export default function AddAnimalsFormCard({
         }}
       />
       {!shouldCreateIndividualProfiles && (
-        // @ts-ignore
+        // @ts-expect-error
         <Input
           label={t('ADD_ANIMAL.BATCH_NAME')}
           optional

--- a/packages/webapp/src/components/Animals/AddAnimalsFormCard/AnimalSelect.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsFormCard/AnimalSelect.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { RefObject } from 'react';
 import { GroupBase, SelectInstance, OptionsOrGroups } from 'react-select';
 import { Error } from '../../Typography';
-import { hookFormSelectOptionMaxLength } from '../../Form/hookformValidationUtils';
+import { validateOptionLength } from '../../Form/hookformValidationUtils';
 
 export type Option = {
   label: string;
@@ -50,8 +50,7 @@ export function AnimalTypeSelect<T extends FieldValues>({
         control={control}
         rules={{
           required: { value: true, message: t('common:REQUIRED') },
-          // @ts-ignore
-          validate: hookFormSelectOptionMaxLength,
+          validate: validateOptionLength,
         }}
         render={({ field: { onChange, value } }) => (
           <CreatableSelect
@@ -98,8 +97,7 @@ export function AnimalBreedSelect<T extends FieldValues>({
         name={name}
         control={control}
         rules={{
-          // @ts-ignore
-          validate: hookFormSelectOptionMaxLength,
+          validate: validateOptionLength,
         }}
         render={({ field: { onChange, value } }) => (
           <CreatableSelect

--- a/packages/webapp/src/components/Animals/AddAnimalsFormCard/AnimalSelect.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsFormCard/AnimalSelect.tsx
@@ -110,7 +110,6 @@ export function AnimalBreedSelect<T extends FieldValues>({
             isDisabled={!isTypeSelected || isDisabled}
             onChange={(option: any) => {
               onChange(option);
-              // @ts-ignore
               onBreedChange?.(option);
             }}
             value={value || null}

--- a/packages/webapp/src/components/Animals/DetailCards/General.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/General.tsx
@@ -104,7 +104,7 @@ const GeneralDetails = ({
     animalOrBatch === AnimalOrBatchKeys.ANIMAL ? (
       <div>
         <InputBaseLabel optional label={t('ANIMAL.ANIMAL_SEXES')} />
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <RadioGroup
           name={`${namePrefix}${DetailsFields.SEX}`}
           radios={sexOptions}
@@ -160,7 +160,6 @@ const GeneralDetails = ({
     <div className={clsx(styles.sectionWrapper, mode === 'edit' && styles.edit)}>
       {(mode === 'readonly' || mode === 'edit') && (
         <>
-          {/* @ts-ignore */}
           <LockedInput
             label={t('ANIMAL.ATTRIBUTE.LITEFARM_ID')}
             placeholder={`${t('ANIMAL.ANIMAL_ID')}${getValues(`${namePrefix}${DetailsFields.ID}`)}`}
@@ -169,7 +168,7 @@ const GeneralDetails = ({
       )}
       {animalOrBatch === AnimalOrBatchKeys.BATCH && (
         <>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             type="text"
             label={t('ANIMAL.ATTRIBUTE.BATCH_NAME')}
@@ -226,7 +225,7 @@ const GeneralDetails = ({
       />
       {isOtherUseSelected && (
         <>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             type="text"
             label={t('ANIMAL.ATTRIBUTE.OTHER_USE')}

--- a/packages/webapp/src/components/Animals/DetailCards/Origin.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Origin.tsx
@@ -55,7 +55,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
   const fields = useMemo(() => {
     return origin === AnimalOrigins.BROUGHT_IN ? (
       <>
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <Input
           key={DetailsFields.BROUGHT_IN_DATE}
           type="date"
@@ -79,7 +79,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
           optional
           disabled={mode === 'readonly'}
         />
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <Input
           key={DetailsFields.SUPPLIER}
           type="text"
@@ -94,7 +94,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
           errors={getInputErrors(errors, `${namePrefix}${DetailsFields.SUPPLIER}`)}
           disabled={mode === 'readonly'}
         />
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <Input
           key={DetailsFields.PRICE}
           type="number"
@@ -112,7 +112,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
       </>
     ) : (
       <>
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <Input
           key={DetailsFields.DAM}
           type="text"
@@ -127,7 +127,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
           errors={getInputErrors(errors, `${namePrefix}${DetailsFields.DAM}`)}
           disabled={mode === 'readonly'}
         />
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <Input
           key={DetailsFields.SIRE}
           type="text"
@@ -147,7 +147,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
   }, [origin, Object.entries(errors)]);
   return (
     <div className={styles.sectionWrapper}>
-      {/* @ts-ignore */}
+      {/* @ts-expect-error */}
       <Input
         type="date"
         label={t('ANIMAL.ATTRIBUTE.DATE_OF_BIRTH')}
@@ -171,7 +171,7 @@ const Origin = ({ t, currency, originOptions, namePrefix = '', mode = 'add' }: O
         disabled={mode === 'readonly'}
       />
       <div>
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <RadioGroup
           name={`${namePrefix}${DetailsFields.ORIGIN}`}
           radios={originOptions}

--- a/packages/webapp/src/components/Animals/DetailCards/Other.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Other.tsx
@@ -79,7 +79,7 @@ const OtherDetails = ({
     <div className={styles.sectionWrapper}>
       {animalOrBatch === AnimalOrBatchKeys.ANIMAL && (
         <>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             type="date"
             label={t('ANIMAL.ATTRIBUTE.WEANING_DATE')}
@@ -102,7 +102,7 @@ const OtherDetails = ({
           />
         )}
       />
-      {/* @ts-ignore */}
+      {/* @ts-expect-error */}
       <InputAutoSize
         label={t(`ANIMAL.ATTRIBUTE.OTHER_DETAILS_${animalOrBatch.toUpperCase()}`)}
         hookFormRegister={register(`${namePrefix}${DetailsFields.OTHER_DETAILS}`, {

--- a/packages/webapp/src/components/Animals/DetailCards/Unique.tsx
+++ b/packages/webapp/src/components/Animals/DetailCards/Unique.tsx
@@ -48,7 +48,7 @@ const UniqueDetails = ({
 
   return (
     <div className={styles.sectionWrapper}>
-      {/* @ts-ignore */}
+      {/* @ts-expect-error */}
       <Input
         type="text"
         label={t('common:NAME')}
@@ -61,7 +61,7 @@ const UniqueDetails = ({
         errors={getInputErrors(errors, `${namePrefix}${DetailsFields.NAME}`)}
         disabled={mode === 'readonly'}
       />
-      {/* @ts-ignore */}
+      {/* @ts-expect-error */}
       <Input
         type="text"
         label={t('ANIMAL.ATTRIBUTE.TAG_NUMBER')}
@@ -106,7 +106,7 @@ const UniqueDetails = ({
       />
       {shouldShowTagTypeInput && (
         <>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             type="text"
             hookFormRegister={register(`${namePrefix}${DetailsFields.TAG_TYPE_INFO}`, {

--- a/packages/webapp/src/components/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/components/Animals/Inventory/index.tsx
@@ -165,7 +165,7 @@ const PureAnimalInventory = ({
       {showActionFloaterButton && (
         <div className={styles.ctaButtonWrapper}>
           <FloatingActionButton
-            // @ts-ignore
+            // @ts-expect-error
             type={'add'}
             onClick={() => history.push(ADD_ANIMALS_URL)}
             aria-label={t('ADD_ANIMAL.ADD_ANIMALS')}

--- a/packages/webapp/src/components/Animals/RemoveAnimalsModal/index.tsx
+++ b/packages/webapp/src/components/Animals/RemoveAnimalsModal/index.tsx
@@ -124,7 +124,6 @@ export default function RemoveAnimalsModal(props: RemoveAnimalsModalProps) {
 
   return (
     <>
-      {/* @ts-ignore */}
       <Drawer
         title={t('REMOVE_ANIMALS.REMOVE_ANIMALS')}
         isOpen={props.isOpen}
@@ -189,7 +188,7 @@ export default function RemoveAnimalsModal(props: RemoveAnimalsModalProps) {
             )}
 
             {!isCreatedInError(selectedOption) && (
-              /* @ts-ignore */
+              /* @ts-expect-error */
               <Input
                 type={'date'}
                 label={t('common:DATE')}
@@ -209,7 +208,7 @@ export default function RemoveAnimalsModal(props: RemoveAnimalsModalProps) {
                 </div>
               ) : (
                 <>
-                  {/*@ts-ignore*/}
+                  {/*@ts-expect-error*/}
                   <Input
                     hookFormRegister={register(EXPLANATION)}
                     label={t('REMOVE_ANIMALS.EXPLANATION')}

--- a/packages/webapp/src/components/Form/ContextForm/WithPageTitle.tsx
+++ b/packages/webapp/src/components/Form/ContextForm/WithPageTitle.tsx
@@ -52,7 +52,7 @@ export const WithPageTitle = ({
     <ClickAwayListener onClickAway={onClickAway} mouseEvent="onMouseDown" touchEvent="onTouchStart">
       <div>
         <Layout>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <MultiStepPageTitle
             title={title}
             onGoBack={onGoBack}

--- a/packages/webapp/src/components/Form/ReactSelect/CreatableSelect.tsx
+++ b/packages/webapp/src/components/Form/ReactSelect/CreatableSelect.tsx
@@ -75,7 +75,7 @@ const CreatableSelect = React.forwardRef((props, ref) => {
     return (
       inputValue.trim().length > 0 &&
       !options?.some((opt) => {
-        // @ts-ignore
+        // @ts-expect-error
         return compareUpperCaseTrim(opt?.label, inputValue);
       })
     );

--- a/packages/webapp/src/components/Form/hookformValidationUtils.ts
+++ b/packages/webapp/src/components/Form/hookformValidationUtils.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 LiteFarm.org
+ *  Copyright 2023, 2025 LiteFarm.org
  *  This file is part of LiteFarm.
  *
  *  LiteFarm is free software: you can redistribute it and/or modify
@@ -16,20 +16,24 @@
 // This file contains validation functions for use with react-hook-forms input validator
 
 import i18n from '../../locales/i18n';
+import { TFunction } from 'react-i18next';
 
-export const hookFormMaxValidation = (max = 9999, message = '') => ({
+export const hookFormMaxValidation = (max: number = 9999, message: string = '') => ({
   value: max,
   message: message || i18n.t('common:MAX_ERROR', { value: max + 1 }),
 });
-export const hookFormMinValidation = (min) => ({
+
+export const hookFormMinValidation = (min: number) => ({
   value: min,
   message: i18n.t('common:MIN_ERROR', { value: min - 1 }),
 });
-export const hookFormMaxLengthValidation = (length = 60) => ({
+
+export const hookFormMaxLengthValidation = (length: number = 60) => ({
   value: length,
   message: i18n.t('common:WORD_LIMIT_ERROR', { value: length }),
 });
-export const hookFormMaxCharsValidation = (max = 9999) => ({
+
+export const hookFormMaxCharsValidation = (max: number = 9999) => ({
   value: max,
   message: i18n.t('common:CHAR_LIMIT_ERROR', { value: max }),
 });
@@ -43,8 +47,12 @@ export const hookFormMaxCharsValidation = (max = 9999) => ({
  * @returns {(value: any) => string|boolean} A validation function that takes a value to validate and returns
  * either the error message (if not unique) or `true` (if unique).
  */
-export const hookFormUniquePropertyValidation = (objArr, property, message) => {
-  return (value) => {
+export const hookFormUniquePropertyValidation = (
+  objArr: Array<{ [key: string]: any }>,
+  property: string,
+  message: string,
+) => {
+  return (value: any) => {
     const alreadyExists = objArr.some((item) => {
       return item[property] === value;
     });
@@ -57,7 +65,7 @@ export const hookFormUniquePropertyValidation = (objArr, property, message) => {
 
 /**
  * Validates if a value is unique within an array of objects based on a specified property.
- * Returns different messages depending on the bolean status of a specified property in the found object.
+ * Returns different messages depending on the boolean status of a specified property in the found object.
  *
  * @param {Array<Object>} objArr - The array of objects to search for duplicates in.
  * @param {string} property - The property within each object to check for uniqueness.
@@ -73,8 +81,14 @@ export const hookFormUniquePropertyWithStatusValidation = ({
   status = 'deleted',
   messageStatusTrue,
   messageStatusFalse,
+}: {
+  objArr: Array<{ [key: string]: any }>;
+  property: string;
+  status?: string;
+  messageStatusTrue: string;
+  messageStatusFalse: string;
 }) => {
-  return (value) => {
+  return (value: any) => {
     const foundItem = objArr.find((item) => item[property] === value);
 
     if (foundItem) {
@@ -92,13 +106,16 @@ export const hookFormUniquePropertyWithStatusValidation = ({
  * Validates whether the length of the selected option's label exceeds the specified maximum.
  * Returns an error message if the length is greater than the allowed limit; otherwise, returns true.
  *
- * @param {string} Option - The option whose label length is being validated.
+ * @param {string} selectedOption - The option whose label length is being validated.
  * @param {number} length - The maximum allowed length for the label.
  * @returns {string | boolean} A validation function that checks the label's length
  * and returns either an error message or `true` if the validation passes.
  */
-export const hookFormSelectOptionMaxLength = (selectedOption, length = 255) => {
-  return (
-    selectedOption?.label.length <= length || i18n.t('common:CHAR_LIMIT_ERROR', { value: length })
-  );
+const hookFormSelectOptionMaxLength = (selectedOption: { label: string }, length: number = 255) => {
+  const t: TFunction = i18n.t;
+  return selectedOption?.label.length <= length || t('common:CHAR_LIMIT_ERROR', { value: length });
+};
+
+export const validateOptionLength = (value: { label: string }) => {
+  return hookFormSelectOptionMaxLength(value);
 };

--- a/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
+++ b/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
@@ -86,7 +86,7 @@ export default function useImagePickerUpload(): { getOnFileUpload: GetOnFileUplo
           }
 
           dispatch(
-            // @ts-ignore
+            // @ts-expect-error
             uploadImage({
               file: blob,
               onUploadSuccess,

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/ProductDetails.tsx
@@ -359,7 +359,7 @@ const ProductDetails = ({
 
       <Collapse id={`product_details-${productId}`} in={isExpanded} timeout="auto" unmountOnExit>
         <div className={styles.productDetailsContent}>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             name={SUPPLIER}
             label={t('ADD_PRODUCT.SUPPLIER_LABEL')}
@@ -381,7 +381,7 @@ const ProductDetails = ({
           {interested && inCanada && (
             <div className={styles.permitedSubstance}>
               <InputBaseLabel hasLeaf label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.IS_PERMITTED')} />
-              {/* @ts-ignore */}
+              {/* @ts-expect-error */}
               <RadioGroup
                 hookFormControl={control}
                 name={PERMITTED}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/ProductCard/index.tsx
@@ -196,7 +196,7 @@ const SoilAmendmentProductCard = ({
 
       {purposes?.includes(otherPurposeId) && (
         <>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER_PURPOSE')}
             name={OTHER_PURPOSE}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/index.tsx
@@ -143,7 +143,7 @@ const QuantityApplicationRate = ({
       />
       <div className={styles.applicationRateCard}>
         <div>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Unit
             label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.QUANTITY')}
             data-cy="soilAmendment-quantity"
@@ -193,7 +193,7 @@ const QuantityApplicationRate = ({
                   defaultValue={100}
                 />
                 <SwapIcon />
-                {/* @ts-ignore */}
+                {/* @ts-expect-error */}
                 <Unit
                   register={register}
                   label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.TOTAL_AREA')}
@@ -210,7 +210,7 @@ const QuantityApplicationRate = ({
                   required
                 />
               </div>
-              {/* @ts-ignore */}
+              {/* @ts-expect-error */}
               <Unit
                 label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.APPLICATION_RATE')}
                 register={register}

--- a/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
+++ b/packages/webapp/src/components/Task/AddSoilAmendmentProducts/QuantityApplicationRate/useQuantityApplicationRate.ts
@@ -65,7 +65,7 @@ export const useQuantityApplicationRate = ({
     /* set unit of the total area component according to default breakpoints */
     setValue(
       TOTAL_AREA_AMENDED_UNIT,
-      /* @ts-ignore */
+      /* @ts-expect-error */
       getUnitOptionMap()[getDefaultUnit(location_area, calculatedArea, system).displayUnit],
       { shouldValidate: true },
     );
@@ -141,7 +141,7 @@ export const useQuantityApplicationRate = ({
       previewStringUnit =
         total_area_unit && location_area[system].units.includes(total_area_unit)
           ? getUnitOptionMap()[total_area_unit]
-          : /* @ts-ignore */
+          : /* @ts-expect-error */
             getUnitOptionMap()[getDefaultUnit(location_area, total_area, system).displayUnit];
 
       previewStringValue =

--- a/packages/webapp/src/components/Task/MovementTask/index.tsx
+++ b/packages/webapp/src/components/Task/MovementTask/index.tsx
@@ -87,7 +87,7 @@ const PureMovementTask = (props: PureMovementTaskProps) => {
       />
       {selectedPurposes?.some((purpose) => purpose.key === 'OTHER') && (
         <>
-          {/* @ts-ignore */}
+          {/* @ts-expect-error */}
           <Input
             label={t('ADD_TASK.MOVEMENT_VIEW.OTHER_PURPOSE_EXPLANATION_LABEL')}
             name={OTHER_PURPOSE_EXPLANATION}

--- a/packages/webapp/src/components/Task/SoilAmendmentTask/index.tsx
+++ b/packages/webapp/src/components/Task/SoilAmendmentTask/index.tsx
@@ -182,7 +182,7 @@ const PureSoilAmendmentTask = ({
         />
         {methodId === methodIdsMap['FURROW_HOLE'] && (
           <>
-            {/* @ts-ignore */}
+            {/* @ts-expect-error */}
             <Unit
               label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.FURROW_HOLE_DEPTH')}
               name={FURROW_HOLE_DEPTH}
@@ -203,7 +203,7 @@ const PureSoilAmendmentTask = ({
         )}
         {methodId === methodIdsMap['OTHER'] && (
           <>
-            {/* @ts-ignore */}
+            {/* @ts-expect-error */}
             <Input
               label={t('ADD_TASK.SOIL_AMENDMENT_VIEW.OTHER_METHOD')}
               name={OTHER_APPLICATION_METHOD}

--- a/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/index.tsx
+++ b/packages/webapp/src/containers/Animals/AddAnimals/AddAnimalDetails/index.tsx
@@ -36,10 +36,7 @@ import useImagePickerUpload from '../../../../components/ImagePicker/useImagePic
 type AnimalDetailsField = FieldArrayWithId<AddAnimalsFormFields, 'details'>;
 
 const AddAnimalDetails = () => {
-  const { expandedIds, toggleExpanded } = useExpandable(
-    // @ts-ignore
-    { isSingleExpandable: true },
-  );
+  const { expandedIds, toggleExpanded } = useExpandable({ isSingleExpandable: true });
 
   const { control, watch } = useFormContext<AddAnimalsFormFields>();
 

--- a/packages/webapp/src/containers/Animals/Inventory/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/index.tsx
@@ -121,7 +121,6 @@ const SelectedAnimalsSummaryInventory = ({
   expandableTitle: ReactNode;
   animalCountString: string | undefined;
 } & CommonPureAnimalInventoryProps) => {
-  // @ts-ignore
   const { expandedIds, toggleExpanded } = useExpandable({ isSingleExpandable: true });
   const isExpanded = expandedIds.includes(1);
   return (

--- a/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
+++ b/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
@@ -210,7 +210,7 @@ function SingleAnimalView({ isCompactSideMenu, history, match, location }: AddAn
                 onRemove={() => setRemovalModalOpen(true)}
                 isEditing={isEditing}
                 onBack={history.back}
-                /* @ts-ignore */
+                /* @ts-expect-error */
                 animalOrBatch={defaultFormValues}
                 locationText={locationText}
                 defaultBreeds={defaultAnimalBreeds}

--- a/packages/webapp/src/stories/AddAnimalsSummaryCard/AddAnimalsSummaryCard.stories.tsx
+++ b/packages/webapp/src/stories/AddAnimalsSummaryCard/AddAnimalsSummaryCard.stories.tsx
@@ -62,14 +62,14 @@ const animalsInfo: AnimalSummary[] = [
   {
     type: 'Guinea Pig',
     sexDetails: { Male: 4 },
-    /* @ts-ignore */
+    /* @ts-expect-error */
     iconKey: 'GUINEA_PIG', // non-existent keys will default to CUSTOM_ANIMAL icon
     count: 4,
   },
   {
     type: 'Dog',
     sexDetails: {},
-    /* @ts-ignore */
+    /* @ts-expect-error */
     iconKey: 'DOG', // non-existent keys will default to CUSTOM_ANIMAL icon
     count: 2,
   },


### PR DESCRIPTION
**Description**

This PR contains two type fixes discussed in this PR:
- #3680 

1. One is the type error on a validator function which was suppressed with `@ts-ignore` in the PR above, and is explained [here](https://github.com/LiteFarmOrg/LiteFarm/pull/3680#discussion_r1943747052). It was a legitimate issue (although [not well documented](https://www.react-hook-form.com/api/useform/register/#options) and only inferrable from the example code) in that React Hook Form's `validate` function wants its second argument, if supplied, to be a `formState`, which caused this deploy error from earlier:

```
    Types of parameters 'length' and 'formValues' are incompatible.
      Type 'FieldValues' is not assignable to type 'number'.

53           validate: hookFormSelectOptionMaxLength,
             ~~~~~~~~
```

This is one of the type errors that bumping our Node version and updating all our packages uncovered. To fix this I converted the validator utils file to TS and exported a validate function that takes only one parameter (wrapping the call to the original function with two parameters).

2. I find-and-replaced `// @ts-ignore` with `// @ts-expect-error` as @navDhammu explains [here](https://github.com/LiteFarmOrg/LiteFarm/pull/3680#discussion_r1943738373). This highlighted about 10 places in the codebase where we were still exiting from typing even though the underlying typescript error had been resolved. Definitely we'll want to use this going forward. Thanks Nav!
 
 
_HEY take a look at the commit message down below!! Someone made some GitHub accounts to cleverly inform about the same issue_ 😂 (I did not know when I wrote my commit message!)
 
Jira link: none

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

These are type fixes and should not affect runtime code. I am interested in whether `tsc` errors on this branch, which for me it does not!

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
