### PR TITLE
LF-4818: Fix get task type tasks success reducers

### DIFF
--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -350,19 +350,20 @@ const taskTypeActionMap = {
   },
   PLANT_TASK: {
     success: (tasks) =>
-      call(getPlantingTasksAndPlantingManagementPlansSuccessSaga, { payload: tasks }),
+      call(getPlantingTasksAndPlantingManagementPlansSuccessSaga, { payload: { tasks } }),
     getAllSuccess: (tasks) =>
-      call(getPlantingTasksAndPlantingManagementPlansSuccessSaga, { payload: tasks, getAll: true }),
+      call(getPlantingTasksAndPlantingManagementPlansSuccessSaga, {
+        payload: { tasks, getAll: true },
+      }),
     fail: onLoadingPlantTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   TRANSPLANT_TASK: {
     success: (tasks) =>
-      call(getTransplantTasksAndPlantingManagementPlansSuccessSaga, { payload: tasks }),
+      call(getTransplantTasksAndPlantingManagementPlansSuccessSaga, { payload: { tasks } }),
     getAllSuccess: (tasks) =>
       call(getTransplantTasksAndPlantingManagementPlansSuccessSaga, {
-        payload: tasks,
-        getAll: true,
+        payload: { tasks, getAll: true },
       }),
     fail: onLoadingTransplantTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -24,47 +24,56 @@ import { pick } from '../../util/pick';
 import produce from 'immer';
 import { getObjectInnerValues } from '../../util';
 import {
+  getAllCleaningTasksSuccess,
   getCleaningTasksSuccess,
   onLoadingCleaningTaskFail,
   onLoadingCleaningTaskStart,
 } from '../slice/taskSlice/cleaningTaskSlice';
 import {
+  getAllFieldWorkTasksSuccess,
   getFieldWorkTasksSuccess,
   onLoadingFieldWorkTaskFail,
   onLoadingFieldWorkTaskStart,
 } from '../slice/taskSlice/fieldWorkTaskSlice';
 import {
+  getAllIrrigationTasksSuccess,
   getIrrigationTasksSuccess,
   onLoadingIrrigationTaskFail,
   onLoadingIrrigationTaskStart,
 } from '../slice/taskSlice/irrigationTaskSlice';
 import {
+  getAllPestControlTasksSuccess,
   getPestControlTasksSuccess,
   onLoadingPestControlTaskFail,
   onLoadingPestControlTaskStart,
 } from '../slice/taskSlice/pestControlTaskSlice';
 import {
+  getAllSoilAmendmentTasksSuccess,
   getSoilAmendmentTasksSuccess,
   onLoadingSoilAmendmentTaskFail,
   onLoadingSoilAmendmentTaskStart,
 } from '../slice/taskSlice/soilAmendmentTaskSlice';
 import {
+  getAlllHarvestTasksSuccess,
   getHarvestTasksSuccess,
   onLoadingHarvestTaskFail,
   onLoadingHarvestTaskStart,
 } from '../slice/taskSlice/harvestTaskSlice';
 import {
+  getAllPlantTasksSuccess,
   getPlantTasksSuccess,
   onLoadingPlantTaskFail,
   onLoadingPlantTaskStart,
 } from '../slice/taskSlice/plantTaskSlice';
 import {
   deleteTransplantTaskSuccess,
+  getAllTransplantTasksSuccess,
   getTransplantTasksSuccess,
   onLoadingTransplantTaskFail,
   onLoadingTransplantTaskStart,
 } from '../slice/taskSlice/transplantTaskSlice';
 import {
+  getAllAnimalMovementTasksSuccess,
   getAnimalMovementTasksSuccess,
   onLoadingAnimalMovementTaskFail,
   onLoadingAnimalMovementTaskStart,
@@ -251,9 +260,13 @@ export const getPlantingTasksAndPlantingManagementPlansSuccess = createAction(
   'getPlantingTasksAndPlantingManagementPlansSuccessSaga',
 );
 
-export function* getPlantingTasksAndPlantingManagementPlansSuccessSaga({ payload: tasks }) {
+export function* getPlantingTasksAndPlantingManagementPlansSuccessSaga({
+  payload: { tasks, getAll = false },
+}) {
+  const getTasksSuccessFunc = getAll ? getAllPlantTasksSuccess : getPlantTasksSuccess;
+
   yield put(
-    getPlantTasksSuccess(
+    getTasksSuccessFunc(
       tasks.map((task) => ({
         ...task,
         planting_management_plan_id:
@@ -275,9 +288,13 @@ export const getTransplantTasksAndPlantingManagementPlansSuccess = createAction(
   'getTransplantTasksAndPlantingManagementPlansSuccessSaga',
 );
 
-export function* getTransplantTasksAndPlantingManagementPlansSuccessSaga({ payload: tasks }) {
+export function* getTransplantTasksAndPlantingManagementPlansSuccessSaga({
+  payload: { tasks, getAll = false },
+}) {
+  const getTasksSuccessFunc = getAll ? getAllTransplantTasksSuccess : getTransplantTasksSuccess;
+
   yield put(
-    getTransplantTasksSuccess(
+    getTasksSuccessFunc(
       tasks.map((task) => ({
         ...task,
         planting_management_plan_id:
@@ -297,48 +314,62 @@ export function* getTransplantTasksAndPlantingManagementPlansSuccessSaga({ paylo
 const taskTypeActionMap = {
   CLEANING_TASK: {
     success: (tasks) => put(getCleaningTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllCleaningTasksSuccess(tasks)),
     fail: onLoadingCleaningTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   FIELD_WORK_TASK: {
     success: (tasks) => put(getFieldWorkTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllFieldWorkTasksSuccess(tasks)),
     fail: onLoadingFieldWorkTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   IRRIGATION_TASK: {
     success: (tasks) => put(getIrrigationTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllIrrigationTasksSuccess(tasks)),
     fail: onLoadingIrrigationTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   PEST_CONTROL_TASK: {
     success: (tasks) => put(getPestControlTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllPestControlTasksSuccess(tasks)),
     fail: onLoadingPestControlTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   SOIL_AMENDMENT_TASK: {
     success: (tasks) => put(getSoilAmendmentTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllSoilAmendmentTasksSuccess(tasks)),
     fail: onLoadingSoilAmendmentTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   HARVEST_TASK: {
     success: (tasks) => put(getHarvestTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAlllHarvestTasksSuccess(tasks)),
     fail: onLoadingHarvestTaskFail,
     completeUrl: (id) => createCompleteHarvestQuantityTaskUrl(id),
   },
   PLANT_TASK: {
     success: (tasks) =>
       call(getPlantingTasksAndPlantingManagementPlansSuccessSaga, { payload: tasks }),
+    getAllSuccess: (tasks) =>
+      call(getPlantingTasksAndPlantingManagementPlansSuccessSaga, { payload: tasks, getAll: true }),
     fail: onLoadingPlantTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   TRANSPLANT_TASK: {
     success: (tasks) =>
       call(getTransplantTasksAndPlantingManagementPlansSuccessSaga, { payload: tasks }),
+    getAllSuccess: (tasks) =>
+      call(getTransplantTasksAndPlantingManagementPlansSuccessSaga, {
+        payload: tasks,
+        getAll: true,
+      }),
     fail: onLoadingTransplantTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
   MOVEMENT_TASK: {
     success: (tasks) => put(getAnimalMovementTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllAnimalMovementTasksSuccess(tasks)),
     fail: onLoadingAnimalMovementTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -390,7 +390,10 @@ export function* onLoadingTaskStartSaga() {
   yield put(onLoadingAnimalMovementTaskStart());
 }
 
-function* handleGetTasksSuccess(tasks, successAction) {
+function* handleGetTasksSuccess(tasks, isGetAll = false) {
+  const successAction = isGetAll ? addAllTasksFromGetReq : addManyTasksFromGetReq;
+  const taskTypeSuccessActionKey = isGetAll ? 'getAllSuccess' : 'success';
+
   const taskTypeEntities = yield select(taskTypeEntitiesSelector);
   const tasksByTranslationKeyDefault = Object.keys(taskTypeActionMap).reduce(
     (tasksByTranslationKeyDefault, task_translation_key) => {
@@ -409,7 +412,7 @@ function* handleGetTasksSuccess(tasks, successAction) {
 
   for (const task_translation_key in taskTypeActionMap) {
     try {
-      yield taskTypeActionMap[task_translation_key].success(
+      yield taskTypeActionMap[task_translation_key][taskTypeSuccessActionKey](
         tasksByTranslationKey[task_translation_key],
       );
     } catch (e) {
@@ -422,7 +425,7 @@ function* handleGetTasksSuccess(tasks, successAction) {
 }
 
 export function* getTasksSuccessSaga({ payload: tasks }) {
-  yield handleGetTasksSuccess(tasks, addManyTasksFromGetReq);
+  yield handleGetTasksSuccess(tasks);
 }
 
 export const getTasks = createAction('getTasksSaga');
@@ -441,7 +444,7 @@ export function* getTasksSaga() {
 }
 
 export function* getAllTasksSuccessSaga({ payload: tasks }) {
-  yield handleGetTasksSuccess(tasks, addAllTasksFromGetReq);
+  yield handleGetTasksSuccess(tasks, true);
 }
 
 export const getPostTaskBody = (data, endpoint, managementPlanWithCurrentLocationEntities) => {

--- a/packages/webapp/src/containers/slice/taskSlice/animalMovementTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/animalMovementTaskSlice.js
@@ -27,6 +27,13 @@ const getAnimalMovementTask = (task) => {
 const upsertOneAnimalMovementTask = (state, { payload: task }) => {
   animalMovementTaskAdapter.upsertOne(state, getAnimalMovementTask(task));
 };
+const upsertManyAnimalMovementTask = (state, { payload: tasks }) => {
+  animalMovementTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getAnimalMovementTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllAnimalMovementTask = (state, { payload: tasks }) => {
   animalMovementTaskAdapter.setAll(
     state,
@@ -50,7 +57,8 @@ const animalMovementTaskSlice = createSlice({
   reducers: {
     onLoadingAnimalMovementTaskStart: onLoadingStart,
     onLoadingAnimalMovementTaskFail: onLoadingFail,
-    getAnimalMovementTasksSuccess: setAllAnimalMovementTask,
+    getAnimalMovementTasksSuccess: upsertManyAnimalMovementTask,
+    getAllAnimalMovementTasksSuccess: setAllAnimalMovementTask,
     postAnimalMovementTaskSuccess: upsertOneAnimalMovementTask,
     editAnimalMovementTaskSuccess: upsertOneAnimalMovementTask,
     deleteAnimalMovementTaskSuccess: animalMovementTaskAdapter.removeOne,
@@ -58,6 +66,7 @@ const animalMovementTaskSlice = createSlice({
 });
 export const {
   getAnimalMovementTasksSuccess,
+  getAllAnimalMovementTasksSuccess,
   postAnimalMovementTaskSuccess,
   editAnimalMovementTaskSuccess,
   onLoadingAnimalMovementTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/animalMovementTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/animalMovementTaskSlice.js
@@ -27,8 +27,8 @@ const getAnimalMovementTask = (task) => {
 const upsertOneAnimalMovementTask = (state, { payload: task }) => {
   animalMovementTaskAdapter.upsertOne(state, getAnimalMovementTask(task));
 };
-const upsertManyAnimalMovementTask = (state, { payload: tasks }) => {
-  animalMovementTaskAdapter.upsertMany(
+const setAllAnimalMovementTask = (state, { payload: tasks }) => {
+  animalMovementTaskAdapter.setAll(
     state,
     tasks.map((task) => getAnimalMovementTask(task)),
   );
@@ -50,7 +50,7 @@ const animalMovementTaskSlice = createSlice({
   reducers: {
     onLoadingAnimalMovementTaskStart: onLoadingStart,
     onLoadingAnimalMovementTaskFail: onLoadingFail,
-    getAnimalMovementTasksSuccess: upsertManyAnimalMovementTask,
+    getAnimalMovementTasksSuccess: setAllAnimalMovementTask,
     postAnimalMovementTaskSuccess: upsertOneAnimalMovementTask,
     editAnimalMovementTaskSuccess: upsertOneAnimalMovementTask,
     deleteAnimalMovementTaskSuccess: animalMovementTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/cleaningTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/cleaningTaskSlice.js
@@ -23,6 +23,13 @@ const getCleaningTask = (task) => {
 const upsertOneCleaningTask = (state, { payload: task }) => {
   cleaningTaskAdapter.upsertOne(state, getCleaningTask(task));
 };
+const upsertManyCleaningTask = (state, { payload: tasks }) => {
+  cleaningTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getCleaningTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllCleaningTask = (state, { payload: tasks }) => {
   cleaningTaskAdapter.setAll(
     state,
@@ -46,7 +53,8 @@ const cleaningTaskSlice = createSlice({
   reducers: {
     onLoadingCleaningTaskStart: onLoadingStart,
     onLoadingCleaningTaskFail: onLoadingFail,
-    getCleaningTasksSuccess: setAllCleaningTask,
+    getCleaningTasksSuccess: upsertManyCleaningTask,
+    getAllCleaningTasksSuccess: setAllCleaningTask,
     postCleaningTaskSuccess: upsertOneCleaningTask,
     editCleaningTaskSuccess: upsertOneCleaningTask,
     deleteCleaningTaskSuccess: cleaningTaskAdapter.removeOne,
@@ -54,6 +62,7 @@ const cleaningTaskSlice = createSlice({
 });
 export const {
   getCleaningTasksSuccess,
+  getAllCleaningTasksSuccess,
   postCleaningTaskSuccess,
   editCleaningTaskSuccess,
   onLoadingCleaningTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/cleaningTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/cleaningTaskSlice.js
@@ -23,8 +23,8 @@ const getCleaningTask = (task) => {
 const upsertOneCleaningTask = (state, { payload: task }) => {
   cleaningTaskAdapter.upsertOne(state, getCleaningTask(task));
 };
-const upsertManyCleaningTask = (state, { payload: tasks }) => {
-  cleaningTaskAdapter.upsertMany(
+const setAllCleaningTask = (state, { payload: tasks }) => {
+  cleaningTaskAdapter.setAll(
     state,
     tasks.map((task) => getCleaningTask(task)),
   );
@@ -46,7 +46,7 @@ const cleaningTaskSlice = createSlice({
   reducers: {
     onLoadingCleaningTaskStart: onLoadingStart,
     onLoadingCleaningTaskFail: onLoadingFail,
-    getCleaningTasksSuccess: upsertManyCleaningTask,
+    getCleaningTasksSuccess: setAllCleaningTask,
     postCleaningTaskSuccess: upsertOneCleaningTask,
     editCleaningTaskSuccess: upsertOneCleaningTask,
     deleteCleaningTaskSuccess: cleaningTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/fieldWorkTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/fieldWorkTaskSlice.js
@@ -12,8 +12,8 @@ const getFieldWorkTask = (task) => {
 const upsertOneFieldWorkTask = (state, { payload: task }) => {
   fieldWorkTaskAdapter.upsertOne(state, getFieldWorkTask(task));
 };
-const upsertManyFieldWorkTask = (state, { payload: tasks }) => {
-  fieldWorkTaskAdapter.upsertMany(
+const setAllFieldWorkTask = (state, { payload: tasks }) => {
+  fieldWorkTaskAdapter.setAll(
     state,
     tasks.map((task) => getFieldWorkTask(task)),
   );
@@ -35,7 +35,7 @@ const fieldWorkTaskSlice = createSlice({
   reducers: {
     onLoadingFieldWorkTaskStart: onLoadingStart,
     onLoadingFieldWorkTaskFail: onLoadingFail,
-    getFieldWorkTasksSuccess: upsertManyFieldWorkTask,
+    getFieldWorkTasksSuccess: setAllFieldWorkTask,
     postFieldWorkTaskSuccess: upsertOneFieldWorkTask,
     editFieldWorkTaskSuccess: upsertOneFieldWorkTask,
     deleteFieldWorkTaskSuccess: fieldWorkTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/fieldWorkTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/fieldWorkTaskSlice.js
@@ -12,6 +12,13 @@ const getFieldWorkTask = (task) => {
 const upsertOneFieldWorkTask = (state, { payload: task }) => {
   fieldWorkTaskAdapter.upsertOne(state, getFieldWorkTask(task));
 };
+const upsertManyFieldWorkTask = (state, { payload: tasks }) => {
+  fieldWorkTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getFieldWorkTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllFieldWorkTask = (state, { payload: tasks }) => {
   fieldWorkTaskAdapter.setAll(
     state,
@@ -35,7 +42,8 @@ const fieldWorkTaskSlice = createSlice({
   reducers: {
     onLoadingFieldWorkTaskStart: onLoadingStart,
     onLoadingFieldWorkTaskFail: onLoadingFail,
-    getFieldWorkTasksSuccess: setAllFieldWorkTask,
+    getFieldWorkTasksSuccess: upsertManyFieldWorkTask,
+    getAllFieldWorkTasksSuccess: setAllFieldWorkTask,
     postFieldWorkTaskSuccess: upsertOneFieldWorkTask,
     editFieldWorkTaskSuccess: upsertOneFieldWorkTask,
     deleteFieldWorkTaskSuccess: fieldWorkTaskAdapter.removeOne,
@@ -43,6 +51,7 @@ const fieldWorkTaskSlice = createSlice({
 });
 export const {
   getFieldWorkTasksSuccess,
+  getAllFieldWorkTasksSuccess,
   postFieldWorkTaskSuccess,
   editFieldWorkTaskSuccess,
   onLoadingFieldWorkTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/harvestTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/harvestTaskSlice.js
@@ -20,8 +20,8 @@ const getHarvestTask = (task) => {
 const upsertOneHarvestTask = (state, { payload: task }) => {
   harvestTaskAdapter.upsertOne(state, getHarvestTask(task));
 };
-const upsertManyHarvestTask = (state, { payload: tasks }) => {
-  harvestTaskAdapter.upsertMany(
+const setAllHarvestTask = (state, { payload: tasks }) => {
+  harvestTaskAdapter.setAll(
     state,
     tasks.map((task) => getHarvestTask(task)),
   );
@@ -43,7 +43,7 @@ const harvestTaskSlice = createSlice({
   reducers: {
     onLoadingHarvestTaskStart: onLoadingStart,
     onLoadingHarvestTaskFail: onLoadingFail,
-    getHarvestTasksSuccess: upsertManyHarvestTask,
+    getHarvestTasksSuccess: setAllHarvestTask,
     postHarvestTaskSuccess: upsertOneHarvestTask,
     editHarvestTaskSuccess: upsertOneHarvestTask,
     deleteHarvestTaskSuccess: harvestTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/harvestTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/harvestTaskSlice.js
@@ -20,6 +20,13 @@ const getHarvestTask = (task) => {
 const upsertOneHarvestTask = (state, { payload: task }) => {
   harvestTaskAdapter.upsertOne(state, getHarvestTask(task));
 };
+const upsertManyHarvestTask = (state, { payload: tasks }) => {
+  harvestTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getHarvestTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllHarvestTask = (state, { payload: tasks }) => {
   harvestTaskAdapter.setAll(
     state,
@@ -43,7 +50,8 @@ const harvestTaskSlice = createSlice({
   reducers: {
     onLoadingHarvestTaskStart: onLoadingStart,
     onLoadingHarvestTaskFail: onLoadingFail,
-    getHarvestTasksSuccess: setAllHarvestTask,
+    getHarvestTasksSuccess: upsertManyHarvestTask,
+    getAlllHarvestTasksSuccess: setAllHarvestTask,
     postHarvestTaskSuccess: upsertOneHarvestTask,
     editHarvestTaskSuccess: upsertOneHarvestTask,
     deleteHarvestTaskSuccess: harvestTaskAdapter.removeOne,
@@ -51,6 +59,7 @@ const harvestTaskSlice = createSlice({
 });
 export const {
   getHarvestTasksSuccess,
+  getAlllHarvestTasksSuccess,
   postHarvestTaskSuccess,
   editHarvestTaskSuccess,
   onLoadingHarvestTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/irrigationTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/irrigationTaskSlice.js
@@ -34,6 +34,12 @@ const irrigationTaskAdapter = createEntityAdapter({
 const upsertOneIrrigationTask = (state, { payload: task }) => {
   irrigationTaskAdapter.upsertOne(state, getIrrigationTask(task));
 };
+const upsertManyIrrigationTask = (state, { payload: tasks }) => {
+  irrigationTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getIrrigationTask(task)),
+  );
+};
 const setAllIrrigationTask = (state, { payload: tasks }) => {
   irrigationTaskAdapter.setAll(
     state,
@@ -52,7 +58,8 @@ const irrigationTaskSlice = createSlice({
   reducers: {
     onLoadingIrrigationTaskStart: onLoadingStart,
     onLoadingIrrigationTaskFail: onLoadingFail,
-    getIrrigationTasksSuccess: setAllIrrigationTask,
+    getIrrigationTasksSuccess: upsertManyIrrigationTask,
+    getAllIrrigationTasksSuccess: setAllIrrigationTask,
     postIrrigationTaskSuccess: upsertOneIrrigationTask,
     editIrrigationTaskSuccess: upsertOneIrrigationTask,
     deleteIrrigationTaskSuccess: irrigationTaskAdapter.removeOne,
@@ -61,6 +68,7 @@ const irrigationTaskSlice = createSlice({
 
 export const {
   getIrrigationTasksSuccess,
+  getAllIrrigationTasksSuccess,
   postIrrigationTaskSuccess,
   editIrrigationTaskSuccess,
   onLoadingIrrigationTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/pestControlTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/pestControlTaskSlice.js
@@ -20,6 +20,13 @@ const getPestControlTask = (task) => {
 const upsertOnePestControlTask = (state, { payload: task }) => {
   pestControlTaskAdapter.upsertOne(state, getPestControlTask(task));
 };
+const upsertManyPestControlTask = (state, { payload: tasks }) => {
+  pestControlTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getPestControlTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllPestControlTask = (state, { payload: tasks }) => {
   pestControlTaskAdapter.setAll(
     state,
@@ -43,7 +50,8 @@ const pestControlTaskSlice = createSlice({
   reducers: {
     onLoadingPestControlTaskStart: onLoadingStart,
     onLoadingPestControlTaskFail: onLoadingFail,
-    getPestControlTasksSuccess: setAllPestControlTask,
+    getPestControlTasksSuccess: upsertManyPestControlTask,
+    getAllPestControlTasksSuccess: setAllPestControlTask,
     postPestControlTaskSuccess: upsertOnePestControlTask,
     editPestControlTaskSuccess: upsertOnePestControlTask,
     deletePestControlTaskSuccess: pestControlTaskAdapter.removeOne,
@@ -51,6 +59,7 @@ const pestControlTaskSlice = createSlice({
 });
 export const {
   getPestControlTasksSuccess,
+  getAllPestControlTasksSuccess,
   postPestControlTaskSuccess,
   editPestControlTaskSuccess,
   onLoadingPestControlTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/pestControlTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/pestControlTaskSlice.js
@@ -20,8 +20,8 @@ const getPestControlTask = (task) => {
 const upsertOnePestControlTask = (state, { payload: task }) => {
   pestControlTaskAdapter.upsertOne(state, getPestControlTask(task));
 };
-const upsertManyPestControlTask = (state, { payload: tasks }) => {
-  pestControlTaskAdapter.upsertMany(
+const setAllPestControlTask = (state, { payload: tasks }) => {
+  pestControlTaskAdapter.setAll(
     state,
     tasks.map((task) => getPestControlTask(task)),
   );
@@ -43,7 +43,7 @@ const pestControlTaskSlice = createSlice({
   reducers: {
     onLoadingPestControlTaskStart: onLoadingStart,
     onLoadingPestControlTaskFail: onLoadingFail,
-    getPestControlTasksSuccess: upsertManyPestControlTask,
+    getPestControlTasksSuccess: setAllPestControlTask,
     postPestControlTaskSuccess: upsertOnePestControlTask,
     editPestControlTaskSuccess: upsertOnePestControlTask,
     deletePestControlTaskSuccess: pestControlTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/plantTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/plantTaskSlice.js
@@ -14,8 +14,8 @@ const getPlantTask = (task) => {
 const upsertOnePlantTask = (state, { payload: task }) => {
   plantTaskAdapter.upsertOne(state, getPlantTask(task));
 };
-const upsertManyPlantTask = (state, { payload: tasks }) => {
-  plantTaskAdapter.upsertMany(
+const setAllPlantTask = (state, { payload: tasks }) => {
+  plantTaskAdapter.setAll(
     state,
     tasks.map((task) => getPlantTask(task)),
   );
@@ -37,7 +37,7 @@ const plantTaskSlice = createSlice({
   reducers: {
     onLoadingPlantTaskStart: onLoadingStart,
     onLoadingPlantTaskFail: onLoadingFail,
-    getPlantTasksSuccess: upsertManyPlantTask,
+    getPlantTasksSuccess: setAllPlantTask,
     postPlantTaskSuccess: upsertOnePlantTask,
     editPlantTaskSuccess: upsertOnePlantTask,
     deletePlantTaskSuccess: plantTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/plantTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/plantTaskSlice.js
@@ -14,6 +14,13 @@ const getPlantTask = (task) => {
 const upsertOnePlantTask = (state, { payload: task }) => {
   plantTaskAdapter.upsertOne(state, getPlantTask(task));
 };
+const upsertManyPlantTask = (state, { payload: tasks }) => {
+  plantTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getPlantTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllPlantTask = (state, { payload: tasks }) => {
   plantTaskAdapter.setAll(
     state,
@@ -37,7 +44,8 @@ const plantTaskSlice = createSlice({
   reducers: {
     onLoadingPlantTaskStart: onLoadingStart,
     onLoadingPlantTaskFail: onLoadingFail,
-    getPlantTasksSuccess: setAllPlantTask,
+    getPlantTasksSuccess: upsertManyPlantTask,
+    getAllPlantTasksSuccess: setAllPlantTask,
     postPlantTaskSuccess: upsertOnePlantTask,
     editPlantTaskSuccess: upsertOnePlantTask,
     deletePlantTaskSuccess: plantTaskAdapter.removeOne,
@@ -45,6 +53,7 @@ const plantTaskSlice = createSlice({
 });
 export const {
   getPlantTasksSuccess,
+  getAllPlantTasksSuccess,
   postPlantTaskSuccess,
   editPlantTaskSuccess,
   onLoadingPlantTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/soilAmendmentTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/soilAmendmentTaskSlice.js
@@ -18,6 +18,13 @@ const getSoilAmendmentTask = (task) => {
 const upsertOneSoilAmendmentTask = (state, { payload: task }) => {
   soilAmendmentTaskAdapter.upsertOne(state, getSoilAmendmentTask(task));
 };
+const upsertManySoilAmendmentTask = (state, { payload: tasks }) => {
+  soilAmendmentTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getSoilAmendmentTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllSoilAmendmentTask = (state, { payload: tasks }) => {
   soilAmendmentTaskAdapter.setAll(
     state,
@@ -41,7 +48,8 @@ const soilAmendmentTaskSlice = createSlice({
   reducers: {
     onLoadingSoilAmendmentTaskStart: onLoadingStart,
     onLoadingSoilAmendmentTaskFail: onLoadingFail,
-    getSoilAmendmentTasksSuccess: setAllSoilAmendmentTask,
+    getSoilAmendmentTasksSuccess: upsertManySoilAmendmentTask,
+    getAllSoilAmendmentTasksSuccess: setAllSoilAmendmentTask,
     postSoilAmendmentTaskSuccess: upsertOneSoilAmendmentTask,
     editSoilAmendmentTaskSuccess: upsertOneSoilAmendmentTask,
     deleteSoilAmendmentTaskSuccess: soilAmendmentTaskAdapter.removeOne,
@@ -49,6 +57,7 @@ const soilAmendmentTaskSlice = createSlice({
 });
 export const {
   getSoilAmendmentTasksSuccess,
+  getAllSoilAmendmentTasksSuccess,
   postSoilAmendmentTaskSuccess,
   editSoilAmendmentTaskSuccess,
   onLoadingSoilAmendmentTaskStart,

--- a/packages/webapp/src/containers/slice/taskSlice/soilAmendmentTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/soilAmendmentTaskSlice.js
@@ -18,8 +18,8 @@ const getSoilAmendmentTask = (task) => {
 const upsertOneSoilAmendmentTask = (state, { payload: task }) => {
   soilAmendmentTaskAdapter.upsertOne(state, getSoilAmendmentTask(task));
 };
-const upsertManySoilAmendmentTask = (state, { payload: tasks }) => {
-  soilAmendmentTaskAdapter.upsertMany(
+const setAllSoilAmendmentTask = (state, { payload: tasks }) => {
+  soilAmendmentTaskAdapter.setAll(
     state,
     tasks.map((task) => getSoilAmendmentTask(task)),
   );
@@ -41,7 +41,7 @@ const soilAmendmentTaskSlice = createSlice({
   reducers: {
     onLoadingSoilAmendmentTaskStart: onLoadingStart,
     onLoadingSoilAmendmentTaskFail: onLoadingFail,
-    getSoilAmendmentTasksSuccess: upsertManySoilAmendmentTask,
+    getSoilAmendmentTasksSuccess: setAllSoilAmendmentTask,
     postSoilAmendmentTaskSuccess: upsertOneSoilAmendmentTask,
     editSoilAmendmentTaskSuccess: upsertOneSoilAmendmentTask,
     deleteSoilAmendmentTaskSuccess: soilAmendmentTaskAdapter.removeOne,

--- a/packages/webapp/src/containers/slice/taskSlice/transplantTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/transplantTaskSlice.js
@@ -18,8 +18,8 @@ const getTransplantTask = (task) => {
 const upsertOneTransplantTask = (state, { payload: task }) => {
   transplantTaskAdapter.upsertOne(state, getTransplantTask(task));
 };
-const upsertManyTransplantTask = (state, { payload: tasks }) => {
-  transplantTaskAdapter.upsertMany(
+const setAllTransplantTask = (state, { payload: tasks }) => {
+  transplantTaskAdapter.setAll(
     state,
     tasks.map((task) => getTransplantTask(task)),
   );
@@ -41,7 +41,7 @@ const transplantTaskSlice = createSlice({
   reducers: {
     onLoadingTransplantTaskStart: onLoadingStart,
     onLoadingTransplantTaskFail: onLoadingFail,
-    getTransplantTasksSuccess: upsertManyTransplantTask,
+    getTransplantTasksSuccess: setAllTransplantTask,
     postTransplantTaskSuccess: upsertOneTransplantTask,
     editTransplantTaskSuccess: upsertOneTransplantTask,
     deleteTransplantTaskSuccess: transplantTaskAdapter.removeOne,
@@ -69,10 +69,8 @@ export const transplantTaskEntitiesSelector = createSelector(
   (transplantTaskEntities, plantManagementPlanTaskEntities) => {
     return produce(transplantTaskEntities, (transplantTaskEntities) => {
       for (const task_id in transplantTaskEntities) {
-        const {
-          planting_management_plan_id,
-          prev_planting_management_plan_id,
-        } = transplantTaskEntities[task_id];
+        const { planting_management_plan_id, prev_planting_management_plan_id } =
+          transplantTaskEntities[task_id];
         transplantTaskEntities[task_id].planting_management_plan =
           plantManagementPlanTaskEntities[planting_management_plan_id];
         prev_planting_management_plan_id &&

--- a/packages/webapp/src/containers/slice/taskSlice/transplantTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/transplantTaskSlice.js
@@ -18,6 +18,13 @@ const getTransplantTask = (task) => {
 const upsertOneTransplantTask = (state, { payload: task }) => {
   transplantTaskAdapter.upsertOne(state, getTransplantTask(task));
 };
+const upsertManyTransplantTask = (state, { payload: tasks }) => {
+  transplantTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getTransplantTask(task)),
+  );
+  onLoadingSuccess(state);
+};
 const setAllTransplantTask = (state, { payload: tasks }) => {
   transplantTaskAdapter.setAll(
     state,
@@ -41,7 +48,8 @@ const transplantTaskSlice = createSlice({
   reducers: {
     onLoadingTransplantTaskStart: onLoadingStart,
     onLoadingTransplantTaskFail: onLoadingFail,
-    getTransplantTasksSuccess: setAllTransplantTask,
+    getTransplantTasksSuccess: upsertManyTransplantTask,
+    getAllTransplantTasksSuccess: setAllTransplantTask,
     postTransplantTaskSuccess: upsertOneTransplantTask,
     editTransplantTaskSuccess: upsertOneTransplantTask,
     deleteTransplantTaskSuccess: transplantTaskAdapter.removeOne,
@@ -49,6 +57,7 @@ const transplantTaskSlice = createSlice({
 });
 export const {
   getTransplantTasksSuccess,
+  getAllTransplantTasksSuccess,
   postTransplantTaskSuccess,
   editTransplantTaskSuccess,
   onLoadingTransplantTaskStart,


### PR DESCRIPTION
**Description**

While working on https://github.com/LiteFarmOrg/LiteFarm/pull/3752, I noticed that when switching farms, task type tasks were not being updated in the Redux store as expected. The reducer used `upsertMany`, which merges tasks instead of replacing them. As a result, tasks from the previous farm were still present after switching.

This caused a bug when checking if any irrigation task had an IP - it was being evaluated against tasks from a different farm as well.

I fixed the `getIrrigationTasksSuccess` reducer in the PR above. This PR applies the same fix to the remaining task types.

Jira link: https://lite-farm.atlassian.net/browse/LF-4818

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have added "MISSING" for all new language tags to languages I don't speak
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
