### PR TITLE
Migration failure delete task animal relationships too

### DIFF
--- a/packages/api/db/migration/20250527173006_cleanup_previous_sensors_implementation.js
+++ b/packages/api/db/migration/20250527173006_cleanup_previous_sensors_implementation.js
@@ -180,9 +180,14 @@ export const up = async (knex) => {
     table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
   });
 
-  await knex('migration_deletion_logs').insert(
-    rowsToLog.map((row) => ({ migration_name: 'cleanup_previous_sensors_implementation', ...row })),
-  );
+  if (rowsToLog.length) {
+    await knex('migration_deletion_logs').insert(
+      rowsToLog.map((row) => ({
+        migration_name: 'cleanup_previous_sensors_implementation',
+        ...row,
+      })),
+    );
+  }
 
   // Remove notifications for sensors
   const sensorNotifications = await knex('notification').whereRaw(

--- a/packages/api/db/migration/20250527173006_cleanup_previous_sensors_implementation.js
+++ b/packages/api/db/migration/20250527173006_cleanup_previous_sensors_implementation.js
@@ -40,6 +40,8 @@ const sensorRelatedTaskTypeTables = [
   'pest_control_task',
   'field_work_task',
   'cleaning_task',
+  'task_animal_relationship',
+  'task_animal_batch_relationship',
 ];
 
 /**
@@ -131,6 +133,9 @@ export const up = async (knex) => {
   addToLogs(sensorLocations, 'location');
 
   await knex('location_tasks').whereIn('location_id', locationIdsOfSensors).del();
+
+  await knex('task_animal_relationship').whereIn('task_id', sensorTaskIds).del();
+  await knex('task_animal_batch_relationship').whereIn('task_id', sensorTaskIds).del();
 
   await knex('soil_amendment_task_products_purpose_relationship')
     .whereIn(

--- a/packages/api/db/migration/20250527173006_cleanup_previous_sensors_implementation.js
+++ b/packages/api/db/migration/20250527173006_cleanup_previous_sensors_implementation.js
@@ -134,9 +134,6 @@ export const up = async (knex) => {
 
   await knex('location_tasks').whereIn('location_id', locationIdsOfSensors).del();
 
-  await knex('task_animal_relationship').whereIn('task_id', sensorTaskIds).del();
-  await knex('task_animal_batch_relationship').whereIn('task_id', sensorTaskIds).del();
-
   await knex('soil_amendment_task_products_purpose_relationship')
     .whereIn(
       'task_products_id',


### PR DESCRIPTION
**Description**

***My db crashed and in order to add this to beta we need to rollback the last migration on beta.

1. Adds two more missing task relationships, it is good to be complete and cover all cases since we don't know state of all LiteFarm developers local databases. Are there any more that we skipped because they were not on beta?

This is the case where we are deleting a task that is also related to an animal. (Custom task)

2. Fix migrate:testing:db
- testing database migration fails because there is an empty array being attempted to insert

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
