### PR TITLE
LF-4889 User data deletion and export scripts

### DIFF
--- a/packages/api/db/user_data_requests/02-export_user_data.sql
+++ b/packages/api/db/user_data_requests/02-export_user_data.sql
@@ -34,7 +34,7 @@ AS $$
 DECLARE
     target_user_id            VARCHAR := 'user_id_here';
     user_data                 user_data_collections;
-    farm_item                 farm_data_collections;
+    farm_data                 farm_data_collections;
     farm_count                INTEGER;
 
     task_tables               RECORD;
@@ -57,7 +57,7 @@ DECLARE
 BEGIN
 user_data := get_user_data(target_user_id);
 
-FOREACH farm_item IN ARRAY user_data.farms LOOP
+FOREACH farm_data IN ARRAY user_data.farms LOOP
     farm_json := '{}'::jsonb;
 
     -- ==== 1) TASK PRODUCT-SCOPED TABLE ====
@@ -67,7 +67,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         task_prod_tables.table_name
       )
       INTO table_data
-      USING farm_item.task_products_ids;
+      USING farm_data.task_products_ids;
 
       farm_json := jsonb_merge(farm_json, task_prod_tables.table_name, table_data);
     END LOOP;
@@ -79,7 +79,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         task_tables.table_name
       )
       INTO table_data
-      USING farm_item.task_ids;
+      USING farm_data.task_ids;
 
       farm_json := jsonb_merge(farm_json, task_tables.table_name, table_data);
     END LOOP;
@@ -92,7 +92,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         pmp_tables.table_name
       )
       INTO table_data
-      USING farm_item.pmp_ids;
+      USING farm_data.pmp_ids;
 
       farm_json := jsonb_merge(farm_json, pmp_tables.table_name, table_data);
     END LOOP;
@@ -104,7 +104,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         mp_tables.table_name
       )
       INTO table_data
-      USING farm_item.management_plan_ids;
+      USING farm_data.management_plan_ids;
 
       farm_json := jsonb_merge(farm_json, mp_tables.table_name, table_data);
     END LOOP;
@@ -116,7 +116,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         plan_repetition_tables.table_name
       )
       INTO table_data
-      USING farm_item.management_plan_group_ids;
+      USING farm_data.management_plan_group_ids;
 
       farm_json := jsonb_merge(farm_json, plan_repetition_tables.table_name, table_data);
     END LOOP;
@@ -129,7 +129,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         animal_tables.table_name
       )
       INTO table_data
-      USING farm_item.animal_ids;
+      USING farm_data.animal_ids;
 
       farm_json := jsonb_merge(farm_json, animal_tables.table_name, table_data);
     END LOOP;
@@ -141,7 +141,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         animal_batch_tables.table_name
       )
       INTO table_data
-      USING farm_item.animal_batch_ids;
+      USING farm_data.animal_batch_ids;
 
       farm_json := jsonb_merge(farm_json, animal_batch_tables.table_name, table_data);
     END LOOP;
@@ -154,7 +154,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         figure_tables.table_name
       )
       INTO table_data
-      USING farm_item.figure_ids;
+      USING farm_data.figure_ids;
 
       farm_json := jsonb_merge(farm_json, figure_tables.table_name, table_data);
     END LOOP;
@@ -166,7 +166,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         location_tables.table_name
       )
       INTO table_data
-      USING farm_item.location_ids;
+      USING farm_data.location_ids;
 
       farm_json := jsonb_merge(farm_json, location_tables.table_name, table_data);
     END LOOP;
@@ -183,7 +183,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         secondary_tables.join_key
       )
       INTO table_data
-      USING farm_item.farm_id;
+      USING farm_data.farm_id;
 
       farm_json := jsonb_merge(farm_json, secondary_tables.child_table, table_data);
     END LOOP;
@@ -196,7 +196,7 @@ FOREACH farm_item IN ARRAY user_data.farms LOOP
         farm_tables.table_name
       )
       INTO table_data
-      USING farm_item.farm_id;
+      USING farm_data.farm_id;
 
       farm_json := jsonb_merge(farm_json, farm_tables.table_name, table_data);
     END LOOP;

--- a/packages/api/db/user_data_requests/02-export_user_data.sql
+++ b/packages/api/db/user_data_requests/02-export_user_data.sql
@@ -1,0 +1,254 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+-- @description: Return new JSONB = base + (key→payload) if payload IS NOT NULL. A helper function to build the export data object
+CREATE OR REPLACE FUNCTION jsonb_merge(
+  base    JSONB,
+  key     TEXT,
+  payload JSONB
+) RETURNS JSONB
+  LANGUAGE sql AS $$
+    SELECT CASE
+      WHEN payload IS NULL THEN base
+      ELSE base || jsonb_build_object(key, payload)
+    END;
+$$;
+
+-- @description: Build a JSONB payload containing every user- and farm-scoped record for export
+CREATE OR REPLACE FUNCTION export_user_data()
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    target_user_id            VARCHAR := 'user_id_here';
+    user_data                 user_data_collections;
+    farm_item                 farm_data_collections;
+    farm_count                INTEGER;
+
+    task_tables               RECORD;
+    task_prod_tables          RECORD;
+    pmp_tables                RECORD;
+    mp_tables                 RECORD;
+    plan_repetition_tables    RECORD;
+    figure_tables             RECORD;
+    animal_tables             RECORD;
+    animal_batch_tables       RECORD;
+    location_tables           RECORD;
+    secondary_tables          RECORD;
+    farm_tables               RECORD;
+    created_by_tables         RECORD;
+    user_tables               RECORD;
+
+    farm_json                 JSONB;
+    table_data                JSONB;
+    full_export               JSONB := '{}'::jsonb;
+BEGIN
+    user_data := get_user_data(target_user_id);
+
+    FOREACH farm_item IN ARRAY user_data.farms LOOP
+        farm_json := '{}'::jsonb;
+
+          -- ==== 1) TASK PRODUCT-SCOPED TABLE ====
+          FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_products_id = ANY($1)',
+              task_prod_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.task_products_ids;
+
+            farm_json := jsonb_merge(farm_json, task_prod_tables.table_name, table_data);
+          END LOOP;
+
+          -- ==== 2) TASK‐SCOPED TABLES ====
+          FOR task_tables IN SELECT * FROM get_task_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_id = ANY($1)',
+              task_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.task_ids;
+
+            farm_json := jsonb_merge(farm_json, task_tables.table_name, table_data);
+          END LOOP;
+
+          -- ==== 3) CROP PLAN TABLES ====
+          FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(p)) FROM %I p ' ||
+              'WHERE p.planting_management_plan_id = ANY($1)',
+              pmp_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.pmp_ids;
+
+            farm_json := jsonb_merge(farm_json, pmp_tables.table_name, table_data);
+          END LOOP;
+
+          FOR mp_tables IN SELECT * FROM get_management_plan_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(m)) FROM %I m ' ||
+              'WHERE m.management_plan_id = ANY($1)',
+              mp_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.management_plan_ids;
+
+            farm_json := jsonb_merge(farm_json, mp_tables.table_name, table_data);
+          END LOOP;
+
+          FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(r)) FROM %I r ' ||
+              'WHERE r.management_plan_group_id = ANY($1)',
+              plan_repetition_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.management_plan_group_ids;
+
+            farm_json := jsonb_merge(farm_json, plan_repetition_tables.table_name, table_data);
+          END LOOP;
+
+          -- ==== 3) ANIMALS ====
+          FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(a)) FROM %I a ' ||
+              'WHERE a.animal_id = ANY($1)',
+              animal_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.animal_ids;
+
+            farm_json := jsonb_merge(farm_json, animal_tables.table_name, table_data);
+          END LOOP;
+
+          FOR animal_batch_tables IN
+            SELECT * FROM get_animal_batch_tables()
+          LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(ab)) FROM %I ab ' ||
+              'WHERE ab.animal_batch_id = ANY($1)',
+              animal_batch_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.animal_batch_ids;
+
+            farm_json := jsonb_merge(farm_json, animal_batch_tables.table_name, table_data);
+          END LOOP;
+
+          -- ==== 3) LOCATIONS ====
+          FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(f)) FROM %I f ' ||
+              'WHERE f.figure_id = ANY($1)',
+              figure_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.figure_ids;
+
+            farm_json := jsonb_merge(farm_json, figure_tables.table_name, table_data);
+          END LOOP;
+
+          FOR location_tables IN SELECT * FROM get_location_export_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(l)) FROM %I l ' ||
+              'WHERE l.location_id = ANY($1)',
+              location_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.location_ids;
+
+            farm_json := jsonb_merge(farm_json, location_tables.table_name, table_data);
+          END LOOP;
+
+          -- ==== TABLES REQUIRING SECONDARY JOIN FOR FARM_ID ====
+          FOR secondary_tables IN SELECT * FROM get_secondary_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(c)) ' ||
+              'FROM %I c JOIN %I p ON c.%I = p.%I ' ||
+              'WHERE p.farm_id = $1',
+              secondary_tables.child_table,
+              secondary_tables.join_table,
+              secondary_tables.join_key,
+              secondary_tables.join_key
+            )
+            INTO table_data
+            USING farm_item.farm_id;
+
+            farm_json := jsonb_merge(farm_json, secondary_tables.child_table, table_data);
+          END LOOP;
+
+          -- ==== REMAINING FARM-SCOPED TABLES  ====
+          FOR farm_tables IN SELECT * FROM get_farm_export_tables() LOOP
+            EXECUTE format(
+              'SELECT json_agg(to_jsonb(fm)) ' ||
+              'FROM %I fm WHERE fm.farm_id = $1',
+              farm_tables.table_name
+            )
+            INTO table_data
+            USING farm_item.farm_id;
+
+            farm_json := jsonb_merge(farm_json, farm_tables.table_name, table_data);
+          END LOOP;
+
+      -- append this farm into the "farms" array
+      full_export := jsonb_merge(
+        full_export,
+        'farms', 
+        COALESCE(full_export->'farms','[]'::jsonb) || farm_json
+      );
+
+    END LOOP;
+
+    -- ==== USER DATA NOT SPECIFIC TO FARM ====
+    FOR created_by_tables IN
+        SELECT * FROM get_created_by_user_tables()
+    LOOP
+        EXECUTE format(
+          'SELECT json_agg(to_jsonb(cb)) ' ||
+          'FROM %I cb WHERE cb.created_by_user_id = $1',
+          created_by_tables.table_name
+        )
+        INTO table_data
+        USING target_user_id;
+
+        full_export := jsonb_merge(full_export, created_by_tables.table_name, table_data);
+    END LOOP;
+
+    FOR user_tables IN
+        SELECT * FROM get_user_scoped_tables()
+    LOOP
+        EXECUTE format(
+          'SELECT json_agg(to_jsonb(u)) ' ||
+          'FROM %I u WHERE u.user_id = $1',
+          user_tables.table_name
+        )
+        INTO table_data
+        USING target_user_id;
+
+        full_export := jsonb_merge(full_export, user_tables.table_name, table_data);
+    END LOOP;
+
+    -- Format export object
+    RETURN jsonb_build_object(
+      'user_id',       target_user_id,
+      'exported_at',   to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'export_type',   'all_user_data',
+      'data',          full_export
+    );
+
+END $$;
+
+SELECT export_user_data() as export;

--- a/packages/api/db/user_data_requests/02-export_user_data.sql
+++ b/packages/api/db/user_data_requests/02-export_user_data.sql
@@ -55,199 +55,193 @@ DECLARE
     table_data                JSONB;
     full_export               JSONB := '{}'::jsonb;
 BEGIN
-    user_data := get_user_data(target_user_id);
+user_data := get_user_data(target_user_id);
 
-    FOREACH farm_item IN ARRAY user_data.farms LOOP
-        farm_json := '{}'::jsonb;
+FOREACH farm_item IN ARRAY user_data.farms LOOP
+    farm_json := '{}'::jsonb;
 
-          -- ==== 1) TASK PRODUCT-SCOPED TABLE ====
-          FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_products_id = ANY($1)',
-              task_prod_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.task_products_ids;
+    -- ==== 1) TASK PRODUCT-SCOPED TABLE ====
+    FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_products_id = ANY($1)',
+        task_prod_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.task_products_ids;
 
-            farm_json := jsonb_merge(farm_json, task_prod_tables.table_name, table_data);
-          END LOOP;
-
-          -- ==== 2) TASK‐SCOPED TABLES ====
-          FOR task_tables IN SELECT * FROM get_task_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_id = ANY($1)',
-              task_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.task_ids;
-
-            farm_json := jsonb_merge(farm_json, task_tables.table_name, table_data);
-          END LOOP;
-
-          -- ==== 3) CROP PLAN TABLES ====
-          FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(p)) FROM %I p ' ||
-              'WHERE p.planting_management_plan_id = ANY($1)',
-              pmp_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.pmp_ids;
-
-            farm_json := jsonb_merge(farm_json, pmp_tables.table_name, table_data);
-          END LOOP;
-
-          FOR mp_tables IN SELECT * FROM get_management_plan_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(m)) FROM %I m ' ||
-              'WHERE m.management_plan_id = ANY($1)',
-              mp_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.management_plan_ids;
-
-            farm_json := jsonb_merge(farm_json, mp_tables.table_name, table_data);
-          END LOOP;
-
-          FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(r)) FROM %I r ' ||
-              'WHERE r.management_plan_group_id = ANY($1)',
-              plan_repetition_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.management_plan_group_ids;
-
-            farm_json := jsonb_merge(farm_json, plan_repetition_tables.table_name, table_data);
-          END LOOP;
-
-          -- ==== 3) ANIMALS ====
-          FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(a)) FROM %I a ' ||
-              'WHERE a.animal_id = ANY($1)',
-              animal_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.animal_ids;
-
-            farm_json := jsonb_merge(farm_json, animal_tables.table_name, table_data);
-          END LOOP;
-
-          FOR animal_batch_tables IN
-            SELECT * FROM get_animal_batch_tables()
-          LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(ab)) FROM %I ab ' ||
-              'WHERE ab.animal_batch_id = ANY($1)',
-              animal_batch_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.animal_batch_ids;
-
-            farm_json := jsonb_merge(farm_json, animal_batch_tables.table_name, table_data);
-          END LOOP;
-
-          -- ==== 3) LOCATIONS ====
-          FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(f)) FROM %I f ' ||
-              'WHERE f.figure_id = ANY($1)',
-              figure_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.figure_ids;
-
-            farm_json := jsonb_merge(farm_json, figure_tables.table_name, table_data);
-          END LOOP;
-
-          FOR location_tables IN SELECT * FROM get_location_export_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(l)) FROM %I l ' ||
-              'WHERE l.location_id = ANY($1)',
-              location_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.location_ids;
-
-            farm_json := jsonb_merge(farm_json, location_tables.table_name, table_data);
-          END LOOP;
-
-          -- ==== TABLES REQUIRING SECONDARY JOIN FOR FARM_ID ====
-          FOR secondary_tables IN SELECT * FROM get_secondary_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(c)) ' ||
-              'FROM %I c JOIN %I p ON c.%I = p.%I ' ||
-              'WHERE p.farm_id = $1',
-              secondary_tables.child_table,
-              secondary_tables.join_table,
-              secondary_tables.join_key,
-              secondary_tables.join_key
-            )
-            INTO table_data
-            USING farm_item.farm_id;
-
-            farm_json := jsonb_merge(farm_json, secondary_tables.child_table, table_data);
-          END LOOP;
-
-          -- ==== REMAINING FARM-SCOPED TABLES  ====
-          FOR farm_tables IN SELECT * FROM get_farm_export_tables() LOOP
-            EXECUTE format(
-              'SELECT json_agg(to_jsonb(fm)) ' ||
-              'FROM %I fm WHERE fm.farm_id = $1',
-              farm_tables.table_name
-            )
-            INTO table_data
-            USING farm_item.farm_id;
-
-            farm_json := jsonb_merge(farm_json, farm_tables.table_name, table_data);
-          END LOOP;
-
-      -- append this farm into the "farms" array
-      full_export := jsonb_merge(
-        full_export,
-        'farms', 
-        COALESCE(full_export->'farms','[]'::jsonb) || farm_json
-      );
-
+      farm_json := jsonb_merge(farm_json, task_prod_tables.table_name, table_data);
     END LOOP;
 
-    -- ==== USER DATA NOT SPECIFIC TO FARM ====
-    FOR created_by_tables IN
-        SELECT * FROM get_created_by_user_tables()
-    LOOP
-        EXECUTE format(
-          'SELECT json_agg(to_jsonb(cb)) ' ||
-          'FROM %I cb WHERE cb.created_by_user_id = $1',
-          created_by_tables.table_name
-        )
-        INTO table_data
-        USING target_user_id;
+    -- ==== 2) TASK‐SCOPED TABLES ====
+    FOR task_tables IN SELECT * FROM get_task_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_id = ANY($1)',
+        task_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.task_ids;
 
-        full_export := jsonb_merge(full_export, created_by_tables.table_name, table_data);
+      farm_json := jsonb_merge(farm_json, task_tables.table_name, table_data);
     END LOOP;
 
-    FOR user_tables IN
-        SELECT * FROM get_user_scoped_tables()
-    LOOP
-        EXECUTE format(
-          'SELECT json_agg(to_jsonb(u)) ' ||
-          'FROM %I u WHERE u.user_id = $1',
-          user_tables.table_name
-        )
-        INTO table_data
-        USING target_user_id;
+    -- ==== 3) CROP PLAN TABLES ====
+    FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(p)) FROM %I p ' ||
+        'WHERE p.planting_management_plan_id = ANY($1)',
+        pmp_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.pmp_ids;
 
-        full_export := jsonb_merge(full_export, user_tables.table_name, table_data);
+      farm_json := jsonb_merge(farm_json, pmp_tables.table_name, table_data);
     END LOOP;
 
-    -- Format export object
-    RETURN jsonb_build_object(
-      'user_id',       target_user_id,
-      'exported_at',   to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-      'export_type',   'all_user_data',
-      'data',          full_export
-    );
+    FOR mp_tables IN SELECT * FROM get_management_plan_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(m)) FROM %I m ' ||
+        'WHERE m.management_plan_id = ANY($1)',
+        mp_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.management_plan_ids;
+
+      farm_json := jsonb_merge(farm_json, mp_tables.table_name, table_data);
+    END LOOP;
+
+    FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(r)) FROM %I r ' ||
+        'WHERE r.management_plan_group_id = ANY($1)',
+        plan_repetition_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.management_plan_group_ids;
+
+      farm_json := jsonb_merge(farm_json, plan_repetition_tables.table_name, table_data);
+    END LOOP;
+
+    -- ==== 3) ANIMALS ====
+    FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(a)) FROM %I a ' ||
+        'WHERE a.animal_id = ANY($1)',
+        animal_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.animal_ids;
+
+      farm_json := jsonb_merge(farm_json, animal_tables.table_name, table_data);
+    END LOOP;
+
+    FOR animal_batch_tables IN SELECT * FROM get_animal_batch_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(ab)) FROM %I ab ' ||
+        'WHERE ab.animal_batch_id = ANY($1)',
+        animal_batch_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.animal_batch_ids;
+
+      farm_json := jsonb_merge(farm_json, animal_batch_tables.table_name, table_data);
+    END LOOP;
+
+    -- ==== 3) LOCATIONS ====
+    FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(f)) FROM %I f ' ||
+        'WHERE f.figure_id = ANY($1)',
+        figure_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.figure_ids;
+
+      farm_json := jsonb_merge(farm_json, figure_tables.table_name, table_data);
+    END LOOP;
+
+    FOR location_tables IN SELECT * FROM get_location_export_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(l)) FROM %I l ' ||
+        'WHERE l.location_id = ANY($1)',
+        location_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.location_ids;
+
+      farm_json := jsonb_merge(farm_json, location_tables.table_name, table_data);
+    END LOOP;
+
+    -- ==== TABLES REQUIRING SECONDARY JOIN FOR FARM_ID ====
+    FOR secondary_tables IN SELECT * FROM get_secondary_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(c)) ' ||
+        'FROM %I c JOIN %I p ON c.%I = p.%I ' ||
+        'WHERE p.farm_id = $1',
+        secondary_tables.child_table,
+        secondary_tables.join_table,
+        secondary_tables.join_key,
+        secondary_tables.join_key
+      )
+      INTO table_data
+      USING farm_item.farm_id;
+
+      farm_json := jsonb_merge(farm_json, secondary_tables.child_table, table_data);
+    END LOOP;
+
+    -- ==== REMAINING FARM-SCOPED TABLES  ====
+    FOR farm_tables IN SELECT * FROM get_farm_export_tables() LOOP
+      EXECUTE format(
+        'SELECT json_agg(to_jsonb(fm)) ' ||
+        'FROM %I fm WHERE fm.farm_id = $1',
+        farm_tables.table_name
+      )
+      INTO table_data
+      USING farm_item.farm_id;
+
+      farm_json := jsonb_merge(farm_json, farm_tables.table_name, table_data);
+    END LOOP;
+
+  -- append this farm into the "farms" array
+  full_export := jsonb_merge(
+    full_export,
+    'farms', 
+    COALESCE(full_export->'farms','[]'::jsonb) || farm_json
+  );
+
+END LOOP;
+
+-- ==== USER DATA NOT SPECIFIC TO FARM ====
+FOR created_by_tables IN SELECT * FROM get_created_by_user_tables() LOOP
+    EXECUTE format(
+      'SELECT json_agg(to_jsonb(cb)) ' ||
+      'FROM %I cb WHERE cb.created_by_user_id = $1',
+      created_by_tables.table_name
+    )
+    INTO table_data
+    USING target_user_id;
+
+    full_export := jsonb_merge(full_export, created_by_tables.table_name, table_data);
+END LOOP;
+
+FOR user_tables IN SELECT * FROM get_user_scoped_tables() LOOP
+    EXECUTE format(
+      'SELECT json_agg(to_jsonb(u)) ' ||
+      'FROM %I u WHERE u.user_id = $1',
+      user_tables.table_name
+    )
+    INTO table_data
+    USING target_user_id;
+
+    full_export := jsonb_merge(full_export, user_tables.table_name, table_data);
+END LOOP;
+
+-- Format export object
+RETURN jsonb_build_object(
+  'user_id',       target_user_id,
+  'exported_at',   to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+  'export_type',   'all_user_data',
+  'data',          full_export
+);
 
 END $$;
 

--- a/packages/api/db/user_data_requests/02-export_user_data.sql
+++ b/packages/api/db/user_data_requests/02-export_user_data.sql
@@ -60,7 +60,7 @@ user_data := get_user_data(target_user_id);
 FOREACH farm_data IN ARRAY user_data.farms LOOP
     farm_json := '{}'::jsonb;
 
-    -- ==== 1) TASK PRODUCT-SCOPED TABLE ====
+    -- ==== TASK PRODUCT-SCOPED TABLES ====
     FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_products_id = ANY($1)',
@@ -72,7 +72,7 @@ FOREACH farm_data IN ARRAY user_data.farms LOOP
       farm_json := jsonb_merge(farm_json, task_prod_tables.table_name, table_data);
     END LOOP;
 
-    -- ==== 2) TASK‐SCOPED TABLES ====
+    -- ==== TASK‐SCOPED TABLES ====
     FOR task_tables IN SELECT * FROM get_task_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(t)) FROM %I t WHERE t.task_id = ANY($1)',
@@ -84,7 +84,7 @@ FOREACH farm_data IN ARRAY user_data.farms LOOP
       farm_json := jsonb_merge(farm_json, task_tables.table_name, table_data);
     END LOOP;
 
-    -- ==== 3) CROP PLAN TABLES ====
+    -- ==== PLANTING MANAGEMENT PLAN TABLES ====
     FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(p)) FROM %I p ' ||
@@ -97,6 +97,7 @@ FOREACH farm_data IN ARRAY user_data.farms LOOP
       farm_json := jsonb_merge(farm_json, pmp_tables.table_name, table_data);
     END LOOP;
 
+    -- ==== MANAGEMENT PLAN TABLES ====
     FOR mp_tables IN SELECT * FROM get_management_plan_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(m)) FROM %I m ' ||
@@ -109,6 +110,7 @@ FOREACH farm_data IN ARRAY user_data.farms LOOP
       farm_json := jsonb_merge(farm_json, mp_tables.table_name, table_data);
     END LOOP;
 
+    -- ==== MANAGEMENT PLAN GROUP TABLES ====
     FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(r)) FROM %I r ' ||
@@ -121,7 +123,7 @@ FOREACH farm_data IN ARRAY user_data.farms LOOP
       farm_json := jsonb_merge(farm_json, plan_repetition_tables.table_name, table_data);
     END LOOP;
 
-    -- ==== 3) ANIMALS ====
+    -- ==== ANIMALS ====
     FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(a)) FROM %I a ' ||
@@ -146,7 +148,7 @@ FOREACH farm_data IN ARRAY user_data.farms LOOP
       farm_json := jsonb_merge(farm_json, animal_batch_tables.table_name, table_data);
     END LOOP;
 
-    -- ==== 3) LOCATIONS ====
+    -- ==== LOCATIONS ====
     FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
       EXECUTE format(
         'SELECT json_agg(to_jsonb(f)) FROM %I f ' ||

--- a/packages/api/db/user_data_requests/03-delete_user_data.sql
+++ b/packages/api/db/user_data_requests/03-delete_user_data.sql
@@ -50,15 +50,15 @@ user_data := get_user_data(target_user_id);
 
 FOREACH farm_data IN ARRAY user_data.farms LOOP
     -- prevent deletion of multi-user farms
-    SELECT COUNT(*) INTO farm_count
+    SELECT COUNT(*) INTO user_count
         FROM "userFarm"
         WHERE farm_id = farm_data.farm_id;
 
-        IF farm_count > 1 THEN
+        IF user_count > 1 THEN
         RAISE EXCEPTION
             'Cannot delete: farm % has % users',
             farm_data.farm_id,
-            farm_count;
+            user_count;
         END IF;
 
     FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP

--- a/packages/api/db/user_data_requests/03-delete_user_data.sql
+++ b/packages/api/db/user_data_requests/03-delete_user_data.sql
@@ -1,0 +1,186 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+ -- @description: Manually delete all rows associated with a user (and their farms) inside a transaction.
+- The syntax of this "comment" is intentionally incorrect, to prevent running this file as a script.
+
+-- This SQL is never executed by LiteFarm app or server code.
+-- It is intended for manual use by administrators to completely remove a user's data. It will delete ALL data associated with a user and their farm if they are the only user.
+
+-- You should run this within a transaction and verify results before committing.
+
+
+BEGIN TRANSACTION;
+
+DO $$
+DECLARE
+    target_user_id VARCHAR := 'user_id_here';
+    user_data        user_data_collections;
+    farm_item        farm_data_collections;
+    farm_count       INTEGER;
+
+    task_tables          RECORD;
+    task_prod_tables     RECORD;
+    figure_tables        RECORD;
+    location_tables      RECORD;
+    pmp_tables           RECORD;
+    management_plan_tables  RECORD;
+    plan_repetition_tables  RECORD;
+    animal_tables        RECORD;
+    animal_batch_tables  RECORD;
+    secondary_tables     RECORD;
+    farm_tables          RECORD;
+    created_by_tables    RECORD;
+    user_tables          RECORD;
+
+BEGIN
+
+    user_data := get_user_data(target_user_id);
+
+    FOREACH farm_item IN ARRAY user_data.farms LOOP
+        -- prevent deletion of multi-user farms
+        SELECT COUNT(*) INTO farm_count
+            FROM "userFarm"
+            WHERE farm_id = farm_item.farm_id;
+
+            IF farm_count > 1 THEN
+            RAISE EXCEPTION
+                'Cannot delete: farm % has % users',
+                farm_item.farm_id,
+                farm_count;
+            END IF;
+
+        FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE task_products_id = ANY($1)',
+                task_prod_tables.table_name
+            )
+            USING farm_item.task_products_ids;
+        END LOOP;
+
+        FOR task_tables IN SELECT * FROM get_task_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE task_id = ANY($1)',
+                task_tables.table_name
+            )
+            USING farm_item.task_ids;
+        END LOOP;
+
+        FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE planting_management_plan_id = ANY($1)',
+            pmp_tables.table_name
+        )
+            USING farm_item.pmp_ids;
+        END LOOP;
+
+        FOR management_plan_tables IN SELECT * FROM get_management_plan_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE management_plan_id = ANY($1)',
+            management_plan_tables.table_name
+        )
+            USING farm_item.management_plan_ids;
+        END LOOP;
+
+        FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE management_plan_group_id = ANY($1)',
+            plan_repetition_tables.table_name
+        )
+            USING farm_item.management_plan_group_ids;
+        END LOOP;
+
+        FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE animal_id = ANY($1)',
+            animal_tables.table_name
+        )
+            USING farm_item.animal_ids;
+        END LOOP;
+
+        FOR animal_batch_tables IN SELECT * FROM get_animal_batch_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE animal_batch_id = ANY($1)',
+            animal_batch_tables.table_name
+        )
+            USING farm_item.animal_batch_ids;
+        END LOOP;
+
+        FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE figure_id = ANY($1)',
+                figure_tables.table_name
+            )
+            USING farm_item.figure_ids;
+        END LOOP;
+
+        -- locations
+        -- First NULL problematic circular reference between farm and location
+        UPDATE "farm"
+            SET default_initial_location_id = NULL
+        WHERE farm_id = farm_item.farm_id;
+
+        FOR location_tables IN SELECT * FROM get_location_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE location_id = ANY($1)',
+                location_tables.table_name
+                )
+            USING farm_item.location_ids;
+        END LOOP;
+
+        -- tables requiring join to a second table with farm_id
+        FOR secondary_tables IN SELECT * FROM get_secondary_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I AS c USING %I AS p WHERE p.farm_id = $1 AND c.%I = p.%I',
+                secondary_tables.child_table,
+                secondary_tables.join_table,
+                secondary_tables.join_key,
+                secondary_tables.join_key
+            )
+            USING farm_item.farm_id;
+        END LOOP;
+
+        -- remaining farm-scoped data
+        FOR farm_tables IN SELECT * FROM get_farm_scoped_tables() LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE farm_id = $1',
+                farm_tables.table_name
+                )
+            USING farm_item.farm_id;
+        END LOOP;
+
+    END LOOP;
+
+    -- user data not specific to farm
+    FOR created_by_tables IN SELECT * FROM get_created_by_user_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE created_by_user_id = $1',
+            created_by_tables.table_name
+            )
+        USING target_user_id;
+    END LOOP;
+
+    FOR user_tables IN SELECT * FROM get_user_scoped_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE user_id = $1',
+            user_tables.table_name
+            )
+        USING target_user_id;
+    END LOOP;
+
+    RAISE NOTICE 'Data deletion complete for user_id: %', target_user_id;
+END $$;
+
+-- COMMIT

--- a/packages/api/db/user_data_requests/03-delete_user_data.sql
+++ b/packages/api/db/user_data_requests/03-delete_user_data.sql
@@ -46,141 +46,140 @@ DECLARE
     user_tables          RECORD;
 
 BEGIN
+user_data := get_user_data(target_user_id);
 
-    user_data := get_user_data(target_user_id);
-
-    FOREACH farm_item IN ARRAY user_data.farms LOOP
-        -- prevent deletion of multi-user farms
-        SELECT COUNT(*) INTO farm_count
-            FROM "userFarm"
-            WHERE farm_id = farm_item.farm_id;
-
-            IF farm_count > 1 THEN
-            RAISE EXCEPTION
-                'Cannot delete: farm % has % users',
-                farm_item.farm_id,
-                farm_count;
-            END IF;
-
-        FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE task_products_id = ANY($1)',
-                task_prod_tables.table_name
-            )
-            USING farm_item.task_products_ids;
-        END LOOP;
-
-        FOR task_tables IN SELECT * FROM get_task_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE task_id = ANY($1)',
-                task_tables.table_name
-            )
-            USING farm_item.task_ids;
-        END LOOP;
-
-        FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE planting_management_plan_id = ANY($1)',
-            pmp_tables.table_name
-        )
-            USING farm_item.pmp_ids;
-        END LOOP;
-
-        FOR management_plan_tables IN SELECT * FROM get_management_plan_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE management_plan_id = ANY($1)',
-            management_plan_tables.table_name
-        )
-            USING farm_item.management_plan_ids;
-        END LOOP;
-
-        FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE management_plan_group_id = ANY($1)',
-            plan_repetition_tables.table_name
-        )
-            USING farm_item.management_plan_group_ids;
-        END LOOP;
-
-        FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE animal_id = ANY($1)',
-            animal_tables.table_name
-        )
-            USING farm_item.animal_ids;
-        END LOOP;
-
-        FOR animal_batch_tables IN SELECT * FROM get_animal_batch_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE animal_batch_id = ANY($1)',
-            animal_batch_tables.table_name
-        )
-            USING farm_item.animal_batch_ids;
-        END LOOP;
-
-        FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE figure_id = ANY($1)',
-                figure_tables.table_name
-            )
-            USING farm_item.figure_ids;
-        END LOOP;
-
-        -- locations
-        -- First NULL problematic circular reference between farm and location
-        UPDATE "farm"
-            SET default_initial_location_id = NULL
+FOREACH farm_item IN ARRAY user_data.farms LOOP
+    -- prevent deletion of multi-user farms
+    SELECT COUNT(*) INTO farm_count
+        FROM "userFarm"
         WHERE farm_id = farm_item.farm_id;
 
-        FOR location_tables IN SELECT * FROM get_location_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE location_id = ANY($1)',
-                location_tables.table_name
-                )
-            USING farm_item.location_ids;
-        END LOOP;
+        IF farm_count > 1 THEN
+        RAISE EXCEPTION
+            'Cannot delete: farm % has % users',
+            farm_item.farm_id,
+            farm_count;
+        END IF;
 
-        -- tables requiring join to a second table with farm_id
-        FOR secondary_tables IN SELECT * FROM get_secondary_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I AS c USING %I AS p WHERE p.farm_id = $1 AND c.%I = p.%I',
-                secondary_tables.child_table,
-                secondary_tables.join_table,
-                secondary_tables.join_key,
-                secondary_tables.join_key
-            )
-            USING farm_item.farm_id;
-        END LOOP;
-
-        -- remaining farm-scoped data
-        FOR farm_tables IN SELECT * FROM get_farm_scoped_tables() LOOP
-            EXECUTE format(
-                'DELETE FROM %I WHERE farm_id = $1',
-                farm_tables.table_name
-                )
-            USING farm_item.farm_id;
-        END LOOP;
-
-    END LOOP;
-
-    -- user data not specific to farm
-    FOR created_by_tables IN SELECT * FROM get_created_by_user_tables() LOOP
+    FOR task_prod_tables IN SELECT * FROM get_task_product_tables() LOOP
         EXECUTE format(
-            'DELETE FROM %I WHERE created_by_user_id = $1',
-            created_by_tables.table_name
-            )
-        USING target_user_id;
+            'DELETE FROM %I WHERE task_products_id = ANY($1)',
+            task_prod_tables.table_name
+        )
+        USING farm_item.task_products_ids;
     END LOOP;
 
-    FOR user_tables IN SELECT * FROM get_user_scoped_tables() LOOP
+    FOR task_tables IN SELECT * FROM get_task_tables() LOOP
         EXECUTE format(
-            'DELETE FROM %I WHERE user_id = $1',
-            user_tables.table_name
-            )
-        USING target_user_id;
+            'DELETE FROM %I WHERE task_id = ANY($1)',
+            task_tables.table_name
+        )
+        USING farm_item.task_ids;
     END LOOP;
 
-    RAISE NOTICE 'Data deletion complete for user_id: %', target_user_id;
+    FOR pmp_tables IN SELECT * FROM get_pmp_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE planting_management_plan_id = ANY($1)',
+        pmp_tables.table_name
+    )
+        USING farm_item.pmp_ids;
+    END LOOP;
+
+    FOR management_plan_tables IN SELECT * FROM get_management_plan_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE management_plan_id = ANY($1)',
+        management_plan_tables.table_name
+    )
+        USING farm_item.management_plan_ids;
+    END LOOP;
+
+    FOR plan_repetition_tables IN SELECT * FROM get_mp_repetition_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE management_plan_group_id = ANY($1)',
+        plan_repetition_tables.table_name
+    )
+        USING farm_item.management_plan_group_ids;
+    END LOOP;
+
+    FOR animal_tables IN SELECT * FROM get_animal_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE animal_id = ANY($1)',
+        animal_tables.table_name
+    )
+        USING farm_item.animal_ids;
+    END LOOP;
+
+    FOR animal_batch_tables IN SELECT * FROM get_animal_batch_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE animal_batch_id = ANY($1)',
+        animal_batch_tables.table_name
+    )
+        USING farm_item.animal_batch_ids;
+    END LOOP;
+
+    FOR figure_tables IN SELECT * FROM get_figure_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE figure_id = ANY($1)',
+            figure_tables.table_name
+        )
+        USING farm_item.figure_ids;
+    END LOOP;
+
+    -- locations
+    -- First NULL problematic circular reference between farm and location
+    UPDATE "farm"
+        SET default_initial_location_id = NULL
+    WHERE farm_id = farm_item.farm_id;
+
+    FOR location_tables IN SELECT * FROM get_location_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE location_id = ANY($1)',
+            location_tables.table_name
+            )
+        USING farm_item.location_ids;
+    END LOOP;
+
+    -- tables requiring join to a second table with farm_id
+    FOR secondary_tables IN SELECT * FROM get_secondary_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I AS c USING %I AS p WHERE p.farm_id = $1 AND c.%I = p.%I',
+            secondary_tables.child_table,
+            secondary_tables.join_table,
+            secondary_tables.join_key,
+            secondary_tables.join_key
+        )
+        USING farm_item.farm_id;
+    END LOOP;
+
+    -- remaining farm-scoped data
+    FOR farm_tables IN SELECT * FROM get_farm_scoped_tables() LOOP
+        EXECUTE format(
+            'DELETE FROM %I WHERE farm_id = $1',
+            farm_tables.table_name
+            )
+        USING farm_item.farm_id;
+    END LOOP;
+
+END LOOP;
+
+-- user data not specific to farm
+FOR created_by_tables IN SELECT * FROM get_created_by_user_tables() LOOP
+    EXECUTE format(
+        'DELETE FROM %I WHERE created_by_user_id = $1',
+        created_by_tables.table_name
+        )
+    USING target_user_id;
+END LOOP;
+
+FOR user_tables IN SELECT * FROM get_user_scoped_tables() LOOP
+    EXECUTE format(
+        'DELETE FROM %I WHERE user_id = $1',
+        user_tables.table_name
+        )
+    USING target_user_id;
+END LOOP;
+
+RAISE NOTICE 'Data deletion complete for user_id: %', target_user_id;
 END $$;
 
 -- COMMIT

--- a/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
+++ b/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
@@ -86,6 +86,7 @@ CREATE OR REPLACE FUNCTION get_location_tables()
       'gate',
       'water_valve',
       'buffer_zone',
+      'soil_sample_location',
       'watercourse',
       'fence',
       'barn',

--- a/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
+++ b/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
@@ -1,0 +1,286 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+-- @description: Defines all tables queried by export and delete scripts
+
+-- @description returns tables related to task_id
+CREATE OR REPLACE FUNCTION get_task_tables()
+  RETURNS TABLE(table_name TEXT) 
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+        -- relationship tables
+        'location_tasks',
+        'task_document',
+        'management_tasks',
+        'animal_movement_task_purpose_relationship',
+        'task_animal_relationship',
+        'task_animal_batch_relationship',
+        'soil_amendment_task_products',
+
+        -- task types
+        'field_work_task',
+        'harvest_task',
+        'harvest_use',
+        'irrigation_task',
+        'scouting_task',
+        'pest_control_task',
+        'soil_amendment_task',
+        'soil_sample_task',
+        'cleaning_task',
+        'plant_task',
+        'transplant_task',
+        'animal_movement_task',
+
+        -- legacy task types
+        'soil_task',
+        'maintenance_task',
+        'transport_task',
+        'social_task',
+        'sale_task',
+        'wash_and_pack_task',
+
+        'task'
+    ]);
+$$;
+
+-- @description returns tables related to task_products_id
+CREATE OR REPLACE FUNCTION get_task_product_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'soil_amendment_task_products_purpose_relationship'
+    ]);
+$$;
+
+-- @description returns tables related to figure_id
+CREATE OR REPLACE FUNCTION get_figure_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'area',
+      'line',
+      'point',
+      'figure'
+    ]);
+$$;
+
+-- @description returns tables related to location_id
+CREATE OR REPLACE FUNCTION get_location_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'field',
+      'garden',
+      'gate',
+      'water_valve',
+      'buffer_zone',
+      'watercourse',
+      'fence',
+      'barn',
+      'farm_site_boundary',
+      'natural_area',
+      'surface_water',
+      'residence',
+      'greenhouse',
+      'ceremonial_area',
+      'organic_history',
+
+      -- animal & batches specified to a location via movement task
+      'animal',
+      'animal_batch',
+
+      -- legacy tables with location_id
+      'nitrogenBalance',
+
+      'location'
+    ]);
+$$;
+
+-- @description as above, but removing redundant tables for export
+CREATE OR REPLACE FUNCTION get_location_export_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT table_name
+      FROM get_location_tables()
+     WHERE table_name NOT IN (
+       'animal','animal_batch'
+     );
+$$;
+
+-- @description returns tables related to planting_management_plan_id
+CREATE OR REPLACE FUNCTION get_pmp_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'container_method',
+      'broadcast_method',
+      'bed_method',
+      'row_method',
+      'planting_management_plan'
+    ]);
+$$;
+
+-- @description returns tables related to management_plan_id
+CREATE OR REPLACE FUNCTION get_management_plan_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'crop_management_plan',
+      'management_plan'
+    ]);
+$$;
+
+-- @description returns tables related to management_plan_group_id 
+CREATE OR REPLACE FUNCTION get_mp_repetition_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'management_plan_group'
+    ]);
+$$;
+
+-- @description returns tables related to animal_id
+CREATE OR REPLACE FUNCTION get_animal_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'animal_use_relationship',
+      'animal_group_relationship'
+    ]);
+$$;
+
+-- @description returns tables related to animal_batch_id
+CREATE OR REPLACE FUNCTION get_animal_batch_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'animal_batch_use_relationship',
+      'animal_batch_group_relationship',
+      'animal_batch_sex_detail'
+    ]);
+$$;
+
+-- @description returns tables related to farm_id via a join on a secondary table
+CREATE OR REPLACE FUNCTION get_secondary_tables()
+  RETURNS TABLE(child_table TEXT,join_table TEXT,join_key TEXT)
+LANGUAGE sql AS $$
+SELECT * FROM (
+ VALUES
+  ('soil_amendment_product','product','product_id'),
+  ('crop_variety_sale','crop_variety','crop_variety_id'),
+  ('notification_user','notification','notification_id'),
+  ('nomination_crop','nomination','nomination_id'),
+  ('nomination_status','nomination','nomination_id'),
+  ('file', 'document', 'document_id'),
+
+  -- legacy
+  ('cropDisease','disease','disease_id'),
+  ('cropDisease','crop','crop_id'),
+  ('shiftTask','shift','shift_id'),
+  ('waterBalance','crop','crop_id')
+) AS t(child_table,join_table,join_key);
+$$;
+
+
+-- @description returns tables related to farm_id
+CREATE OR REPLACE FUNCTION get_farm_scoped_tables()
+  RETURNS TABLE(table_name TEXT) 
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      -- financial data
+      'sale',
+      'farmExpense',
+      'revenue_type',
+      'farmExpenseType',
+      'finance_report',
+
+      -- legacy crop data
+      'waterBalanceSchedule',
+      'price',
+      'yield',
+
+      -- crop data
+      'crop_variety',
+      'crop',
+
+      -- animal data
+      'animal',
+      'animal_batch',
+      'custom_animal_breed',
+      'custom_animal_type',
+    --   'animal_group', -- has wrong schema for farm_id, but no data on prod anyway
+
+      -- custom task data
+      'irrigation_type',
+      'harvest_use_type',
+      'field_work_type',
+      'task_type',
+
+      -- other legacy tables
+      'shift',
+      'disease',
+      'fertilizer',
+      'pesticide',
+      'nitrogenSchedule',
+
+      -- remaining custom data
+      'organicCertifierSurvey',
+      'notification',
+      'nomination',
+      'farm_addon',
+      'document',
+      'product',
+      'userLog',
+      'userFarm',
+      'farm'
+    ]);
+$$;
+
+-- @description as above, but removing redundant tables for export
+CREATE OR REPLACE FUNCTION get_farm_export_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT table_name
+      FROM get_farm_scoped_tables()
+     WHERE table_name NOT IN (
+       'userLog'
+     );
+$$;
+
+-- @description returns tables related to user_id via created_by_user_id
+CREATE OR REPLACE FUNCTION get_created_by_user_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'supportTicket'
+    ]);
+$$;
+
+-- @description returns tables related to user_id
+CREATE OR REPLACE FUNCTION get_user_scoped_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'userLog',
+      'password',
+      'showedSpotlight',
+      'release_badge',
+
+      -- invite tokens are not possible for single userFarm farms:
+      -- 'emailToken',
+
+      'users'
+    ]);
+$$;

--- a/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
+++ b/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
@@ -279,8 +279,9 @@ CREATE OR REPLACE FUNCTION get_user_scoped_tables()
       'showedSpotlight',
       'release_badge',
 
-      -- invite tokens are not possible for single userFarm farms:
-      -- 'emailToken',
+      -- invite tokens are not possible for single userFarm farms
+      -- LF-4895 should be addressed if deletion is expanded beyond that
+      'emailToken',
 
       'users'
     ]);

--- a/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
+++ b/packages/api/db/user_data_requests/common/00-scoped_table_lists.sql
@@ -15,6 +15,15 @@
 
 -- @description: Defines all tables queried by export and delete scripts
 
+-- @description returns tables related to task_products_id
+CREATE OR REPLACE FUNCTION get_task_product_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'soil_amendment_task_products_purpose_relationship'
+    ]);
+$$;
+
 -- @description returns tables related to task_id
 CREATE OR REPLACE FUNCTION get_task_tables()
   RETURNS TABLE(table_name TEXT) 
@@ -55,12 +64,56 @@ CREATE OR REPLACE FUNCTION get_task_tables()
     ]);
 $$;
 
--- @description returns tables related to task_products_id
-CREATE OR REPLACE FUNCTION get_task_product_tables()
+-- @description returns tables related to planting_management_plan_id
+CREATE OR REPLACE FUNCTION get_pmp_tables()
   RETURNS TABLE(table_name TEXT)
   LANGUAGE sql AS $$
     SELECT unnest(ARRAY[
-      'soil_amendment_task_products_purpose_relationship'
+      'container_method',
+      'broadcast_method',
+      'bed_method',
+      'row_method',
+      'planting_management_plan'
+    ]);
+$$;
+
+-- @description returns tables related to management_plan_id
+CREATE OR REPLACE FUNCTION get_management_plan_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'crop_management_plan',
+      'management_plan'
+    ]);
+$$;
+
+-- @description returns tables related to management_plan_group_id 
+CREATE OR REPLACE FUNCTION get_mp_repetition_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'management_plan_group'
+    ]);
+$$;
+
+-- @description returns tables related to animal_id
+CREATE OR REPLACE FUNCTION get_animal_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'animal_use_relationship',
+      'animal_group_relationship'
+    ]);
+$$;
+
+-- @description returns tables related to animal_batch_id
+CREATE OR REPLACE FUNCTION get_animal_batch_tables()
+  RETURNS TABLE(table_name TEXT)
+  LANGUAGE sql AS $$
+    SELECT unnest(ARRAY[
+      'animal_batch_use_relationship',
+      'animal_batch_group_relationship',
+      'animal_batch_sex_detail'
     ]);
 $$;
 
@@ -118,59 +171,6 @@ CREATE OR REPLACE FUNCTION get_location_export_tables()
      WHERE table_name NOT IN (
        'animal','animal_batch'
      );
-$$;
-
--- @description returns tables related to planting_management_plan_id
-CREATE OR REPLACE FUNCTION get_pmp_tables()
-  RETURNS TABLE(table_name TEXT)
-  LANGUAGE sql AS $$
-    SELECT unnest(ARRAY[
-      'container_method',
-      'broadcast_method',
-      'bed_method',
-      'row_method',
-      'planting_management_plan'
-    ]);
-$$;
-
--- @description returns tables related to management_plan_id
-CREATE OR REPLACE FUNCTION get_management_plan_tables()
-  RETURNS TABLE(table_name TEXT)
-  LANGUAGE sql AS $$
-    SELECT unnest(ARRAY[
-      'crop_management_plan',
-      'management_plan'
-    ]);
-$$;
-
--- @description returns tables related to management_plan_group_id 
-CREATE OR REPLACE FUNCTION get_mp_repetition_tables()
-  RETURNS TABLE(table_name TEXT)
-  LANGUAGE sql AS $$
-    SELECT unnest(ARRAY[
-      'management_plan_group'
-    ]);
-$$;
-
--- @description returns tables related to animal_id
-CREATE OR REPLACE FUNCTION get_animal_tables()
-  RETURNS TABLE(table_name TEXT)
-  LANGUAGE sql AS $$
-    SELECT unnest(ARRAY[
-      'animal_use_relationship',
-      'animal_group_relationship'
-    ]);
-$$;
-
--- @description returns tables related to animal_batch_id
-CREATE OR REPLACE FUNCTION get_animal_batch_tables()
-  RETURNS TABLE(table_name TEXT)
-  LANGUAGE sql AS $$
-    SELECT unnest(ARRAY[
-      'animal_batch_use_relationship',
-      'animal_batch_group_relationship',
-      'animal_batch_sex_detail'
-    ]);
 $$;
 
 -- @description returns tables related to farm_id via a join on a secondary table

--- a/packages/api/db/user_data_requests/common/01-user_data_indices.sql
+++ b/packages/api/db/user_data_requests/common/01-user_data_indices.sql
@@ -1,0 +1,181 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+DROP FUNCTION IF EXISTS get_user_data(VARCHAR);
+DROP TYPE IF EXISTS user_data_collections;
+DROP TYPE IF EXISTS farm_data_collections;
+
+CREATE TYPE farm_data_collections AS (
+  farm_id             UUID,
+  task_ids            INTEGER[],
+  task_products_ids   INTEGER[],
+  location_ids        UUID[],
+  figure_ids          UUID[],
+  animal_ids          INTEGER[],
+  animal_batch_ids    INTEGER[],
+  management_plan_ids INTEGER[],
+  pmp_ids             UUID[],
+  management_plan_group_ids UUID[]
+);
+
+CREATE TYPE user_data_collections AS (
+  user_farm_ids       UUID[],
+  farms               farm_data_collections[]
+);
+
+
+-- @description: Gather per-farm arrays of IDs (tasks, locations, animals, etc.) for a given user.
+CREATE OR REPLACE FUNCTION get_user_data(p_user_id VARCHAR)
+  RETURNS user_data_collections
+  LANGUAGE plpgsql
+AS $$
+DECLARE
+  result    user_data_collections;
+  farm_record  RECORD;
+  farm_data farm_data_collections;
+BEGIN
+
+  SELECT 
+    COALESCE(array_agg(farm_id), ARRAY[]::UUID[])
+    INTO result.user_farm_ids
+    FROM "userFarm"
+    WHERE user_id = p_user_id;
+
+  result.farms := ARRAY[]::farm_data_collections[];
+
+  FOR farm_record IN
+    SELECT unnest(result.user_farm_ids) AS farm_id
+  LOOP
+    farm_data.farm_id := farm_record.farm_id;
+    
+    -- crop-plan related IDs
+    SELECT 
+        COALESCE(array_agg(mp.management_plan_id), ARRAY[]::INTEGER[])
+    INTO farm_data.management_plan_ids
+    FROM "management_plan" mp
+    JOIN "crop_variety" cv ON mp.crop_variety_id = cv.crop_variety_id
+    WHERE cv.farm_id = farm_data.farm_id;
+
+    SELECT 
+        COALESCE(array_agg(pmp.planting_management_plan_id), ARRAY[]::UUID[])
+      INTO farm_data.pmp_ids
+    FROM "planting_management_plan" pmp
+    WHERE pmp.management_plan_id = ANY(farm_data.management_plan_ids);
+
+    SELECT
+      COALESCE(array_agg(DISTINCT mp.management_plan_group_id), ARRAY[]::UUID[])
+    INTO farm_data.management_plan_group_ids
+    FROM management_plan mp
+    WHERE mp.management_plan_id = ANY(farm_data.management_plan_ids)
+      AND mp.management_plan_group_id IS NOT NULL;
+
+    -- task IDs
+    SELECT 
+        COALESCE(array_agg(DISTINCT id), ARRAY[]::INTEGER[])
+    INTO farm_data.task_ids
+    FROM (
+        -- via task_type (custom tasks)
+        SELECT t.task_id           AS id
+        FROM "task" t
+        JOIN "task_type" tt ON t.task_type_id = tt.task_type_id
+        AND tt.farm_id = farm_record.farm_id
+
+        UNION
+
+        -- via location_tasks
+        SELECT lt.task_id          AS id
+        FROM "location_tasks" lt
+        JOIN "location" l ON lt.location_id = l.location_id
+        AND l.farm_id = farm_record.farm_id
+
+        UNION
+
+        -- via management_tasks + planting_manangement_plans
+        SELECT mt.task_id          AS id
+        FROM "management_tasks" mt
+        WHERE mt.planting_management_plan_id = ANY(farm_data.pmp_ids)
+
+        UNION
+
+        -- via transplant_task
+        SELECT tt.task_id          AS id
+        FROM transplant_task tt
+        WHERE tt.planting_management_plan_id = ANY(farm_data.pmp_ids)
+         OR tt.prev_planting_management_plan_id = ANY(farm_data.pmp_ids)
+
+        UNION
+
+        -- via planting management plan ids (plant tasks)
+        SELECT pt.task_id
+          FROM plant_task pt
+          WHERE pt.planting_management_plan_id = ANY(farm_data.pmp_ids)
+
+        UNION
+
+        -- via task_animal_relationship
+        SELECT tar.task_id         AS id
+        FROM "task_animal_relationship" tar
+        JOIN "animal" a ON tar.animal_id = a.id
+        AND a.farm_id = farm_record.farm_id
+
+        UNION
+
+        -- via task_animal_batch_relationship
+        SELECT tabr.task_id        AS id
+        FROM "task_animal_batch_relationship" tabr
+        JOIN "animal_batch" ab ON tabr.animal_batch_id = ab.id
+        AND ab.farm_id = farm_record.farm_id
+    ) AS farm_tasks;
+
+    -- soil amendment task products (needed for the purpose relationship table)
+    SELECT
+      COALESCE(array_agg(id), ARRAY[]::INTEGER[])
+    INTO farm_data.task_products_ids
+    FROM soil_amendment_task_products
+    WHERE task_id = ANY(farm_data.task_ids);
+
+    -- locations
+    SELECT 
+        COALESCE(array_agg(location_id), ARRAY[]::UUID[])
+    INTO farm_data.location_ids
+    FROM "location"
+    WHERE farm_id = farm_data.farm_id;
+
+    -- figures
+    SELECT 
+        COALESCE(array_agg(figure_id), ARRAY[]::UUID[])
+    INTO farm_data.figure_ids
+    FROM "figure"
+    WHERE location_id = ANY(farm_data.location_ids);
+
+    -- animals & batches
+    SELECT 
+        COALESCE(array_agg(id), ARRAY[]::INTEGER[])
+    INTO farm_data.animal_ids
+    FROM "animal"
+    WHERE farm_id = farm_data.farm_id;
+
+    SELECT 
+        COALESCE(array_agg(id), ARRAY[]::INTEGER[])
+    INTO farm_data.animal_batch_ids
+    FROM "animal_batch"
+    WHERE farm_id = farm_data.farm_id;
+
+    -- append this farm’s results
+    result.farms := array_append(result.farms, farm_data);
+  END LOOP;
+
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
**Description**

So sorry @SayakaOno -- I didn't set out to give you 900 lines of SQL to review when I was thinking about the fastest way to implement deletion 🙇 I also had forgotten about export at that time. I don't think this is an ideal method, and I'll mention some future improvements at the end of this description, but I think for now improving this isn't a very high priority overall.

## Explanation of the four scripts

I would lightly recommend reading the scripts in execution (numbered) order.

```
db/user_data_requests/
├──common/
    ├── 00-scoped_table_lists.sql 
    └── 01-user_data_indices.sql
├── 02-export_user_data.sql 
└── 03-delete_user_data.sql
```

The logic behind the scripts is that for user export, basically we want to to loop through a pattern that looks like this:

```sql
  SELECT json_build_object(
    'userLog', (
      SELECT json_agg(ul)
      FROM "userLog" ul
      WHERE ul.user_id = target_user_id
    ),
    -- ...
```

where we select the correct records from each table using some identifier (here, `user_id` on the `userLog` table) and add them to some big jsonb object that will be our export

For deletion, it's very similar:

```sql
DELETE FROM "userLog" WHERE user_id = target_user_id;
```

Initially, in the first pass I (with AI help) wrote out all our tables and the logic needed to select the right record, and just repeated it all for both [delete](https://github.com/LiteFarmOrg/LiteFarm/blob/0ca8d89aeacbb7f40cc0ec2c8ed97cc71649243e/packages/api/db/sql/deleteUserData.sql) and [export](https://github.com/LiteFarmOrg/LiteFarm/blob/0ca8d89aeacbb7f40cc0ec2c8ed97cc71649243e/packages/api/db/sql/exportUserData.sql).

The problem was that there was no way of keeping the two files in sync or making sure that the exact same data was exported and deleted, and that was the initial impetus for the current solution. Here, the two files in `common/` identify the tables to search and the ids to search under, and these are exported as functions for use in both the export and delete loops.

- **00-scoped_table_lists.sql:** manually groups all the tables in LiteFarm (including legacy tables that had some sort of data on prod) according to the primary identifier (`task_id`, `location_id`, `farm_id`) that can be traced back to a farm or user. The order of tables is catered to deletion, so that the records can be removed top to bottom without triggering FK violations 
- **01-user_data_indices.sql:** this script handles finding the actual record keys that we can delete / export on. It's slightly ugly, which I guess you could say comes from LiteFarm's own messiness when it comes to tying records to farms (especially when it comes to tasks).

Export and delete are kind of a messy mix (sorry) between SQL loops and manual writing-out. In essence I was just trying to programatically perform the loops described above, but I'm not that good at SQL, and in the end both export and delete run through the different table types in `00-scoped_table_lists.sql` manually, rather than in a programmatic way. That makes them kind of long to read through, but I'm not very good at SQL and I think writing any more SQL functions would have made them even harder to reason about.

The upside of the current approach is that the only file that should have to be updated in the future as our schema changes is `00-scoped_table_lists.sql`, particularly if we are mindful (and I think we should be) of making sure any new tables we create can be mapped to `farm_id` without too many joins. You can see that some tables (`soil_amendment_task_products_purpose_relationship` for instance) don't have this characteristic and I think in general we might want to avoid that level of complication in the future?

## Using the four scripts

The scripts should be run on your db in order. I just used the SQL query feature of Postico and copy-pasted each script there (into its own query file):

1. Run the `00-scoped_table_lists.sql` to populate the db with the getter functions which return the table lists
2. Run `01-user_data_indices.sql` to populate the db with `get_user_data()` and its required variables

It's not necessary for the flow, but if you want to inspect the identifiers that get output from `get_user_data()`, you can do that with:

```sql
SELECT to_jsonb(get_user_data) AS user_data
FROM get_user_data('user_id_here');
```

3. Copy `02-export_user_data.sql`, populate the correct `user_id` at the top of the file, and run. To save the output, I have been just right-clicking on the data > Copy special > Copy JSON. You could also just expand the data and select all. Using Copy JSON does create an unnecessary top-level array and key "export", but they can both be deleted.

Note: [jsonb doesn't preserve key order](https://www.postgresql.org/docs/current/datatype-json.html) so the order of tables under farm / user come out completely random. To look at them myself I have been sorting the JSON keys alphabetically with a Node script -- not included in the PR -- but I don't know if that is really necessary for export purposes.

The final overall export structure will be like this:

```js
{
  "user_id": "<user_id_here>",
  "exported_at": "<timestamp>",
  "export_type": "all_user_data",
  "data": {
    "farms": [
      {
        /* farm_scoped tables */
        "location_tasks": [
          // ...
        ],
        "task_document": [
          // ...
        ]
        // ...
      }
      /* additional farms, if present */
    ],

    /* user_scoped tables */
    "supportTicket": [
      // ...
    ],
    // ...
    "userLog": [
      // ...
    ],
    "users": [
      // ...
    ]
  }
}

```


5. Copy `03-delete_user_data.sql`, populate the correct `user_id` at the top of the file, uncomment the safety comment (to prevent accidental running), and run. By default the `COMMIT` of the transaction is commented out so you can inspect the deletion or `ROLLBACK;`. Note that if you disconnect from the db in Postico, it will rollback, _but if you shut down Postico without disconnecting, all transactions are committed_ (I learned this the hard way!)

Deletion should not work on farms with multiple `userFarm` records -- it will error.

## Issues / Future Improvements
As mentioned above, this is wrapped up at this point because it's not a high priority and probably not worth much dev time. If we had more time, I wonder if it would have been better to either:
- Use the `information_schema.table_constraints` to grab the tables and foreign keys and do something more automated in place of the two scripts in `common/` (which would avoid having to update `00-scoped_table_lists.sql` each time we add tables)
  - to be clear, I don't expect us to keep this file updated in general, though -- I think it can be updated when a deletion request comes in
- Handle this via the API. Looking back I regret entirely that this was done in SQL; I think would have been much less painful to write and understand in JS/TS with the ORM + `.withGraphFetched()`. To do this as a controller function I think it would be necessary to create some sort of `admin` auth level in the API, but maybe we already have the precedent via the job scheduler? In any case, the one advantage of this method of SQL run directly in the db is that we are completely un-tied to release in order to perform these requests.

Not the most beautiful or readable solution, but it should tide us over for all our current data policy requests.

Jira link: https://lite-farm.atlassian.net/browse/LF-4889

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Please see section above "Using the four scripts". I targetted a user account with a few single-user farms (you can also delete `userFarm` records to make an existing multi-user farm single-user) and ran the deletion without commit.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
