### PR TITLE
LF-4873: Issues in custom date range filter for sensor readings

### DIFF
--- a/packages/webapp/src/containers/SensorReadings/v2/Charts/useFormattedSensorReadings.ts
+++ b/packages/webapp/src/containers/SensorReadings/v2/Charts/useFormattedSensorReadings.ts
@@ -123,6 +123,7 @@ function useFormattedSensorReadings({
           readings,
           truncPeriod,
           sensorIds,
+          startDate,
           valueConverter,
           timezoneOffset,
         ),

--- a/packages/webapp/src/containers/SensorReadings/v2/utils.ts
+++ b/packages/webapp/src/containers/SensorReadings/v2/utils.ts
@@ -15,6 +15,7 @@
 
 import { TFunction } from 'react-i18next';
 import { type ChartTruncPeriod } from '../../../components/Charts/LineChart';
+import { getUnixTime } from '../../../components/Charts/utils';
 import { getDateDifference } from '../../../util/moment';
 import { roundToTwo } from '../../../util/roundToTwo';
 import { convert } from '../../../util/convert-units/convert';
@@ -127,7 +128,7 @@ export const formatDataPoint = (
       const value =
         valueConverter && isValidNumber(data[dataKey])
           ? valueConverter(data[dataKey])
-          : data[dataKey] ?? null;
+          : (data[dataKey] ?? null);
 
       return { ...acc, [dataKey]: value };
     },
@@ -151,6 +152,7 @@ export const formatSensorDatapoints = (
   data: SensorDatapoint[],
   truncPeriod: ChartTruncPeriod,
   dataKeys: string[],
+  startDate: string, // ISO 8601
   valueConverter?: (value: number) => number | null,
   timezoneOffset?: number,
 ): FormattedSensorDatapoint[] => {
@@ -161,7 +163,16 @@ export const formatSensorDatapoints = (
   const adjustDateTime = getAdjustDateTimeFunc(truncPeriod, timezoneOffset);
 
   const result: FormattedSensorDatapoint[] = [];
-  let currentTimeStamp = data[0].dateTime;
+
+  // If the first data point doesn't start at startDate, insert a placeholder
+  const firstTimeStamp = data[0].dateTime;
+  const adjustedFirstTimeStamp = adjustDateTime?.(firstTimeStamp) || firstTimeStamp;
+  const expectedFirstTimeStamp = getUnixTime(new Date(startDate));
+  if (adjustedFirstTimeStamp !== expectedFirstTimeStamp) {
+    result.push(formatDataPoint({ dateTime: expectedFirstTimeStamp }, dataKeys, undefined));
+  }
+
+  let currentTimeStamp = firstTimeStamp;
   let dataPointer = 0;
 
   while (dataPointer < data.length || currentTimeStamp <= data[data.length - 1].dateTime) {

--- a/packages/webapp/src/tests/sensorChartUtils.test.js
+++ b/packages/webapp/src/tests/sensorChartUtils.test.js
@@ -31,6 +31,12 @@ const createData = (date) => {
   return { dateTime: getUnixTime(date) };
 };
 
+const getUTCDateISOString = (date) => {
+  const [year, month, day] = date.split('-').map((number) => +number);
+
+  return new Date(Date.UTC(year, month - 1, day)).toISOString();
+};
+
 describe('Test chart data formatting', () => {
   test('adjustDailyDateTime shifts UTC midnight to intended local midnight', () => {
     const localMidnight = new Date(2025, 3, 1); // April 1, 2025 at 00:00 LOCAL
@@ -108,7 +114,7 @@ describe('Test chart data formatting', () => {
         '2025-03-04',
         '2025-03-06',
       ].map(createData);
-      const result = formatSensorDatapoints(fakeData, 'day', []);
+      const result = formatSensorDatapoints(fakeData, 'day', [], getUTCDateISOString('2025-03-01'));
       expect(result).toEqual(expectedData);
     });
 
@@ -122,7 +128,7 @@ describe('Test chart data formatting', () => {
         '2025-03-03',
         '2025-03-04',
       ].map(createData);
-      const result = formatSensorDatapoints(fakeData, 'day', []);
+      const result = formatSensorDatapoints(fakeData, 'day', [], getUTCDateISOString('2025-02-26'));
       expect(result).toEqual(expectedData);
     });
 
@@ -142,7 +148,12 @@ describe('Test chart data formatting', () => {
         '2025-03-01T05:00:00Z',
       ].map(createData);
 
-      const result = formatSensorDatapoints(fakeData, 'hour', []);
+      const result = formatSensorDatapoints(
+        fakeData,
+        'hour',
+        [],
+        new Date('2025-03-01T00:00:00Z').toISOString(),
+      );
       expect(result).toEqual(expectedData);
     });
 
@@ -162,7 +173,48 @@ describe('Test chart data formatting', () => {
         '2025-03-01T05:15:00Z',
       ].map(createData);
 
-      const result = formatSensorDatapoints(fakeData, 'hour', []);
+      const result = formatSensorDatapoints(
+        fakeData,
+        'hour',
+        [],
+        new Date('2025-03-01T00:15:00Z').toISOString(),
+      );
+      expect(result).toEqual(expectedData);
+    });
+
+    test('fills missing start date correctly', () => {
+      const startDate = '2025-02-20';
+      const fakeData = ['2025-03-01', '2025-03-03', '2025-03-06'].map(createData);
+      const expectedData = [
+        '2025-02-20',
+        '2025-03-01',
+        '2025-03-02',
+        '2025-03-03',
+        '2025-03-04',
+        '2025-03-06',
+      ].map(createData);
+      const result = formatSensorDatapoints(fakeData, 'day', [], getUTCDateISOString(startDate));
+      expect(result).toEqual(expectedData);
+    });
+
+    test('fills missing start hour correctly', () => {
+      const startDateTime = '2025-03-01T00:00:00Z';
+      const fakeData = ['2025-03-01T03:00:00Z', '2025-03-01T04:00:00Z', '2025-03-01T05:00:00Z'].map(
+        createData,
+      );
+      const expectedData = [
+        '2025-03-01T00:00:00Z',
+        '2025-03-01T03:00:00Z',
+        '2025-03-01T04:00:00Z',
+        '2025-03-01T05:00:00Z',
+      ].map(createData);
+
+      const result = formatSensorDatapoints(
+        fakeData,
+        'hour',
+        [],
+        new Date(startDateTime).toISOString(),
+      );
       expect(result).toEqual(expectedData);
     });
   });


### PR DESCRIPTION
**Description**

- Update `formatSensorDatapoints` function to insert a placeholder if the first data point doesn't start at startDate
- Add tests (run `pnpm test sensorChartUtils`

This won't change the x-axis but will adjust the left padding.
(I force-pushed to fix a commit message)

Jira link: https://lite-farm.atlassian.net/browse/LF-4873

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
