### PR TITLE
LF-4839 Add endpoint to complete a soil sampling task

### DIFF
--- a/packages/api/src/routes/taskRoute.js
+++ b/packages/api/src/routes/taskRoute.js
@@ -197,6 +197,15 @@ router.patch(
 );
 
 router.patch(
+  '/complete/soil_sample_task/:task_id',
+  modelMapping['soil_sample_task'],
+  hasFarmAccess({ params: 'task_id' }),
+  checkScope(['edit:task']),
+  checkCompleteTask('soil_sample_task'),
+  taskController.completeTask('soil_sample_task'),
+);
+
+router.patch(
   '/complete/cleaning_task/:task_id',
   modelMapping['cleaning_task'],
   hasFarmAccess({ params: 'task_id' }),

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -15,8 +15,8 @@ function fakeStation(defaultData = {}) {
   };
 }
 
-function usersFactory(userObject = fakeUser()) {
-  return knex('users').insert(userObject).returning('*');
+async function usersFactory(userObject = fakeUser()) {
+  return await knex('users').insert(userObject).returning('*');
 }
 
 function fakeUser(defaultData = {}) {

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -1238,6 +1238,22 @@ function fakeSoilAmendmentTaskProduct(defaultData = {}) {
   };
 }
 
+async function soil_sample_taskFactory(
+  { promisedTask = taskFactory() } = {},
+  soilSampleTask = fakeSoilSampleTask(),
+) {
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
+
+  return knex('soil_sample_task')
+    .insert({
+      task_id,
+      ...soilSampleTask,
+      sample_depths: JSON.stringify(soilSampleTask.sample_depths),
+    })
+    .returning('*');
+}
+
 function fakeSoilSampleTask(defaultData = {}) {
   const samples_per_location = faker.datatype.number({ min: 1, max: 5 });
   const sample_depths = Array(samples_per_location)
@@ -2722,6 +2738,7 @@ export default {
   fakeSoilTask,
   fakeSoilAmendmentTaskProduct,
   fakeSoilSampleTask,
+  soil_sample_taskFactory,
   irrigation_taskFactory,
   fakeIrrigationTask,
   scouting_taskFactory,

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -230,3 +230,13 @@ export const generateUserFarms = async (number) => {
 export async function getTask(task_id) {
   return knex('task').where({ task_id }).first();
 }
+
+export function expectTaskCompletionFields(
+  task,
+  { complete_date, duration, happiness, completion_notes },
+) {
+  expect(toLocal8601Extended(task.complete_date)).toBe(complete_date);
+  expect(task.duration).toBe(duration);
+  expect(task.happiness).toBe(happiness);
+  expect(task.completion_notes).toBe(completion_notes);
+}

--- a/packages/api/tests/utils/testDataSetup.ts
+++ b/packages/api/tests/utils/testDataSetup.ts
@@ -33,7 +33,7 @@ export async function returnUserFarms(role: number): Promise<{ mainFarm: Farm; u
 
   await mocks.userFarmFactory(
     {
-      promisedUser: [user],
+      promisedUser: Promise.resolve([user]),
       promisedFarm: Promise.resolve([mainFarm]),
     },
     fakeUserFarm(role),
@@ -52,7 +52,7 @@ export async function setupFarmEnvironment(role: number = 1) {
     const [nonOwnerUser] = await mocks.usersFactory();
     await mocks.userFarmFactory(
       {
-        promisedUser: [nonOwnerUser],
+        promisedUser: Promise.resolve([nonOwnerUser]),
         promisedFarm: Promise.resolve([farm]),
       },
       fakeUserFarm(role),

--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -13,6 +13,7 @@ import PureFieldWorkTask from '../FieldWorkTask';
 import PurePestControlTask from '../PestControlTask';
 import { PurePlantingTask } from '../PlantingTask';
 import PureIrrigationTask from '../PureIrrigationTask';
+import PureSoilSampleTask from '../SoilSampleTask';
 import {
   formatTaskAnimalsAsInventoryIds,
   formatTaskReadOnlyDefaultValues,
@@ -199,4 +200,5 @@ const taskComponents = {
   TRANSPLANT_TASK: (props) => <PurePlantingTask disabled isPlantTask={false} {...props} />,
   IRRIGATION_TASK: (props) => <PureIrrigationTask {...props} />,
   MOVEMENT_TASK: (props) => <PureMovementTask disabled {...props} />,
+  SOIL_SAMPLE_TASK: (props) => <PureSoilSampleTask {...props} />,
 };


### PR DESCRIPTION
**Description**

This is the boilerplate (no unique checks) implementation of the complete endpoint for soil sample task. The frontend only needed a single change (addition of the details component into `TaskComplete/StepOne` so I have included that too.

With that change, the complete flow should be totally functional, and just needs the document part, which is a separate set of tickets.

Jira link: https://lite-farm.atlassian.net/browse/LF-4839

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
