### PR TITLE
LF-4835: Soil sampling task read-only view

### DIFF
--- a/packages/webapp/src/components/Task/SoilSampleTask/styles.module.scss
+++ b/packages/webapp/src/components/Task/SoilSampleTask/styles.module.scss
@@ -17,6 +17,7 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  padding-bottom: 24px;
 }
 
 .locationDetail {

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -58,6 +58,7 @@ import {
   formatTaskReadOnlyDefaultValues,
 } from '../../../util/task';
 import PureMovementTask from '../MovementTask';
+import PureSoilSampleTask from '../SoilSampleTask';
 import AnimalInventory, { View } from '../../../containers/Animals/Inventory';
 import PureIrrigationPrescription from '../../IrrigationPrescription';
 import PureDocumentTile from '../../../containers/Documents/DocumentTile';
@@ -587,4 +588,5 @@ const taskComponents = {
   HARVEST_TASK: (props) => <PureHarvestingTaskReadOnly {...props} />,
   IRRIGATION_TASK: (props) => <PureIrrigationTask {...props} />,
   MOVEMENT_TASK: (props) => <PureMovementTask disabled {...props} />,
+  SOIL_SAMPLE_TASK: (props) => <PureSoilSampleTask {...props} />,
 };

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -78,6 +78,12 @@ import {
   onLoadingAnimalMovementTaskFail,
   onLoadingAnimalMovementTaskStart,
 } from '../slice/taskSlice/animalMovementTaskSlice';
+import {
+  getAllSoilSampleTasksSuccess,
+  getSoilSampleTasksSuccess,
+  onLoadingSoilSampleTaskFail,
+  onLoadingSoilSampleTaskStart,
+} from '../slice/taskSlice/soilSampleTaskSlice';
 import { getPlantingMethodReqBody } from '../Crop/AddManagementPlan/ManagementPlanName/getManagementPlanReqBody';
 
 import {
@@ -375,6 +381,12 @@ const taskTypeActionMap = {
     fail: onLoadingAnimalMovementTaskFail,
     completeUrl: (id) => createBeforeCompleteTaskUrl(id),
   },
+  SOIL_SAMPLE_TASK: {
+    success: (tasks) => put(getSoilSampleTasksSuccess(tasks)),
+    getAllSuccess: (tasks) => put(getAllSoilSampleTasksSuccess(tasks)),
+    fail: onLoadingSoilSampleTaskFail,
+    completeUrl: (id) => createBeforeCompleteTaskUrl(id),
+  },
 };
 
 export const onLoadingTaskStart = createAction('onLoadingTaskStartSaga');
@@ -389,6 +401,7 @@ export function* onLoadingTaskStartSaga() {
   yield put(onLoadingTransplantTaskStart());
   yield put(onLoadingIrrigationTaskStart());
   yield put(onLoadingAnimalMovementTaskStart());
+  yield put(onLoadingSoilSampleTaskStart());
 }
 
 function* handleGetTasksSuccess(tasks, isGetAll = false) {

--- a/packages/webapp/src/containers/slice/taskSlice/soilSampleTaskSlice.js
+++ b/packages/webapp/src/containers/slice/taskSlice/soilSampleTaskSlice.js
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import { onLoadingFail, onLoadingStart, onLoadingSuccess } from '../../userFarmSlice';
+import { createSelector } from 'reselect';
+import { pick } from '../../../util/pick';
+
+const soilSampleTaskProperties = [
+  'task_id',
+  'samples_per_location',
+  'sample_depths',
+  'sample_depths_unit',
+  'sampling_tool',
+];
+
+const getSoilSampleTask = (task) => {
+  return pick(task, soilSampleTaskProperties);
+};
+
+const upsertOneSoilSampleTask = (state, { payload: task }) => {
+  soilSampleTaskAdapter.upsertOne(state, getSoilSampleTask(task));
+};
+const upsertManySoilSampleTask = (state, { payload: tasks }) => {
+  soilSampleTaskAdapter.upsertMany(
+    state,
+    tasks.map((task) => getSoilSampleTask(task)),
+  );
+  onLoadingSuccess(state);
+};
+const setAllSoilSampleTask = (state, { payload: tasks }) => {
+  soilSampleTaskAdapter.setAll(
+    state,
+    tasks.map((task) => getSoilSampleTask(task)),
+  );
+  onLoadingSuccess(state);
+};
+
+const soilSampleTaskAdapter = createEntityAdapter({
+  selectId: (soilSampleTask) => soilSampleTask.task_id,
+});
+
+const soilSampleTaskSlice = createSlice({
+  name: 'soilSampleTaskReducer',
+  initialState: soilSampleTaskAdapter.getInitialState({
+    loading: false,
+    error: undefined,
+    task_id: undefined,
+    loaded: false,
+  }),
+  reducers: {
+    onLoadingSoilSampleTaskStart: onLoadingStart,
+    onLoadingSoilSampleTaskFail: onLoadingFail,
+    getSoilSampleTasksSuccess: upsertManySoilSampleTask,
+    getAllSoilSampleTasksSuccess: setAllSoilSampleTask,
+    postSoilSampleTaskSuccess: upsertOneSoilSampleTask,
+    editSoilSampleTaskSuccess: upsertOneSoilSampleTask,
+    deleteSoilSampleTaskSuccess: soilSampleTaskAdapter.removeOne,
+  },
+});
+export const {
+  getSoilSampleTasksSuccess,
+  getAllSoilSampleTasksSuccess,
+  postSoilSampleTaskSuccess,
+  editSoilSampleTaskSuccess,
+  onLoadingSoilSampleTaskStart,
+  onLoadingSoilSampleTaskFail,
+  deleteSoilSampleTaskSuccess,
+} = soilSampleTaskSlice.actions;
+export default soilSampleTaskSlice.reducer;
+
+export const soilSampleTaskReducerSelector = (state) =>
+  state.entitiesReducer[soilSampleTaskSlice.name];
+
+const soilSampleTaskSelectors = soilSampleTaskAdapter.getSelectors(
+  (state) => state.entitiesReducer[soilSampleTaskSlice.name],
+);
+
+export const soilSampleTaskEntitiesSelector = soilSampleTaskSelectors.selectEntities;
+
+export const soilSampleTaskStatusSelector = createSelector(
+  [soilSampleTaskReducerSelector],
+  ({ loading, error, loaded }) => {
+    return { loading, error, loaded };
+  },
+);

--- a/packages/webapp/src/containers/taskSlice.js
+++ b/packages/webapp/src/containers/taskSlice.js
@@ -22,6 +22,7 @@ import { transplantTaskEntitiesSelector } from './slice/taskSlice/transplantTask
 import { plantingManagementPlanEntitiesSelector } from './plantingManagementPlanSlice';
 import { irrigationTaskEntitiesSelector } from './slice/taskSlice/irrigationTaskSlice';
 import { animalMovementTaskEntitiesSelector } from './slice/taskSlice/animalMovementTaskSlice';
+import { soilSampleTaskEntitiesSelector } from './slice/taskSlice/soilSampleTaskSlice';
 import { getSubtaskName } from '../util/task';
 
 export const getTask = (obj) => {
@@ -184,6 +185,7 @@ export const taskEntitiesSelector = createSelector(
     plantTaskEntitiesSelector,
     transplantTaskEntitiesSelector,
     animalMovementTaskEntitiesSelector,
+    soilSampleTaskEntitiesSelector,
     plantingManagementPlanEntitiesSelector,
   ],
   (
@@ -202,6 +204,7 @@ export const taskEntitiesSelector = createSelector(
     plantTaskEntities,
     transplantTaskEntities,
     animalMovementTaskEntities,
+    soilSampleTaskEntities,
     plantingManagementPlanEntities,
   ) => {
     const subTaskEntities = {
@@ -214,6 +217,7 @@ export const taskEntitiesSelector = createSelector(
       ...plantTaskEntities,
       ...transplantTaskEntities,
       ...animalMovementTaskEntities,
+      ...soilSampleTaskEntities,
     };
 
     const getManagementPlanByPlantingManagementPlan = ({

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -56,6 +56,7 @@ import soilAmendmentTaskReducer from '../containers/slice/taskSlice/soilAmendmen
 import plantTaskReducer from '../containers/slice/taskSlice/plantTaskSlice';
 import transplantTaskReducer from '../containers/slice/taskSlice/transplantTaskSlice';
 import animalMovementTaskReducer from '../containers/slice/taskSlice/animalMovementTaskSlice';
+import soilSampleTaskReducer from '../containers/slice/taskSlice/soilSampleTaskSlice';
 import harvestUseTypeReducer from '../containers/harvestUseTypeSlice';
 import taskTypeReducer from '../containers/taskTypeSlice';
 import productReducer from '../containers/productSlice';
@@ -205,6 +206,7 @@ const entitiesReducer = combineReducers({
   plantTaskReducer,
   transplantTaskReducer,
   animalMovementTaskReducer,
+  soilSampleTaskReducer,
   taskTypeReducer,
   harvestUseTypeReducer,
   productReducer,

--- a/packages/webapp/src/util/siteMapConstants.ts
+++ b/packages/webapp/src/util/siteMapConstants.ts
@@ -77,7 +77,8 @@ export const createReadonlyCustomRevenueUrl = (id: string | number): string => {
 export const ADD_TASK_DETAILS = '/add_task/task_details';
 export const ADD_TASK_ASSIGNMENT = '/add_task/task_assignment';
 
-// First complete page for cleaning, field work, irrigation, pest, planting, soil amendment, transplant tasks
+// First complete page for cleaning, field work, irrigation, pest, planting, soil amendment,
+// transplant, animal movement, soil sample tasks
 export const createBeforeCompleteTaskUrl = (id: string | number): string => {
   return `/tasks/${id}/before_complete`;
 };


### PR DESCRIPTION
**Description**
 
- Set up slices, reducers, sagas to process soil sample tasks. (copied from another task type)
- Add `PureSoilSampleTask` to `TaskReadOnly`.
- Adjust `PureSoilSampleTask` styling.

Jira link: https://lite-farm.atlassian.net/browse/LF-4835

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
