### PR TITLE
Add .js extension to knex import

### DIFF
--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import knex from '../src/util/knex';
+import knex from '../src/util/knex.js';
 
 function weather_stationFactory(station = fakeStation()) {
   return knex('weather_station').insert(station).returning('*');


### PR DESCRIPTION
**Description**

After the last merge, this old import line in `mock.factories.js` file crashed the backend container as follows:

<img width="1432" alt="Screenshot 2025-05-27 at 9 05 50 AM" src="https://github.com/user-attachments/assets/e1b68468-0ae9-4332-8674-91e06b1e38bd" />

In PR #3755 there is a mocking function residing in a file which imports the file above. This mocking function is used in a service file that is called by a controller. This chain is the first time that `mock.factories.js` has been called from the actual `server.js` and not just by the jest testing environment (presumably more forgiving about imports), causing this crash.

This PR adds the extension to fix the crash, but @Duncan-Brain will be opening a PR to also fix the import chain to avoid importing from `/tests` entirely 🙏  Right now we don't exclude `/tests` from the backend docker container but that's more on oversight than anything else; ideally all server-called code should reside in `/src` and only that should be part of the production container.

Jira link: None

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Did not test; please merge to test on beta.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
