### PR TITLE
LF-4872 Show irrigation system name somewhere on the sensor list

### DIFF
--- a/packages/api/src/util/ensemble.js
+++ b/packages/api/src/util/ensemble.js
@@ -85,7 +85,10 @@ const getEnsembleSensors = async (farm_id) => {
     const mappedProfiles = systemProfiles
       .filter((profile) => profile.water_profile?.sensors?.length)
       .map((profile) =>
-        mapProfileToSensorArray(enrichProfileWithDefaultPosition(profile, farmCenterCoordinates)),
+        mapProfileToSensorArray(
+          enrichProfileWithDefaultPosition(profile, farmCenterCoordinates),
+          system.name,
+        ),
       );
 
     if (mappedProfiles?.length) {
@@ -142,9 +145,10 @@ const mapDeviceToSensor = (device) => {
 /**
  * Maps an Ensemble profile object to a simplified format for sensor arrays
  * @param {Object} profile - The profile to map
+ * @param {string} systemName - The name of the system this profile belongs to
  * @returns {Object} - The mapped sensor array object
  */
-const mapProfileToSensorArray = (profile) => {
+const mapProfileToSensorArray = (profile, systemName) => {
   return {
     id: profile.id,
     sensors: profile.water_profile.sensors,
@@ -153,6 +157,7 @@ const mapProfileToSensorArray = (profile) => {
       lng: profile.water_profile.position?.longitude,
     },
     label: profile.description,
+    system: systemName,
 
     // For backwards compatibility
     location_id: profile.id,

--- a/packages/webapp/src/components/LocationFieldTechnology/index.jsx
+++ b/packages/webapp/src/components/LocationFieldTechnology/index.jsx
@@ -26,6 +26,7 @@ import { getDeviceType } from '../Sensor/v2/constants';
 import { Variant } from '../RouterTab/Tab';
 import { locationEnum } from '../../containers/Map/constants';
 import ManageESciSection from '../ManageESciSection';
+import { createSensorsDisplayName } from '../Sensor/v2/utils';
 
 export default function PureLocationFieldTechnology({
   location,
@@ -126,7 +127,10 @@ export default function PureLocationFieldTechnology({
           fieldTechnology.addonSensorArrays.map((addonSensorArray) => (
             <SensorList
               key={addonSensorArray.name}
-              title={addonSensorArray.name}
+              title={createSensorsDisplayName({
+                ...addonSensorArray,
+                fallback: t('SENSOR.SENSOR_ARRAY'),
+              })}
               sensors={addonSensorArray.sensors}
               onClickLocationMapper={() => addonSensorArray}
               isAddonSensor

--- a/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
+++ b/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
@@ -38,6 +38,7 @@ import { toTranslationKey } from '../../../../util';
 import styles from './styles.module.scss';
 import LocationViewer from '../../../LocationPicker/LocationViewer';
 import { useMaxZoom } from '../../../../containers/Map/useMaxZoom';
+import { createSensorsDisplayName } from '../utils';
 
 const FormatKpiLabel: OverviewStatsProps['FormattedLabelComponent'] = ({ statKey, label }) => {
   const Icon = statKey === SensorType.SENSOR_ARRAY ? SensorArrayIcon : SensorIcon;
@@ -115,10 +116,6 @@ const EsciSensorList = ({ groupedSensors, summary, userFarm }: EsciSensorListPro
     return acc;
   }, []);
 
-  const createItemHeader = (typeString: string, label?: string): string => {
-    return label ? `${label} | ${typeString}` : typeString;
-  };
-
   return (
     <>
       {mapOpen ? (
@@ -141,7 +138,7 @@ const EsciSensorList = ({ groupedSensors, summary, userFarm }: EsciSensorListPro
             isCompact={isCompact}
           />
           <div className={styles.sensorGroups}>
-            {groupedSensors.map(({ id, point, type, sensors, fields, label }) => {
+            {groupedSensors.map(({ id, point, type, sensors, fields, label, system }) => {
               const isExpanded = expandedIds.includes(id);
 
               return (
@@ -161,9 +158,14 @@ const EsciSensorList = ({ groupedSensors, summary, userFarm }: EsciSensorListPro
                         <div className={styles.mainContent}>
                           <SensorIconWithNumber number={sensors.length} />
                           <span>
-                            {type === SensorType.SENSOR_ARRAY
-                              ? createItemHeader(t('SENSOR.SENSOR_ARRAY'), label)
-                              : createItemHeader(t('SENSOR.STANDALONE_SENSOR'), label)}
+                            {createSensorsDisplayName({
+                              label,
+                              system,
+                              fallback:
+                                type === SensorType.SENSOR_ARRAY
+                                  ? t('SENSOR.SENSOR_ARRAY')
+                                  : t('SENSOR.STANDALONE_SENSOR'),
+                            })}
                           </span>
                         </div>
                       </MainContent>

--- a/packages/webapp/src/components/Sensor/v2/utils.ts
+++ b/packages/webapp/src/components/Sensor/v2/utils.ts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+export function createSensorsDisplayName({
+  system,
+  label,
+  fallback,
+}: {
+  system?: string;
+  label?: string;
+  fallback?: string;
+}) {
+  return [system, label].filter(Boolean).join(' | ') || fallback;
+}

--- a/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
+++ b/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
@@ -39,6 +39,7 @@ export type SensorSummary = Record<Sensor['name'] | typeof SensorType.SENSOR_ARR
 export type GroupedSensors = {
   id: string;
   label?: string;
+  system?: string;
   point: Sensor['point'];
   fields: Pick<Location, 'name' | 'location_id'>[];
   type: SensorType;

--- a/packages/webapp/src/containers/SensorReadings/v2/index.tsx
+++ b/packages/webapp/src/containers/SensorReadings/v2/index.tsx
@@ -39,6 +39,7 @@ import type { ChartSupportedReadingTypes } from './types';
 import { SensorType } from '../../../types/sensor';
 import { Sensor } from '../../../store/api/types';
 import styles from './styles.module.scss';
+import { createSensorsDisplayName } from '../../../components/Sensor/v2/utils';
 
 interface RouteParams {
   id: string;
@@ -124,12 +125,16 @@ const SensorReadings = ({ match, history, type }: SensorReadingsProps) => {
     }
   }, [isFetching, sensors?.length, history]);
 
-  const label = sensorArray?.label ?? sensors?.[0]?.label;
+  const label = sensorArray ? sensorArray.label : sensors?.[0]?.label;
 
   return (
     <CardLayout>
       <PageTitle
-        title={label ? `${label} | ${t(PAGE_TITLE_KEY[type])}` : t(PAGE_TITLE_KEY[type])}
+        title={createSensorsDisplayName({
+          label,
+          system: sensorArray?.system,
+          fallback: t(PAGE_TITLE_KEY[type]),
+        })}
         onGoBack={history.back}
         classNames={{ wrapper: styles.title }}
       />

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -273,6 +273,7 @@ export interface Sensor {
 export interface SensorArray {
   id: string;
   label: string; // descriptive name provided by Ensemble
+  system: string; // descriptive name for the irrigation system
   sensors: Sensor['external_id'][];
   point: {
     lat: number;


### PR DESCRIPTION
**Description**

This passes down the system that a profile is nested under (I don't think sensors not within profiles have systems), and displays it in the UI.

It also fixes (restores) the Field Technology grouping headers that I destroyed by deleting the fake sensor array "name" (the property that used to say "Sensor Array 1", etc). We looked at that on the Bug Bash table, but I don't think a ticket was made for it, so I have just linked the system name ticket.

Jira link: https://lite-farm.atlassian.net/browse/LF-4872

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
