### PR TITLE
Lf 4772 display ip details and file on task detail view

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -46,6 +46,7 @@
     "@sentry/react": "^6.19.7",
     "@sentry/tracing": "^6.19.7",
     "@turf/boolean-point-in-polygon": "7.2.0",
+    "@turf/centroid": "^7.2.0",
     "@turf/helpers": "7.2.0",
     "axios": "^1.7.4",
     "chart.js": "^4.4.0",

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@turf/boolean-point-in-polygon':
         specifier: 7.2.0
         version: 7.2.0
+      '@turf/centroid':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@turf/helpers':
         specifier: 7.2.0
         version: 7.2.0
@@ -2343,11 +2346,17 @@ packages:
   '@turf/boolean-point-in-polygon@7.2.0':
     resolution: {integrity: sha512-lvEOjxeXIp+wPXgl9kJA97dqzMfNexjqHou+XHVcfxQgolctoJiRYmcVCWGpiZ9CBf/CJha1KmD1qQoRIsjLaA==}
 
+  '@turf/centroid@7.2.0':
+    resolution: {integrity: sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==}
+
   '@turf/helpers@7.2.0':
     resolution: {integrity: sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==}
 
   '@turf/invariant@7.2.0':
     resolution: {integrity: sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==}
+
+  '@turf/meta@7.2.0':
+    resolution: {integrity: sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -9690,6 +9699,13 @@ snapshots:
       point-in-polygon-hao: 1.2.4
       tslib: 2.8.1
 
+  '@turf/centroid@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/helpers@7.2.0':
     dependencies:
       '@types/geojson': 7946.0.16
@@ -9700,6 +9716,11 @@ snapshots:
       '@turf/helpers': 7.2.0
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
+
+  '@turf/meta@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
 
   '@types/acorn@4.0.6':
     dependencies:

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1219,6 +1219,7 @@
     "DATA_FROM": "Data From",
     "ESTIMATED_WATER_CONSUMPTION": "Estimated water consumption",
     "ET_RATE": "ET Rate",
+    "IRRIGATION_PRESCRIPTION_FILES": "Irrigation prescription files",
     "IRRIGATION_PRESCRIPTIONS": "Irrigation prescriptions",
     "IRRIGATION_ZONE": "Irrigation zone",
     "PRESCRIPTION_DATE": "Prescription Date",

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -488,8 +488,8 @@ export default function PureTaskReadOnly({
       )}
 
       {!!files.length && (
-        <div className={styles.files}>
-          <Semibold style={{ marginTop: '8px', marginBottom: '18px' }}>
+        <div>
+          <Semibold className={styles.filesTitle}>
             {t('IRRIGATION_PRESCRIPTION.IRRIGATION_PRESCRIPTION_FILES')}
           </Semibold>
           <PureDocumentTileContainer gap={16} padding={0}>
@@ -497,7 +497,7 @@ export default function PureTaskReadOnly({
               <PureDocumentTile
                 key={index}
                 title={file.split('/').at(-1)}
-                extensionName={file.split('.').pop()}
+                extensionName={file.split('.').at(-1)}
                 fileUrls={[file]}
               />
             ))}

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -376,7 +376,6 @@ export default function PureTaskReadOnly({
               farm: user,
               system,
               products,
-              externalIrrigationPrescription,
               task,
               isCompleted,
             })}
@@ -476,7 +475,6 @@ export default function PureTaskReadOnly({
           farm: { farm_id, country_id, interested },
           system,
           products,
-          externalIrrigationPrescription,
           task,
         })}
       {showTaskNotes && (

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -15,7 +15,7 @@
 
 import Layout from '../../Layout';
 import Button from '../../Form/Button';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PageTitle from '../../PageTitle/v2';
@@ -59,6 +59,9 @@ import {
 } from '../../../util/task';
 import PureMovementTask from '../MovementTask';
 import AnimalInventory, { View } from '../../../containers/Animals/Inventory';
+import PureIrrigationPrescription from '../../IrrigationPrescription';
+import PureDocumentTile from '../../../containers/Documents/DocumentTile';
+import PureDocumentTileContainer from '../../../containers/Documents/DocumentTile/DocumentTileContainer';
 
 export default function PureTaskReadOnly({
   onGoBack,
@@ -73,6 +76,8 @@ export default function PureTaskReadOnly({
   isAdmin,
   system,
   products,
+  externalIrrigationPrescription,
+  files,
   harvestUseTypes,
   maxZoomRef,
   getMaxZoom,
@@ -110,7 +115,6 @@ export default function PureTaskReadOnly({
       };
     }
   }, [task]);
-  const locationIds = task.locations.map(({ location_id }) => location_id);
   const owner_user_id = task.owner_user_id;
   const {
     register,
@@ -170,6 +174,13 @@ export default function PureTaskReadOnly({
   const preDelete = () => {
     setIsDeleting(true);
   };
+
+  const isIrrigationTaskWithExternalPrescription =
+    isTaskType(taskType, 'IRRIGATION_TASK') &&
+    task.irrigation_task?.irrigation_prescription_external_id != null;
+  const showLocations =
+    (task.locations?.length || task.pinCoordinates?.length) &&
+    !isIrrigationTaskWithExternalPrescription;
 
   return (
     <Layout
@@ -238,7 +249,7 @@ export default function PureTaskReadOnly({
         </div>
       )}
 
-      {task.locations?.length || task.pinCoordinates?.length ? (
+      {showLocations ? (
         <>
           <Semibold style={{ marginBottom: '12px' }}>{t('TASK.LOCATIONS')}</Semibold>
           {isTaskType(taskType, 'TRANSPLANT_TASK') && (
@@ -263,6 +274,20 @@ export default function PureTaskReadOnly({
           />
         </>
       ) : null}
+
+      {isIrrigationTaskWithExternalPrescription && (
+        <div className={styles.irrigationPrescription}>
+          <PureIrrigationPrescription
+            fieldLocation={task.locations[0]}
+            pivotCenter={externalIrrigationPrescription.pivot.center}
+            pivotRadiusInMeters={externalIrrigationPrescription.pivot.radius}
+            {...(externalIrrigationPrescription.prescription.uriData
+              ? { uriData: externalIrrigationPrescription.prescription.uriData }
+              : { vriData: externalIrrigationPrescription.prescription.vriData?.zones })}
+            system={system}
+          />
+        </div>
+      )}
 
       {Object.keys(task.managementPlansByLocation).map((location_id) => {
         return (
@@ -351,6 +376,7 @@ export default function PureTaskReadOnly({
               farm: user,
               system,
               products,
+              externalIrrigationPrescription,
               task,
               isCompleted,
             })}
@@ -450,6 +476,7 @@ export default function PureTaskReadOnly({
           farm: { farm_id, country_id, interested },
           system,
           products,
+          externalIrrigationPrescription,
           task,
         })}
       {showTaskNotes && (
@@ -460,6 +487,24 @@ export default function PureTaskReadOnly({
           optional
           disabled
         />
+      )}
+
+      {!!files.length && (
+        <div className={styles.files}>
+          <Semibold style={{ marginTop: '8px', marginBottom: '18px' }}>
+            {t('IRRIGATION_PRESCRIPTION.IRRIGATION_PRESCRIPTION_FILES')}
+          </Semibold>
+          <PureDocumentTileContainer gap={16} padding={0}>
+            {files.map((file, index) => (
+              <PureDocumentTile
+                key={index}
+                title={file.split('/').at(-1)}
+                extensionName={file.split('.').pop()}
+                fileUrls={[file]}
+              />
+            ))}
+          </PureDocumentTileContainer>
+        </div>
       )}
 
       {isAdmin && isCurrent && !isDeleting && (

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -251,7 +251,7 @@ export default function PureTaskReadOnly({
 
       {showLocations ? (
         <>
-          <Semibold style={{ marginBottom: '12px' }}>{t('TASK.LOCATIONS')}</Semibold>
+          <Semibold className={styles.taskLocationsTitle}>{t('TASK.LOCATIONS')}</Semibold>
           {isTaskType(taskType, 'TRANSPLANT_TASK') && (
             <TransplantLocationLabel
               locations={task.locations}
@@ -331,7 +331,9 @@ export default function PureTaskReadOnly({
 
       {isCompleted && (
         <div>
-          <Semibold style={{ marginBottom: '24px' }}>{t('TASK.COMPLETION_DETAILS')}</Semibold>
+          <Semibold className={styles.completeAbandonDetailsTitle}>
+            {t('TASK.COMPLETION_DETAILS')}
+          </Semibold>
           <TimeSlider
             style={{ marginBottom: '40px' }}
             label={t('TASK.DURATION')}
@@ -399,7 +401,9 @@ export default function PureTaskReadOnly({
 
       {isAbandoned && (
         <div>
-          <Semibold style={{ marginBottom: '24px' }}>{t('TASK.ABANDONMENT_DETAILS')}</Semibold>
+          <Semibold className={styles.completeAbandonDetailsTitle}>
+            {t('TASK.ABANDONMENT_DETAILS')}
+          </Semibold>
 
           <ReactSelect
             label={t('TASK.ABANDON.REASON_FOR_ABANDONMENT')}
@@ -455,7 +459,7 @@ export default function PureTaskReadOnly({
         </div>
       )}
 
-      <Semibold style={{ marginTop: '8px', marginBottom: '18px' }}>
+      <Semibold className={styles.filesTitle}>
         {t(`task:${taskType.task_translation_key}`) + ' ' + t('TASK.DETAILS')}
       </Semibold>
 

--- a/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
+++ b/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
@@ -106,3 +106,8 @@
 .irrigationPrescription {
   margin-bottom: 16px;
 }
+
+.filesTitle { 
+  margin-top: 8px;
+  margin-bottom: 18px;
+}

--- a/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
+++ b/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
@@ -111,3 +111,11 @@
   margin-top: 8px;
   margin-bottom: 18px;
 }
+
+.taskLocationsTitle {
+  margin-bottom: 12px;
+}
+
+.completeAbandonDetailsTitle {
+  margin-bottom: 24px;
+}

--- a/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
+++ b/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
@@ -102,3 +102,7 @@
 .section {
   margin-bottom: 24px;
 }
+
+.irrigationPrescription {
+  margin-bottom: 16px;
+}

--- a/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
@@ -41,11 +41,10 @@ import {
   deleteTask,
 } from '../saga';
 import {
-  mockField,
+  generateMockPieSliceZones,
   mockUriData,
-  mockVriZones,
-  mockPivot,
 } from '../../../stories/IrrigationPrescription/mockData';
+import { getCentroidOfPolygon } from '../../../util/geoUtils';
 
 function TaskReadOnly({ history, match, location }) {
   const task_id = match.params.task_id;
@@ -62,10 +61,14 @@ function TaskReadOnly({ history, match, location }) {
   
   TODO LF-4788: Call the backend here to get the actual data for the given uuid 
   
-  Also handle case of no matching uuid (unknown record) */
+  */
+  const mockPivot = {
+    center: getCentroidOfPolygon(task.locations[0].grid_points),
+    radius: 150,
+  };
 
   const commonMockData = {
-    location_id: mockField.location_id,
+    location_id: task.locations[0].location_id,
     management_plan_id: null,
     recommended_start_datetime: new Date().toISOString(),
     pivot: mockPivot,
@@ -102,7 +105,7 @@ function TaskReadOnly({ history, match, location }) {
           id: task?.irrigation_task?.irrigation_prescription_external_id,
           prescription: {
             vriData: {
-              zones: mockVriZones,
+              zones: generateMockPieSliceZones(mockPivot),
               file_url: 'https://example.com/vri_data.vri',
             },
           },
@@ -113,10 +116,8 @@ function TaskReadOnly({ history, match, location }) {
     ? irrigationPrescription
     : undefined;
 
-  // const fieldLocation =
-  //   useSelector(locationByIdSelector(irrigationPrescription?.location_id ?? '')) || mockField;
-
   /* ------------------------------------- */
+
   let files = [];
   if (externalIrrigationPrescription?.prescription?.vriData?.file_url) {
     files.push(externalIrrigationPrescription.prescription.vriData.file_url);

--- a/packages/webapp/src/stories/IrrigationPrescription/mockData.tsx
+++ b/packages/webapp/src/stories/IrrigationPrescription/mockData.tsx
@@ -65,7 +65,7 @@ export const mockUriData = {
 };
 
 /* -----------------
-3-zone dynamic test case
+3-zone test case
 --------------------*/
 // Mock data for VRI zones (AI-generated polygons)
 const boundaryA = { lat: 49.0663, lng: -123.1563 };
@@ -127,6 +127,9 @@ export const mockZone3 = {
 
 export const mockVriZones = [mockZone2, mockZone3, mockZone1];
 
+/* -----------------
+3-zone dynamic test case
+--------------------*/
 // Dynamic mock data for VRI zones (AI-generated function using haversine formula)
 interface VriZone {
   soil_moisture_deficit: number;

--- a/packages/webapp/src/stories/IrrigationPrescription/mockData.tsx
+++ b/packages/webapp/src/stories/IrrigationPrescription/mockData.tsx
@@ -13,6 +13,8 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { Point } from '../../util/geoUtils';
+
 // Pass your real location object
 export const mockField = {
   name: 'Second Field',
@@ -63,7 +65,7 @@ export const mockUriData = {
 };
 
 /* -----------------
-3-zone test case
+3-zone dynamic test case
 --------------------*/
 // Mock data for VRI zones (AI-generated polygons)
 const boundaryA = { lat: 49.0663, lng: -123.1563 };
@@ -124,6 +126,72 @@ export const mockZone3 = {
 };
 
 export const mockVriZones = [mockZone2, mockZone3, mockZone1];
+
+// Dynamic mock data for VRI zones (AI-generated function using haversine formula)
+interface VriZone {
+  soil_moisture_deficit: number;
+  application_depth: number;
+  application_depth_unit: 'mm';
+  grid_points: Point[];
+}
+
+const EARTH_RADIUS = 6371000; // meters
+
+function offsetPoint(center: Point, distance: number, angleDeg: number): Point {
+  const angleRad = (angleDeg * Math.PI) / 180;
+  const deltaLat = (distance * Math.cos(angleRad)) / EARTH_RADIUS;
+  const deltaLng =
+    (distance * Math.sin(angleRad)) / (EARTH_RADIUS * Math.cos((center.lat * Math.PI) / 180));
+
+  return {
+    lat: center.lat + (deltaLat * 180) / Math.PI,
+    lng: center.lng + (deltaLng * 180) / Math.PI,
+  };
+}
+
+export function generateMockPieSliceZones({
+  center,
+  radius,
+}: {
+  center: Point;
+  radius: number;
+}): VriZone[] {
+  const zones: VriZone[] = [];
+  const zoneCount = 3;
+  const arcSpan = 120; // degrees per slice
+
+  for (let i = 0; i < zoneCount; i++) {
+    const startAngle = i * arcSpan;
+    const endAngle = startAngle + arcSpan;
+    const step = 30; // spacing for outer arc points
+
+    // Generate arc points in increasing angle order
+    const arcPoints: Point[] = [];
+    for (let angle = startAngle; angle <= endAngle; angle += step) {
+      arcPoints.push(offsetPoint(center, radius, angle));
+    }
+
+    // Add points forming the inner triangle: arc end -> center -> arc start (in reverse to maintain winding)
+    const innerEdgePoint = offsetPoint(center, radius * 0.6, endAngle);
+    const innerStartPoint = offsetPoint(center, radius * 0.6, startAngle);
+
+    const polygonPoints = [
+      ...arcPoints, // outer arc (clockwise or CCW)
+      innerEdgePoint, // from outer arc end inward
+      center, // center point
+      innerStartPoint, // from center back out to arc start
+    ];
+
+    zones.push({
+      soil_moisture_deficit: 40 + i * 10,
+      application_depth: 10 + i * 5,
+      application_depth_unit: 'mm',
+      grid_points: polygonPoints,
+    });
+  }
+
+  return zones;
+}
 
 /* -----------------
 5-zone test case

--- a/packages/webapp/src/util/geoUtils.ts
+++ b/packages/webapp/src/util/geoUtils.ts
@@ -15,6 +15,7 @@
 
 import { booleanPointInPolygon } from '@turf/boolean-point-in-polygon';
 import { point, polygon } from '@turf/helpers';
+import { centroid } from '@turf/centroid';
 
 export interface Point {
   lat: number;
@@ -129,6 +130,24 @@ const safeCreatePolygon = (coordinates: TurfPoint[]): ReturnType<typeof polygon>
   } catch (error) {
     // turf will throw an error if the polygon is invalid
     console.error(error);
+    return null;
+  }
+};
+
+export const getCentroidOfPolygon = (gridPoints: Point[]): Point | null => {
+  const coordinates = gridPoints.map((p: Point): TurfPoint => [p.lng, p.lat]);
+  const areaPolygon = safeCreatePolygon(coordinates);
+
+  if (!areaPolygon) {
+    return areaPolygon;
+  }
+
+  try {
+    const centroidFeature = centroid(areaPolygon);
+    const [lng, lat] = centroidFeature.geometry.coordinates;
+    return { lat, lng };
+  } catch (err) {
+    console.error('Error computing centroid:', err);
     return null;
   }
 };


### PR DESCRIPTION
**Description**

This Displays the IP detail and files on the task read only view.

Adds dynamic mock to show some details on local locations instead of near ubc.

Jira link: [LF-4772](https://lite-farm.atlassian.net/browse/LF-4772)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4772]: https://lite-farm.atlassian.net/browse/LF-4772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ