### PR TITLE
LF-4820 Refactor api slice and switch farm saga to purge data between…

### DIFF
--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -151,7 +151,7 @@ import {
   onLoadingWatercourseFail,
   onLoadingWatercourseStart,
 } from './watercourseSlice';
-import { api } from '../store/api/apiSlice';
+import { api, FarmLibraryTags, FarmTags } from '../store/api/apiSlice';
 
 const logUserInfoUrl = () => `${url}/userLog`;
 const getCropsByFarmIdUrl = (farm_id) => `${url}/crop/farm/${farm_id}`;
@@ -623,16 +623,7 @@ export function* clearOldFarmStateSaga() {
   yield put(resetTasks());
   yield put(resetDateRange());
 
-  yield put(
-    api.util.invalidateTags([
-      'Animals',
-      'AnimalBatches',
-      'CustomAnimalBreeds',
-      'CustomAnimalTypes',
-      'DefaultAnimalTypes', // needs to be cleared for KPI count
-      'FarmAddon',
-    ]),
-  );
+  yield put(api.util.invalidateTags([...FarmTags, ...FarmLibraryTags]));
 
   // Reset finance loading state
   yield put(setIsFetchingData(true));

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -61,7 +61,56 @@ import type {
   SensorReadings,
   IrrigationPrescription,
 } from './types';
-import i18n from '../../locales/i18n';
+
+/**
+ * These tags have endpoints that do not return farm specific data, and are not created by a farm
+ *
+ *  LiteFarm provides these data as defaults
+ */
+export const LibraryTags = [
+  'DefaultAnimalBreeds',
+  'AnimalSexes',
+  'AnimalIdentifierTypes',
+  'AnimalIdentifierColors',
+  'AnimalMovementPurposes',
+  'AnimalOrigins',
+  'AnimalUses',
+  'AnimalRemovalReasons',
+  'SoilAmendmentMethods',
+  'SoilAmendmentPurposes',
+  'SoilAmendmentFertiliserTypes',
+];
+
+/**
+ * These tags contain endpoints that return farm specific data
+ *
+ * These data should not persist when switching farms,
+ * or should be stored in a separate farm store.
+ */
+export const FarmTags = [
+  'Animals',
+  'AnimalBatches',
+  'CustomAnimalBreeds',
+  'CustomAnimalTypes',
+  'SoilAmendmentProduct',
+  'Sensors',
+  'SensorReadings',
+  'FarmAddon',
+  'IrrigationPrescriptions',
+  'Weather',
+];
+
+/**
+ * These tags contain endpoints that could either return farm specific data
+ * or farm neutral defaults data.
+ *
+ * For data safety these data should also not persist when switching farms,
+ * or should be stored in a separate farm store.
+ */
+export const FarmLibraryTags = [
+  // 'count' param returns farm specific data
+  'AnimalIdentifierTypes',
+];
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({
@@ -73,35 +122,11 @@ export const api = createApi({
       headers.set('Authorization', `Bearer ${localStorage.getItem('id_token')}`);
       headers.set('user_id', state.entitiesReducer.userFarmReducer.user_id || '');
       headers.set('farm_id', state.entitiesReducer.userFarmReducer.farm_id || '');
-
       return headers;
     },
     responseHandler: 'content-type',
   }),
-  tagTypes: [
-    'Animals',
-    'AnimalBatches',
-    'CustomAnimalBreeds',
-    'CustomAnimalTypes',
-    'DefaultAnimalBreeds',
-    'DefaultAnimalTypes',
-    'AnimalSexes',
-    'AnimalIdentifierTypes',
-    'AnimalIdentifierColors',
-    'AnimalMovementPurposes',
-    'AnimalOrigins',
-    'AnimalUses',
-    'AnimalRemovalReasons',
-    'SoilAmendmentMethods',
-    'SoilAmendmentPurposes',
-    'SoilAmendmentFertiliserTypes',
-    'SoilAmendmentProduct',
-    'Sensors',
-    'SensorReadings',
-    'FarmAddon',
-    'IrrigationPrescriptions',
-    'Weather',
-  ],
+  tagTypes: [...LibraryTags, ...FarmTags, ...FarmLibraryTags],
   endpoints: (build) => ({
     // redux-toolkit.js.org/rtk-query/usage-with-typescript#typing-query-and-mutation-endpoints
     // <ResultType, QueryArg>


### PR DESCRIPTION
**Description**

Refactors the store and the switch farm saga to :

- No longer need to define tags inside the saga.
- Discriminate between farm data and common data
- Bugfix data being persisted between farms

Jira link: [LF-4820](https://lite-farm.atlassian.net/browse/LF-4820)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
