### PR TITLE
LF-4802 Finance pages crash when selecting a custom date range and closing the component without clicking away

### DIFF
--- a/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
+++ b/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
@@ -26,7 +26,7 @@ import styles from './styles.module.scss';
 import { Popover } from '@mui/material';
 
 export default function DateRangeInput({
-  optionValue,
+  defaultDateRangeOptionValue,
   defaultCustomDateRange = {},
   onChangeDateRangeOption,
   placeholder,
@@ -35,7 +35,7 @@ export default function DateRangeInput({
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isCustomDatePickerOpen, setIsCustomDatePickerOpen] = useState(false);
-  const isCustomOptionSelected = optionValue === rangeOptions.CUSTOM;
+  const [isCustomOptionSelected, setIsCustomOptionSelected] = useState(false);
 
   const { t } = useTranslation();
   const selectRef = useRef(null);
@@ -142,11 +142,17 @@ export default function DateRangeInput({
         onChange={(e) => {
           if (e?.value === rangeOptions.CUSTOM) {
             setIsCustomDatePickerOpen(true);
+            setIsCustomOptionSelected(true);
+          } else {
+            setIsCustomOptionSelected(false);
           }
           onChangeDateRangeOption && e?.value && onChangeDateRangeOption(e.value);
         }}
         formatOptionLabel={formatOptionLabel}
-        value={options.find(({ value }) => value === optionValue)}
+        defaultValue={
+          defaultDateRangeOptionValue &&
+          options.find(({ value }) => value === defaultDateRangeOptionValue)
+        }
         isSearchable={false}
       />
       <Popover
@@ -177,7 +183,7 @@ export default function DateRangeInput({
 }
 
 DateRangeInput.propTypes = {
-  optionValue: PropTypes.string,
+  defaultDateRangeOptionValue: PropTypes.string,
   defaultCustomDateRange: PropTypes.shape({
     [FROM_DATE]: PropTypes.object,
     [TO_DATE]: PropTypes.object,

--- a/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
+++ b/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
@@ -153,6 +153,7 @@ export default function DateRangeInput({
         open={isCustomDatePickerOpen}
         onClose={closeCustomDatePicker}
         anchorEl={selectRef.current?.controlRef}
+        className={styles.popover}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
+++ b/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
@@ -35,7 +35,9 @@ export default function DateRangeInput({
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isCustomDatePickerOpen, setIsCustomDatePickerOpen] = useState(false);
-  const [isCustomOptionSelected, setIsCustomOptionSelected] = useState(false);
+  const [isCustomOptionSelected, setIsCustomOptionSelected] = useState(
+    defaultDateRangeOptionValue === rangeOptions.CUSTOM,
+  );
 
   const { t } = useTranslation();
   const selectRef = useRef(null);

--- a/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
+++ b/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
@@ -60,6 +60,12 @@ export default function DateRangeInput({
   ];
 
   useEffect(() => {
+    if (isMenuOpen) {
+      selectRef.current?.focus();
+    }
+  }, [isMenuOpen]);
+
+  useEffect(() => {
     onValidityChange?.(isValid);
   }, [isValid, onValidityChange]);
 

--- a/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
+++ b/packages/webapp/src/components/DateRangeSelector/DateRangeInput.jsx
@@ -26,7 +26,7 @@ import styles from './styles.module.scss';
 import { Popover } from '@mui/material';
 
 export default function DateRangeInput({
-  defaultDateRangeOptionValue,
+  optionValue,
   defaultCustomDateRange = {},
   onChangeDateRangeOption,
   placeholder,
@@ -35,7 +35,7 @@ export default function DateRangeInput({
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isCustomDatePickerOpen, setIsCustomDatePickerOpen] = useState(false);
-  const [isCustomOptionSelected, setIsCustomOptionSelected] = useState(false);
+  const isCustomOptionSelected = optionValue === rangeOptions.CUSTOM;
 
   const { t } = useTranslation();
   const selectRef = useRef(null);
@@ -136,17 +136,11 @@ export default function DateRangeInput({
         onChange={(e) => {
           if (e?.value === rangeOptions.CUSTOM) {
             setIsCustomDatePickerOpen(true);
-            setIsCustomOptionSelected(true);
-          } else {
-            setIsCustomOptionSelected(false);
           }
           onChangeDateRangeOption && e?.value && onChangeDateRangeOption(e.value);
         }}
         formatOptionLabel={formatOptionLabel}
-        defaultValue={
-          defaultDateRangeOptionValue &&
-          options.find(({ value }) => value === defaultDateRangeOptionValue)
-        }
+        value={options.find(({ value }) => value === optionValue)}
         isSearchable={false}
       />
       <Popover
@@ -176,7 +170,7 @@ export default function DateRangeInput({
 }
 
 DateRangeInput.propTypes = {
-  defaultDateRangeOptionValue: PropTypes.string,
+  optionValue: PropTypes.string,
   defaultCustomDateRange: PropTypes.shape({
     [FROM_DATE]: PropTypes.object,
     [TO_DATE]: PropTypes.object,

--- a/packages/webapp/src/components/DateRangeSelector/index.tsx
+++ b/packages/webapp/src/components/DateRangeSelector/index.tsx
@@ -63,9 +63,7 @@ const DateRangeSelector = ({
   weekStartDate = SUNDAY,
 }: DateRangeSelectorProps) => {
   const { option, customRange = {} } = dateRange;
-  const initialOption = option || defaultValue;
   const dateRangeUtil = new DateRange(new Date(), weekStartDate);
-
   const initialStartDate = customRange.startDate ? moment(customRange.startDate) : undefined;
   const initialEndDate = customRange.endDate ? moment(customRange.endDate) : undefined;
 
@@ -98,7 +96,7 @@ const DateRangeSelector = ({
   return (
     <div className={clsx(styles.rangeContainer, className)}>
       <DateRangeInput
-        defaultDateRangeOptionValue={initialOption}
+        optionValue={option || defaultValue}
         defaultCustomDateRange={{ [FROM_DATE]: initialStartDate, [TO_DATE]: initialEndDate }}
         onChangeDateRangeOption={onChangeDateRangeOption}
         changeDateRangeMethod={changeDateRange}

--- a/packages/webapp/src/components/DateRangeSelector/index.tsx
+++ b/packages/webapp/src/components/DateRangeSelector/index.tsx
@@ -63,7 +63,9 @@ const DateRangeSelector = ({
   weekStartDate = SUNDAY,
 }: DateRangeSelectorProps) => {
   const { option, customRange = {} } = dateRange;
+  const initialOption = option || defaultValue;
   const dateRangeUtil = new DateRange(new Date(), weekStartDate);
+
   const initialStartDate = customRange.startDate ? moment(customRange.startDate) : undefined;
   const initialEndDate = customRange.endDate ? moment(customRange.endDate) : undefined;
 
@@ -96,7 +98,7 @@ const DateRangeSelector = ({
   return (
     <div className={clsx(styles.rangeContainer, className)}>
       <DateRangeInput
-        optionValue={option || defaultValue}
+        defaultDateRangeOptionValue={initialOption}
         defaultCustomDateRange={{ [FROM_DATE]: initialStartDate, [TO_DATE]: initialEndDate }}
         onChangeDateRangeOption={onChangeDateRangeOption}
         changeDateRangeMethod={changeDateRange}

--- a/packages/webapp/src/components/DateRangeSelector/styles.module.scss
+++ b/packages/webapp/src/components/DateRangeSelector/styles.module.scss
@@ -49,16 +49,10 @@
 
 // CustomDateRangeSelector
 .customDateRangeSelector {
-  position: absolute;
-  top: 100%;
-  left: 2px;
-  width: calc(100% - 4px);
   height: 405px;
   padding: 6px 15px 15px 15px;
   background: var(--white, #fff);
   border-radius: 4px;
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-  z-index: 1000; // should be over the carrousel in Finances
 }
 
 .buttons {

--- a/packages/webapp/src/components/DateRangeSelector/styles.module.scss
+++ b/packages/webapp/src/components/DateRangeSelector/styles.module.scss
@@ -47,10 +47,15 @@
   }
 }
 
+.popover {
+  margin-top: 4px;
+}
+
 // CustomDateRangeSelector
 .customDateRangeSelector {
   height: 405px;
-  padding: 6px 15px 15px 15px;
+  width: 360px;
+  padding: 16px;
   background: var(--white, #fff);
   border-radius: 4px;
 }


### PR DESCRIPTION
**Description**

Fixes the crash that results from the click away listener not firing and updating the redux state properly. Since the whole react select is a child of ClickAwayListener, clicking on the react select itself while the dropdown is open doesn't trigger the callback.

Not documented in the jira ticket but the app also crashed by immediately navigating to another finances page right after opening the custom date picker (while its open). So the click away solution didn't feel right, it also lacked accessibility like not able to use the keyboard for closing / navigating properly.

**Solution**
- Uses the Popover component from MUI for the custom date picker.
- Updating the redux state for date range happens on popover close. 
- Fully accessible by default.

**Potential drawbacks**
- Differs from the original styling, like not taking the full width of the react select. This is because the popover renders in a portal as a child of document.body so it can't inherit the width of the react select. It will likely require some dynamic solution if necessary.
- Storybook tests are failing and will need updating.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira link: https://lite-farm.atlassian.net/browse/LF-4802

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
