### PR TITLE
Hide GoogleLoginButton if no Google OAuth key provided.

### DIFF
--- a/packages/webapp/src/components/CustomSignUp/index.jsx
+++ b/packages/webapp/src/components/CustomSignUp/index.jsx
@@ -36,7 +36,7 @@ export default function PureCustomSignUp({
           <NewReleaseCard style={{ marginTop: '32px', maxWidth: '312px' }} />
           {(!isChrome || !!errorMessage) && (
             <div className={styles.otherBrowserMessageTop}>
-              {!!errorMessage ? (
+              {errorMessage ? (
                 <Error style={{ maxWidth: '300px' }}>{errorMessage}</Error>
               ) : (
                 <>
@@ -47,12 +47,16 @@ export default function PureCustomSignUp({
             </div>
           )}
 
-          <div data-cy="continueGoogle" className={styles.ssoButton}>
-            {GoogleLoginButton}
-          </div>
-          <div className={styles.lineBreak}>
-            <LineBreak />
-          </div>
+          {GoogleLoginButton && (
+            <div data-cy="continueGoogle" className={styles.ssoButton}>
+              {GoogleLoginButton}
+            </div>
+          )}
+          {GoogleLoginButton && (
+            <div className={styles.lineBreak}>
+              <LineBreak />
+            </div>
+          )}
 
           <div className={styles.continueButton}>
             <Input data-cy="email" classes={inputClasses} {...inputs[0]} />

--- a/packages/webapp/src/containers/CustomSignUp/index.jsx
+++ b/packages/webapp/src/containers/CustomSignUp/index.jsx
@@ -32,6 +32,8 @@ const PureCustomSignUpStyle = {
   },
 };
 
+const showGoogleOAuth = !!import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID;
+
 function CustomSignUp() {
   const {
     register,
@@ -168,7 +170,9 @@ function CustomSignUp() {
           classes={PureCustomSignUpStyle}
           onSubmit={handleSubmit(onSubmit)}
           disabled={disabled}
-          GoogleLoginButton={<GoogleLoginButton className={'google-login-button'} />}
+          GoogleLoginButton={
+            showGoogleOAuth && <GoogleLoginButton className={'google-login-button'} />
+          }
           isChrome={isChrome()}
           errorMessage={errorMessage}
           inputs={[


### PR DESCRIPTION
**Description**

I have make a simple change to webapp, that hides `GoogleLoginButton` if key in environment variable `VITE_GOOGLE_OAUTH_CLIENT_ID` is not provided (empty).

This change makes sense for self-hosting installation without Google OAuth.

**Warning:** Default value of `VITE_GOOGLE_OAUTH_CLIENT_ID = ?` is not interpreded as empty key. Question mark (`?`) needs to be removed.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [x] Other (please explain)

Installed on self-hosted server with `VITE_GOOGLE_OAUTH_CLIENT_ID` empty and non empty values. 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
