### PR TITLE
LF-4831 UI flow to view and edit soil sample location

### DIFF
--- a/packages/webapp/src/components/LocationPicker/SingleLocationPicker/index.jsx
+++ b/packages/webapp/src/components/LocationPicker/SingleLocationPicker/index.jsx
@@ -183,7 +183,6 @@ const LocationPicker = ({
         maps.event.addListener(assetGeometry.circle, 'click', (e) => areaOnClick(e.latLng, maps));
       } else {
         maps.event.addListener(assetGeometry.polygon, 'click', (e) => {
-          console.log('event listener firing');
           areaOnClick(e.latLng, maps);
         });
       }

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SoilSampleLocationDetailForm/EditSoilSampleLocation.jsx
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SoilSampleLocationDetailForm/EditSoilSampleLocation.jsx
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import PureSoilSampleLocation from '../../../../components/LocationDetailLayout/PointDetails/SoilSampleLocation';
+import { deleteSoilSampleLocationLocation, editSoilSampleLocationLocation } from './saga';
+import { checkLocationDependencies } from '../../saga';
+import { useDispatch, useSelector } from 'react-redux';
+import { isAdminSelector, measurementSelector } from '../../../userFarmSlice';
+import { soilSampleLocationSelector } from '../../../soilSampleLocationSlice';
+import { useLocationPageType } from '../../utils';
+import UnableToRetireModal from '../../../../components/Modals/UnableToRetireModal';
+import RetireConfirmationModal from '../../../../components/Modals/RetireConfirmationModal';
+
+function EditSoilSampleLocationDetailForm({ history, match }) {
+  const dispatch = useDispatch();
+  const isAdmin = useSelector(isAdminSelector);
+  const system = useSelector(measurementSelector);
+  const submitForm = (data) => {
+    isEditLocationPage &&
+      dispatch(
+        editSoilSampleLocationLocation({
+          ...data,
+          ...match.params,
+          figure_id: soilSampleLocation.figure_id,
+        }),
+      );
+  };
+  const soilSampleLocation = useSelector(soilSampleLocationSelector(match.params.location_id));
+
+  useEffect(() => {
+    if (history?.location?.state?.error?.retire) {
+      setShowCannotRetireModal(true);
+    }
+  }, [history?.location?.state?.error]);
+
+  const { isViewLocationPage, isEditLocationPage } = useLocationPageType(match);
+
+  const [showCannotRetireModal, setShowCannotRetireModal] = useState(false);
+  const [showConfirmRetireModal, setShowConfirmRetireModal] = useState(false);
+  const { location_id } = match.params;
+  const handleRetire = () => {
+    dispatch(
+      checkLocationDependencies({
+        location_id,
+        setShowConfirmRetireModal,
+        setShowCannotRetireModal,
+      }),
+    );
+  };
+
+  const confirmRetire = () => {
+    isViewLocationPage && dispatch(deleteSoilSampleLocationLocation({ location_id }));
+    setShowConfirmRetireModal(false);
+  };
+
+  return (
+    <>
+      <PureSoilSampleLocation
+        history={history}
+        match={match}
+        submitForm={submitForm}
+        system={system}
+        persistedFormData={soilSampleLocation}
+        isEditLocationPage={isEditLocationPage}
+        isViewLocationPage={isViewLocationPage}
+        handleRetire={handleRetire}
+        isAdmin={isAdmin}
+      />
+      {isViewLocationPage && showCannotRetireModal && (
+        <UnableToRetireModal dismissModal={() => setShowCannotRetireModal(false)} />
+      )}
+      {showConfirmRetireModal && (
+        <RetireConfirmationModal
+          dismissModal={() => setShowConfirmRetireModal(false)}
+          handleRetire={confirmRetire}
+        />
+      )}
+    </>
+  );
+}
+
+export default EditSoilSampleLocationDetailForm;

--- a/packages/webapp/src/containers/LocationDetails/PointDetails/SoilSampleLocationDetailForm/saga.js
+++ b/packages/webapp/src/containers/LocationDetails/PointDetails/SoilSampleLocationDetailForm/saga.js
@@ -20,6 +20,8 @@ import { axios, getHeader } from '../../../saga';
 import apiConfig from '../../../../apiConfig';
 import { loginSelector } from '../../../userFarmSlice';
 import {
+  deleteSoilSampleLocationSuccess,
+  editSoilSampleLocationSuccess,
   getLocationObjectFromSoilSampleLocation,
   postSoilSampleLocationSuccess,
 } from '../../../soilSampleLocationSlice';
@@ -70,6 +72,91 @@ export function* postSoilSampleLocationLocationSaga({ payload: data }) {
   }
 }
 
+export const editSoilSampleLocationLocation = createAction(`editSoilSampleLocationLocationSaga`);
+
+export function* editSoilSampleLocationLocationSaga({ payload: data }) {
+  const { formData, location_id, figure_id } = data;
+  const { locationURL } = apiConfig;
+  let { user_id, farm_id } = yield select(loginSelector);
+  formData.farm_id = farm_id;
+  const header = getHeader(user_id, farm_id);
+  const locationObject = getLocationObjectFromSoilSampleLocation({
+    ...formData,
+    location_id,
+    figure_id,
+  });
+
+  try {
+    const result = yield call(
+      axios.put,
+      `${locationURL}/${locationObject.figure.type}/${location_id}`,
+      locationObject,
+      header,
+    );
+    yield put(editSoilSampleLocationSuccess(result.data));
+
+    yield put(
+      setSuccessMessage([
+        i18n.t('FARM_MAP.MAP_FILTER.SOIL_SAMPLE_LOCATION'),
+        i18n.t('message:MAP.SUCCESS_PATCH'),
+      ]),
+    );
+    yield put(canShowSuccessHeader(true));
+    history.push({ pathname: '/map' });
+  } catch (e) {
+    history.push(
+      {
+        pathname: history.location.pathname,
+      },
+      {
+        error: `${i18n.t('message:MAP.FAIL_PATCH')} ${i18n
+          .t('FARM_MAP.MAP_FILTER.SOIL_SAMPLE_LOCATION')
+          .toLowerCase()}`,
+      },
+    );
+    console.log(e);
+  }
+}
+
+export const deleteSoilSampleLocationLocation = createAction(
+  `deleteSoilSampleLocationLocationSaga`,
+);
+
+export function* deleteSoilSampleLocationLocationSaga({ payload: data }) {
+  const { location_id } = data;
+  const { locationURL } = apiConfig;
+  let { user_id, farm_id } = yield select(loginSelector);
+  const header = getHeader(user_id, farm_id);
+
+  try {
+    yield call(axios.delete, `${locationURL}/${location_id}`, header);
+    yield put(setMapCache({ maxZoom: undefined, farm_id }));
+    yield put(deleteSoilSampleLocationSuccess(location_id));
+    yield put(
+      setSuccessMessage([
+        i18n.t('FARM_MAP.MAP_FILTER.SOIL_SAMPLE_LOCATION'),
+        i18n.t('message:MAP.SUCCESS_DELETE'),
+      ]),
+    );
+    yield put(canShowSuccessHeader(true));
+    history.push({ pathname: '/map' });
+  } catch (e) {
+    history.push(
+      {
+        pathname: history.location.pathname,
+      },
+      {
+        error: {
+          retire: true,
+        },
+      },
+    );
+    console.log(e);
+  }
+}
+
 export default function* soilSampleLocationLocationSaga() {
   yield takeLeading(postSoilSampleLocationLocation.type, postSoilSampleLocationLocationSaga);
+  yield takeLeading(editSoilSampleLocationLocation.type, editSoilSampleLocationLocationSaga);
+  yield takeLeading(deleteSoilSampleLocationLocation.type, deleteSoilSampleLocationLocationSaga);
 }

--- a/packages/webapp/src/routes/SoilSampleLocationDetailsRoutes.jsx
+++ b/packages/webapp/src/routes/SoilSampleLocationDetailsRoutes.jsx
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Route } from 'react-router-dom';
+import EditSoilSampleLocationDetailForm from '../containers/LocationDetails/PointDetails/SoilSampleLocationDetailForm/EditSoilSampleLocation';
+import { useSelector } from 'react-redux';
+import { isAdminSelector } from '../containers/userFarmSlice';
+import LocationTasks from '../containers/LocationDetails/LocationTasks';
+
+export default function SoilSampleLocationDetailsRoutes() {
+  const isAdmin = useSelector(isAdminSelector);
+  return (
+    <>
+      <Route
+        path="/soil_sample_location/:location_id/details"
+        exact
+        component={EditSoilSampleLocationDetailForm}
+      />
+      {isAdmin && (
+        <Route
+          path="/soil_sample_location/:location_id/edit"
+          exact
+          component={EditSoilSampleLocationDetailForm}
+        />
+      )}
+      <Route path="/soil_sample_location/:location_id/tasks" exact component={LocationTasks} />
+    </>
+  );
+}

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -96,6 +96,7 @@ const PostSoilSampleLocationForm = React.lazy(() =>
 const EditSensor = React.lazy(() =>
   import('../containers/LocationDetails/PointDetails/SensorDetail/EditSensor'),
 );
+const SoilSampleLocationDetails = React.lazy(() => import('./SoilSampleLocationDetailsRoutes'));
 
 const PostBarnForm = React.lazy(() =>
   import('../containers/LocationDetails/AreaDetails/BarnDetailForm/PostBarn'),
@@ -572,6 +573,10 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
             <Route path="/field/:location_id" component={FieldDetails} />
             <Route path="/gate/:location_id" component={GateDetails} />
             <Route path="/water_valve/:location_id" component={WaterValveDetails} />
+            <Route
+              path="/soil_sample_location/:location_id"
+              component={SoilSampleLocationDetails}
+            />
             <Route path="/fence/:location_id" component={FenceDetails} />
             <Route path="/buffer_zone/:location_id" component={BufferZoneDetails} />
             <Route path="/watercourse/:location_id" component={WatercourseDetails} />
@@ -680,7 +685,6 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
             <Route path="/profile" exact component={Account} />
             <Route path="/people" exact component={People} />
             <Route path="/user/:user_id" exact component={EditUser} />
-
             <Route path="/farm" exact component={Farm} />
             <Route path="/consent" exact component={ConsentForm} />
             <Route path="/crop/new" exact component={AddNewCrop} />
@@ -882,6 +886,10 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
             <Route path="/field/:location_id" component={FieldDetails} />
             <Route path="/gate/:location_id" component={GateDetails} />
             <Route path="/water_valve/:location_id" component={WaterValveDetails} />
+            <Route
+              path="/soil_sample_location/:location_id"
+              component={SoilSampleLocationDetails}
+            />
             <Route path="/fence/:location_id" component={FenceDetails} />
             <Route path="/buffer_zone/:location_id" component={BufferZoneDetails} />
             <Route path="/watercourse/:location_id" component={WatercourseDetails} />
@@ -1033,6 +1041,10 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
             <Route path="/field/:location_id" component={FieldDetails} />
             <Route path="/gate/:location_id" component={GateDetails} />
             <Route path="/water_valve/:location_id" component={WaterValveDetails} />
+            <Route
+              path="/soil_sample_location/:location_id"
+              component={SoilSampleLocationDetails}
+            />
             <Route path="/fence/:location_id" component={FenceDetails} />
             <Route path="/buffer_zone/:location_id" component={BufferZoneDetails} />
             <Route path="/watercourse/:location_id" component={WatercourseDetails} />


### PR DESCRIPTION
**Description**

This completes the frontend of the new location type by adding the routing, sagas for edit (and delete), and the last component (`EditSoilSampleLocationDetailForm`) to the frontend.

As before, this is based on exactly copying the existing point locations.

Jira link: https://lite-farm.atlassian.net/browse/LF-4831

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
