### PR TITLE
LF-4773: Cancel and back buttons are not working on the add sensors flow

### DIFF
--- a/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
+++ b/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
@@ -69,6 +69,11 @@ interface WithStepperProgressBarProps {
   onAfterSave?: (values: FieldValues) => void;
 }
 
+/**
+ * Only provide setIsEditing when the form needs to toggle to read-only mode (e.g., SingleAnimalView).
+ * If setIsEditing is provided, ContextForm will call setIsEditing(false) instead of history.back()
+ * when the user cancels or goes back from step 0
+ */
 export const WithStepperProgressBar = ({
   children,
   history,

--- a/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
+++ b/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
@@ -67,6 +67,7 @@ interface WithStepperProgressBarProps {
   showPreviousButton?: boolean;
   showLoading?: boolean;
   onAfterSave?: (values: FieldValues) => void;
+  hideFormNavigationButtons?: boolean;
 }
 
 export const WithStepperProgressBar = ({
@@ -95,6 +96,7 @@ export const WithStepperProgressBar = ({
   showPreviousButton = true,
   showLoading,
   onAfterSave,
+  hideFormNavigationButtons,
 }: WithStepperProgressBarProps) => {
   const [transition, setTransition] = useState<{ unblock?: () => void; retry?: () => void }>({
     unblock: undefined,
@@ -137,7 +139,7 @@ export const WithStepperProgressBar = ({
     (!hasSummaryWithinForm && activeStepIndex === steps.length - 1) ||
     (hasSummaryWithinForm && activeStepIndex === steps.length - 2);
 
-  const shouldShowFormNavigationButtons = !isSummaryPage && isEditing;
+  const shouldShowFormNavigationButtons = !hideFormNavigationButtons && !isSummaryPage && isEditing;
 
   const onSuccess = () => {
     reset(getValues());

--- a/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
+++ b/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx
@@ -67,7 +67,6 @@ interface WithStepperProgressBarProps {
   showPreviousButton?: boolean;
   showLoading?: boolean;
   onAfterSave?: (values: FieldValues) => void;
-  hideFormNavigationButtons?: boolean;
 }
 
 export const WithStepperProgressBar = ({
@@ -96,7 +95,6 @@ export const WithStepperProgressBar = ({
   showPreviousButton = true,
   showLoading,
   onAfterSave,
-  hideFormNavigationButtons,
 }: WithStepperProgressBarProps) => {
   const [transition, setTransition] = useState<{ unblock?: () => void; retry?: () => void }>({
     unblock: undefined,
@@ -139,7 +137,7 @@ export const WithStepperProgressBar = ({
     (!hasSummaryWithinForm && activeStepIndex === steps.length - 1) ||
     (hasSummaryWithinForm && activeStepIndex === steps.length - 2);
 
-  const shouldShowFormNavigationButtons = !hideFormNavigationButtons && !isSummaryPage && isEditing;
+  const shouldShowFormNavigationButtons = !isSummaryPage && isEditing;
 
   const onSuccess = () => {
     reset(getValues());

--- a/packages/webapp/src/containers/AddSensors/index.tsx
+++ b/packages/webapp/src/containers/AddSensors/index.tsx
@@ -65,7 +65,12 @@ const AddSensor = ({ history, isCompactSideMenu }: AddSensorProps) => {
     history.push(createSensorsUrl(+values[PARTNER]?.[FarmAddonField.PARTNER_ID]));
   };
 
-  const getFormSteps = () => [{ FormContent: Partners, dataName: PARTNERS.ESCI.shortName }];
+  const getFormSteps = () => [
+    {
+      FormContent: () => <Partners setIsEditing={setIsEditing} />,
+      dataName: PARTNERS.ESCI.shortName,
+    },
+  ];
 
   const defaultFormValues = {
     [PARTNER]: { [FarmAddonField.PARTNER_ID]: PARTNERS.ESCI.id, [FarmAddonField.ORG_UUID]: '' },
@@ -88,8 +93,7 @@ const AddSensor = ({ history, isCompactSideMenu }: AddSensorProps) => {
         isCompactSideMenu={isCompactSideMenu}
         onAfterSave={onAfterSave}
         showLoading
-        setIsEditing={setIsEditing}
-        isEditing={isEditing}
+        hideFormNavigationButtons={!isEditing}
       />
     </div>
   );

--- a/packages/webapp/src/containers/AddSensors/index.tsx
+++ b/packages/webapp/src/containers/AddSensors/index.tsx
@@ -93,7 +93,7 @@ const AddSensor = ({ history, isCompactSideMenu }: AddSensorProps) => {
         isCompactSideMenu={isCompactSideMenu}
         onAfterSave={onAfterSave}
         showLoading
-        hideFormNavigationButtons={!isEditing}
+        isEditing={isEditing}
       />
     </div>
   );


### PR DESCRIPTION
**Description**

We were passing `isEditing` and `setIsEditing` to `<ContextForm />` to hide the form navigation buttons. However, when `setIsEditing` is passed, `ContextForm` skips calling `history.back()` on cancel (`onCancel`).

This PR adds a new `hideFormNavigationButtons` prop on `WithStepperProgressBar` to control button visibility.

Jira link: https://lite-farm.atlassian.net/browse/LF-4773

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
