### PR TITLE
LF-4882 (2) Skip sending crop + field data to null ESci org_pks

### DIFF
--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -319,6 +319,9 @@ export const getOrgLocationAndCropData = async (farm_id?: string) => {
   const organisationFarmData: AllOrganisationsFarmData = {};
 
   for (const org of organisations) {
+    if (!org.org_pk) {
+      continue;
+    }
     const locations = await LocationModel.getCropSupportingLocationsByFarmId(org.farm_id);
 
     const cropsAndLocations: LocationAndCropGraph[] = [];


### PR DESCRIPTION
**Description**

Many records in beta's `farm_addon` table (legacy data) have NULL `org_pk`s. They were included in our loop through existing Ensemble orgs, but 403 when sent to Ensemble:

<img width="698" alt="Screenshot 2025-07-04 at 9 31 21 AM" src="https://github.com/user-attachments/assets/2c3d2b59-301b-46a6-87d3-687920f4ea99" />

The legacy data should be cleaned up, but also it would make sense to skip any such `farm_addon` record rather than generating the bunk request.

Jira link: https://lite-farm.atlassian.net/browse/LF-4882

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested using the local scheduler + NULLing some org_pks in my local DB.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
