### PR TITLE
Adjust Ensemble sensor GET to handle missing paramter_types

### DIFF
--- a/packages/api/src/util/ensemble.js
+++ b/packages/api/src/util/ensemble.js
@@ -135,7 +135,8 @@ const mapDeviceToSensor = (device) => {
   return {
     name: device.name,
     external_id: device.esid,
-    sensor_reading_types: device.parameter_types.map(
+    sensor_reading_types: device.parameter_types?.map(
+      // not currently receiving this data as of March 5, 2025
       (type) => ENSEMBLE_READING_TYPES_MAPPING[type],
     ),
     last_seen: device.last_seen,


### PR DESCRIPTION
**Description**

This is not a full-fledged solution for the problem of the Ensemble API maybe being in flux, this is just restoring our Sensor List for now.

`paramter_types` is no longer returned from the device endpoint. Actually I don't think the info has been replaced yet -- I see a property `paramaters` but it is `null`. Maybe `parameter_types` will be restored? I'm not sure.

As of yet I don't think the frontend uses it so it may be safe to remove entirely in the future when we revisit the Ensemble device endpoint closer to release.

Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

There are Sentry errors and everything for this :) Based on the timing I guess the Ensemble API was changed yesterday.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
