### PR TITLE
LF-4862 Add back the add task button to location task screen

### DIFF
--- a/packages/webapp/src/components/LocationTasks/index.jsx
+++ b/packages/webapp/src/components/LocationTasks/index.jsx
@@ -7,9 +7,9 @@ import TaskCount from '../Task/TaskCount';
 import TaskCard from '../../containers/Task/TaskCard';
 import PageBreak from '../PageBreak';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
-import { onAddTask } from '../../containers/Task/onAddTask';
-import { useDispatch } from 'react-redux';
 import { Variant } from '../RouterTab/Tab';
+import FloatingActionButton from '../Button/FloatingActionButton';
+import styles from './styles.module.scss';
 
 export default function PureLocationTasks({
   location,
@@ -17,12 +17,11 @@ export default function PureLocationTasks({
   match,
   tasks,
   count,
-  isAdmin,
   routerTabs,
+  handleAddTask,
 }) {
   const language = getLanguageFromLocalStorage();
   const { t } = useTranslation();
-  const dispatch = useDispatch();
 
   const renderTasksForDay = (dateString, tasksForDate) => (
     <div key={`tasks-${dateString}`}>
@@ -58,25 +57,30 @@ export default function PureLocationTasks({
   };
 
   return (
-    <CardLayout>
-      <PageTitle title={location.name} onGoBack={() => history.push('/map')} />
-      <RouterTab
-        classes={{ container: { margin: '30px 0 26px 0' } }}
-        history={history}
-        match={match}
-        tabs={routerTabs}
-        variant={Variant.UNDERLINE}
-      />
-      <TaskCount
-        handleAddTask={onAddTask(dispatch, history, { location })}
-        count={count}
-        isAdmin={isAdmin}
-      />
-      {count > 0 ? (
-        renderTasksByDay(tasks)
-      ) : (
-        <Semibold style={{ color: 'var(--teal700)' }}>{t('TASK.NO_TASKS_TO_DISPLAY')}</Semibold>
-      )}
-    </CardLayout>
+    <>
+      <CardLayout>
+        <PageTitle title={location.name} onGoBack={() => history.push('/map')} />
+        <RouterTab
+          classes={{ container: { margin: '30px 0 26px 0' } }}
+          history={history}
+          match={match}
+          tabs={routerTabs}
+          variant={Variant.UNDERLINE}
+        />
+        <TaskCount count={count} />
+        {count > 0 ? (
+          renderTasksByDay(tasks)
+        ) : (
+          <Semibold style={{ color: 'var(--teal700)' }}>{t('TASK.NO_TASKS_TO_DISPLAY')}</Semibold>
+        )}
+      </CardLayout>
+      <div className={styles.ctaButtonWrapper}>
+        <FloatingActionButton
+          type={'add'}
+          onClick={handleAddTask}
+          aria-label={t('TASK.ADD_TASK')}
+        />
+      </div>
+    </>
   );
 }

--- a/packages/webapp/src/components/LocationTasks/styles.module.scss
+++ b/packages/webapp/src/components/LocationTasks/styles.module.scss
@@ -1,0 +1,20 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+ .ctaButtonWrapper {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+}

--- a/packages/webapp/src/containers/LocationDetails/LocationTasks/index.jsx
+++ b/packages/webapp/src/containers/LocationDetails/LocationTasks/index.jsx
@@ -1,12 +1,14 @@
 import { useEffect } from 'react';
 import { isAdminSelector } from '../../userFarmSlice';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { locationByIdSelector } from '../../locationSlice';
 import PureLocationTasks from '../../../components/LocationTasks';
 import useLocationTasks from './useLocationTasks';
 import useLocationRouterTabs from '../useLocationRouterTabs';
+import { onAddTask } from '../../Task/onAddTask';
 
 export default function LocationTasks({ history, match }) {
+  const dispatch = useDispatch();
   const isAdmin = useSelector(isAdminSelector);
   const { location_id } = match.params;
   const location = useSelector(locationByIdSelector(location_id));
@@ -31,6 +33,7 @@ export default function LocationTasks({ history, match }) {
           tasks={tasks}
           count={count}
           routerTabs={routerTabs}
+          handleAddTask={onAddTask(dispatch, history, { location })}
         />
       )}
     </>


### PR DESCRIPTION
**Description**

Adds the floating action button to add a task to the location tasks menu tab.

Notes
- also looked to see if it was on management plan tasks -- it is not but "Add task" link is present. Presumably adding the floating button would clash with the complete buttons?
- In management plan tasks the "Add task" button is restricted to `isAdmin`. But not in tasks or location tasks -- not sure the reason for this

Jira link: [LF-4862](https://lite-farm.atlassian.net/browse/LF-4862)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-4862]: https://lite-farm.atlassian.net/browse/LF-4862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ