### PR TITLE
LF-4882 Update IP request POST to match Ensemble specifications

### DIFF
--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -213,13 +213,18 @@ export const getOrgLocationAndCropData = async (farm_id?: string) => {
   return organisationFarmData;
 };
 
-/* Sends field and crop data to Ensemble API */
-export async function sendFieldAndCropDataToEsci(organisationFarmData: OrganisationFarmData) {
+/**
+ * Sends field and crop data to Ensemble API for a single organization
+ */
+export async function sendFieldAndCropDataToEsci(
+  organisationFarmData: EnsembleLocationAndCropData[],
+  org_pk: number,
+) {
   try {
     const axiosObject = {
       method: 'post',
       body: organisationFarmData,
-      url: `${ensembleAPI}/irrigation_prescription/request/`, // real URL TBD
+      url: `${ensembleAPI}/organizations/${org_pk}/prescriptions/`,
     };
 
     const onError = (error: AxiosError) => {

--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -196,12 +196,12 @@ export const getOrgLocationAndCropData = async (farm_id?: string) => {
     const cropsAndLocations: LocationAndCropGraph[] = [];
 
     for (const location of locations) {
-      const managementPlanGraph = await ManagementPlanModel.getManagementPlansByLocationId(
+      const managementPlanGraph = await ManagementPlanModel.getMostRecentManagementPlanByLocationId(
         location.location_id,
       );
       cropsAndLocations.push({
         ...location,
-        management_plans: managementPlanGraph,
+        management_plan: managementPlanGraph,
       });
     }
 
@@ -243,7 +243,7 @@ function selectEnsembleProperties(
   return cropsAndLocations.map((location) => {
     return {
       ...selectLocationData(location),
-      crop_data: selectCropData(location.management_plans),
+      crop_data: selectCropData(location.management_plan),
     };
   });
 }
@@ -258,25 +258,24 @@ function selectLocationData(location: LocationAndCropGraph) {
   };
 }
 
-function selectCropData(managementPlans: ManagementPlan[]) {
-  if (managementPlans.length === 0) {
+function selectCropData(managementPlan: ManagementPlan) {
+  if (!managementPlan) {
     return [];
   }
 
-  return managementPlans.map((managementPlan: ManagementPlan) => {
-    const { crop_common_name, crop_genus, crop_specie } = managementPlan.crop_variety.crop;
+  const { crop_common_name, crop_genus, crop_specie } = managementPlan.crop_variety.crop;
 
-    const seed_date = managementPlan.crop_management_plan?.seed_date;
+  const seed_date = managementPlan.crop_management_plan?.seed_date;
 
-    return {
-      // plan_id for dev purposes; remove after QA on endpoint
+  return [
+    {
       management_plan_id: managementPlan.management_plan_id,
       crop_common_name,
       crop_genus,
       crop_specie,
       seed_date,
-    };
-  });
+    },
+  ];
 }
 
 /* Update Ensemble to indicate an irrigation prescription has been approved */

--- a/packages/api/src/util/ensembleService.types.ts
+++ b/packages/api/src/util/ensembleService.types.ts
@@ -83,8 +83,8 @@ export interface EnsembleLocationAndCropData {
   crop_data: EnsembleCropData[];
 }
 
-export interface OrganisationFarmData {
-  [org_uuid: string]: EnsembleLocationAndCropData[];
+export interface AllOrganisationsFarmData {
+  [org_pk: number]: EnsembleLocationAndCropData[];
 }
 
 export type ExternalIrrigationPrescription = {

--- a/packages/api/src/util/ensembleService.types.ts
+++ b/packages/api/src/util/ensembleService.types.ts
@@ -64,7 +64,7 @@ export interface LocationAndCropGraph {
       grid_points: Point[];
     };
   };
-  management_plans: ManagementPlan[];
+  management_plan: ManagementPlan;
 }
 
 interface EnsembleCropData {

--- a/packages/api/tests/irrigation_prescription_request.test.ts
+++ b/packages/api/tests/irrigation_prescription_request.test.ts
@@ -92,6 +92,12 @@ describe('Irrigation Prescription Request Tests', () => {
           field,
         });
 
+        const seedDate = new Date(seedManagementPlan.seed_date);
+        const transplantDate = new Date(transplantManagementPlan.seed_date);
+
+        const mostRecentPlan =
+          seedDate > transplantDate ? seedManagementPlan : transplantManagementPlan;
+
         await initiateIrrigationPrescriptionRequest({
           user_id: user.user_id,
           farm_id: farm.farm_id,
@@ -103,19 +109,13 @@ describe('Irrigation Prescription Request Tests', () => {
           crop_specie: crop.crop_specie,
         };
 
-        const expectedSeedCrop = expect.objectContaining({
-          management_plan_id: seedManagementPlan.management_plan_id,
-          seed_date: seedManagementPlan.seed_date,
-          ...cropConstants,
-        });
-
-        const expectedTransplantCrop = expect.objectContaining({
-          management_plan_id: transplantManagementPlan.management_plan_id,
-          seed_date: transplantManagementPlan.seed_date,
-          ...cropConstants,
-        });
-
-        const expectedCropData = [expectedSeedCrop, expectedTransplantCrop];
+        const expectedCropData = [
+          expect.objectContaining({
+            management_plan_id: mostRecentPlan.management_plan_id,
+            seed_date: mostRecentPlan.seed_date,
+            ...cropConstants,
+          }),
+        ];
 
         const expectedFieldData = {
           farm_id: farm.farm_id,

--- a/packages/api/tests/irrigation_prescription_request.test.ts
+++ b/packages/api/tests/irrigation_prescription_request.test.ts
@@ -124,14 +124,12 @@ describe('Irrigation Prescription Request Tests', () => {
           grid_points: field.figure.area.grid_points,
         };
 
-        const expectedFieldAndCropData = {
-          [farmAddon.org_uuid]: [
-            {
-              ...expectedFieldData,
-              crop_data: expect.arrayContaining(expectedCropData),
-            },
-          ],
-        };
+        const expectedFieldAndCropData = [
+          {
+            ...expectedFieldData,
+            crop_data: expect.arrayContaining(expectedCropData),
+          },
+        ];
 
         expect(axios).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/packages/api/tests/irrigation_prescription_request.test.ts
+++ b/packages/api/tests/irrigation_prescription_request.test.ts
@@ -136,9 +136,7 @@ describe('Irrigation Prescription Request Tests', () => {
         expect(axios).toHaveBeenCalledWith(
           expect.objectContaining({
             method: 'post',
-            url: expect.stringContaining(
-              `/irrigation_prescription/request`, // real URL here
-            ),
+            url: expect.stringContaining(`${farmAddon.org_pk}/prescriptions/`),
             body: expectedFieldAndCropData,
           }),
         );


### PR DESCRIPTION
TODO: with the go-ahead from Ensemble on Monday, the daily cron can be set to `shouldSend = true` and the ability to call with `allOrgs = true` can be removed from the API endpoint -- but it is preserved in this draft state to make it easier to test together on Monday.

**Description**

This updates the Ensemble POST request (Irrigation Prescription request) according to the revised specifications:

1. POST should be directed to an organisation-level endpoint with only that organisation's data in the request
2. Shape of the request should be just the location array; no more reference to org_uuids as keys
3. `crop_data` should contain at most one crop -- this has been done by selecting the crop management plan with the most recent seed date and sending only that one

Jira link: https://lite-farm.atlassian.net/browse/LF-4882

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

At the moment, this can be tested locally as follows on this endpoint, if you have farms locally connected to valid Ensemble orgs:

```
/irrigation_prescription_request?allOrgs=true&shouldSend=false
```

(I'll update once the `allOrgs` change is pushed)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
