### PR TITLE
Fix import of lodash isEqual in documents

### DIFF
--- a/packages/webapp/src/components/Documents/Add/index.jsx
+++ b/packages/webapp/src/components/Documents/Add/index.jsx
@@ -9,7 +9,7 @@ import MultiStepPageTitle from '../../PageTitle/MultiStepPageTitle';
 import PageTitle from '../../PageTitle/v2';
 import { Controller, useForm } from 'react-hook-form';
 import FilePicker from '../../FilePicker';
-import _isEqual from 'lodash/isEqual';
+import _isEqual from 'lodash-es/isEqual';
 
 function PureDocumentDetailView({
   submit,


### PR DESCRIPTION
**Description**

Addresses the [deploy failure](https://github.com/LiteFarmOrg/LiteFarm/actions/runs/15596857822/job/43929126972) on the merge of:
- #3800 

by fixing the import syntax (we use `lodash-es` and import from it). I'm surprised neither dev environment nor local `pnpm build` complained 🤷

Jira link: none

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Couldn't really test; will merge

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
