### PR TITLE
LF-4871 Sensor KPIs & sensor readings tooltips should be to one decimal place not two

### DIFF
--- a/packages/webapp/src/components/Tile/SensorTile/SensorKPI.tsx
+++ b/packages/webapp/src/components/Tile/SensorTile/SensorKPI.tsx
@@ -19,6 +19,7 @@ import BentoLayout from '../../Layout/BentoLayout';
 import { StatusIndicatorPill, StatusIndicatorPillProps } from '../../StatusIndicatorPill';
 import styles from './styles.module.scss';
 import { TMeasurement } from './SensorReadingKPI';
+import { roundToOne } from '../../../util/rounding';
 
 export interface SensorKPIprops extends React.HTMLAttributes<HTMLDivElement> {
   sensor: {
@@ -85,7 +86,7 @@ export default function SensorKPI({
         <div className={styles.discriminator}>
           <Icon iconName={discriminatorIconName[measurement] || 'RULER'} className={styles.icon} />
           <div className={styles.discriminatorText}>
-            {value}
+            {roundToOne(value)}
             {unit}
           </div>
         </div>

--- a/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
+++ b/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
@@ -15,11 +15,8 @@
 
 import { useSelector } from 'react-redux';
 import { measurementSelector } from '../userFarmSlice';
-import {
-  container_planting_depth,
-  convertFn,
-  roundToTwoDecimal,
-} from '../../util/convert-units/unit';
+import { container_planting_depth, convertFn } from '../../util/convert-units/unit';
+import { roundToOne } from '../../util/rounding';
 import { useGetSensorsQuery } from '../../store/api/apiSlice';
 import { areaSelector } from '../locationSlice';
 import { AreaLocation, getAreaLocationsContainingPoint } from '../../util/geoUtils';
@@ -66,7 +63,7 @@ const formatSensorToSimpleTableFormat = (
   return {
     ...sensor,
     id: external_id,
-    formattedDepth: `${roundToTwoDecimal(convertedDepth)}${displayUnit}`,
+    formattedDepth: `${roundToOne(convertedDepth)}${displayUnit}`,
     deviceTypeKey: sensor.name.toUpperCase().replaceAll(' ', '_'),
   };
 };

--- a/packages/webapp/src/containers/SensorReadings/v2/utils.ts
+++ b/packages/webapp/src/containers/SensorReadings/v2/utils.ts
@@ -17,7 +17,7 @@ import { TFunction } from 'react-i18next';
 import { type ChartTruncPeriod } from '../../../components/Charts/LineChart';
 import { getUnixTime } from '../../../components/Charts/utils';
 import { getDateDifference } from '../../../util/moment';
-import { roundToTwo } from '../../../util/roundToTwo';
+import { roundToOne } from '../../../util/rounding';
 import { convert } from '../../../util/convert-units/convert';
 import { isValidNumber } from '../../../util/validation';
 import { isLessThanTwelveHrsAgo } from '../../../util/date-migrate-TS';
@@ -128,7 +128,7 @@ export const formatDataPoint = (
       const value =
         valueConverter && isValidNumber(data[dataKey])
           ? valueConverter(data[dataKey])
-          : (data[dataKey] ?? null);
+          : data[dataKey] ?? null;
 
       return { ...acc, [dataKey]: value };
     },
@@ -218,10 +218,10 @@ export const convertEsciReadingValue = (
 ): number => {
   if (esciUnitTypeMap[param]) {
     const unitType = esciUnitTypeMap[param];
-    return roundToTwo(convert(value).from(unitType.baseUnit).to(unitType[system].unit));
+    return roundToOne(convert(value).from(unitType.baseUnit).to(unitType[system].unit));
   }
 
-  return roundToTwo(value);
+  return roundToOne(value);
 };
 
 export const getReadingUnit = (

--- a/packages/webapp/src/tests/sensorChartUtils.test.js
+++ b/packages/webapp/src/tests/sensorChartUtils.test.js
@@ -244,14 +244,14 @@ describe('Test chart data formatting', () => {
     test('convert reading values properly', () => {
       [
         ['barometric_pressure', 8, 8, 8],
-        ['cumulative_rainfall', 20, 20, 0.79],
-        ['rainfall_rate', 2, 2, 0.08],
+        ['cumulative_rainfall', 20, 20, 0.8],
+        ['rainfall_rate', 2, 2, 0.1],
         ['relative_humidity', 33, 33, 33],
         ['soil_water_potential', -210, -210, -210],
         ['solar_radiation', 20, 20, 20],
         ['temperature', 23, 23, 73.4],
         ['wind_direction', 11, 11, 11],
-        ['wind_speed', 2.22, 7.99, 4.97],
+        ['wind_speed', 2.22, 8, 5],
       ].forEach(([param, apiValue, expecteMetricValue, expecteImperialValue]) => {
         const metricValue = convertEsciReadingValue(apiValue, param, 'metric');
         const imperialValue = convertEsciReadingValue(apiValue, param, 'imperial');
@@ -318,7 +318,7 @@ describe('Test chart data formatting', () => {
           i18n.t,
         );
         expect(label).toBe(i18n.t('SENSOR.READING.WIND_SPEED'));
-        expect(data).toBe(system === 'metric' ? '9km/h' : '5.59mph');
+        expect(data).toBe(system === 'metric' ? '9km/h' : '5.6mph');
       });
     });
 
@@ -343,7 +343,7 @@ describe('Test chart data formatting', () => {
         );
         expect(label).toBe(i18n.t('SENSOR.READING.WIND_SPEED_AND_DIRECTION'));
         expect(JSON.stringify(data)).toContain(
-          `"speed":"${system === 'metric' ? '9km/h' : '5.59mph'}"`,
+          `"speed":"${system === 'metric' ? '9km/h' : '5.6mph'}"`,
         );
         expect(JSON.stringify(data)).toContain('"directionText":"NNE"');
       });

--- a/packages/webapp/src/util/rounding.js
+++ b/packages/webapp/src/util/rounding.js
@@ -13,6 +13,10 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+export const roundToOne = (num) => {
+  return +(Math.round(num + 'e+1') + 'e-1');
+};
+
 export const roundToTwo = (num) => {
   return +(Math.round(num + 'e+2') + 'e-2');
 };


### PR DESCRIPTION
**Description**

As requested by Ensemble -- we were showing these values at a higher level of precision than the actual measurements warrant. They asked us to show all values to the tenths place.

This also adds rounding on the depth value shown in the sensor KPI, which is a [separate ticket](https://lite-farm.atlassian.net/browse/LF-4867) but easiest to solve both with a the new rounding function `roundToOne`

Jira link: https://lite-farm.atlassian.net/browse/LF-4871

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
