### PR TITLE
LF-4828 Add database migration to support new location type

### DIFF
--- a/packages/api/db/migration/20250514175826_create_soil_sample_location.js
+++ b/packages/api/db/migration/20250514175826_create_soil_sample_location.js
@@ -1,0 +1,111 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { formatAlterTableEnumSql } from '../util.js';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.createTable('soil_sample_location', (table) => {
+    table
+      .uuid('location_id')
+      .primary()
+      .references('location_id')
+      .inTable('location')
+      .onDelete('CASCADE');
+  });
+
+  await knex.raw(
+    formatAlterTableEnumSql('figure', 'type', [
+      'field',
+      'farm_site_boundary',
+      'greenhouse',
+      'buffer_zone',
+      'gate',
+      'surface_water',
+      'fence',
+      'garden',
+      'residence',
+      'water_valve',
+      'watercourse',
+      'barn',
+      'natural_area',
+      'ceremonial_area',
+      'pin',
+      'sensor',
+      'soil_sample_location',
+    ]),
+  );
+
+  await knex('permissions').insert([
+    {
+      permission_id: 177,
+      name: 'add:soil_sample_location',
+      description: 'Create a soil sample location',
+    },
+    {
+      permission_id: 178,
+      name: 'edit:soil_sample_location',
+      description: 'Edit a soil sample location',
+    },
+  ]);
+
+  await knex('rolePermissions').insert([
+    { role_id: 1, permission_id: 177 },
+    { role_id: 2, permission_id: 177 },
+    { role_id: 5, permission_id: 177 },
+    { role_id: 1, permission_id: 178 },
+    { role_id: 2, permission_id: 178 },
+    { role_id: 5, permission_id: 178 },
+  ]);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+export const down = async function (knex) {
+  const permissions = [177, 178];
+
+  await knex('rolePermissions').whereIn('permission_id', permissions).del();
+
+  await knex('permissions').whereIn('permission_id', permissions).del();
+
+  await knex.raw(
+    formatAlterTableEnumSql('figure', 'type', [
+      'field',
+      'farm_site_boundary',
+      'greenhouse',
+      'buffer_zone',
+      'gate',
+      'surface_water',
+      'fence',
+      'garden',
+      'residence',
+      'water_valve',
+      'watercourse',
+      'barn',
+      'natural_area',
+      'ceremonial_area',
+      'pin',
+      'sensor',
+    ]),
+  );
+
+  await knex.schema.dropTable('soil_sample_location');
+};


### PR DESCRIPTION
**Description**

This migration:
- Adds the new database table with one column (`location_id`) as in the DB diagram
- Adds the typical location permissions (all locations cannot be added/edited by workers)
- Adds the type to the figure check

Loïc has [confirmed](https://www.figma.com/design/eMffC0h3JPlWtzNttxJpil?node-id=40203-127413&m=dev#1256712377) that there are no other columns on this table (= properties on soil sample location details). The `lat`/`lng` will be shown, but that resides on the `point` table.

Jira link: https://lite-farm.atlassian.net/browse/LF-4828

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Database inspection + have the rest of the user story locally.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
