### PR TITLE
[Quick Bugfix] Add optional chaining on label localeCompare

### DIFF
--- a/packages/webapp/src/components/Filter/FilterMultiSelectV2/index.tsx
+++ b/packages/webapp/src/components/Filter/FilterMultiSelectV2/index.tsx
@@ -124,7 +124,7 @@ export const FilterMultiSelectV2 = ({
     const sorted = [...options].sort((a, b) => {
       const isSelected = (option: ComponentFilterOption) =>
         value.some((item) => item.label === option.label);
-      return Number(isSelected(b)) - Number(isSelected(a)) || a.label.localeCompare(b.label);
+      return Number(isSelected(b)) - Number(isSelected(a)) || a.label?.localeCompare(b.label);
     });
     return sorted;
   }, [options, value]);


### PR DESCRIPTION
**Description**

More of a band-aid than a comprehensive solution, this restores the task list for bug bashing on the Ensemble sensor arrays, which are crashing the tasks filter due to missing label.

A more complete solution would double-check if the name property previously returned was important here AND/OR be more careful about selectors to remove sensor arrays from the pointSelector entirely.

But no harm in also making the filter more robust to missing labels.

Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
