### PR TITLE
Added Polish language to i18n configurations.

### DIFF
--- a/packages/api/src/jobs/locales/i18n.js
+++ b/packages/api/src/jobs/locales/i18n.js
@@ -4,7 +4,7 @@ import Backend from 'i18next-fs-backend';
 i18n.use(Backend).init(
   {
     fallbackLng: 'en',
-    preload: ['en', 'es', 'pt', 'fr', 'de', 'hi', 'pa', 'ml'],
+    preload: ['en', 'es', 'pt', 'fr', 'de', 'hi', 'pa', 'ml', 'pl'],
     ns: ['translation', 'crop'],
     defaultNS: 'translation',
     nsSeparator: ':',

--- a/packages/api/src/templates/sendEmailTemplate.js
+++ b/packages/api/src/templates/sendEmailTemplate.js
@@ -71,7 +71,7 @@ const emailTransporter = new EmailTemplates({
     root: path.join(dir, 'emails'),
   },
   i18n: {
-    locales: ['en', 'es', 'fr', 'pt', 'de', 'hi', 'pa', 'ml'],
+    locales: ['en', 'es', 'fr', 'pt', 'de', 'hi', 'pa', 'ml', 'pl'],
     directory: path.join(dir, 'locales'),
     objectNotation: true,
   },

--- a/packages/webapp/src/hooks/useLanguageOptions.ts
+++ b/packages/webapp/src/hooks/useLanguageOptions.ts
@@ -22,6 +22,7 @@ const supportedLanguages = [
   ['hi', 'हिंदी'],
   ['ml', 'മലയാളം'],
   ['pa', 'ਪੰਜਾਬੀ'],
+  ['pl', 'Polski'],
 ];
 
 const useLanguageOptions = () => {

--- a/packages/webapp/src/locales/i18n.js
+++ b/packages/webapp/src/locales/i18n.js
@@ -12,8 +12,8 @@ i18n
     defaultNS: 'translation',
     nsSeparator: ':',
     fallbackLng: 'en',
-    supportedLngs: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml'], // i18n allow list
-    locales: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml'],
+    supportedLngs: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml', 'pl'], // i18n allow list
+    locales: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml', 'pl'],
     debug: false,
     detection: {
       order: ['localStorage', 'navigator', 'querystring'],


### PR DESCRIPTION
**Description**

Polish translations are 100% ready in Crowdin LiteFarm project and I think they can be included in LiteFarm relase.
I have prepared PR with configuration changes to code to include Polish language to LiteFarm.

This PR only adds `pl` to language lists and one option for language select. 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I have installed LiteFarm on our server for 3 weeks and everything works ok with Polish language.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
