### PR TITLE
Farm Addon & Partner visual adjustments

### DIFF
--- a/packages/webapp/src/components/Form/Button/button.module.scss
+++ b/packages/webapp/src/components/Form/Button/button.module.scss
@@ -59,6 +59,7 @@
   --active-background: var(--Colors-Secondary-Secondary-green-100);
   --active-border: 1px solid var(--Colors-Primary-Primary-teal-600);
   --active-color: var(--Colors-Primary-Primary-teal-600);
+  --focus-border: 1px solid transparent;
 }
 
 .btn.secondary-cta {

--- a/packages/webapp/src/containers/AddSensors/Partners.tsx
+++ b/packages/webapp/src/containers/AddSensors/Partners.tsx
@@ -12,6 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
+import { useEffect } from 'react';
 import PurePartners from '../../components/AddSensors/Partners';
 import { useGetFarmAddonQuery } from '../../store/api/apiSlice';
 import { PARTNERS } from './constants';
@@ -21,7 +22,9 @@ const Partners = ({
 }: {
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
-  const { data: esciData = [] } = useGetFarmAddonQuery(`?addon_partner_id=${PARTNERS.ESCI.id}`);
+  const { data: esciData = [], isLoading: esciLoading } = useGetFarmAddonQuery(
+    `?addon_partner_id=${PARTNERS.ESCI.id}`,
+  );
 
   const hasActiveConnection = {
     esci: esciData.length > 0,
@@ -29,9 +32,13 @@ const Partners = ({
 
   const allConnectionsActive = Object.values(hasActiveConnection).every(Boolean);
 
-  setIsEditing(allConnectionsActive ? false : true);
+  const isLoading = esciLoading; // subsequent partner loading states here
 
-  return <PurePartners hasActiveConnection={hasActiveConnection} />;
+  useEffect(() => {
+    !isLoading && setIsEditing(allConnectionsActive ? false : true);
+  }, [allConnectionsActive]);
+
+  return !isLoading && <PurePartners hasActiveConnection={hasActiveConnection} />;
 };
 
 export default Partners;

--- a/packages/webapp/src/containers/AddSensors/Partners.tsx
+++ b/packages/webapp/src/containers/AddSensors/Partners.tsx
@@ -36,7 +36,7 @@ const Partners = ({
 
   useEffect(() => {
     !isLoading && setIsEditing(allConnectionsActive ? false : true);
-  }, [allConnectionsActive]);
+  }, [allConnectionsActive, isLoading]);
 
   return !isLoading && <PurePartners hasActiveConnection={hasActiveConnection} />;
 };


### PR DESCRIPTION
**Description**

This is the PR to address visual issues described in #3696 that weren't strictly related to the delete functionality. Addressed:

1. The focus > hover button layout shift at narrow desktop widths [shown here](https://github.com/LiteFarmOrg/LiteFarm/pull/3696#pullrequestreview-2645957264) (thank you @SayakaOno for spotting this)
2. This flash of content / blip on `<Partners />` which I'll demostrate here with 4x cpu throttling for clarity -- both the text input and the form buttons are showing momentarily if the connection is active and the RTK query cache is missing (e.g. on first login).  Within the PR code, `useEffect()` address the buttons while the conditional rendering is for the text input flash. Both make use of `isLoading` which it was my mistake to not include originally!

https://github.com/user-attachments/assets/cbbeef51-981e-4252-a21a-ebe5eedb3997


The solution for the flash of buttons also fixes the console warning: `Cannot update a component ('AddSensor') while rendering a different component ('Partners').`:

<img width="650" alt="Screenshot 2025-02-27 at 10 34 39 AM" src="https://github.com/user-attachments/assets/64f085f3-520f-468c-9afc-950073273efc" />

Thank you @Duncan-Brain for suggesting a `useEffect()` yesterday although maybe today you weren't into it 😂 (I think it's a good suggestion though!)

Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
