### PR TITLE
LF-4725 Restore ability to --inspect (debug) the API

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,7 @@
     "start": "set NODE_ENV=development&& node --import @swc-node/register/esm-register src/server.ts",
     "start:prod": "node dist/app/src/server.js",
     "build": "rimraf dist && tsc -p src/tsconfig.json",
-    "dev": "set NODE_ENV=development && node --watch --import @swc-node/register/esm-register src/server.ts",
+    "dev": "set NODE_ENV=development && node --inspect=0.0.0.0:9230 --watch --import @swc-node/register/esm-register src/server.ts",
     "debug-email-template": "DEBUG=email-templates npm run dev",
     "debug-i18n": "DEBUG=i18n:* npm run dev",
     "production": "NODE_ENV=production npm run start:prod",


### PR DESCRIPTION
**Description**

Sorry I missed that this was removed!

The `API: Attach to Node` Run and Debug launch configuration still works fine in both JS and TS files, it just needs its inspect port.

Jira link: https://lite-farm.atlassian.net/browse/LF-4725

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(It's not really a bug or a feature. We just lost the ability to attach debugger to backend and this restores it).

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I wasn't sure if launch config had to be altered to make sure the source file was found, but I had no issues with a debugger statement in both `server.ts` (a file that gets 'compiled') and a regular controller (JS) as soon as the inspect was restored.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
