### PR TITLE
LF-4764 Add irrigation_prescription_external_id to irrigation_task table

### DIFF
--- a/packages/api/db/migration/20250430202219_add_irrigation_prescription_id_and_permissions.js
+++ b/packages/api/db/migration/20250430202219_add_irrigation_prescription_id_and_permissions.js
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+export const up = async function (knex) {
+  await knex.schema.alterTable('irrigation_task', (table) => {
+    table.integer('irrigation_prescription_external_id');
+  });
+
+  // Rename get:sensors (only used in sensors v2) to get:smart_irrigation
+  await knex('permissions').where({ permission_id: 172 }).update({
+    name: 'get:smart_irrigation',
+    description: 'get smart irrigation',
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+export const down = async function (knex) {
+  // Restore get:sensors permissions name
+  await knex('permissions').where({ permission_id: 172 }).update({
+    name: 'get:sensors',
+    description: 'get sensors',
+  });
+
+  await knex.schema.alterTable('irrigation_task', (table) => {
+    table.dropColumn('irrigation_prescription_external_id');
+  });
+};

--- a/packages/api/src/models/irrigationTaskModel.js
+++ b/packages/api/src/models/irrigationTaskModel.js
@@ -52,6 +52,9 @@ class IrrigationTaskModel extends Model {
         default_location_application_depth: { type: 'boolean' },
         default_irrigation_task_type_location: { type: 'boolean' },
         default_irrigation_task_type_measurement: { type: 'boolean' },
+        irrigation_prescription_external_id: {
+          type: ['number', 'null'],
+        },
       },
       additionalProperties: false,
     };
@@ -109,6 +112,7 @@ class IrrigationTaskModel extends Model {
       default_location_application_depth: 'omit',
       default_irrigation_task_type_location: 'omit',
       default_irrigation_task_type_measurement: 'omit',
+      irrigation_prescription_external_id: 'omit',
       // relationMappings
       task: 'omit',
       irrigation_type: 'omit',

--- a/packages/api/src/routes/irrigationPrescriptionRequestRoute.ts
+++ b/packages/api/src/routes/irrigationPrescriptionRequestRoute.ts
@@ -21,7 +21,7 @@ const router = express.Router();
 
 router.post(
   '/',
-  checkScope(['get:sensors']), // (Optional) - add a new scope for irrigation prescription. However as both sensors and irrigation prescription data is coming from Ensemble with the same authentication rules, sharing scope seems reasonable
+  checkScope(['get:smart_irrigation']),
   IrrigationPrescriptionRequestController.initiateFarmIrrigationPrescription(),
 );
 

--- a/packages/api/src/routes/sensorRoute.js
+++ b/packages/api/src/routes/sensorRoute.js
@@ -28,7 +28,7 @@ const upload = multer({ storage });
 
 const router = express.Router();
 
-router.get('/', checkScope(['get:sensors']), SensorController.getSensors);
+router.get('/', checkScope(['get:smart_irrigation']), SensorController.getSensors);
 router.post(
   '/',
   checkScope(['add:sensors']),
@@ -44,7 +44,7 @@ router.post(
 );
 router.get(
   '/readings',
-  checkScope(['get:sensors']),
+  checkScope(['get:smart_irrigation']),
   checkSensorReadingsQuery(),
   SensorController.getSensorReadings,
 );


### PR DESCRIPTION
**Description**

- Adds a column to store the ESci Irrigation Prescription primary key on the `irrigation_task` table
  - As previously decided in group discussion, this should not be copied in copy crop plan so is omitted from the template mapping schema
- Updates `get:sensors` permission (recently added for the new sensor routes) to `get:smart_irrigation` for shared use between the sensor + IP routes of the new project, see [this GitHub comment](https://github.com/LiteFarmOrg/LiteFarm/pull/3723#discussion_r2032184628)

Jira link: https://lite-farm.atlassian.net/browse/LF-4764

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Inspected database table + schema, checked sensor routes with new permissions

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
