### PR TITLE
LF-4749 Bump Ubuntu actions runner to 24.04

### DIFF
--- a/.github/workflows/automated_tests.yml
+++ b/.github/workflows/automated_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   api_unit_tests:
     name: API Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: node:20.17
     services:
       postgres:

--- a/.github/workflows/beta-export-deploy.yml
+++ b/.github/workflows/beta-export-deploy.yml
@@ -1,7 +1,7 @@
-name: 'Beta-Export-Server-Deploy'
+name: "Beta-Export-Server-Deploy"
 on:
   workflow_run:
-    workflows: ['Deploy']
+    workflows: ["Deploy"]
     types:
       - completed
 
@@ -9,7 +9,7 @@ jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy on beta export server
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ concurrency: beta-deploy
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/lint_translation_files.yml
+++ b/.github/workflows/lint_translation_files.yml
@@ -33,7 +33,7 @@ jobs:
 
   run-linters-in-api:
     name: Run linters in api
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: packages/api/

--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -1,4 +1,4 @@
-name: 'Roll out'
+name: "Roll out"
 on:
   workflow_dispatch:
   push:
@@ -6,9 +6,9 @@ on:
       - integration
 jobs:
   rollout:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - name: Docker deploy 
+      - name: Docker deploy
         uses: TapTap21/docker-remote-deployment-action@v1.0
         with:
           remote_docker_host: root@avocado.litefarm.org


### PR DESCRIPTION
**Description**

This was the recommended course of action emailed to us and notified via today's brownout -- see Jira or [action workflow failure here](https://github.com/LiteFarmOrg/LiteFarm/actions/runs/13660101822).

As droplets are still on 20.04 this is not ideal (test environment not matching beta + prod environments) but remains to be seen if this discrepancy is a problem (and in any case we have to do it to run our workflows).

Jira link: https://lite-farm.atlassian.net/browse/LF-4749

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

None, I'm opening the PR to see how the workflows behave.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
