### PR TITLE
LF-4887 Zambia Currency (ZMW) Displays as USD on Finance Page

### DIFF
--- a/packages/webapp/src/containers/AddFarm/currency/commonCurrency.json
+++ b/packages/webapp/src/containers/AddFarm/currency/commonCurrency.json
@@ -1061,13 +1061,13 @@
     "code": "ZAR",
     "name_plural": "South African rand"
   },
-  "ZMK": {
+  "ZMW": {
     "symbol": "ZK",
     "name": "Zambian Kwacha",
     "symbol_native": "ZK",
     "decimal_digits": 0,
     "rounding": 0,
-    "code": "ZMK",
+    "code": "ZMW",
     "name_plural": "Zambian kwachas"
   }
 }


### PR DESCRIPTION
**Description**

This PR fixes the issue where the Finance page incorrectly displayed the currency for Zambia as USD ($) instead of the correct Zambian Kwacha (ZK).

Jira link:https://lite-farm.atlassian.net/browse/LF-4887

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
