### PR TITLE
LF-4832 Add database migration to support new task type

### DIFF
--- a/packages/api/db/migration/20250520185926_create_soil_sample_task_table.js
+++ b/packages/api/db/migration/20250520185926_create_soil_sample_task_table.js
@@ -27,6 +27,11 @@ export const up = async function (knex) {
       .comment('Report document if uploaded');
     table.integer('samples_per_location').notNullable();
     table.jsonb('sample_depths').notNullable();
+    table.enu('sample_depths_unit', ['cm', 'in']).notNullable().defaultTo('cm');
+    table
+      .enu('sampling_tool', ['SOIL_PROBE', 'AUGER', 'SPADE'])
+      .notNullable()
+      .defaultTo('SOIL_PROBE');
 
     table.check('jsonb_array_length(??) > 0', ['sample_depths'], 'sample_depths_not_empty_check');
 

--- a/packages/api/db/migration/20250520185926_create_soil_sample_task_table.js
+++ b/packages/api/db/migration/20250520185926_create_soil_sample_task_table.js
@@ -20,11 +20,6 @@
 export const up = async function (knex) {
   await knex.schema.createTable('soil_sample_task', (table) => {
     table.integer('task_id').references('task_id').inTable('task').primary();
-    table
-      .uuid('document_id')
-      .references('document_id')
-      .inTable('document')
-      .comment('Report document if uploaded');
     table.integer('samples_per_location').notNullable();
     table.jsonb('sample_depths').notNullable();
     table.enu('sample_depths_unit', ['cm', 'in']).notNullable().defaultTo('cm');

--- a/packages/api/db/migration/20250520185926_create_soil_sample_task_table.js
+++ b/packages/api/db/migration/20250520185926_create_soil_sample_task_table.js
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.createTable('soil_sample_task', (table) => {
+    table.integer('task_id').references('task_id').inTable('task').primary();
+    table
+      .uuid('document_id')
+      .references('document_id')
+      .inTable('document')
+      .comment('Report document if uploaded');
+    table.integer('samples_per_location').notNullable();
+    table.jsonb('sample_depths').notNullable();
+
+    table.check('jsonb_array_length(??) > 0', ['sample_depths'], 'sample_depths_not_empty_check');
+
+    table.check(
+      'jsonb_array_length(??) = ??',
+      ['sample_depths', 'samples_per_location'],
+      'sample_depths_length_check',
+    );
+  });
+
+  await knex('task_type').insert({
+    task_name: 'Soil Sample',
+    task_translation_key: 'SOIL_SAMPLE_TASK',
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+export const down = async function (knex) {
+  await knex('task_type')
+    .where({ task_translation_key: 'SOIL_SAMPLE_TASK' })
+    .andWhere({ farm_id: null })
+    .del();
+
+  await knex.schema.dropTable('soil_sample_task');
+};


### PR DESCRIPTION
**Description**

This is the migration for the new task type. The PR:
- Adds the task type to the `task_type` table (this holds custom types as well so the generated id will depend on the db environment)
- Creates the table for the new task type
- Assumes the task locations will be associated via the `location_tasks` table (i.e. in the normal way) for both field + soil sample locations
- Uses an array for the sampling depths. This array is implemented in `jsonb` which is our codebase pattern for other tables with array datatypes (e.g. `grid_points` of area or `variables` of notification)
  - Update May 21st: this will end up being an array of _objects_ (indicating `upperDepth` and `lowerDepth` of a depth range) but from the perspective of the database, the datatype and checks are unchanged from the original `number[]`
- Sampling depths array has checks on being non-empty and having the correct length
- `sampling_depths_unit` is required (despite no dropdown) as this is where we store whether the user was in `in` or `cm` when they input the value

Jira link: https://lite-farm.atlassian.net/browse/LF-4832

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Database inspected and inserted in using the model (will open PR for that momentarily) to check constraints.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
