### PR TITLE
LF-4769 Pre-PR Linting Commit -- taskController and task.test.js

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -42,12 +42,8 @@ import { customError } from '../util/customErrors.js';
 const adminRoles = [1, 2, 5];
 
 async function getTaskAssigneeAndFinalWage(farm_id, user_id, task_id) {
-  const {
-    assignee_user_id,
-    assignee_role_id,
-    wage_at_moment,
-    override_hourly_wage,
-  } = await TaskModel.getTaskAssignee(task_id, farm_id);
+  const { assignee_user_id, assignee_role_id, wage_at_moment, override_hourly_wage } =
+    await TaskModel.getTaskAssignee(task_id, farm_id);
   const { role_id } = await UserFarmModel.getUserRoleId(user_id, farm_id);
   if (!canCompleteTask(assignee_user_id, assignee_role_id, user_id, role_id)) {
     throw new Error("Not authorized to complete other people's task");
@@ -395,11 +391,7 @@ const taskController = {
 
       const checkTaskStatus = await TaskModel.getTaskStatus(task_id);
 
-      const {
-        assignee_user_id,
-        wage_at_moment,
-        override_hourly_wage,
-      } = await TaskModel.query()
+      const { assignee_user_id, wage_at_moment, override_hourly_wage } = await TaskModel.query()
         .select('assignee_user_id', 'wage_at_moment', 'override_hourly_wage')
         .where({ task_id })
         .first();
@@ -445,7 +437,7 @@ const taskController = {
 
   createTask(typeOfTask) {
     const nonModifiable = getNonModifiable(typeOfTask);
-    return async (req, res, next) => {
+    return async (req, res) => {
       try {
         // Do not allow to create a task if location is deleted
         const locations = req.body.locations;
@@ -566,9 +558,8 @@ const taskController = {
       case 'irrigation_task':
         return await (async () => {
           if (data.irrigation_task) {
-            const {
-              irrigation_type_id,
-            } = await IrrigationTypesModel.checkAndAddCustomIrrigationType(data, farm_id);
+            const { irrigation_type_id } =
+              await IrrigationTypesModel.checkAndAddCustomIrrigationType(data, farm_id);
             if (data.irrigation_task.default_irrigation_task_type_measurement) {
               await IrrigationTypesModel.updateIrrigationType({
                 irrigation_type_id,
@@ -752,7 +743,7 @@ const taskController = {
 
   completeTask(typeOfTask) {
     const nonModifiable = getNonModifiable(typeOfTask);
-    return async (req, res, next) => {
+    return async (req, res) => {
       try {
         const { farm_id } = req.headers;
         const { user_id } = req.auth;
@@ -917,9 +908,7 @@ const taskController = {
       const filteredTasks = graphTasks.map(removeNullTypes);
 
       /* Clean before returning to frontend */
-      const {
-        task_type_id: soilAmendmentTypeId,
-      } = await TaskTypeModel.query()
+      const { task_type_id: soilAmendmentTypeId } = await TaskTypeModel.query()
         .whereNotDeleted()
         .where({ farm_id: null, task_translation_key: 'SOIL_AMENDMENT_TASK' })
         .first();
@@ -971,9 +960,8 @@ const taskController = {
   async getIrrigationTaskTypes(req, res) {
     const { farm_id } = req.params;
     try {
-      const irrigationTaskTypes = await IrrigationTypesModel.getAllIrrigationTaskTypesByFarmId(
-        farm_id,
-      );
+      const irrigationTaskTypes =
+        await IrrigationTypesModel.getAllIrrigationTaskTypesByFarmId(farm_id);
       res.status(200).json(irrigationTaskTypes);
     } catch (error) {
       return res.status(400).send(error);
@@ -1030,73 +1018,68 @@ async function getTasksForFarm(farm_id) {
   const customTaskTypesForFarm = await TaskTypeModel.query()
     .select('task_type_id')
     .where({ farm_id });
-  const [
-    managementTasks,
-    locationTasks,
-    plantTasks,
-    transplantTasks,
-    customTasks,
-  ] = await Promise.all([
-    TaskModel.query()
-      .select('task.task_id')
-      .whereNotDeleted()
-      .distinct('task.task_id')
-      .join('management_tasks', 'management_tasks.task_id', 'task.task_id')
-      .join(
-        'planting_management_plan',
-        'management_tasks.planting_management_plan_id',
-        'planting_management_plan.planting_management_plan_id',
-      )
-      .join(
-        'management_plan',
-        'planting_management_plan.management_plan_id',
-        'management_plan.management_plan_id',
-      )
-      .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
-      .where('crop_variety.farm_id', farm_id),
-    TaskModel.query()
-      .select('task.task_id')
-      .whereNotDeleted()
-      .distinct('task.task_id')
-      .join('location_tasks', 'location_tasks.task_id', 'task.task_id')
-      .join('location', 'location.location_id', 'location_tasks.location_id')
-      .where('location.farm_id', farm_id),
-    PlantTaskModel.query()
-      .select('plant_task.task_id')
-      .join(
-        'planting_management_plan',
-        'planting_management_plan.planting_management_plan_id',
-        'plant_task.planting_management_plan_id',
-      )
-      .join(
-        'management_plan',
-        'management_plan.management_plan_id',
-        'planting_management_plan. management_plan_id',
-      )
-      .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
-      .where('crop_variety.farm_id', farm_id),
-    TransplantTaskModel.query()
-      .select('transplant_task.task_id')
-      .join(
-        'planting_management_plan',
-        'planting_management_plan.planting_management_plan_id',
-        'transplant_task.planting_management_plan_id',
-      )
-      .join(
-        'management_plan',
-        'management_plan.management_plan_id',
-        'planting_management_plan. management_plan_id',
-      )
-      .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
-      .where('crop_variety.farm_id', farm_id),
-    TaskModel.query()
-      .select('task.task_id')
-      .whereNotDeleted()
-      .whereIn(
-        'task_type_id',
-        customTaskTypesForFarm.map(({ task_type_id }) => task_type_id),
-      ),
-  ]);
+  const [managementTasks, locationTasks, plantTasks, transplantTasks, customTasks] =
+    await Promise.all([
+      TaskModel.query()
+        .select('task.task_id')
+        .whereNotDeleted()
+        .distinct('task.task_id')
+        .join('management_tasks', 'management_tasks.task_id', 'task.task_id')
+        .join(
+          'planting_management_plan',
+          'management_tasks.planting_management_plan_id',
+          'planting_management_plan.planting_management_plan_id',
+        )
+        .join(
+          'management_plan',
+          'planting_management_plan.management_plan_id',
+          'management_plan.management_plan_id',
+        )
+        .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
+        .where('crop_variety.farm_id', farm_id),
+      TaskModel.query()
+        .select('task.task_id')
+        .whereNotDeleted()
+        .distinct('task.task_id')
+        .join('location_tasks', 'location_tasks.task_id', 'task.task_id')
+        .join('location', 'location.location_id', 'location_tasks.location_id')
+        .where('location.farm_id', farm_id),
+      PlantTaskModel.query()
+        .select('plant_task.task_id')
+        .join(
+          'planting_management_plan',
+          'planting_management_plan.planting_management_plan_id',
+          'plant_task.planting_management_plan_id',
+        )
+        .join(
+          'management_plan',
+          'management_plan.management_plan_id',
+          'planting_management_plan. management_plan_id',
+        )
+        .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
+        .where('crop_variety.farm_id', farm_id),
+      TransplantTaskModel.query()
+        .select('transplant_task.task_id')
+        .join(
+          'planting_management_plan',
+          'planting_management_plan.planting_management_plan_id',
+          'transplant_task.planting_management_plan_id',
+        )
+        .join(
+          'management_plan',
+          'management_plan.management_plan_id',
+          'planting_management_plan. management_plan_id',
+        )
+        .join('crop_variety', 'crop_variety.crop_variety_id', 'management_plan.crop_variety_id')
+        .where('crop_variety.farm_id', farm_id),
+      TaskModel.query()
+        .select('task.task_id')
+        .whereNotDeleted()
+        .whereIn(
+          'task_type_id',
+          customTaskTypesForFarm.map(({ task_type_id }) => task_type_id),
+        ),
+    ]);
   return [...managementTasks, ...locationTasks, ...plantTasks, ...transplantTasks, ...customTasks];
 }
 

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 
@@ -7,7 +9,7 @@ import knex from '../src/util/knex.js';
 
 jest.mock('jsdom');
 jest.mock('../src/middleware/acl/checkJwt.js', () =>
-  jest.fn((req, res, next) => {
+  jest.fn((req, _res, next) => {
     req.auth = {};
     req.auth.user_id = req.get('user_id');
     next();
@@ -1223,12 +1225,11 @@ describe('Task tests', () => {
               task_name: 'Transplant',
             },
           );
-          const [
-            { location_id, management_plan_id },
-          ] = await mocks.planting_management_planFactory({ promisedFarm: [userFarm] });
-          const [
-            { planting_management_plan_id: prev_planting_management_plan_id },
-          ] = await mocks.planting_management_planFactory({ promisedFarm: [userFarm] });
+          const [{ location_id, management_plan_id }] = await mocks.planting_management_planFactory(
+            { promisedFarm: [userFarm] },
+          );
+          const [{ planting_management_plan_id: prev_planting_management_plan_id }] =
+            await mocks.planting_management_planFactory({ promisedFarm: [userFarm] });
           const transplant_task = {
             ...mocks.fakeTask(),
             task_type_id: transplantTaskType.task_type_id,
@@ -1295,10 +1296,10 @@ describe('Task tests', () => {
         test(`should fail to create a transplant task when previous plan is for different farm's location`, async (done) => {
           const [userFarm2] = await generateUserFarms(1);
           const { transplant_task, userFarm } = await getBody('row_method');
-          const [
-            { planting_management_plan_id: prev_planting_management_plan_id },
-          ] = await mocks.planting_management_planFactory({ promisedFarm: [userFarm2] });
-          transplant_task.transplant_task.prev_planting_management_plan_id = prev_planting_management_plan_id;
+          const [{ planting_management_plan_id: prev_planting_management_plan_id }] =
+            await mocks.planting_management_planFactory({ promisedFarm: [userFarm2] });
+          transplant_task.transplant_task.prev_planting_management_plan_id =
+            prev_planting_management_plan_id;
 
           postTransplantTaskRequest(userFarm, transplant_task, async (err, res) => {
             expect(res.status).toBe(403);
@@ -1347,13 +1348,8 @@ describe('Task tests', () => {
 
       Object.keys(fakeTaskData).map((type) => {
         test(`should successfully create a ${type} with a management plan`, async (done) => {
-          const {
-            user_id,
-            farm_id,
-            location_id,
-            planting_management_plan_id,
-            task_type_id,
-          } = await userFarmTaskGenerator();
+          const { user_id, farm_id, location_id, planting_management_plan_id, task_type_id } =
+            await userFarmTaskGenerator();
 
           const data = {
             ...mocks.fakeTask({
@@ -1762,12 +1758,8 @@ describe('Task tests', () => {
       });
 
       test('should fail to create a task were a worker is trying to assign someone else', async (done) => {
-        const {
-          farm_id,
-          location_id,
-          management_plan_id,
-          task_type_id,
-        } = await userFarmTaskGenerator(true);
+        const { farm_id, location_id, management_plan_id, task_type_id } =
+          await userFarmTaskGenerator(true);
         const [{ user_id: worker_id }] = await mocks.userFarmFactory(
           { promisedFarm: [{ farm_id }] },
           fakeUserFarm(3),
@@ -1799,12 +1791,8 @@ describe('Task tests', () => {
       });
 
       test('should fail to create a task were a worker is trying to modify wage for himself ', async (done) => {
-        const {
-          farm_id,
-          location_id,
-          management_plan_id,
-          task_type_id,
-        } = await userFarmTaskGenerator(true);
+        const { farm_id, location_id, management_plan_id, task_type_id } =
+          await userFarmTaskGenerator(true);
         const [{ user_id: worker_id }] = await mocks.userFarmFactory(
           { promisedFarm: [{ farm_id }] },
           fakeUserFarm(3),
@@ -1944,9 +1932,8 @@ describe('Task tests', () => {
       await mocks.soil_amendment_taskFactory({ promisedTask: [{ task_id }] });
 
       const new_soil_amendment_task = fakeTaskData.soil_amendment_task(farm_id);
-      const new_soil_amendment_task_products = await fakeProductData.soil_amendment_task_products(
-        farm_id,
-      );
+      const new_soil_amendment_task_products =
+        await fakeProductData.soil_amendment_task_products(farm_id);
 
       completeTaskRequest(
         { user_id, farm_id },
@@ -2437,12 +2424,11 @@ describe('Task tests', () => {
         );
 
         // Replace second task product with new taskProduct with id of first task product
-        createdTask.soil_amendment_task_products[
-          indexOfSecondProduct
-        ] = mocks.fakeSoilAmendmentTaskProduct({
-          product_id: soilAmendmentProductOne.product_id,
-          purpose_relationships: [{ purpose_id: soilAmendmentPurpose }],
-        });
+        createdTask.soil_amendment_task_products[indexOfSecondProduct] =
+          mocks.fakeSoilAmendmentTaskProduct({
+            product_id: soilAmendmentProductOne.product_id,
+            purpose_relationships: [{ purpose_id: soilAmendmentPurpose }],
+          });
 
         // Update first task product id to second product id
         createdTask.soil_amendment_task_products[indexOfFirstProduct].product_id =


### PR DESCRIPTION
**Description**

This PR commits the linting changes to `taskController.js` and `task.test.js` and handles the es-lint errors preventing commit to those files by either bypassing (in the test file, which had 88 eslint errors) or fixing (in the controller, which had two). This is so that:
- the files can be committed to with the current version of our linting packages
- the diff is not impossibly messy to read when the meaningful changes are added in LF-4769.

Jira link: none

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
