### PR TITLE
LF-4817 (1): Set revision date and revision author when re-completing a task

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -822,9 +822,6 @@ const taskController = {
           data = this.formatAnimalAndBatchIds(data);
         }
 
-        // Duplicates middleware until all endpoints are migrated to use middleware
-        checkCompleteTaskDocument(req.body, typeOfTask);
-
         const result = await TaskModel.transaction(async (trx) => {
           const task = await updateTaskWithCompletedData(
             trx,

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -802,6 +802,7 @@ const taskController = {
         const { farm_id } = req.headers;
         const { user_id } = req.auth;
         const task_id = parseInt(req.params.task_id);
+        const { isReCompleting } = res.locals;
 
         if (await baseController.isDeleted(null, TaskModel, { task_id })) {
           return res.status(400).send('Task has been deleted');
@@ -820,6 +821,11 @@ const taskController = {
         );
         if ([...ANIMAL_TASKS, CUSTOM_TASK].includes(typeOfTask)) {
           data = this.formatAnimalAndBatchIds(data);
+        }
+
+        if (isReCompleting) {
+          data.revision_date = new Date().toISOString();
+          data.revised_by_user_id = assignee_user_id;
         }
 
         const result = await TaskModel.transaction(async (trx) => {

--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -802,7 +802,7 @@ const taskController = {
         const { farm_id } = req.headers;
         const { user_id } = req.auth;
         const task_id = parseInt(req.params.task_id);
-        const { isReCompleting } = res.locals;
+        const { isRecompleting } = res.locals;
 
         if (await baseController.isDeleted(null, TaskModel, { task_id })) {
           return res.status(400).send('Task has been deleted');
@@ -823,7 +823,7 @@ const taskController = {
           data = this.formatAnimalAndBatchIds(data);
         }
 
-        if (isReCompleting) {
+        if (isRecompleting) {
           data.revision_date = new Date().toISOString();
           data.revised_by_user_id = assignee_user_id;
         }

--- a/packages/api/src/middleware/validation/checkTask.js
+++ b/packages/api/src/middleware/validation/checkTask.js
@@ -117,8 +117,17 @@ export function checkCompleteTask(taskType) {
       }
 
       const checkTaskStatus = await TaskModel.getTaskStatus(task_id);
-      if (checkTaskStatus.complete_date || checkTaskStatus.abandon_date) {
-        return res.status(400).send('Task has already been completed or abandoned');
+      if (checkTaskStatus.abandon_date) {
+        return res.status(400).send('Task has already been abandoned');
+      }
+
+      // https://expressjs.com/en/api.html#res.locals
+      res.locals.isReCompleting = !!checkTaskStatus.complete_date;
+
+      if (checkTaskStatus.complete_date && taskType === 'animal_movement_task') {
+        return res
+          .status(400)
+          .send('Re-completion of animal movement tasks is not yet supported (see LF-4815)');
       }
 
       if ([...ANIMAL_TASKS, CUSTOM_TASK].includes(taskType)) {

--- a/packages/api/src/middleware/validation/checkTask.js
+++ b/packages/api/src/middleware/validation/checkTask.js
@@ -122,7 +122,7 @@ export function checkCompleteTask(taskType) {
       }
 
       // https://expressjs.com/en/api.html#res.locals
-      res.locals.isReCompleting = !!checkTaskStatus.complete_date;
+      res.locals.isRecompleting = !!checkTaskStatus.complete_date;
 
       if (checkTaskStatus.complete_date && taskType === 'animal_movement_task') {
         return res

--- a/packages/api/src/routes/taskRoute.js
+++ b/packages/api/src/routes/taskRoute.js
@@ -210,6 +210,7 @@ router.patch(
   modelMapping['cleaning_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('cleaning_task'),
   createOrPatchProduct('cleaning_task'),
   taskController.completeTask('cleaning_task'),
 );
@@ -219,6 +220,7 @@ router.patch(
   modelMapping['pest_control_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('pest_control_task'),
   createOrPatchProduct('pest_control_task'),
   taskController.completeTask('pest_control_task'),
 );
@@ -228,6 +230,7 @@ router.patch(
   modelMapping['irrigation_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('irrigation_task'),
   taskController.completeTask('irrigation_task'),
 );
 
@@ -236,6 +239,7 @@ router.patch(
   modelMapping['scouting_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('scouting_task'),
   taskController.completeTask('scouting_task'),
 );
 
@@ -244,6 +248,7 @@ router.patch(
   modelMapping['soil_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('soil_task'),
   taskController.completeTask('soil_task'),
 );
 
@@ -252,6 +257,7 @@ router.patch(
   modelMapping['field_work_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('field_work_task'),
   taskController.completeTask('field_work_task'),
 );
 
@@ -268,6 +274,7 @@ router.patch(
   modelMapping['plant_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('plant_task'),
   taskController.completeTask('plant_task'),
 );
 
@@ -276,6 +283,7 @@ router.patch(
   modelMapping['plant_task'],
   hasFarmAccess({ params: 'task_id' }),
   checkScope(['edit:task']),
+  checkCompleteTask('transplant_task'),
   taskController.completeTask('transplant_task'),
 );
 

--- a/packages/api/tests/testEnvironment.js
+++ b/packages/api/tests/testEnvironment.js
@@ -53,6 +53,7 @@ async function tableCleanup(knex) {
     DELETE FROM "harvest_task";
     DELETE FROM "harvest_use_type";
     DELETE FROM "irrigation_task";
+    DELETE FROM "irrigation_type";
     DELETE FROM "scouting_task";
     DELETE FROM "pest_control_task";
     DELETE FROM "social_task";


### PR DESCRIPTION
**Description**

_(This is a blocker for [LF-4815](https://lite-farm.atlassian.net/browse/LF-4815), but otherwise, no rush!)_
Update the `completeTask` method in `taskController` to add `revision_date` and `revised_by_user_id` if the task is being re-completed (= the task already has a `complete_date`).

NOTE:
- Harvest task type will be handled in [LF-4819](https://lite-farm.atlassian.net/browse/LF-4819)
- Task completion is not always working properly ([LF-3134](https://lite-farm.atlassian.net/browse/LF-3134)), so tests will be added once that issue is resolved.

Details:
- The `checkTask` middleware already checks whether a task is completed or abandoned. I added `res.locals.isReCompleting` there to avoid duplicating that logic in the controller.
   - `checkTask` was previously only used for some task types. It’s now applied to all routes using `completeTask`.
   - `checkCompleteTaskDocument`, which is included in `checkTask`, is no longer needed in `completeTask` and has been removed.
- While running tests, the DB connection appeared to hang. This was caused by `irrigation_type` not being deleted, which prevented the `farm` table from being deleted. (`irrigation_type` table has `farm_id`) That’s been fixed as well.

Jira link: https://lite-farm.atlassian.net/browse/LF-4817

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I used a cleaning task for testing, since I think it's the simplest:
1. Create a cleaning task
2. Complete it
3. Send a PATCH request via Postman to:
    `/task/complete/cleaning_task/{task_id}`

 Sample request body:
 ```
{
    "duration": 15,
    "happiness": 5,
    "completion_notes": "re-complete",
    "complete_date": "2025-07-17"
}
```
In the DB, `complete_date`, `revision_date` and `revised_by_user_id` should be updated as expected.
I'll confirm how `happiness` and `completion_notes` should be handled.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files

[LF-4815]: https://lite-farm.atlassian.net/browse/LF-4815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LF-4819]: https://lite-farm.atlassian.net/browse/LF-4819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LF-3134]: https://lite-farm.atlassian.net/browse/LF-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ