### PR TITLE
LF-4834: Pure task details for new task type, LF-4841: Complete UI for soil sample task creation (data formatting + saga)

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -269,6 +269,17 @@
       "VOLUME": "Volume",
       "WEIGHT": "Weight"
     },
+    "SOIL_SAMPLE_VIEW": {
+      "LOCATION_COUNT": "Number of sampling locations",
+      "SAMPLE_DEPTH_RANGE": "Sample depth range #{{number}}",
+      "SAMPLE_PER_LOCATION_COUNT": "Number of samples per location",
+      "SAMPLE_TOOL": {
+        "AUGER": "Auger",
+        "SOIL_PROBE": "Soil probe",
+        "SPADE": "Spade"
+      },
+      "SAMPLING_TOOL": "Sampling tool"
+    },
     "TASK": "task",
     "TASK_NOTES_CHAR_LIMIT": "Notes must be less than 10,000 characters",
     "TELL_US_ABOUT_YOUR_TASK_TYPE_ONE": "Tell us about this task",

--- a/packages/webapp/src/components/Task/PureTaskDetails/index.jsx
+++ b/packages/webapp/src/components/Task/PureTaskDetails/index.jsx
@@ -14,6 +14,7 @@ import PurePestControlTask from '../PestControlTask';
 import PureIrrigationTask from '../PureIrrigationTask';
 import PureSoilAmendmentTask from '../SoilAmendmentTask';
 import PureMovementTask from '../MovementTask';
+import PureSoilSampleTask from '../SoilSampleTask';
 import { defaultValues as soilAmendmentProductDefaultValues } from '../AddSoilAmendmentProducts';
 import { getProgress } from '../../../containers/Task/util';
 
@@ -43,6 +44,14 @@ export default function PureTaskDetails({
     CLEANING_TASK: { cleaning_task: { agent_used: false } },
     SOIL_AMENDMENT_TASK: {
       soil_amendment_task_products: [soilAmendmentProductDefaultValues],
+    },
+    SOIL_SAMPLE_TASK: {
+      soil_sample_task: {
+        samples_per_location: 1,
+        sample_depths_unit:
+          system === 'metric' ? { label: 'cm', value: 'cm' } : { label: 'in', value: 'in' },
+        sample_depths: [{ from: null, to: null }],
+      },
     },
   };
 
@@ -191,4 +200,5 @@ const taskComponents = {
   HARVEST_TASK: (props) => <PureHarvestingTask {...props} />,
   IRRIGATION_TASK: (props) => <PureIrrigationTask {...props} createTask />,
   MOVEMENT_TASK: (props) => <PureMovementTask {...props} />,
+  SOIL_SAMPLE_TASK: (props) => <PureSoilSampleTask {...props} />,
 };

--- a/packages/webapp/src/components/Task/SoilSampleTask/index.tsx
+++ b/packages/webapp/src/components/Task/SoilSampleTask/index.tsx
@@ -121,7 +121,7 @@ const PureSoilSampleTask = ({
                     <Unit
                       name={`${SAMPLE_DEPTHS}.${index}.from`}
                       displayUnitName={SAMPLE_DEPTHS_UNIT}
-                      // defaultValue={null} // TODO: check later for read-only
+                      // defaultValue={null} // TODO: LF-4835 Confirm
                       {...unitProps}
                     />
                     <span className={styles.arrow}>
@@ -131,7 +131,7 @@ const PureSoilSampleTask = ({
                     <Unit
                       name={`${SAMPLE_DEPTHS}.${index}.to`}
                       displayUnitName={SAMPLE_DEPTHS_UNIT}
-                      // defaultValue={null} // TODO: check later for read-only
+                      // defaultValue={null} // TODO: LF-4835 Confirm
                       {...unitProps}
                     />
                   </div>

--- a/packages/webapp/src/components/Task/SoilSampleTask/index.tsx
+++ b/packages/webapp/src/components/Task/SoilSampleTask/index.tsx
@@ -1,0 +1,164 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Controller, useFieldArray, UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { BsChevronRight } from 'react-icons/bs';
+import ReactSelect from '../../Form/ReactSelect';
+import Input from '../../Form/Input';
+import Unit from '../../Form/Unit';
+import NumberInput from '../../Form/NumberInput';
+import InputBaseLabel from '../../Form/InputBase/InputBaseLabel';
+import { furrow_hole_depth } from '../../../util/convert-units/unit';
+import { Location, System } from '../../../types';
+import styles from './styles.module.scss';
+
+type PureSoilSampleTaskProps = UseFormReturn & {
+  system: System;
+  disabled: boolean;
+  task?: { locations: Location[] };
+  locations: { location_id: number }[];
+};
+
+const PREFIX = 'soil_sample_task.';
+const SAMPLES_PER_LOCATION = `${PREFIX}samples_per_location`;
+const SAMPLE_DEPTHS_UNIT = `${PREFIX}sample_depths_unit`;
+const SAMPLE_DEPTHS = `${PREFIX}sample_depths`;
+const SAMPLING_TOOL = `${PREFIX}sampling_tool`;
+
+const PureSoilSampleTask = ({
+  system,
+  disabled = false,
+  task,
+  locations: propLocations,
+  ...props
+}: PureSoilSampleTaskProps) => {
+  const { control, register, setValue, getValues, watch } = props;
+
+  const { fields, append, remove } = useFieldArray({
+    name: SAMPLE_DEPTHS,
+    control,
+  });
+
+  const { t } = useTranslation(['translation', 'common']);
+
+  const locationLength = (task?.locations || propLocations)?.length;
+
+  const sampleToolOptions = [
+    { value: 'SOIL_PROBE', label: t('ADD_TASK.SOIL_SAMPLE_VIEW.SAMPLE_TOOL.SOIL_PROBE') },
+    { value: 'AUGER', label: t('ADD_TASK.SOIL_SAMPLE_VIEW.SAMPLE_TOOL.AUGER') },
+    { value: 'SPADE', label: t('ADD_TASK.SOIL_SAMPLE_VIEW.SAMPLE_TOOL.SPADE') },
+  ];
+
+  const adjustDepthRangeInputs = () => {
+    const samplesPerLocation = getValues(SAMPLES_PER_LOCATION);
+    if (fields.length < samplesPerLocation) {
+      for (let i = 0; i < samplesPerLocation - fields.length; i++) {
+        append({ from: null, to: null });
+      }
+    } else {
+      for (let i = fields.length; i >= samplesPerLocation; i--) {
+        remove(i);
+      }
+    }
+  };
+
+  const unitProps = {
+    unitType: furrow_hole_depth,
+    register,
+    control,
+    hookFormSetValue: setValue,
+    hookFormGetValue: getValues,
+    hookFromWatch: watch,
+    system,
+    disabled,
+    required: true,
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      {/* @ts-expect-error */}
+      <Input
+        label={t('ADD_TASK.SOIL_SAMPLE_VIEW.LOCATION_COUNT')}
+        value={locationLength}
+        disabled
+      />
+      <div className={styles.locationDetail}>
+        <NumberInput
+          name={SAMPLES_PER_LOCATION}
+          control={control}
+          label={t('ADD_TASK.SOIL_SAMPLE_VIEW.SAMPLE_PER_LOCATION_COUNT')}
+          showStepper
+          defaultValue={getValues(SAMPLES_PER_LOCATION)}
+          disabled={disabled}
+          min={1}
+          max={5} // TODO: confirm
+          onBlur={adjustDepthRangeInputs}
+          rules={{ required: { value: true, message: t('common:REQUIRED') } }}
+        />
+        {!!getValues(SAMPLES_PER_LOCATION) && !!fields.length && (
+          <div className={styles.depths}>
+            {fields.map((field, index) => {
+              return (
+                <div key={field.id}>
+                  <InputBaseLabel
+                    label={t('ADD_TASK.SOIL_SAMPLE_VIEW.SAMPLE_DEPTH_RANGE', { number: index + 1 })}
+                  />
+                  <div className={styles.depthRange}>
+                    {/* @ts-expect-error */}
+                    <Unit
+                      name={`${SAMPLE_DEPTHS}.${index}.from`}
+                      displayUnitName={SAMPLE_DEPTHS_UNIT}
+                      // defaultValue={null} // TODO: check later for read-only
+                      {...unitProps}
+                    />
+                    <span className={styles.arrow}>
+                      <BsChevronRight />
+                    </span>
+                    {/* @ts-expect-error */}
+                    <Unit
+                      name={`${SAMPLE_DEPTHS}.${index}.to`}
+                      displayUnitName={SAMPLE_DEPTHS_UNIT}
+                      // defaultValue={null} // TODO: check later for read-only
+                      {...unitProps}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <Controller
+        control={control}
+        name={SAMPLING_TOOL}
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <ReactSelect
+            isDisabled={disabled}
+            label={t('ADD_TASK.SOIL_SAMPLE_VIEW.SAMPLING_TOOL')}
+            options={sampleToolOptions}
+            value={sampleToolOptions.find((option) => option.value === value)}
+            onChange={(e) => {
+              onChange(e?.value);
+            }}
+          />
+        )}
+      />
+    </div>
+  );
+};
+
+export default PureSoilSampleTask;

--- a/packages/webapp/src/components/Task/SoilSampleTask/styles.module.scss
+++ b/packages/webapp/src/components/Task/SoilSampleTask/styles.module.scss
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.locationDetail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid var(--Colors-Neutral-Neutral-50);
+
+  .depths {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px 8px;
+    border: 1px solid var(--Colors-Neutral-Neutral-50);
+  }
+}
+
+.depthRange {
+  display: flex;
+
+  > div {
+    flex: 1;
+  }
+
+  .arrow {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+
+    svg {
+      color: var(--Colors-Neutral-Neutral-100);
+      stroke-width: 2;
+    }
+  }
+}

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -98,6 +98,7 @@ import {
   getCompleteMovementTaskBody,
   getEndpoint,
   getMovementTaskBody,
+  getSoilSampleTaskBody,
 } from './sagaUtils';
 import { api } from '../../store/api/apiSlice';
 
@@ -582,6 +583,7 @@ const taskTypeGetPostTaskBodyFunctionMap = {
   TRANSPLANT_TASK: getTransplantTaskBody,
   IRRIGATION_TASK: getIrrigationTaskBody,
   MOVEMENT_TASK: getMovementTaskBody,
+  SOIL_SAMPLE_TASK: getSoilSampleTaskBody,
 };
 
 const getPostTaskReqBody = (

--- a/packages/webapp/src/containers/Task/sagaUtils.js
+++ b/packages/webapp/src/containers/Task/sagaUtils.js
@@ -70,3 +70,15 @@ export const getCompleteMovementTaskBody = ({ taskData }) => {
     ...formatMovementTask(movement_task),
   };
 };
+
+const formatSoilSampleTask = (soilSampleTask) => {
+  const { sample_depths_unit, ...rest } = soilSampleTask;
+
+  return { ...rest, sample_depths_unit: sample_depths_unit.value };
+};
+
+export const getSoilSampleTaskBody = (data, endpoint) => {
+  const { soil_sample_task, managementPlans, ...formattedData } = getPostTaskBody(data, endpoint);
+  // Remove managementPlans from the data
+  return { ...formattedData, soil_sample_task: formatSoilSampleTask(soil_sample_task) };
+};


### PR DESCRIPTION
**Description**

- Add `PureSoilSampleTask` component
- Update `createTaskSaga` to process soil sample tasks ([LF-4841](https://lite-farm.atlassian.net/browse/LF-4841) - I forgot about the separate ticket, sorry 🙏 )

NOTE:
- TODO: I’ll update the maximum number of samples per location once Loïc confirms.
- When returning to this view a second time from the last step, the data isn’t persisted as expected. I believe this is a known bug, but I ended up spending some time looking into it since I thought I was missing something 😢 ...so just a reminder!

Jira link:
- https://lite-farm.atlassian.net/browse/LF-4834
- https://lite-farm.atlassian.net/browse/LF-4841

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
