### PR TITLE
LF-4886 Users should get one IP notification per location, not per day

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -42,6 +42,7 @@
         "jwks-rsa": "^3.0.1",
         "knex": "^3.1.0",
         "lodash": "^4.17.20",
+        "lodash.groupby": "^4.6.0",
         "multer": "^1.4.2",
         "node-cron": "^3.0.3",
         "nodemailer": "^6.9.9",
@@ -16588,7 +16589,8 @@
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -88,6 +88,7 @@
     "jwks-rsa": "^3.0.1",
     "knex": "^3.1.0",
     "lodash": "^4.17.20",
+    "lodash.groupby": "^4.6.0",
     "multer": "^1.4.2",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.9",

--- a/packages/api/src/controllers/timeNotificationController.js
+++ b/packages/api/src/controllers/timeNotificationController.js
@@ -13,8 +13,8 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import groupBy from 'lodash.groupby';
 import UserFarmModel from '../models/userFarmModel.js';
-
 import TaskModel from '../models/taskModel.js';
 import LocationModel from '../models/locationModel.js';
 import NotificationModel from '../models/notificationModel.js';
@@ -132,10 +132,15 @@ const timeNotificationController = {
 
       let notificationsSent = 0;
 
-      const latestIrrigationPrescription = farmIrrigationPrescriptions.at(-1);
+      // Notify on the latest irrigation prescription for each location
+      const prescriptionsByLocation = groupBy(
+        farmIrrigationPrescriptions,
+        ({ location_id }) => location_id,
+      );
 
-      if (latestIrrigationPrescription) {
-        const { id: irrigation_prescription_id } = latestIrrigationPrescription;
+      for (const locationId in prescriptionsByLocation) {
+        const latestPrescription = prescriptionsByLocation[locationId].at(-1);
+        const { id: irrigation_prescription_id } = latestPrescription;
 
         const previousNotification = await NotificationModel.query()
           .where('farm_id', farm_id)

--- a/packages/api/src/models/locationModel.js
+++ b/packages/api/src/models/locationModel.js
@@ -284,15 +284,20 @@ class Location extends baseModel {
   }
 
   /**
-   * Get the farm_id for a specified location
+   * Get the farm_id for a specified (non-deleted) location
    * @param {string} location_id - The location to check
    * @param {Knex.Transaction} [trx] - Optional transaction object
    * @static
    * @async
-   * @returns {Promise<{farm_id: string}|undefined>} Resolves to an object with `farm_id` if found, or `undefined` otherwise
+   * @returns {Promise<{farm_id: string}|undefined>}
+   *   Resolves to `{ farm_id }` if the location exists and is not deleted, otherwise `undefined`.
    */
   static async getFarmIdByLocationId(location_id, trx) {
-    return Location.query(trx).select('farm_id').where('location_id', location_id).first();
+    return Location.query(trx)
+      .select('farm_id')
+      .where('location_id', location_id)
+      .whereNotDeleted()
+      .first();
   }
 }
 

--- a/packages/api/src/services/addonPartner.ts
+++ b/packages/api/src/services/addonPartner.ts
@@ -76,7 +76,7 @@ export const getAddonPartnerIrrigationPrescriptions = async (
       }
 
       // Filter by farm_id
-      // (Temporarily using model method; please replace with direct filtering on farm_id when available)
+      // (Temporarily using model method; please replace with direct filtering on farm_id when available. At that time, a different method to filter out deleted locations will also be needed.)
       const irrigationPrescriptionsForFarm = [];
       for (const irrigationPrescription of data) {
         const prescriptionFarmRecord = await LocationModel.getFarmIdByLocationId(

--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -159,7 +159,10 @@ export const getEnsembleIrrigationPrescriptionDetails = async (
     irrigationPrescription.location_id,
   );
   if (!prescriptionFarmRecord) {
-    throw customError(`location_id on IP ${irrigationPrescriptionId} does not exist`, 404);
+    throw customError(
+      `location_id on IP ${irrigationPrescriptionId} does not exist or has been deleted`,
+      404,
+    );
   }
   if (prescriptionFarmRecord.farm_id !== farm_id) {
     throw customError(

--- a/packages/api/tests/utils/testDataSetup.ts
+++ b/packages/api/tests/utils/testDataSetup.ts
@@ -125,3 +125,25 @@ export async function setupManagementPlans({ farm, field }: { farm: Farm; field:
     seedManagementPlan,
   };
 }
+
+/**
+ * Creates a field for an existing farm and returns the location with field data
+ */
+export async function createField(farm: Farm) {
+  const [location] = await mocks.locationFactory({ promisedFarm: Promise.resolve([farm]) });
+
+  await mocks.fieldFactory({
+    promisedLocation: Promise.resolve([location]),
+  });
+
+  const field = await LocationModel
+    /* @ts-expect-error don't know how to fix */
+    .query()
+    .context({ showHidden: true })
+    .whereNotDeleted()
+    .findById(location.location_id).withGraphFetched(`[
+      figure.[area], field
+    ]`);
+
+  return field;
+}

--- a/packages/api/tests/utils/testDataSetup.ts
+++ b/packages/api/tests/utils/testDataSetup.ts
@@ -60,20 +60,8 @@ export async function setupFarmEnvironment(role: number = 1) {
     user = nonOwnerUser;
   }
 
-  const [location] = await mocks.locationFactory({ promisedFarm: Promise.resolve([farm]) });
+  const field = await createField(farm);
 
-  await mocks.fieldFactory({
-    promisedLocation: Promise.resolve([location]),
-  });
-
-  const field = await LocationModel
-    /* @ts-expect-error don't know how to fix */
-    .query()
-    .context({ showHidden: true })
-    .whereNotDeleted()
-    .findById(location.location_id).withGraphFetched(`[
-        figure.[area], field
-      ]`);
   return { owner, farm, field, user };
 }
 


### PR DESCRIPTION
**Description**

This PR fixes two bugs with IP notifications:

1. We had been returning only the latest IP _per farm_, when a given farm potentially has 2-3+ new IPs per day, depending on the number of pivot-containing locations defined.
2. (Noticed this when testing notifications, but it's an oversight affecting all IPs) IPs from deleted locations weren't being filtered out. That filtering has been added to the location model method that we have been using to identify + filter the correct farm. This means notifications, the list GET, and the details GET will all no longer return IPs if their listed location has been deleted.

This PR also includes updates to the test cases on IP notifications to reflect the above.

Jira link: https://lite-farm.atlassian.net/browse/LF-4886

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Triggered the notifications flow by running the scheduler (`docker compose export`) with `MOCK_TIMER=true`.

Bumping this line to something a little higher than 5 will also make 4am Alberta time come faster -- I think I used `9`? But I haven't been precise, I do usually just let it run for a bit.

```js
let utcHour = mockTimer ? 5 : undefined; // mock starts 2 "hours" before day shifts
```

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
