### PR TITLE
LF-4785: Fix crash when long pressing ESci sensor icon

### DIFF
--- a/packages/webapp/src/components/Map/PreviewPopup/index.jsx
+++ b/packages/webapp/src/components/Map/PreviewPopup/index.jsx
@@ -64,7 +64,8 @@ const useStyles = makeStyles((theme) => ({
 export default function PurePreviewPopup({ location, history, sensorReadings, styleOverride }) {
   const classes = useStyles();
   const { t } = useTranslation();
-  const { reading_types = [] } = useSelector(sensorReadingTypesByLocationSelector(location.id));
+  const { reading_types = [] } =
+    useSelector(sensorReadingTypesByLocationSelector(location.id)) || {};
 
   const displayPopup =
     reading_types?.includes(TEMPERATURE) || reading_types?.includes(SOIL_WATER_POTENTIAL);

--- a/packages/webapp/src/containers/Map/LocationSelectionModal/index.jsx
+++ b/packages/webapp/src/containers/Map/LocationSelectionModal/index.jsx
@@ -18,7 +18,12 @@ export default function LocationSelectionModal({ history, selectingOnly }) {
   );
   const sensorReadings = useSelector(mapSensorSelector);
 
-  if (showSelection && locations.length === 1 && selectedLocation.type === SensorType.SENSOR) {
+  if (
+    showSelection &&
+    locations.length === 1 &&
+    !selectedLocation.isAddonSensor &&
+    selectedLocation.type === SensorType.SENSOR
+  ) {
     return (
       <div className={styles.selectionModal} onClick={dismissSelectionModal}>
         <div className={styles.selectionContainer}>


### PR DESCRIPTION
**Description**

- Add fallback object for reading_types selector result
- Update condition for showing `<PurePreviewPopup />` so it doesn't appear when ESci sensor icons are clicked

Jira link: https://lite-farm.atlassian.net/browse/LF-4785

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
