### PR TITLE
ESci Sensor List KPI and string adjustments

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1823,8 +1823,8 @@
     },
     "DEVICE_TYPES": {
       "DRIP_LINE_PRESSURE_SENSOR": "Drip line pressure sensor",
-      "IR_TEMPERATURE_SENSOR": "IR Temperature Sensor",
-      "SOIL_WATER_POTENTIAL_SENSOR": "Soil Water Potential Sensor",
+      "IR_TEMPERATURE_SENSOR": "IR temperature sensor",
+      "SOIL_WATER_POTENTIAL_SENSOR": "Soil water potential sensor",
       "WEATHER_STATION": "Weather station",
       "WIND_SPEED_SENSOR": "Wind speed sensor"
     },
@@ -1899,7 +1899,7 @@
       "TITLE": "Soil water potential",
       "Y_AXIS_LABEL": "in {{units}}"
     },
-    "STANDALONE_SENSOR": "Standalone Sensor",
+    "STANDALONE_SENSOR": "Standalone sensor",
     "TEMPERATURE_READINGS_OF_SENSOR": {
       "AMBIENT_TEMPERATURE_FOR": "Ambient temperature for",
       "C": "Celsius (°C)",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1802,7 +1802,6 @@
   "SENSOR": {
     "BRAND": "Brand",
     "BRAND_HELPTEXT": "Brands that LiteFarm can integrate with are shown below. If you would no longer like to use this sensor brand, try retiring this sensor instead.",
-    "CANOPY_TEMPERATURE": "Canopy temperature",
     "DAYS_AGO": "{{time}} day(s) ago",
     "DEPTH": "Depth",
     "DETAIL": {

--- a/packages/webapp/src/components/OverviewStats/index.tsx
+++ b/packages/webapp/src/components/OverviewStats/index.tsx
@@ -35,8 +35,9 @@ const OverviewStats = ({
   return (
     <div className={clsx(styles.wrapper, isCompact ? styles.isCompact : '')}>
       {translationMappings.map(({ key, translationKey }) => {
+        if (!(key in stats)) return null;
         const label = t(translationKey);
-        const count = key in stats ? stats[key] : 0;
+        const count = stats[key];
 
         return (
           <div key={key} className={styles.tile}>

--- a/packages/webapp/src/components/OverviewStats/index.tsx
+++ b/packages/webapp/src/components/OverviewStats/index.tsx
@@ -35,9 +35,8 @@ const OverviewStats = ({
   return (
     <div className={clsx(styles.wrapper, isCompact ? styles.isCompact : '')}>
       {translationMappings.map(({ key, translationKey }) => {
-        if (!(key in stats)) return null;
         const label = t(translationKey);
-        const count = stats[key];
+        const count = key in stats ? stats[key] : 0;
 
         return (
           <div key={key} className={styles.tile}>

--- a/packages/webapp/src/components/OverviewStats/styles.module.scss
+++ b/packages/webapp/src/components/OverviewStats/styles.module.scss
@@ -25,8 +25,7 @@
   }
 
   &:not(.isCompact) .tile {
-    flex-basis: calc((100% - 8px * 2) / 3);
-    max-width: calc((100% - 8px * 2) / 3);
+    flex: 1 1 calc((100% - 8px * 2) / 3);
   }
 }
 

--- a/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
+++ b/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
@@ -35,19 +35,30 @@ import { ReactComponent as SensorArrayIcon } from '../../../../assets/images/far
 import { SENSOR_ARRAY } from '../../../../containers/SensorReadings/constants';
 import { Location } from '../../../../types';
 import { Sensor } from '../../../../store/api/types';
+import { toTranslationKey } from '../../../../util';
 import styles from './styles.module.scss';
 
-const kpiTranslationMappings: {
-  key: Sensor['name'] | typeof SENSOR_ARRAY;
-  translationKey: string;
-}[] = [
+const kpiSensorTypes: Sensor['name'][] = [
+  'Weather station',
+  'Soil Water Potential Sensor',
+  'IR Temperature Sensor',
+  'Wind speed sensor',
+  'Drip line pressure sensor',
+];
+
+const kpiTranslationMappings = [
   { key: SENSOR_ARRAY, translationKey: 'SENSOR.SENSOR_ARRAYS' },
-  { key: 'Soil Water Potential Sensor', translationKey: 'SENSOR.READING.SOIL_WATER_POTENTIAL' },
-  { key: 'IR Temperature Sensor', translationKey: 'SENSOR.CANOPY_TEMPERATURE' },
+  ...kpiSensorTypes.map((name) => ({
+    key: name,
+    translationKey: `SENSOR.DEVICE_TYPES.${toTranslationKey(name)}`,
+  })),
 ];
 // t('SENSOR.SENSOR_ARRAYS')
-// t('SENSOR.READING.SOIL_WATER_POTENTIAL')
-// t('SENSOR.CANOPY_TEMPERATURE')
+// t('SENSOR.DEVICE_TYPES.WEATHER_STATION')
+// t('SENSOR.DEVICE_TYPES.SOIL_WATER_POTENTIAL')
+// t('SENSOR.DEVICE_TYPES.IR_TEMPERATURE_SENSOR')
+// t('SENSOR.DEVICE_TYPES.WIND_SPEED_SENSOR')
+// t('SENSOR.DEVICE_TYPES.DRIP_LINE_PRESSURE_SENSOR')
 
 const FormatKpiLabel: OverviewStatsProps['FormattedLabelComponent'] = ({ statKey, label }) => {
   const Icon = statKey === SENSOR_ARRAY ? SensorArrayIcon : SensorIcon;

--- a/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
+++ b/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
@@ -34,31 +34,8 @@ import { ReactComponent as SensorIcon } from '../../../../assets/images/map/sign
 import { ReactComponent as SensorArrayIcon } from '../../../../assets/images/farmMapFilter/SensorArray.svg';
 import { SENSOR_ARRAY } from '../../../../containers/SensorReadings/constants';
 import { Location } from '../../../../types';
-import { Sensor } from '../../../../store/api/types';
 import { toTranslationKey } from '../../../../util';
 import styles from './styles.module.scss';
-
-const kpiSensorTypes: Sensor['name'][] = [
-  'Weather station',
-  'Soil Water Potential Sensor',
-  'IR Temperature Sensor',
-  'Wind speed sensor',
-  'Drip line pressure sensor',
-];
-
-const kpiTranslationMappings = [
-  { key: SENSOR_ARRAY, translationKey: 'SENSOR.SENSOR_ARRAYS' },
-  ...kpiSensorTypes.map((name) => ({
-    key: name,
-    translationKey: `SENSOR.DEVICE_TYPES.${toTranslationKey(name)}`,
-  })),
-];
-// t('SENSOR.SENSOR_ARRAYS')
-// t('SENSOR.DEVICE_TYPES.WEATHER_STATION')
-// t('SENSOR.DEVICE_TYPES.SOIL_WATER_POTENTIAL')
-// t('SENSOR.DEVICE_TYPES.IR_TEMPERATURE_SENSOR')
-// t('SENSOR.DEVICE_TYPES.WIND_SPEED_SENSOR')
-// t('SENSOR.DEVICE_TYPES.DRIP_LINE_PRESSURE_SENSOR')
 
 const FormatKpiLabel: OverviewStatsProps['FormattedLabelComponent'] = ({ statKey, label }) => {
   const Icon = statKey === SENSOR_ARRAY ? SensorArrayIcon : SensorIcon;
@@ -108,6 +85,26 @@ const EsciSensorList = ({ groupedSensors, summary }: EsciSensorListProps) => {
   const { expandedIds, toggleExpanded } = useExpandable({ isSingleExpandable: true });
   const theme = useTheme();
   const isCompact = useMediaQuery(theme.breakpoints.down('md'));
+
+  const kpiTranslationMappings = Object.entries(summary).reduce<
+    OverviewStatsProps['translationMappings']
+  >((acc, [key, count]) => {
+    if (count) {
+      acc.push(
+        key === SENSOR_ARRAY
+          ? { key: SENSOR_ARRAY, translationKey: 'SENSOR.SENSOR_ARRAYS' }
+          : { key, translationKey: `SENSOR.DEVICE_TYPES.${toTranslationKey(key)}` },
+        // t('SENSOR.SENSOR_ARRAYS')
+        // t('SENSOR.DEVICE_TYPES.WEATHER_STATION')
+        // t('SENSOR.DEVICE_TYPES.SOIL_WATER_POTENTIAL')
+        // t('SENSOR.DEVICE_TYPES.IR_TEMPERATURE_SENSOR')
+        // t('SENSOR.DEVICE_TYPES.WIND_SPEED_SENSOR')
+        // t('SENSOR.DEVICE_TYPES.DRIP_LINE_PRESSURE_SENSOR')
+      );
+    }
+
+    return acc;
+  }, []);
 
   return (
     <div className={styles.wrapper}>

--- a/packages/webapp/src/stories/OverviewStats/OverviewStats.stories.tsx
+++ b/packages/webapp/src/stories/OverviewStats/OverviewStats.stories.tsx
@@ -80,7 +80,6 @@ export const WithFormatFunction: Story = {
 
 const stats2 = {
   ...stats,
-  Temperature2: 2,
 };
 
 const translationMappings2 = [

--- a/packages/webapp/src/stories/OverviewStats/OverviewStats.stories.tsx
+++ b/packages/webapp/src/stories/OverviewStats/OverviewStats.stories.tsx
@@ -40,7 +40,7 @@ const stats = {
 const translationMappings = [
   { key: 'SENSOR_ARRAY', translationKey: 'SENSOR.SENSOR_ARRAYS' },
   { key: 'Soil Water Potential Sensor', translationKey: 'SENSOR.READING.SOIL_WATER_POTENTIAL' },
-  { key: 'Temperature', translationKey: 'SENSOR.CANOPY_TEMPERATURE' },
+  { key: 'Temperature', translationKey: 'SENSOR.DEVICE_TYPES.IR_TEMPERATURE_SENSOR' },
 ];
 
 export const LargeScreen: Story = {
@@ -86,7 +86,7 @@ const stats2 = {
 const translationMappings2 = [
   { key: 'SENSOR_ARRAY', translationKey: 'SENSOR.SENSOR_ARRAYS' },
   { key: 'Soil Water Potential Sensor', translationKey: 'SENSOR.READING.SOIL_WATER_POTENTIAL' },
-  { key: 'Temperature', translationKey: 'SENSOR.CANOPY_TEMPERATURE' },
+  { key: 'Temperature', translationKey: 'SENSOR.DEVICE_TYPES.IR_TEMPERATURE_SENSOR' },
   { key: 'Temperature2', translationKey: 'SENSOR.READING.TEMPERATURE' },
 ];
 

--- a/packages/webapp/src/util/index.js
+++ b/packages/webapp/src/util/index.js
@@ -166,3 +166,14 @@ export const uppercaseTheFirstLetter = (text) => {
 export const sumObjectValues = (obj) => {
   return Object.values(obj).reduce((total, current) => total + current, 0);
 };
+
+/**
+ * Converts a string to translation key format.
+ * Converts the string to uppercase and replaces all spaces with underscores.
+ *
+ * @param {string} text - The input string to be converted.
+ * @returns {string} The converted string in translation key format.
+ */
+export const toTranslationKey = (text) => {
+  return text.toUpperCase().replaceAll(' ', '_');
+};


### PR DESCRIPTION
**Description**

Some small adjustments to the ESci Sensor List as discussed today with Loïc:
- All strings to be in sentence case (only first word capitalized)
- KPI labels should match sensor types; remove 'Canopy temperature' string since it will no longer be used
- Exclude missing types from OverviewStats tiles instead of showing a zero value
- "bento-style" flexbox behaviour if the OverviewStats KPIs span two rows

@SayakaOno I did not keep the ability to show zero counts as a prop on OverviewStats and maybe I should have 🤔 Please let me know if I've ruined your vision for OverviewStats 😅🙏 

Jira link: none

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
