### PR TITLE
LF-4743 "Completion notes" instead of "Abandonment notes" is displayed once the user tries to abandon the crop plan.

### DIFF
--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -48,7 +48,7 @@ export function PureCompleteManagementPlan({
   const DATE = isAbandonPage ? 'abandon_date' : 'complete_date';
 
   const RATING = 'rating';
-  const NOTES = 'complete_notes';
+  const NOTES = isAbandonPage ? 'abandon_notes' : 'complete_notes';
   const {
     register,
     handleSubmit,
@@ -180,7 +180,11 @@ export function PureCompleteManagementPlan({
       />
       <InputAutoSize
         style={{ marginBottom: '40px' }}
-        label={t('MANAGEMENT_PLAN.COMPLETION_NOTES')}
+        label={
+          isAbandonPage
+            ? t('MANAGEMENT_PLAN.COMPLETE_PLAN.ABANDON_NOTES')
+            : t('MANAGEMENT_PLAN.COMPLETION_NOTES')
+        }
         hookFormRegister={register(NOTES, {
           maxLength: { value: 10000, message: t('MANAGEMENT_PLAN.COMPLETE_PLAN.NOTES_CHAR_LIMIT') },
         })}

--- a/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
+++ b/packages/webapp/src/components/Crop/CompleteManamgenentPlan/PureCompleteManagementPlan.jsx
@@ -48,7 +48,7 @@ export function PureCompleteManagementPlan({
   const DATE = isAbandonPage ? 'abandon_date' : 'complete_date';
 
   const RATING = 'rating';
-  const NOTES = isAbandonPage ? 'abandon_notes' : 'complete_notes';
+  const NOTES = 'complete_notes';
   const {
     register,
     handleSubmit,


### PR DESCRIPTION
**Description**

Fix completion notes vs abandonment notes display issue

Jira link:
https://lite-farm.atlassian.net/browse/LF-4743
**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
