### PR TITLE
LF-4701 Call DELETE endpoint when clicking disconnect from Farm Addon

### DIFF
--- a/packages/api/src/controllers/farmAddonController.js
+++ b/packages/api/src/controllers/farmAddonController.js
@@ -60,7 +60,7 @@ const farmAddonController = {
           .skipUndefined()
           .whereNotDeleted();
         if (!rows.length) {
-          return res.sendStatus(404);
+          return res.status(200).send([]);
         }
         const result = rows.map(({ id, addon_partner_id, org_uuid }) => {
           return { id, addon_partner_id, org_uuid };

--- a/packages/api/src/controllers/farmAddonController.js
+++ b/packages/api/src/controllers/farmAddonController.js
@@ -79,7 +79,7 @@ const farmAddonController = {
       try {
         const { id } = req.params;
         await baseController.delete(FarmAddonModel, id, req);
-        return res.sendStatus(200);
+        return res.sendStatus(204);
       } catch (error) {
         console.error(error);
         return res.status(500).json({

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -86,6 +86,10 @@
       "UPDATE": "Successfully updated farm info!"
     }
   },
+  "FARM_ADDON": {
+    "FAILED_DISCONNECT_ADDON": "Failed to disconnect addon",
+    "SUCCESS_DISCONNECT_ADDON": "Successfully disconnected addon"
+  },
   "HELP_REQUEST": {
     "ERROR": {
       "SEND": "Something went wrong while submitting your feedback. Please try again."

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -281,14 +281,14 @@
   },
   "ADDON": {
     "DISCONNECT_MODAL": {
-      "CONFIRM": "Disconnect",
-      "CANCEL": "Don't disconnect"
+      "CANCEL": "Don't disconnect",
+      "CONFIRM": "Disconnect"
     },
     "ESCI": {
-      "MODAL_INFO": "You will not be able to access your ESci sensors data until you reconnect",
-      "MODAL_TITLE": "Are you sure you want to disconnect your ESci sensors?",
       "DISCONNECT_ESCI": "Disconnect ESci",
-      "INFO": "You can disconnect Ensemble Scientific sensors from your farm, this will remove all sensors from ESci. You can still access your sensors and associated data on your ESci dashboard."
+      "INFO": "You can disconnect Ensemble Scientific sensors from your farm, this will remove all sensors from ESci. You can still access your sensors and associated data on your ESci dashboard.",
+      "MODAL_INFO": "You will not be able to access your ESci sensors data until you reconnect",
+      "MODAL_TITLE": "Are you sure you want to disconnect your ESci sensors?"
     },
     "ORGANISATION_ID": "Organisation ID:"
   },
@@ -1575,8 +1575,8 @@
       "USER_ADDRESS_LENGTH": "User address cannot exceed 255 characters"
     },
     "FARM": {
-      "ADDRESS": "Address",
       "ADDONS": "Add-ons",
+      "ADDRESS": "Address",
       "CHANGE_IMAGE": "Change Image",
       "CLICK_TO_UPLOAD": "Click to upload",
       "CURRENCY": "Currency",
@@ -1810,8 +1810,8 @@
       "BRAND": "Brand",
       "BRAND_TOOLTIP": "Brands that LiteFarm can integrate with are shown below. If you would no longer like to use this sensor brand, try retiring this sensor instead.",
       "DEPTH": "Depth",
-      "DEVICE_TYPE": "Device type",
       "DETECTED_FIELD": "We detected the field location to be:",
+      "DEVICE_TYPE": "Device type",
       "EDIT": "Edit",
       "EXTERNAL_ID_TOOLTIP": "This id is used to uniquely identify this sensor in other, integrated systems and cannot be changed. If it is no longer being used, try retiring this sensor and adding a new one.",
       "EXTERNAL_IDENTIFIER": "External Identifier",

--- a/packages/webapp/src/containers/AddSensors/Partners.tsx
+++ b/packages/webapp/src/containers/AddSensors/Partners.tsx
@@ -21,12 +21,10 @@ const Partners = ({
 }: {
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
-  const { isSuccess: hasEsciConnection } = useGetFarmAddonQuery(
-    `?addon_partner_id=${PARTNERS.ESCI.id}`,
-  );
+  const { data: esciData = [] } = useGetFarmAddonQuery(`?addon_partner_id=${PARTNERS.ESCI.id}`);
 
   const hasActiveConnection = {
-    esci: hasEsciConnection,
+    esci: esciData.length > 0,
   };
 
   const allConnectionsActive = Object.values(hasActiveConnection).every(Boolean);

--- a/packages/webapp/src/containers/Profile/Farm/Addons/index.tsx
+++ b/packages/webapp/src/containers/Profile/Farm/Addons/index.tsx
@@ -12,6 +12,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
+import { useDispatch } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../../../Snackbar/snackbarSlice';
 import PureFarmAddons from '../../../../components/Profile/Addons';
 import { useGetFarmAddonQuery, useDeleteFarmAddonMutation } from '../../../../store/api/apiSlice';
 import { PARTNERS } from '../../../AddSensors/constants';
@@ -33,10 +36,20 @@ const FarmAddons = () => {
 
   const [deleteFarmAddon] = useDeleteFarmAddonMutation();
 
+  const dispatch = useDispatch();
+  const { t } = useTranslation(['message']);
+
+  const handleDisconnect = async (addonId: number) => {
+    try {
+      await deleteFarmAddon(addonId).unwrap();
+      dispatch(enqueueSuccessSnackbar(t('FARM_ADDON.SUCCESS_DISCONNECT_ADDON')));
+    } catch (error) {
+      dispatch(enqueueErrorSnackbar(t('FARM_ADDON.FAILED_DISCONNECT_ADDON')));
+    }
+  };
+
   const onDisconnect = {
-    esci: () => {
-      deleteFarmAddon(esciData?.id);
-    },
+    esci: () => handleDisconnect(esciData?.id),
   };
 
   const hasAnyActiveConnection = Object.values(hasActiveConnection).some(Boolean);

--- a/packages/webapp/src/containers/Profile/Farm/Addons/index.tsx
+++ b/packages/webapp/src/containers/Profile/Farm/Addons/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 import PureFarmAddons from '../../../../components/Profile/Addons';
-import { useGetFarmAddonQuery } from '../../../../store/api/apiSlice';
+import { useGetFarmAddonQuery, useDeleteFarmAddonMutation } from '../../../../store/api/apiSlice';
 import { PARTNERS } from '../../../AddSensors/constants';
 
 const FarmAddons = () => {
@@ -31,8 +31,12 @@ const FarmAddons = () => {
     esci: esciData?.org_uuid,
   };
 
+  const [deleteFarmAddon] = useDeleteFarmAddonMutation();
+
   const onDisconnect = {
-    esci: () => {}, // TODO: LF-4701
+    esci: () => {
+      deleteFarmAddon(esciData?.id);
+    },
   };
 
   const hasAnyActiveConnection = Object.values(hasActiveConnection).some(Boolean);

--- a/packages/webapp/src/containers/Profile/Farm/Addons/index.tsx
+++ b/packages/webapp/src/containers/Profile/Farm/Addons/index.tsx
@@ -20,15 +20,15 @@ import { useGetFarmAddonQuery, useDeleteFarmAddonMutation } from '../../../../st
 import { PARTNERS } from '../../../AddSensors/constants';
 
 const FarmAddons = () => {
-  const { isSuccess: hasEsciConnection, data: esciDataArray } = useGetFarmAddonQuery(
+  const { data: esciDataArray = [] } = useGetFarmAddonQuery(
     `?addon_partner_id=${PARTNERS.ESCI.id}`,
   );
 
   const hasActiveConnection = {
-    esci: hasEsciConnection,
+    esci: esciDataArray.length > 0,
   };
 
-  const [esciData] = esciDataArray || [];
+  const [esciData] = esciDataArray;
 
   const organizationIds = {
     esci: esciData?.org_uuid,

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -261,7 +261,7 @@ export const api = createApi({
       query: (param = '') => `${farmAddonUrl}${param}`,
       providesTags: ['FarmAddon'],
     }),
-    deleteFarmAddon: build.mutation<FarmAddon[], number>({
+    deleteFarmAddon: build.mutation<void, number>({
       query: (id) => ({
         url: `${farmAddonUrl}/${id}`,
         method: 'DELETE',

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -266,7 +266,7 @@ export const api = createApi({
         url: `${farmAddonUrl}/${id}`,
         method: 'DELETE',
       }),
-      invalidatesTags: ['FarmAddon', 'Sensors'],
+      invalidatesTags: (_result, error) => (error ? [] : ['FarmAddon', 'Sensors']),
     }),
   }),
 });

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -261,6 +261,13 @@ export const api = createApi({
       query: (param = '') => `${farmAddonUrl}${param}`,
       providesTags: ['FarmAddon'],
     }),
+    deleteFarmAddon: build.mutation<FarmAddon[], number>({
+      query: (id) => ({
+        url: `${farmAddonUrl}/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['FarmAddon', 'Sensors'],
+    }),
   }),
 });
 
@@ -295,4 +302,5 @@ export const {
   useLazyGetSensorsQuery,
   useAddFarmAddonMutation,
   useGetFarmAddonQuery,
+  useDeleteFarmAddonMutation,
 } = api;

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -272,6 +272,7 @@ export interface SensorData {
 }
 
 export interface FarmAddon {
+  id: number;
   addon_partner_id: number;
   org_uuid: string;
 }


### PR DESCRIPTION
**Description**

This PR connects the delete endpoint from @Duncan-Brain's PR #3692 to the frontend of app, wrapping up the disconnect user story and the whole FarmAddon arc (🎉!)

There weren't any snackbars on this flow in Figma so I didn't include them, but have been wondering about that. I think it would be okay to exclude because there is no 'success' snackbar for adding an addon (you are routed to the sensor list instead) and with the disconnect confirmation modal it would be a bit of a 'noisy' screen with two popups in a row. But it also kind of depends on how much it is supposed to feel like deleting another entity (e.g. task, animal, transaction) which always snackbar 🤔  I think I'm okay with the snackbar-less UX here, but what do you guys think? Should we check with Loïc?

Jira link: https://lite-farm.atlassian.net/browse/LF-4701

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
