### PR TITLE
LF-4734 It is not possible to continue animal creation flow without specifying animal breed

### DIFF
--- a/packages/webapp/src/components/Form/hookformValidationUtils.ts
+++ b/packages/webapp/src/components/Form/hookformValidationUtils.ts
@@ -117,5 +117,8 @@ const hookFormSelectOptionMaxLength = (selectedOption: { label: string }, length
 };
 
 export const validateOptionLength = (value: { label: string }) => {
+  if (!value) {
+    return true;
+  }
   return hookFormSelectOptionMaxLength(value);
 };


### PR DESCRIPTION
**Description**

Fixing a very small bug I stumbled across.

We recently added max-length validation to the animal breed + type that inadvertently also made them required; this just repairs that.

Jira link: https://lite-farm.atlassian.net/browse/LF-4734

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
