### PR TITLE
LF-4876 The worker is directed to create a location for a soil sample task even though he is not allowed to do this

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -209,6 +209,7 @@
     "NEED_ANIMAL_LOCATION_MOVEMENT": "You'll need a location or area where animals can be moved. Go to the map to create an animal location.",
     "NEED_MANAGEMENT_PLAN": "You'll need an active or planned crop plan before you can schedule a harvest task or transplant task. Go to the crop catalogue to create a plan now.",
     "NEED_SOIL_SAMPLE_LOCATION": "You'll need a specific location designated to sample the soil. Go to the map to create a soil sampling location.",
+    "NEED_SOIL_SAMPLE_LOCATION_WORKER": "You’ll need management to create at least one soil sample location before you can create a soil sample task.",
     "NO_ANIMAL_LOCATION": "No eligible animal locations",
     "NO_MANAGEMENT_PLAN": "No eligible crop plans",
     "NO_SOIL_SAMPLE_LOCATION": "No eligible soil sample locations",

--- a/packages/webapp/src/components/Modals/NoSoilSampleLocationsModal/index.jsx
+++ b/packages/webapp/src/components/Modals/NoSoilSampleLocationsModal/index.jsx
@@ -17,13 +17,17 @@ import ModalComponent from '../ModalComponent/v2';
 import { useTranslation } from 'react-i18next';
 import Button from '../../Form/Button';
 
-export function NoSoilSampleLocationsModal({ dismissModal, goToMap }) {
+export function NoSoilSampleLocationsModal({ dismissModal, goToMap, isAdmin }) {
   const { t } = useTranslation();
 
   return (
     <ModalComponent
       title={t('ADD_TASK.NO_SOIL_SAMPLE_LOCATION')}
-      contents={[t('ADD_TASK.NEED_SOIL_SAMPLE_LOCATION')]}
+      contents={[
+        isAdmin
+          ? t('ADD_TASK.NEED_SOIL_SAMPLE_LOCATION')
+          : t('ADD_TASK.NEED_SOIL_SAMPLE_LOCATION_WORKER'),
+      ]}
       dismissModal={dismissModal}
       buttonGroup={
         <>
@@ -34,11 +38,18 @@ export function NoSoilSampleLocationsModal({ dismissModal, goToMap }) {
             type={'button'}
             sm
           >
-            {t('common:CANCEL')}
+            {isAdmin ? t('common:CANCEL') : t('common:GO_BACK')}
           </Button>
-          <Button data-cy="tasks-noSoilSampleLocationContinue" onClick={goToMap} type={'submit'} sm>
-            {t('LOCATION_CREATION.CREATE_BUTTON')}
-          </Button>
+          {isAdmin && (
+            <Button
+              data-cy="tasks-noSoilSampleLocationContinue"
+              onClick={goToMap}
+              type={'submit'}
+              sm
+            >
+              {t('LOCATION_CREATION.CREATE_BUTTON')}
+            </Button>
+          )}
         </>
       }
     ></ModalComponent>

--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -248,6 +248,7 @@ export const PureTaskTypeSelection = ({
         <NoSoilSampleLocationsModal
           dismissModal={() => setShowNoSoilSampleLocationsModal(false)}
           goToMap={goToMap}
+          isAdmin={isAdmin}
         />
       )}
     </>


### PR DESCRIPTION
**Description**

This PR adjusts the "No eligible soil sample locations" modal for workers based on the corresponding modal for no locations ("No locations for tasks" / "You’ll need management to create at least one location before you can create a task."). It updates the string and fixes the buttons so workers are not directed to the map.

Jira link: https://lite-farm.atlassian.net/browse/LF-4876

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
