### PR TITLE
Fixed bug with calling next Express middleware after sending response

### DIFF
--- a/packages/api/src/controllers/farmController.js
+++ b/packages/api/src/controllers/farmController.js
@@ -31,15 +31,13 @@ const farmController = {
         const { country } = req.body;
         if (!country) {
           await trx.rollback();
-          res.status(400).send('No country selected');
-          return next();
+          return res.status(400).send('No country selected');
         }
 
         const { id, ...units } = await this.getCountry(country);
         if (!units) {
           await trx.rollback();
-          res.status(400).send('No unit info for given country');
-          return next();
+          return res.status(400).send('No unit info for given country');
         }
 
         const utc_offset = await this.getUTCOffsetFromGridPoints(req.body.grid_points);
@@ -57,14 +55,12 @@ const farmController = {
         const new_user = await farmController.getUser(req, trx);
         const userFarm = await farmController.insertUserFarm(new_user[0], result.farm_id, trx);
         await trx.commit();
-        res.status(201).send(Object.assign({}, result, userFarm));
-        return next();
+        return res.status(201).send(Object.assign({}, result, userFarm));
       } catch (error) {
         //handle more exceptions
         console.log(error);
         await trx.rollback();
-        res.status(400).send(error);
-        return next();
+        return res.status(400).send(error);
       }
     };
   },

--- a/packages/api/src/controllers/fieldController.js
+++ b/packages/api/src/controllers/fieldController.js
@@ -31,9 +31,8 @@ const fieldController = {
           return res.sendStatus(403);
         } else {
           await trx.commit();
-          res.status(201).send(result);
           req.field = { fieldId: result.field_id, point: result.grid_points[0] };
-          next();
+          return res.status(201).send(result);
         }
       } catch (error) {
         //handle more exceptions


### PR DESCRIPTION
**Description**

There were few places in code when response was send (`res.send`) and then called `next()` middleware from ExpressJS.
This caused error in response, because `404` handler was executed and tried to send response (`status` header) once again.

The exception:
```
VM560:1 Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (node:_http_outgoing:659:11)
    at ServerResponse.header (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/response.js:794:10)
    at ServerResponse.send (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/response.js:174:12)
    at ServerResponse.json (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/response.js:278:15)
    at errorHandler (file:///home/fruitapp/app/LiteFarm/packages/api/dist/api/src/server.js:326:9)
    at Layer.handle_error (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/layer.js:71:5)
    at trim_prefix (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:326:13)
    at /home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:346:12)
    at next (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:280:10)
    at file:///home/fruitapp/app/LiteFarm/packages/api/dist/api/src/server.js:336:5
    at Layer.handle [as handle_request] (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:328:13)
    at /home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:346:12)
    at next (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:280:10)
    at /home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:646:15
    at next (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/index.js:265:14)
    at next (/home/fruitapp/app/LiteFarm/packages/api/node_modules/express/lib/router/route.js:141:14)
    at file:///home/fruitapp/app/LiteFarm/packages/api/dist/api/src/controllers/farmController.js:55:24
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Code causing error:
```javascript
// server.ts - error handler
// handle errors
const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
  res.status(error.status || 500);
  res.json({
    error: {
      message: error.message,
    },
  });
};

app
  .use((_req, _res, next) => {
    const error: Error & { status?: number } = new Error('Not found');
    error.status = 404;
    next(error);
  })
  .use(errorHandler);

// farmControler.js
          res.status(400).send('No country selected');
          return next();
```
Status is set ` res.status(400)` then `next()` is called which exececutes error handler, which trying once again status `res.status(error.status || 500);`


Jira link: N/A

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested on self hosted server before there was an error in console now this error not happens.

