### PR TITLE
LF-4707: Clear error icon position is off on input without a label

### DIFF
--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -135,18 +135,6 @@ const Input = ({
           {icon && <span className={styles.icon}>{icon}</span>}
         </div>
       )}
-      {showError && !unit && showCross && (
-        <Cross
-          onClick={onClear}
-          style={{
-            position: 'absolute',
-            right: 0,
-            transform: inputType === 'date' ? 'translate(-26px, 15px)' : 'translate(-17px, 15px)',
-            cursor: 'pointer',
-            zIndex: 1,
-          }}
-        />
-      )}
       {isPassword &&
         !showError &&
         (showPassword ? (
@@ -169,6 +157,12 @@ const Input = ({
         </div>
       )}
       <div className={styles.inputWrapper}>
+        {showError && !unit && showCross && (
+          <Cross
+            className={clsx(styles.clearIcon, inputType === 'date' && styles.date)}
+            onClick={onClear}
+          />
+        )}
         <input
           data-testid={testId}
           disabled={disabled}

--- a/packages/webapp/src/components/Form/Input/input.module.scss
+++ b/packages/webapp/src/components/Form/Input/input.module.scss
@@ -195,3 +195,15 @@ input:focus::placeholder {
 .inputWrapper input:disabled + .stepper .stepperIcons {
   pointer-events: none;
 }
+
+.clearIcon {
+  position: absolute;
+  right: 17px;
+  top: -5px;
+  cursor: pointer;
+  z-index: 1;
+
+  &.date {
+    right: 26px;
+  }
+}

--- a/packages/webapp/src/stories/Form/Input/Input.stories.jsx
+++ b/packages/webapp/src/stories/Form/Input/Input.stories.jsx
@@ -153,6 +153,12 @@ WithError.args = {
   label: 'With error',
 };
 
+export const WithErrorWithoutLabel = Template.bind({});
+WithErrorWithoutLabel.args = {
+  errors: 'error error error error',
+  label: null,
+};
+
 export const WithInfo = Template.bind({});
 WithInfo.args = {
   info: 'info info info info info',
@@ -202,4 +208,17 @@ PasswordWithLink.args = {
   label: 'Password',
   type: 'password',
   icon: <Underlined>Forget password</Underlined>,
+};
+
+export const Date = Template.bind({});
+Date.args = {
+  type: 'date',
+  label: 'Date',
+};
+
+export const DateWithError = Template.bind({});
+DateWithError.args = {
+  type: 'date',
+  label: 'Date',
+  errors: 'error error error error',
 };


### PR DESCRIPTION
**Description**

The clear icon was previously positioned inside the wrapper that also contained the label and error message. When no label or error was present, its absolute positioning caused it to appear misaligned.
This PR moves the icon into the wrapper that only contains the input field, ensuring correct positioning in all cases.

Stories:
- [with error without label](http://localhost:6006/?path=/story/components-input--with-error-without-label)
- [Date input](http://localhost:6006/?path=/story/components-input--date)
- [Date input with error](http://localhost:6006/?path=/story/components-input--date-with-error)

Jira link: https://lite-farm.atlassian.net/browse/LF-4707

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
