### PR TITLE
LF-4800 Remove white background colour from <Icon /> component and clean up related code

### DIFF
--- a/packages/webapp/src/components/ActionMenu/index.tsx
+++ b/packages/webapp/src/components/ActionMenu/index.tsx
@@ -60,7 +60,7 @@ const ActionMenu = ({ headerLeftText, textActions = [], iconActions }: ActionMen
             visible && (
               <div key={label} className={clsx(styles.iconGroup, iconCountClassName)}>
                 <TextButton onClick={onClick}>
-                  <Icon iconName={iconName} className={styles.icon} />
+                  <Icon iconName={iconName} />
                 </TextButton>
                 <div className={styles.iconLabel}>{label}</div>
               </div>

--- a/packages/webapp/src/components/ActionMenu/styles.module.scss
+++ b/packages/webapp/src/components/ActionMenu/styles.module.scss
@@ -90,20 +90,16 @@
       &:hover {
         background-color: var(--Colors-Secondary-Secondary-green-700);
 
-        @include svgColorFill(var(--Btn-primary-hover))
+        @include svgColorFill(var(--Btn-primary-hover));
       }
     }
 
     &:active {
       background-color: var(--Btn-primary-pristine);
 
-      @include svgColorFill(var(--Colors-Secondary-Secondary-green-900))
+      @include svgColorFill(var(--Colors-Secondary-Secondary-green-900));
     }
   }
-}
-
-.icon {
-  background: none;
 }
 
 .iconLabel {

--- a/packages/webapp/src/components/Animals/AddAnimalsForm/MoreAnimalsCard.tsx
+++ b/packages/webapp/src/components/Animals/AddAnimalsForm/MoreAnimalsCard.tsx
@@ -41,7 +41,7 @@ export const MoreAnimalsCard = ({ className, onClick }: MoreAnimalCardProps) => 
       <Icons pill iconDetails={iconDetails} className={styles.animalIcons} />
       <p className={styles.addMoreText}>{t('ANIMAL.ADD_MORE_BODY_TEXT')}</p>
       <Button color="secondary-2" type="button" onClick={onClick}>
-        <Icon iconName="PLUS_CIRCLE" className={styles.buttonIcon} />
+        <Icon iconName="PLUS_CIRCLE" />
         {t('ANIMAL.ADD_MORE_BUTTON')}
       </Button>
     </div>

--- a/packages/webapp/src/components/Animals/AddAnimalsForm/styles.module.scss
+++ b/packages/webapp/src/components/Animals/AddAnimalsForm/styles.module.scss
@@ -12,7 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
- @import '../../../assets/mixin.scss';
+@import '../../../assets/mixin.scss';
 
 .card {
   // Layout
@@ -30,14 +30,14 @@
 }
 
 .animalIcons {
-  @include svgColorFill(var(--Colors-Primary-Primary-teal-600))
+  @include svgColorFill(var(--Colors-Primary-Primary-teal-600));
 }
 
 .addMoreText {
   width: 304px;
   color: var(--Colors-Neutral-Neutral-900);
   text-align: center;
-  font-family: "Open Sans";
+  font-family: 'Open Sans';
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
@@ -46,8 +46,4 @@
 
 .addMoreButton {
   text-decoration-color: var(--Colors-Primary-Primary-teal-600);
-}
-
-button .buttonIcon {
-  background-color: transparent;
 }

--- a/packages/webapp/src/components/Animals/AnimalSingleViewHeader/styles.module.scss
+++ b/packages/webapp/src/components/Animals/AnimalSingleViewHeader/styles.module.scss
@@ -32,7 +32,6 @@
   }
 
   .backButtonIcon {
-    background-color: transparent;
     padding: 0;
   }
 
@@ -221,7 +220,6 @@
 .locationIcon {
   min-width: 100%;
   padding: 0;
-  background-color: transparent;
 }
 
 .locationText {

--- a/packages/webapp/src/components/Expandable/styles.module.scss
+++ b/packages/webapp/src/components/Expandable/styles.module.scss
@@ -145,7 +145,6 @@
 
   .trashIcon {
     @include svgColorFill(var(--Colors-Accent---singles-Red-dark));
-    background-color: transparent;
   }
 
   .inlineIconText,

--- a/packages/webapp/src/components/Form/ContextForm/styles.module.scss
+++ b/packages/webapp/src/components/Form/ContextForm/styles.module.scss
@@ -94,7 +94,6 @@
     padding: 0;
     min-width: 24px;
     min-height: 24px;
-    background-color: transparent;
 
     svg {
       width: 24px;

--- a/packages/webapp/src/components/Form/LockedInput/index.tsx
+++ b/packages/webapp/src/components/Form/LockedInput/index.tsx
@@ -30,7 +30,7 @@ export default function LockedInput<T extends FieldValues>({
       {...props}
       disabled
       className={className}
-      rightSection={<Icon iconName={'LOCKED'} className={clsx(styles.icon)} />}
+      rightSection={<Icon iconName={'LOCKED'} />}
     />
   );
 }

--- a/packages/webapp/src/components/Form/LockedInput/styles.module.scss
+++ b/packages/webapp/src/components/Form/LockedInput/styles.module.scss
@@ -1,3 +1,0 @@
-.icon {
-    background-color: transparent
-}

--- a/packages/webapp/src/components/Icons/styles.module.scss
+++ b/packages/webapp/src/components/Icons/styles.module.scss
@@ -12,7 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <<https://www.gnu.org/licenses/>.>
  */
- @import '../../assets/mixin.scss';
+@import '../../assets/mixin.scss';
 
 .displayBlock {
   display: block;
@@ -26,11 +26,10 @@
 
 .icon {
   // Base style
-  background-color: white;
   min-height: 32px;
   min-width: 32px;
   padding: 4px;
-  
+
   // centered
   display: flex;
   justify-content: center;

--- a/packages/webapp/src/components/IrrigationPrescription/styles.module.scss
+++ b/packages/webapp/src/components/IrrigationPrescription/styles.module.scss
@@ -66,11 +66,6 @@
     fill: var(--zone-colour);
   }
 
-  // TODO: remove after <Icon /> background color is fixed
-  > div:first-child {
-    background-color: transparent;
-  }
-
   // text label
   > div:nth-child(2) {
     color: var(--zone-colour);

--- a/packages/webapp/src/components/List/ListItems/IconDescription/styles.module.scss
+++ b/packages/webapp/src/components/List/ListItems/IconDescription/styles.module.scss
@@ -12,7 +12,7 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
- @import '../../../../assets/mixin.scss';
+@import '../../../../assets/mixin.scss';
 
 .listItem {
   display: flex;
@@ -33,8 +33,7 @@
   width: 36px;
   height: 36px;
   margin: 16px 8px;
-  background: transparent;
-  @include svgColorFill(#ABC7C1);
+  @include svgColorFill(#abc7c1);
   svg {
     width: 36px;
     height: 36px;
@@ -148,7 +147,7 @@
 }
 
 .desktopOnlyMiddleContent {
-  display: flex;  
+  display: flex;
 
   @include md-breakpoint {
     display: none;

--- a/packages/webapp/src/components/ManageESciSection/styles.module.scss
+++ b/packages/webapp/src/components/ManageESciSection/styles.module.scss
@@ -72,6 +72,5 @@
 }
 
 .externalLinkIcon {
-  background: transparent;
   @include svgColorFill(var(--Colors-Neutral-Neutral-900));
 }

--- a/packages/webapp/src/components/MapDrawer/MapDrawerMenuItem.jsx
+++ b/packages/webapp/src/components/MapDrawer/MapDrawerMenuItem.jsx
@@ -36,7 +36,7 @@ export default function MapDrawerMenuItem({
           <EyeToggleIcon isFiltered={isFiltered} />
         ) : (
           <div className={styles.plusAdd}>
-            <Icon iconName={'PLUS_CIRCLE'} className={styles.plusIcon} />
+            <Icon iconName={'PLUS_CIRCLE'} />
             {t('common:ADD')}
           </div>
         )}

--- a/packages/webapp/src/components/MapDrawer/styles.module.scss
+++ b/packages/webapp/src/components/MapDrawer/styles.module.scss
@@ -67,10 +67,6 @@
   line-height: 24px;
 }
 
-.plusIcon {
-  background-color: transparent;
-}
-
 // Drawer
 .sideDrawerContainer {
   top: calc(

--- a/packages/webapp/src/components/Tile/SensorTile/styles.module.scss
+++ b/packages/webapp/src/components/Tile/SensorTile/styles.module.scss
@@ -15,7 +15,8 @@
 
 @import '@assets/mixin.scss';
 
-.sensorReadingKpi, .sensorKpi {
+.sensorReadingKpi,
+.sensorKpi {
   border-radius: 4px;
   display: flex;
   // CSS trick to avoid the opacity layer: https://stackoverflow.com/a/77781112
@@ -78,7 +79,6 @@
 
 .icon {
   padding: 0px;
-  background-color: transparent;
 }
 
 .discriminatorText {

--- a/packages/webapp/src/components/TileDashboard/DashboardTile/styles.module.scss
+++ b/packages/webapp/src/components/TileDashboard/DashboardTile/styles.module.scss
@@ -67,7 +67,6 @@
 .icon {
   width: 24px;
   height: 24px;
-  background: transparent;
   @include svgColorFill(var(--Colors-Accent-Accent-yellow-50, #fff8e6));
 }
 

--- a/packages/webapp/src/containers/Animals/Inventory/styles.module.scss
+++ b/packages/webapp/src/containers/Animals/Inventory/styles.module.scss
@@ -128,7 +128,6 @@
 .locationIcon {
   padding: 0;
   min-width: 16px;
-  background-color: transparent;
 }
 
 .locationText {


### PR DESCRIPTION
**Description**

A cleanup task from [this PR discussion](https://github.com/LiteFarmOrg/LiteFarm/pull/3738#pullrequestreview-2784805138) that I figured would touch enough files to be better in its own PR.

This removes the white background from `<Icon />` which apparently
- was never used in any view
- was overwritten ~10x~ 14x in the codebase instead of us just removing the background 😅

How did it happen? I have no idea. We should have removed it long ago!

Note: PR also contains automatic linting on the SCSS files, not sure why our dev team isn't on same settings there 🤔 

Jira link: https://lite-farm.atlassian.net/browse/LF-4800

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
