### PR TITLE
Docker correct workdir

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
     "test-end2end": "jest endToEnd",
     "jest-w": "jest --watch",
     "start": "set NODE_ENV=development&& node --import @swc-node/register/esm-register src/server.ts",
-    "start:prod": "node dist/app/src/server.js",
+    "start:prod": "node dist/api/src/server.js",
     "build": "rimraf dist && tsc -p src/tsconfig.json",
     "dev": "set NODE_ENV=development && node --inspect=0.0.0.0:9230 --watch --import @swc-node/register/esm-register src/server.ts",
     "debug-email-template": "DEBUG=email-templates npm run dev",

--- a/packages/api/prod.Dockerfile
+++ b/packages/api/prod.Dockerfile
@@ -1,14 +1,14 @@
 FROM node:20.17
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/api
 
-COPY ./api/package*.json /usr/src/app/
+COPY ./api/package*.json /usr/src/app/api
 
 RUN npm install
 
-COPY ./api/ /usr/src/app/
+COPY ./api/ /usr/src/app/api
 
-COPY ./shared/ /usr/src/shared/
+COPY ./shared/ /usr/src/app/shared/
 
 RUN npm run build
 


### PR DESCRIPTION
**Description**

The start script is using `dist/app` as for the path to start the backend server. This works for using with docker but fails otherwise, so to keep it consistent I updated the Docker setup to match the local structure. This way the `server.js` file is always in `dist/api/src/server.js`.

Tested locally by running the docker container and starting server.js in /dist.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
