### PR TITLE
Add padding to bottom of map to account for map menu

### DIFF
--- a/packages/webapp/src/containers/Map/styles.module.scss
+++ b/packages/webapp/src/containers/Map/styles.module.scss
@@ -18,6 +18,12 @@
   min-height: 152px;
   flex-grow: 1;
   display: flex;
+
+  // mobile (drawer)
+  @include xs-breakpoint {
+    // Menu svg 24px + 16px to and bottom margin
+    padding-bottom: 56px;
+  }
 }
 
 .selectionModal {


### PR DESCRIPTION
**Description**

Footer was hiding map buttons -- I must have missed it.

![Screenshot 2025-02-27 at 7 17 41 PM](https://github.com/user-attachments/assets/23ef727e-9e41-4c9b-ae54-a6f42b5c6353)
![Screenshot 2025-02-27 at 8 06 59 PM](https://github.com/user-attachments/assets/13ca2e42-9104-4628-afad-05fd80933eae)
Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
