### PR TITLE
LF-4885 Handle pivot arcs

### DIFF
--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -278,7 +278,7 @@ const calculateURIWaterConsumption = (
   const applicationDepthMm = prescription?.uriData?.application_depth ?? 0;
 
   let pivotAreaM2;
-  if (startAngle && endAngle) {
+  if (startAngle !== undefined && endAngle !== undefined) {
     const angleDiff = (startAngle - endAngle + 360) % 360;
     const proportion = angleDiff / 360;
     pivotAreaM2 = proportion * Math.PI * Math.pow(pivotRadius, 2);

--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -215,7 +215,12 @@ export const getEnsembleIrrigationPrescriptionDetails = async (
   // Calculate and return water consumption
   const waterConsumptionL =
     'uriData' in prescriptionDetails
-      ? calculateURIWaterConsumption(prescriptionDetails, mappedPrescription.pivot.radius ?? 0)
+      ? calculateURIWaterConsumption(
+          prescriptionDetails,
+          mappedPrescription.pivot?.radius ?? 0,
+          mappedPrescription.pivot?.arc?.start_angle,
+          mappedPrescription.pivot?.arc?.end_angle,
+        )
       : calculateVRIWaterConsumption(prescriptionDetails);
 
   return {
@@ -255,18 +260,31 @@ const mapEnsembleUnitsToLiteFarmUnits = (prescription: EsciReturnedPrescriptionD
 };
 
 /**
- * Calculates water consumption for Uniform Rate Irrigation (URI).
+ * Calculates water consumption for Uniform Rate Irrigation (URI),
+ * supporting both full circles and partial circle sectors.
  *
  * @param {EsciReturnedPrescriptionDetails['prescription']} prescription - The prescription object containing URI data.
  * @param {number} pivotRadius - The radius of the pivot irrigation system in meters.
+ * @param {number} [startAngle] - Optional start angle in degrees (if defining a sector).
+ * @param {number} [endAngle] - Optional end angle in degrees (if defining a sector).
  * @returns {number} The calculated water consumption in liters.
  */
 const calculateURIWaterConsumption = (
   prescription: EsciReturnedPrescriptionDetails['prescription'],
   pivotRadius: number,
+  startAngle?: number,
+  endAngle?: number,
 ): number => {
   const applicationDepthMm = prescription?.uriData?.application_depth ?? 0;
-  const pivotAreaM2 = Math.PI * Math.pow(pivotRadius, 2);
+
+  let pivotAreaM2;
+  if (startAngle && endAngle) {
+    const angleDiff = (startAngle - endAngle + 360) % 360;
+    const proportion = angleDiff / 360;
+    pivotAreaM2 = proportion * Math.PI * Math.pow(pivotRadius, 2);
+  } else {
+    pivotAreaM2 = Math.PI * Math.pow(pivotRadius, 2);
+  }
   return pivotAreaM2 * applicationDepthMm;
 };
 

--- a/packages/api/src/util/ensembleService.types.ts
+++ b/packages/api/src/util/ensembleService.types.ts
@@ -157,6 +157,10 @@ type CommonPrescriptionDetails = {
   pivot: {
     center: { lat: number; lng: number };
     radius: number;
+    arc?: {
+      start_angle: number;
+      end_angle: number;
+    };
   };
   estimated_time: number;
   estimated_time_unit: string;

--- a/packages/api/src/util/generateMockPrescriptionDetails.ts
+++ b/packages/api/src/util/generateMockPrescriptionDetails.ts
@@ -36,6 +36,7 @@ interface GenerateMockPrescriptionDetailsParams {
   irrigationPrescriptionId: number;
   applicationDepths?: number[];
   pivotRadius?: number;
+  pivotArc?: { start_angle: number; end_angle: number };
 }
 
 export const generateMockPrescriptionDetails = async ({
@@ -43,6 +44,7 @@ export const generateMockPrescriptionDetails = async ({
   irrigationPrescriptionId,
   applicationDepths = [15, 10, 20],
   pivotRadius = 400,
+  pivotArc = { start_angle: 190, end_angle: 45 },
 }: GenerateMockPrescriptionDetailsParams): Promise<EsciReturnedPrescriptionDetails> => {
   const locations = await LocationModel.getCropSupportingLocationsByFarmId(farm_id);
 
@@ -97,10 +99,7 @@ export const generateMockPrescriptionDetails = async ({
         ...commonMockData,
         pivot: {
           ...mockPivot,
-          arc: {
-            start_angle: 190,
-            end_angle: 45,
-          },
+          arc: pivotArc,
         },
         prescription: {
           uriData: mockUriData,

--- a/packages/api/src/util/generateMockPrescriptionDetails.ts
+++ b/packages/api/src/util/generateMockPrescriptionDetails.ts
@@ -95,6 +95,13 @@ export const generateMockPrescriptionDetails = async ({
   return irrigationPrescriptionId % 2 === 0
     ? {
         ...commonMockData,
+        pivot: {
+          ...mockPivot,
+          arc: {
+            start_angle: 190,
+            end_angle: 45,
+          },
+        },
         prescription: {
           uriData: mockUriData,
         },

--- a/packages/api/tests/irrigation_prescription.test.ts
+++ b/packages/api/tests/irrigation_prescription.test.ts
@@ -392,6 +392,7 @@ describe('Get Irrigation Prescription Tests', () => {
           irrigationPrescriptionId: MOCK_ID,
           applicationDepths: [20], // in mm
           pivotRadius: 100, // in meters
+          pivotArc: { start_angle: 90, end_angle: 180 }, // clockwise, in mathematical degrees (3/4 circle)
         }),
       });
 
@@ -405,7 +406,7 @@ describe('Get Irrigation Prescription Tests', () => {
       });
 
       // Pi * r² = Area of circle
-      const pivotArea = Math.PI * Math.pow(100, 2); // in m²
+      const pivotArea = Math.PI * Math.pow(100, 2) * 0.75; // in m²
 
       // Total Volume in L = Area (m²) * Depth (mm)
       const totalVolumeL = pivotArea * 20;

--- a/packages/webapp/.storybook/state.js
+++ b/packages/webapp/.storybook/state.js
@@ -1467,6 +1467,12 @@ export default {
       loading: false,
       loaded: false,
     },
+    soilSampleLocationReducer: {
+      ids: [],
+      entities: {},
+      loading: false,
+      loaded: false,
+    },
     showedSpotlightReducer: {
       loaded: true,
       loading: false,

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -48,6 +48,7 @@
     "@turf/boolean-point-in-polygon": "7.2.0",
     "@turf/centroid": "^7.2.0",
     "@turf/helpers": "7.2.0",
+    "@turf/sector": "^7.2.0",
     "axios": "^1.7.4",
     "chart.js": "^4.4.0",
     "clsx": "^1.2.1",

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       '@turf/helpers':
         specifier: 7.2.0
         version: 7.2.0
+      '@turf/sector':
+        specifier: ^7.2.0
+        version: 7.2.0
       axios:
         specifier: ^1.7.4
         version: 1.8.4
@@ -2401,14 +2404,26 @@ packages:
   '@turf/centroid@7.2.0':
     resolution: {integrity: sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==}
 
+  '@turf/circle@7.2.0':
+    resolution: {integrity: sha512-1AbqBYtXhstrHmnW6jhLwsv7TtmT0mW58Hvl1uZXEDM1NCVXIR50yDipIeQPjrCuJ/Zdg/91gU8+4GuDCAxBGA==}
+
+  '@turf/destination@7.2.0':
+    resolution: {integrity: sha512-8DUxtOO0Fvrh1xclIUj3d9C5WS20D21F5E+j+X9Q+ju6fcM4huOqTg5ckV1DN2Pg8caABEc5HEZJnGch/5YnYQ==}
+
   '@turf/helpers@7.2.0':
     resolution: {integrity: sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==}
 
   '@turf/invariant@7.2.0':
     resolution: {integrity: sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==}
 
+  '@turf/line-arc@7.2.0':
+    resolution: {integrity: sha512-kfWzA5oYrTpslTg5fN50G04zSypiYQzjZv3FLjbZkk6kta5fo4JkERKjTeA8x4XNojb+pfmjMBB0yIh2w2dDRw==}
+
   '@turf/meta@7.2.0':
     resolution: {integrity: sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==}
+
+  '@turf/sector@7.2.0':
+    resolution: {integrity: sha512-zL06MjbbMG4DdpiNz+Q9Ax8jsCekt3R76uxeWShulAGkyDB5smdBOUDoRwxn05UX7l4kKv4Ucq2imQXhxKFd1w==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -9844,6 +9859,20 @@ snapshots:
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
+  '@turf/circle@7.2.0':
+    dependencies:
+      '@turf/destination': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/destination@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/helpers@7.2.0':
     dependencies:
       '@types/geojson': 7946.0.16
@@ -9855,10 +9884,28 @@ snapshots:
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
+  '@turf/line-arc@7.2.0':
+    dependencies:
+      '@turf/circle': 7.2.0
+      '@turf/destination': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/meta@7.2.0':
     dependencies:
       '@turf/helpers': 7.2.0
       '@types/geojson': 7946.0.16
+
+  '@turf/sector@7.2.0':
+    dependencies:
+      '@turf/circle': 7.2.0
+      '@turf/helpers': 7.2.0
+      '@turf/invariant': 7.2.0
+      '@turf/line-arc': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
   '@types/acorn@4.0.6':
     dependencies:

--- a/packages/webapp/src/components/IrrigationPrescription/IrrigationPrescriptionMapView.tsx
+++ b/packages/webapp/src/components/IrrigationPrescription/IrrigationPrescriptionMapView.tsx
@@ -112,13 +112,16 @@ const createPivotMapObjects = (
     const sectorCoordinates = createSectorCoordinates(center, radius, startAngle, endAngle);
 
     pivot = {
-      type: 'irrigation_zone', // or any polygon type
+      type: 'pivot_sector',
       location_id: 'pivot',
       grid_points: sectorCoordinates,
       name: label,
       fillOpacity: vriZonesPresent ? 0 : DEFAULT_POLYGON_OPACITY,
-      colour: moreThanThreeZones ? BRIGHT_PIVOT_COLOUR : undefined,
-      strokeColour: moreThanThreeZones ? BRIGHT_PIVOT_COLOUR : undefined,
+      ...(moreThanThreeZones && {
+        colour: BRIGHT_PIVOT_COLOUR,
+        strokeColour: BRIGHT_PIVOT_COLOUR,
+        markerColour: BRIGHT_PIVOT_COLOUR,
+      }),
     };
   } else {
     pivot = {

--- a/packages/webapp/src/components/IrrigationPrescription/IrrigationPrescriptionMapView.tsx
+++ b/packages/webapp/src/components/IrrigationPrescription/IrrigationPrescriptionMapView.tsx
@@ -21,13 +21,18 @@ import LocationPicker from '../LocationPicker/SingleLocationPicker';
 import { GestureHandling } from '../LocationPicker/SingleLocationPicker/types';
 import { Location, System } from '../../types';
 import { IRRIGATION_ZONE_COLOURS, EARTH_RADIUS, BRIGHT_PIVOT_COLOUR } from './constants';
+import { DEFAULT_POLYGON_OPACITY } from '../LocationPicker/SingleLocationPicker/drawLocations';
 import { VriPrescriptionData } from './types';
-import type { Point } from '../../util/geoUtils';
+import { createSectorCoordinates, type Point } from '../../util/geoUtils';
 
 interface IrrigationPrescriptionMapViewProps {
   fieldLocation?: Location;
   pivotCenter: Point;
   pivotRadiusInMeters: number;
+  pivotArc?: {
+    start_angle: number;
+    end_angle: number;
+  };
   className?: string;
   vriZones?: VriPrescriptionData[];
   system?: System;
@@ -37,19 +42,25 @@ const IrrigationPrescriptionMapView = ({
   fieldLocation,
   pivotCenter,
   pivotRadiusInMeters,
+  pivotArc,
   className,
   vriZones,
   system = 'metric',
 }: IrrigationPrescriptionMapViewProps) => {
   const { maxZoomRef, getMaxZoom } = useMaxZoom();
 
-  const pivotMapObjects = createPivotMapObjects(
-    pivotCenter,
-    pivotRadiusInMeters,
-    !!vriZones?.length,
-    (vriZones?.length || 0) > 3,
-    system,
-  );
+  const pivotMapObjects =
+    pivotCenter && pivotRadiusInMeters
+      ? createPivotMapObjects(
+          pivotCenter,
+          pivotRadiusInMeters,
+          !!vriZones?.length,
+          (vriZones?.length || 0) > 3,
+          system,
+          pivotArc?.start_angle,
+          pivotArc?.end_angle,
+        )
+      : [];
 
   const irrigationZoneMapObjects = vriZones ? createIrrigationZoneMapObjects(vriZones) : [];
 
@@ -83,6 +94,8 @@ const createPivotMapObjects = (
   vriZonesPresent: boolean,
   moreThanThreeZones: boolean,
   system: System,
+  startAngle?: number,
+  endAngle?: number,
 ) => {
   const unit = system === 'imperial' ? 'ft' : 'm';
 
@@ -91,25 +104,62 @@ const createPivotMapObjects = (
 
   const label = `${labelRadius}${unit}`;
 
-  const pivot = {
-    type: 'pivot',
-    location_id: 'pivot',
-    center,
-    radius,
-    name: label,
-    ...(vriZonesPresent ? { fillOpacity: 0 } : {}),
-    ...(moreThanThreeZones
-      ? {
-          markerColour: BRIGHT_PIVOT_COLOUR,
-          lineColour: BRIGHT_PIVOT_COLOUR,
-        }
-      : {}),
-  };
+  const isPartialCircle = startAngle && endAngle;
 
-  // Calculate the endpoint on the circle's circumference (eastward) [Source: Copilot]
-  const latRad = center.lat * (Math.PI / 180);
-  const deltaLng = (radius / (EARTH_RADIUS * Math.cos(latRad))) * (180 / Math.PI);
-  const endpoint = { lat: center.lat, lng: center.lng + deltaLng };
+  let pivot;
+
+  if (isPartialCircle) {
+    const sectorCoordinates = createSectorCoordinates(center, radius, startAngle, endAngle);
+
+    pivot = {
+      type: 'irrigation_zone', // or any polygon type
+      location_id: 'pivot',
+      grid_points: sectorCoordinates,
+      name: label,
+      fillOpacity: vriZonesPresent ? 0 : DEFAULT_POLYGON_OPACITY,
+      colour: moreThanThreeZones ? BRIGHT_PIVOT_COLOUR : undefined,
+      strokeColour: moreThanThreeZones ? BRIGHT_PIVOT_COLOUR : undefined,
+    };
+  } else {
+    pivot = {
+      type: 'pivot',
+      location_id: 'pivot',
+      center,
+      radius,
+      name: label,
+      ...(vriZonesPresent ? { fillOpacity: 0 } : {}),
+      ...(moreThanThreeZones
+        ? {
+            markerColour: BRIGHT_PIVOT_COLOUR,
+            lineColour: BRIGHT_PIVOT_COLOUR,
+          }
+        : {}),
+    };
+  }
+
+  let endpoint;
+
+  if (isPartialCircle) {
+    const clockwiseAngleDiff = (startAngle - endAngle + 360) % 360;
+    const midpointAngle = (startAngle - clockwiseAngleDiff / 2 + 360) % 360;
+
+    const midAngleRad = midpointAngle * (Math.PI / 180);
+    const latRad = center.lat * (Math.PI / 180);
+
+    const deltaLat = (radius / EARTH_RADIUS) * (180 / Math.PI) * Math.sin(midAngleRad);
+    const deltaLng =
+      (radius / (EARTH_RADIUS * Math.cos(latRad))) * (180 / Math.PI) * Math.cos(midAngleRad);
+
+    endpoint = {
+      lat: center.lat + deltaLat,
+      lng: center.lng + deltaLng,
+    };
+  } else {
+    // For full circles, use due eastward direction
+    const latRad = center.lat * (Math.PI / 180);
+    const deltaLng = (radius / (EARTH_RADIUS * Math.cos(latRad))) * (180 / Math.PI);
+    endpoint = { lat: center.lat, lng: center.lng + deltaLng };
+  }
 
   const pivotArm = {
     type: 'pivot_arm',

--- a/packages/webapp/src/components/IrrigationPrescription/IrrigationPrescriptionMapView.tsx
+++ b/packages/webapp/src/components/IrrigationPrescription/IrrigationPrescriptionMapView.tsx
@@ -104,7 +104,7 @@ const createPivotMapObjects = (
 
   const label = `${labelRadius}${unit}`;
 
-  const isPartialCircle = startAngle && endAngle;
+  const isPartialCircle = startAngle !== undefined && endAngle !== undefined;
 
   let pivot;
 

--- a/packages/webapp/src/components/IrrigationPrescription/index.tsx
+++ b/packages/webapp/src/components/IrrigationPrescription/index.tsx
@@ -24,6 +24,12 @@ interface CommonIrrigationPrescriptionProps {
   fieldLocation?: Location;
   pivotCenter: Point;
   pivotRadiusInMeters: number;
+  pivotArc?: {
+    start_angle: number;
+    end_angle: number;
+  };
+  vriData?: VriPrescriptionData[];
+  uriData?: UriPrescriptionData;
   system: System;
 }
 
@@ -43,6 +49,7 @@ const PureIrrigationPrescription = ({
   fieldLocation,
   pivotCenter,
   pivotRadiusInMeters,
+  pivotArc,
   vriData,
   uriData,
   system,
@@ -69,6 +76,7 @@ const PureIrrigationPrescription = ({
         fieldLocation={fieldLocation}
         pivotCenter={pivotCenter}
         pivotRadiusInMeters={pivotRadiusInMeters}
+        pivotArc={pivotArc}
         vriZones={sortedVriData}
         system={system}
       />

--- a/packages/webapp/src/components/IrrigationPrescription/index.tsx
+++ b/packages/webapp/src/components/IrrigationPrescription/index.tsx
@@ -28,8 +28,6 @@ interface CommonIrrigationPrescriptionProps {
     start_angle: number;
     end_angle: number;
   };
-  vriData?: VriPrescriptionData[];
-  uriData?: UriPrescriptionData;
   system: System;
 }
 

--- a/packages/webapp/src/components/LocationPicker/SingleLocationPicker/drawLocations.js
+++ b/packages/webapp/src/components/LocationPicker/SingleLocationPicker/drawLocations.js
@@ -34,7 +34,8 @@ export const drawLocation = (map, maps, mapBounds, location, disableHover = fals
 const drawArea = (map, maps, mapBounds, location, disableHover) => {
   const { grid_points: points, name, type } = location;
   const styles = areaStyles[type];
-  const { colour, selectedColour, dashScale, dashLength } = styles;
+  const { colour, dashScale, dashLength, strokeColour, labelClass, markerColour, fontSize } =
+    styles;
 
   points.forEach((point) => {
     mapBounds.extend(point);
@@ -42,7 +43,7 @@ const drawArea = (map, maps, mapBounds, location, disableHover) => {
 
   const polygon = new maps.Polygon({
     paths: points,
-    strokeColor: location.strokeColour || defaultColour,
+    strokeColor: location.strokeColour ?? strokeColour ?? defaultColour,
     strokeWeight: 2,
     fillColor: location.colour || colour,
     fillOpacity: location.fillOpacity ?? DEFAULT_POLYGON_OPACITY,
@@ -92,9 +93,9 @@ const drawArea = (map, maps, mapBounds, location, disableHover) => {
     crossOnDrag: false,
     label: name && {
       text: name,
-      color: 'white',
-      fontSize: '16px',
-      className: styles.mapLabel,
+      color: location.markerColour ?? markerColour ?? 'white',
+      fontSize: fontSize ?? '16px',
+      className: labelClass ? styles.labelClass : styles.mapLabel,
     },
   });
   polygon.setMap(map);

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -279,8 +279,9 @@ export default function PureTaskReadOnly({
         <div className={styles.irrigationPrescription}>
           <PureIrrigationPrescription
             fieldLocation={task.locations[0]}
-            pivotCenter={externalIrrigationPrescription.pivot.center}
-            pivotRadiusInMeters={externalIrrigationPrescription.pivot.radius}
+            pivotCenter={externalIrrigationPrescription.pivot?.center}
+            pivotRadiusInMeters={externalIrrigationPrescription.pivot?.radius}
+            pivotArc={externalIrrigationPrescription.pivot?.arc}
             {...(externalIrrigationPrescription.prescription.uriData
               ? { uriData: externalIrrigationPrescription.prescription.uriData }
               : { vriData: externalIrrigationPrescription.prescription.vriData?.zones })}

--- a/packages/webapp/src/containers/IrrigationPrescription/index.tsx
+++ b/packages/webapp/src/containers/IrrigationPrescription/index.tsx
@@ -125,8 +125,9 @@ const IrrigationPrescription = ({
         <PureIrrigationPrescription
           system={system}
           fieldLocation={fieldLocation}
-          pivotCenter={pivot.center}
-          pivotRadiusInMeters={pivot.radius}
+          pivotCenter={pivot?.center}
+          pivotRadiusInMeters={pivot?.radius}
+          pivotArc={pivot?.arc}
           {...(uriData ? { uriData } : { vriData: vriData?.zones })}
         />
       </div>

--- a/packages/webapp/src/containers/Map/constants.js
+++ b/packages/webapp/src/containers/Map/constants.js
@@ -19,6 +19,7 @@ export const getAreaLocationTypes = () => [
   locationEnum.natural_area,
   locationEnum.residence,
   locationEnum.irrigation_zone,
+  locationEnum.pivot_sector,
 ];
 
 export const isArea = (type) => {
@@ -85,6 +86,7 @@ export const locationEnum = {
   pivot: 'pivot',
   pivot_arm: 'pivot_arm',
   irrigation_zone: 'irrigation_zone',
+  pivot_sector: 'pivot_sector',
 };
 
 export const polygonPath = (path, width, maps) => {

--- a/packages/webapp/src/containers/Map/mapStyles.js
+++ b/packages/webapp/src/containers/Map/mapStyles.js
@@ -26,6 +26,7 @@ import {
   watercourseColour,
   watercourseSelectedColour,
   pivotCenterLabel,
+  pivotSectorLabel,
 } from './styles.module.scss';
 import waterValve from '../../assets/images/map/water-valve.svg';
 import waterValveHover from '../../assets/images/map/water-valve-hover.svg';
@@ -104,6 +105,16 @@ export const areaStyles = {
     selectedColour: irrigationZoneColour,
     dashScale: 0,
     dashLength: 0,
+  },
+  pivot_sector: {
+    colour: pivotColour,
+    strokeColour: pivotArmColour,
+    fillColour: pivotColour,
+    markerColour: pivotArmColour,
+    dashScale: 0,
+    dashLength: 0,
+    labelClass: pivotSectorLabel,
+    fontSize: '10px',
   },
 };
 

--- a/packages/webapp/src/containers/Map/styles.module.scss
+++ b/packages/webapp/src/containers/Map/styles.module.scss
@@ -131,3 +131,7 @@
 .pivotCenterLabel {
   transform: translateY(-8px);
 }
+
+.pivotSectorLabel {
+  transform: translate(16px, -8px);
+}

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -347,6 +347,10 @@ export type IrrigationPrescriptionDetails = {
   pivot: {
     center: { lat: number; lng: number };
     radius: number; // in meters
+    arc?: {
+      start_angle: number; // in mathematical degrees (0 = east, 90 = north, etc.)
+      end_angle: number; // defined clockwise from start angle
+    };
   };
 
   metadata: {

--- a/packages/webapp/src/stories/IrrigationPrescription/IrrigationPrescriptionMapView.stories.tsx
+++ b/packages/webapp/src/stories/IrrigationPrescription/IrrigationPrescriptionMapView.stories.tsx
@@ -76,8 +76,8 @@ export const PartialAnglePivotVRI: Story = {
     pivotCenter: mockPivot.center,
     pivotRadiusInMeters: mockPivot.radius,
     pivotArc: {
-      start_angle: 230,
-      end_angle: 50,
+      start_angle: 215,
+      end_angle: 360,
     },
     className: styles.mapContainer,
     vriZones: mockVriZones,
@@ -90,8 +90,8 @@ export const PartialAnglePivotURI: Story = {
     pivotCenter: mockPivot.center,
     pivotRadiusInMeters: mockPivot.radius,
     pivotArc: {
-      start_angle: 230,
-      end_angle: 50,
+      start_angle: 215,
+      end_angle: 360,
     },
     className: styles.mapContainer,
   },

--- a/packages/webapp/src/stories/IrrigationPrescription/IrrigationPrescriptionMapView.stories.tsx
+++ b/packages/webapp/src/stories/IrrigationPrescription/IrrigationPrescriptionMapView.stories.tsx
@@ -69,3 +69,30 @@ export const ImperialUnitsPivotArm: Story = {
     system: 'imperial',
   },
 };
+
+export const PartialAnglePivotVRI: Story = {
+  args: {
+    fieldLocation: mockField,
+    pivotCenter: mockPivot.center,
+    pivotRadiusInMeters: mockPivot.radius,
+    pivotArc: {
+      start_angle: 230,
+      end_angle: 50,
+    },
+    className: styles.mapContainer,
+    vriZones: mockVriZones,
+  },
+};
+
+export const PartialAnglePivotURI: Story = {
+  args: {
+    fieldLocation: mockField,
+    pivotCenter: mockPivot.center,
+    pivotRadiusInMeters: mockPivot.radius,
+    pivotArc: {
+      start_angle: 230,
+      end_angle: 50,
+    },
+    className: styles.mapContainer,
+  },
+};


### PR DESCRIPTION
**Description**

These are the updates needed to represent pivots that only traverse partial circles (i.e. pie slices, which Turf.js calls [sectors](https://turfjs.org/docs/api/sector)) in irrigation prescriptions. The code had to be updated in three ways to handle the `pivot.arc` object, listed below. If `pivot.arc` or start/end angle is omitted, the original code -- for a full circle -- will be used in each of these places:

1. The map view needs to render a sector instead of the full circle. The Google Maps circle geometry didn't include the ability to define sectors natively, so the super-useful Turf package has been used once again to create a polygon of lat/lng coordinates based on centre, radius, and angles. Map styles were updated for this polygon type to match the original pivot (purple outline + pivot arm, white fill, small purple label).
3. The pivot arm (also part of the map view) was updated so that it points to an angle within the sector (happens to be the midpoint) instead of due east, which might not fall within the sector. I'm a tiny bit ambivalent about this -- @SayakaOno what do you think? Is that a good default, visually? I couldn't really figure out how to solve the issue of the pivot label and the pivot arm sometimes overlapping depending on the angles selected.
4. The URI water calculation was updated to take into account start and end angles if they are provided.

The mock sent from the backend for URI (but not VRI) was updated, and both URI and VRI Storybook stories were added:
- [Partial angle VRI story](http://localhost:6006/?path=/story/components-irrigationprescription-mapview--partial-angle-pivot-vri)
- [Partial angle URI story](http://localhost:6006/?path=/story/components-irrigationprescription-mapview--partial-angle-pivot-uri)

There's also a little bit of context [in Slack here](https://litefarm.slack.com/archives/C02P3UR5988/p1751914539957019). Please also me know also @SayakaOno what you think of the question of clockwise (CW) vs counterclockwise (CCW) start and end angles 🙏 This code is CW, matching the example images in that Slack thread.

Jira link: https://lite-farm.atlassian.net/browse/LF-4885

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

The API test was also mimally updated to include a sector of obvious proportions intead of a full circle.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
