### PR TITLE
LF-4801 [Nice to have] Route from Sensor List "see on map" to Sensor Readings view

### DIFF
--- a/packages/webapp/src/components/LocationPicker/LocationViewer.tsx
+++ b/packages/webapp/src/components/LocationPicker/LocationViewer.tsx
@@ -25,6 +25,7 @@ type LocationViewerProps = {
   maxZoomRef: MutableRefObject<undefined>;
   getMaxZoom: (maps: any, map?: null) => Promise<void>;
   handleClose: () => void;
+  onSelect?: () => void;
 };
 
 const LocationViewer = ({
@@ -33,18 +34,16 @@ const LocationViewer = ({
   maxZoomRef,
   getMaxZoom,
   handleClose,
+  onSelect,
 }: LocationViewerProps) => {
   const { grid_points, farm_name } = userFarm;
   return (
     <>
       <PureMapHeader farmName={farm_name} handleClose={handleClose} />
       <LocationPicker
-        onSelectLocation={() => {
-          //  TODO: fix onSelectLocationRef in LocationPicker
-        }}
+        onSelectLocation={onSelect}
         locations={locations}
-        // Choose the active state as the way to view-only locations
-        selectedLocationIds={locations.map((l) => l.location_id)}
+        selectedLocationIds={[]}
         farmCenterCoordinate={grid_points}
         maxZoomRef={maxZoomRef}
         getMaxZoom={getMaxZoom}

--- a/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
+++ b/packages/webapp/src/components/Sensor/v2/EsciSensorList/index.tsx
@@ -13,6 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { History } from 'history';
 import { Fragment, useState } from 'react';
 import clsx from 'clsx';
 import { TFunction, useTranslation } from 'react-i18next';
@@ -81,9 +82,10 @@ type EsciSensorListProps = {
   groupedSensors: GroupedSensors[];
   summary: SensorSummary;
   userFarm: UserFarm;
+  history: History;
 };
 
-const EsciSensorList = ({ groupedSensors, summary, userFarm }: EsciSensorListProps) => {
+const EsciSensorList = ({ groupedSensors, summary, userFarm, history }: EsciSensorListProps) => {
   const { t } = useTranslation();
   const { expandedIds, toggleExpanded } = useExpandable({ isSingleExpandable: true });
   const theme = useTheme();
@@ -95,6 +97,20 @@ const EsciSensorList = ({ groupedSensors, summary, userFarm }: EsciSensorListPro
   const handleSeeOnMap = (location: Location) => {
     setMapLocations([location]);
     setMapOpen(true);
+  };
+
+  const handleMapSelect = () => {
+    if (!mapLocations.length) return;
+    const selectedLocation = mapLocations[0];
+
+    const cleanSensorId = (id: string): string => id.replace(/^sensor_/, '');
+
+    const readingsUrl =
+      selectedLocation.type === SensorType.SENSOR_ARRAY
+        ? `/sensor_array/${selectedLocation.id}`
+        : `/sensor/${cleanSensorId(selectedLocation.id)}`;
+
+    history.push(readingsUrl);
   };
 
   const handleClose = () => {
@@ -128,6 +144,7 @@ const EsciSensorList = ({ groupedSensors, summary, userFarm }: EsciSensorListPro
           maxZoomRef={maxZoomRef}
           getMaxZoom={getMaxZoom}
           handleClose={handleClose}
+          onSelect={handleMapSelect}
         />
       ) : (
         <div className={styles.wrapper}>

--- a/packages/webapp/src/containers/SensorList/index.tsx
+++ b/packages/webapp/src/containers/SensorList/index.tsx
@@ -52,6 +52,7 @@ const SensorList = ({ isCompactSideMenu, history }: SensorListProps) => {
       summary={sensorSummary}
       // @ts-expect-error - Selector return empty object without property
       userFarm={userFarm}
+      history={history}
     />
   );
 };


### PR DESCRIPTION
**Description**

This implements the routing from "See on map" as we originally discussed in dev-design: removing the pre-selected state from the sensor icon, and linking from that icon to the correct sensor readings page.

UX Note: When you go back from the sensor readings page to the full list, all the sensor/arrays are collapsed again, which I didn't love, but I don't think storing the right expandable will be a quick fix considering the multiple routes to both the list and the sensor reading page. That said, it could probably done with some effort. I'm curious how bothersome you find this -- please let me know! 🙏 

Jira link: https://lite-farm.atlassian.net/browse/LF-4801

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**


- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
