### PR TITLE
LF-4732: White screen appears when clicking three dots button on animal profile page

### DIFF
--- a/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
+++ b/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
@@ -192,7 +192,6 @@ export const WithStepperProgressBar = ({
 
   return (
     <StepperProgressBarWrapper
-      isSingleStep={isSingleStep}
       {...stepperProgressBarConfig}
       title={stepperProgressBarTitle}
       steps={steps.map(({ title }) => title)}
@@ -232,17 +231,15 @@ type HeaderProps = StepperProgressBarProps & {
 
 type StepperProgressBarWrapperProps = HeaderProps & {
   children: ReactNode;
-  isSingleStep: boolean;
   headerComponent: ((props: HeaderProps) => JSX.Element) | null;
 };
 
 const StepperProgressBarWrapper = ({
   children,
-  isSingleStep,
   headerComponent,
   ...stepperProgressBarProps
 }: StepperProgressBarWrapperProps) => {
-  if (isSingleStep && !headerComponent) {
+  if (!headerComponent) {
     return <>{children}</>;
   }
 

--- a/packages/webapp/src/components/Menu/MeatballsMenu/index.tsx
+++ b/packages/webapp/src/components/Menu/MeatballsMenu/index.tsx
@@ -15,7 +15,7 @@
 import { forwardRef, ReactNode } from 'react';
 import clsx from 'clsx';
 import { BsThreeDots } from 'react-icons/bs';
-import FloatingMenu, { FloatingMenuProps } from '../FloatingButtonMenu/FloatingMenu';
+import FloatingMenu from '../FloatingButtonMenu/FloatingMenu';
 import DropdownButton from '../../Form/DropDownButton';
 import styles from './styles.module.scss';
 
@@ -25,9 +25,21 @@ export type MeatballsMenuProps = {
   disabled: boolean;
 };
 
+interface MenuProps {
+  autoFocusItem: boolean;
+  id: string;
+  'aria-labelledby': string;
+  onCloseMenu: () => void;
+}
+
 const MeatballsMenu = ({ options, classes, disabled = false }: MeatballsMenuProps) => {
-  const Menu = forwardRef<HTMLUListElement, FloatingMenuProps>((menuProps, ref) => (
-    <FloatingMenu ref={ref} classes={{ menuItem: styles.menuItem }} {...menuProps} />
+  const Menu = forwardRef<HTMLUListElement, MenuProps>((menuProps, ref) => (
+    <FloatingMenu
+      ref={ref}
+      options={options}
+      classes={{ menuItem: styles.menuItem }}
+      {...menuProps}
+    />
   ));
   Menu.displayName = 'Menu';
 

--- a/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
+++ b/packages/webapp/src/containers/Animals/SingleAnimalView/index.tsx
@@ -240,6 +240,7 @@ function SingleAnimalView({ isCompactSideMenu, history, match, location }: AddAn
             cancelModalTitle={t('ANIMAL.EDIT_ANIMAL_FLOW')}
             isEditing={isEditing}
             setIsEditing={setIsEditing}
+            headerComponent={null}
           />
         )}
         <RemoveAnimalsModal


### PR DESCRIPTION
**Description**

Fix Single animal view
- Header
  - Update `WithStepperProgressBar` to conditionally hide/show a header based on `headerComponent`.
  - Pass `headerComponent: null` to `ContextForm` from `SingleAnimalView` 
- Meatballs menu
  - Send the missing `options` prop to `FloatingMenu`
  - Fix `forwardRef` typing for `Menu` component props

Jira link: https://lite-farm.atlassian.net/browse/LF-4732

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
