### PR TITLE
LF-4884 Add migration to log and delete legacy farm_addon records

### DIFF
--- a/packages/api/db/migration/20250707200337_cleanup_legacy_ensemble_farm_addons.js
+++ b/packages/api/db/migration/20250707200337_cleanup_legacy_ensemble_farm_addons.js
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  // Rows to be inserted to 'migration_deletion_logs' table
+  // When rolling back, rows will be restored backwards
+  const rowsToLog = [];
+  const addToLogs = (rows, tableName) => {
+    rows.forEach((row) => {
+      rowsToLog.push({ table_name: tableName, data: row });
+    });
+  };
+
+  const legacyEnsembleFarmAddons = await knex('farm_addon')
+    .where('addon_partner_id', 1)
+    .whereNull('org_pk');
+
+  addToLogs(legacyEnsembleFarmAddons, 'farm_addon');
+
+  // Delete logged records
+  await knex('farm_addon').where('addon_partner_id', 1).whereNull('org_pk').del();
+
+  if (rowsToLog.length) {
+    await knex('migration_deletion_logs').insert(
+      rowsToLog.map((row) => ({
+        migration_name: 'cleanup_legacy_ensemble_farm_addons',
+        ...row,
+      })),
+    );
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  // Restore deleted rows from migration_deletion_logs
+  const rows = await knex('migration_deletion_logs')
+    .where('migration_name', 'cleanup_legacy_ensemble_farm_addons')
+    .orderBy('id', 'desc');
+
+  for (const { table_name, data } of rows) {
+    try {
+      await knex(table_name).insert(data);
+    } catch (err) {
+      console.error(`Failed to restore row in ${table_name}:`, err);
+      throw err;
+    }
+  }
+
+  await knex('migration_deletion_logs')
+    .where('migration_name', 'cleanup_legacy_ensemble_farm_addons')
+    .del();
+};


### PR DESCRIPTION
**Description**

This was a fun pattern to try out, and very easy to extend based on the original! I like using the `migration_deletion_logs` table 🥰 

Jira link: https://lite-farm.atlassian.net/browse/LF-4884

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Manually `null`ed some `farm_addon` records and ran the migration both ways.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
