### PR TITLE
LF-4756(2): Strings for wind direction

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -617,6 +617,24 @@
     "TUESDAY": "T",
     "WEDNESDAY": "W"
   },
+  "DIRECTION": {
+    "E": "E",
+    "ENE": "ENE",
+    "ESE": "ESE",
+    "N": "N",
+    "NE": "NE",
+    "NNE": "NNE",
+    "NNW": "NNW",
+    "NW": "NW",
+    "S": "S",
+    "SE": "SE",
+    "SSE": "SSE",
+    "SSW": "SSW",
+    "SW": "SW",
+    "W": "W",
+    "WNW": "WNW",
+    "WSW": "WSW"
+  },
   "DOCUMENTS": {
     "ADD": {
       "ADD_MORE_PAGES": "Add more pages",
@@ -937,9 +955,9 @@
     "TAB": {
       "CROPS": "Crops",
       "DETAILS": "Details",
+      "FIELD_TECHNOLOGY": "Field Technology",
       "READINGS": "Readings",
-      "TASKS": "Tasks",
-      "FIELD_TECHNOLOGY": "Field Technology"
+      "TASKS": "Tasks"
     },
     "TITLE": "Farm map",
     "TUTORIAL": {


### PR DESCRIPTION
**Description**

Add strings for wind direction. (I ran `pnpm i18n`, which sorted the file.)
They can be nested under `SENSOR.READING`, but since there is a possibility we'll use them elsewhere (or not?), I placed them at the top level.

Jira link: https://lite-farm.atlassian.net/browse/LF-4756

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
