### PR TITLE
LF-3134: Cleaning tasks not updating null values on task complete

### DIFF
--- a/packages/api/src/models/cleaningTaskModel.js
+++ b/packages/api/src/models/cleaningTaskModel.js
@@ -63,6 +63,11 @@ class CleaningTaskModel extends Model {
         json.weight = null;
         json.weight_unit = null;
       }
+    } else if (json.product_quantity === null) {
+      json.volume = null;
+      json.volume_unit = null;
+      json.weight = null;
+      json.weight_unit = null;
     }
     delete json.product_quantity;
     delete json.product_quantity_unit;

--- a/packages/api/src/models/cleaningTaskModel.js
+++ b/packages/api/src/models/cleaningTaskModel.js
@@ -87,13 +87,15 @@ class CleaningTaskModel extends Model {
       properties: {
         task_id: { type: 'integer' },
         product_id: { type: ['integer', 'null'] },
-        other_purpose: { type: 'string' },
         cleaning_target: { type: ['string', 'null'] },
         agent_used: { type: ['boolean'] },
         water_usage: { type: ['number', 'null'] },
         water_usage_unit: { type: 'string', enum: ['ml', 'l', 'gal', 'fl-oz'] },
         product_quantity: { type: ['number', 'null'] },
-        product_quantity_unit: { type: 'string', enum: ['ml', 'l', 'gal', 'fl-oz'] },
+        product_quantity_unit: {
+          type: ['string', 'null'],
+          enum: ['ml', 'l', 'gal', 'fl-oz', null],
+        },
       },
       additionalProperties: false,
     };

--- a/packages/api/src/models/pestControlTask.js
+++ b/packages/api/src/models/pestControlTask.js
@@ -72,6 +72,11 @@ class PestControlTask extends Model {
         json.weight = null;
         json.weight_unit = null;
       }
+    } else if (json.product_quantity === null) {
+      json.volume = null;
+      json.volume_unit = null;
+      json.weight = null;
+      json.weight_unit = null;
     }
     delete json.product_quantity;
     delete json.product_quantity_unit;

--- a/packages/api/src/models/pestControlTask.js
+++ b/packages/api/src/models/pestControlTask.js
@@ -95,8 +95,8 @@ class PestControlTask extends Model {
         product_id: { type: ['integer', 'null'] },
         product_quantity: { type: ['number', 'null'] },
         product_quantity_unit: {
-          type: 'string',
-          enum: ['g', 'lb', 'kg', 't', 'mt', 'oz', 'l', 'gal', 'ml', 'fl-oz'],
+          type: ['string', 'null'],
+          enum: ['g', 'lb', 'kg', 't', 'mt', 'oz', 'l', 'gal', 'ml', 'fl-oz', null],
         },
         other_method: { type: ['string', 'null'] },
         pest_target: { type: ['string', 'null'] },

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -1790,6 +1790,7 @@ function fakeIrrigationTask(defaultData = {}) {
   return {
     irrigation_type_name: faker.helpers.arrayElement(['HAND_WATERING']),
     estimated_duration: faker.datatype.number(10),
+    measuring_type: 'DEPTH',
     ...defaultData,
   };
 }
@@ -1810,6 +1811,14 @@ function fakeScoutingTask(defaultData = {}) {
     type: faker.helpers.arrayElement(['harvest', 'pest', 'disease', 'weed', 'other']),
     ...defaultData,
   };
+}
+
+async function cleaning_taskFactory({ promisedTask = taskFactory() } = {}, cleaning_task = {}) {
+  const [activity] = await Promise.all([promisedTask]);
+  const [{ task_id }] = activity;
+  return knex('cleaning_task')
+    .insert({ task_id, ...cleaning_task })
+    .returning('*');
 }
 
 async function animal_movement_taskFactory(
@@ -2750,6 +2759,7 @@ export default {
   irrigation_taskFactory,
   fakeIrrigationTask,
   scouting_taskFactory,
+  cleaning_taskFactory,
   fakeScoutingTask,
   animal_movement_taskFactory,
   fakeAnimalMovementTask,

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -36,9 +36,12 @@ import {
   sampleNote,
   abandonTaskBody,
   expectTaskCompletionFields,
+  completeTaskRequest as completeTaskRequestAsync,
+  taskWithLocationFactory,
 } from './utils/taskUtils.js';
 import { setupFarmEnvironment } from './utils/testDataSetup.js';
 import { connectFarmToEnsemble } from './utils/ensembleUtils.js';
+import { taskCompletionFieldUpdateTestCases } from './utils/taskCompletionTestCases.js';
 
 describe('Task tests', () => {
   function assignTaskRequest({ user_id, farm_id }, data, task_id, callback) {
@@ -3010,6 +3013,79 @@ describe('Task tests', () => {
           expect(toLocal8601Extended(management_plan_2.start_date)).toBe(complete_date);
           expect(toLocal8601Extended(management_plan_3.start_date)).toBe(complete_date);
           done();
+        },
+      );
+    });
+
+    describe('should correctly modify task fields on completion', () => {
+      let farm_id;
+      let user_id;
+      let location_id;
+
+      beforeAll(async () => {
+        const { owner, farm, field } = await setupFarmEnvironment(1);
+        farm_id = farm.farm_id;
+        user_id = owner.user_id;
+        location_id = field.location_id;
+      });
+
+      describe.each(Object.entries(taskCompletionFieldUpdateTestCases))(
+        '%s',
+        (_description, testCases) => {
+          test.each(Object.entries(testCases))(`%s`, async (taskType, taskTypeTestCases) => {
+            for (const testCase of taskTypeTestCases) {
+              const {
+                initialData: initialTaskTypeData,
+                extraSetup,
+                getFakeCompletionData: getFakeTaskTypeCompletionData,
+                getExpectedData: getTaskTypeExpectedData,
+              } = testCase;
+
+              // Insert a task and location_task record
+              const { task_id } = await taskWithLocationFactory({
+                userId: user_id,
+                locationId: location_id,
+                farmId: farm_id,
+              });
+
+              // Create a task-type-specific record (e.g. soil_amendment_task, cleaning_task, etc.)
+              const [initialTaskTypeDataInDB] = await mocks[`${taskType}Factory`](
+                { promisedTask: [{ task_id }] },
+                initialTaskTypeData,
+              );
+
+              // extraSetup sets up task-type-specific related records (e.g. products, purposes, relationships)
+              const extraInitialDataInDB = extraSetup
+                ? await extraSetup(initialTaskTypeDataInDB, farm_id)
+                : {};
+
+              const fakeReqBody = {
+                ...fakeCompletionData,
+                ...getFakeTaskTypeCompletionData(initialTaskTypeDataInDB, extraInitialDataInDB),
+              };
+
+              const res = await completeTaskRequestAsync(
+                { user_id, farm_id },
+                fakeReqBody,
+                task_id,
+                taskType,
+              );
+
+              const completedTaskInDB = await knex('task').where({ task_id }).first();
+              const completedTaskTypeData = await knex(taskType).where({ task_id }).first();
+
+              expect(res.status).toBe(200);
+              expectTaskCompletionFields(completedTaskInDB, fakeCompletionData);
+
+              const expectedData = getTaskTypeExpectedData ? await getTaskTypeExpectedData() : {};
+
+              Object.entries(expectedData).forEach(([property, value]) => {
+                expect(completedTaskTypeData[property]).toBe(value);
+              });
+
+              await testCase.extraExpect?.(task_id);
+            }
+          });
         },
       );
     });

--- a/packages/api/tests/utils/taskCompletionTestCases.js
+++ b/packages/api/tests/utils/taskCompletionTestCases.js
@@ -1,0 +1,271 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { faker } from '@faker-js/faker';
+import knex from '../../src/util/knex.js';
+import { setupSoilAmendmentTaskDependencies } from './testDataSetup.js';
+
+// field_work_task
+const fieldWorkName = faker.lorem.word();
+const fieldWorkTaskTestCases = {
+  newFieldWorkType: {
+    getFakeCompletionData: (initialData) => ({
+      field_work_task: {
+        task_id: initialData.task_id,
+        field_work_task_type: {
+          label: 'Other',
+          value: 'OTHER',
+          field_work_name: fieldWorkName,
+        },
+      },
+    }),
+    getExpectedData: async () => {
+      const { field_work_type_id } = await knex('field_work_type')
+        .where({ field_work_name: fieldWorkName })
+        .first();
+
+      return { field_work_type_id };
+    },
+  },
+};
+
+// pest_control_task
+const pestControlTaskInitialData = {
+  weight: 2,
+  weight_unit: 'kg',
+  pest_target: 'Aphids',
+  control_method: 'foliarSpray',
+};
+const pestControlTaskTestCases = {
+  changeToMethodWithoutProduct: {
+    getFakeCompletionData: (initialData) => ({
+      pest_control_task: {
+        task_id: initialData.task_id,
+        product_quantity: null,
+        product_quantity_unit: null,
+        pest_target: null,
+        control_method: 'biologicalControl',
+      },
+    }),
+    getExpectedData: async () => {
+      return {
+        weight: null,
+        weight_unit: null,
+        volume: null,
+        volume_unit: null,
+        pest_target: null,
+        control_method: 'biologicalControl',
+      };
+    },
+  },
+};
+
+// cleaning_task
+const cleaningTaskInitialData = {
+  cleaning_target: 'Benches',
+  agent_used: true,
+  water_usage: 25,
+  water_usage_unit: 'l',
+  volume: 500,
+  volume_unit: 'ml',
+};
+const cleaningTaskTestCases = {
+  nullOptionalFields: {
+    getFakeCompletionData: (initialData) => ({
+      cleaning_task: {
+        task_id: initialData.task_id,
+        cleaning_target: null,
+        agent_used: false,
+        water_usage: null,
+        water_usage_unit: 'l', // required by model, cannot be null
+        product_quantity: null,
+        product_quantity_unit: null,
+      },
+    }),
+    getExpectedData: async () => ({
+      cleaning_target: null,
+      agent_used: false,
+      water_usage: null,
+      water_usage_unit: 'l',
+      volume: null,
+      volume_unit: null,
+    }),
+  },
+};
+
+// irrigation_task
+const irrigationTypeName = faker.lorem.word();
+const irrigationTaskInitialData = {
+  measuring_type: 'VOLUME',
+  estimated_duration: 60,
+  estimated_duration_unit: 'minutes',
+  estimated_flow_rate: 1.5,
+  estimated_flow_rate_unit: 'l/min',
+  estimated_water_usage: 90,
+  estimated_water_usage_unit: 'l',
+};
+const irrigationTaskFakeCompletionData = {
+  measuring_type: 'DEPTH',
+  irrigation_type_name: 'HAND_WATERING',
+  percent_of_location_irrigated: 3,
+  application_depth_unit: 'mm',
+  application_depth: 0.002,
+  estimated_water_usage: 388.74,
+  estimated_water_usage_unit: 'fl-oz',
+};
+const irrigationTaskTestCases = {
+  newIrrigationType: {
+    getFakeCompletionData: (initialData) => ({
+      irrigation_task: {
+        task_id: initialData.task_id,
+        irrigation_type_name: irrigationTypeName,
+        measuring_type: 'VOLUME',
+      },
+    }),
+    getExpectedData: async () => {
+      const { irrigation_type_id } = await knex('irrigation_type')
+        .where({ irrigation_type_name: irrigationTypeName })
+        .first();
+
+      return {
+        irrigation_type_id,
+        irrigation_type_name: irrigationTypeName,
+      };
+    },
+  },
+  switchMeasuringType: {
+    getFakeCompletionData: (initialData) => ({
+      irrigation_task: {
+        task_id: initialData.task_id,
+        irrigation_type_id: initialData.irrigation_type_id,
+        irrigation_type_name: initialData.irrigation_type_name,
+        ...irrigationTaskFakeCompletionData,
+      },
+    }),
+    getExpectedData: async () => {
+      return {
+        ...irrigationTaskFakeCompletionData,
+        // The following fields are kept but unused when measuring_type is 'DEPTH'
+        estimated_duration: 60,
+        estimated_duration_unit: 'minutes',
+        estimated_flow_rate: 1.5,
+        estimated_flow_rate_unit: 'l/min',
+      };
+    },
+  },
+};
+
+// soil_amendment_task
+const soilAmendmentTaskInitialData = {
+  furrow_hole_depth: 10,
+  furrow_hole_depth_unit: 'cm',
+};
+const soilAmendmentTaskProductFakeCompletionData = {
+  weight: null,
+  weight_unit: null,
+  volume: 3,
+  volume_unit: 'l',
+  application_rate_weight_unit: null,
+  application_rate_volume_unit: 'l/ha',
+  total_area_amended: 10321,
+  percent_of_location_amended: 50,
+};
+const soilAmendmentTaskProductInitialDataSetup = async (initialData, farmId) => {
+  return setupSoilAmendmentTaskDependencies({
+    farmId,
+    taskId: initialData.task_id,
+    soilAmendmentTaskProductData: {
+      weight: 1,
+      weight_unit: 'kg',
+      application_rate_weight_unit: 'kg/ha',
+      percent_of_location_amended: 100,
+      total_area_amended: 20642,
+    },
+  });
+};
+const soilAmendmentTaskTestCases = {
+  nullOptionalFields: {
+    getFakeCompletionData: (initialData) => ({
+      soil_amendment_task: {
+        task_id: initialData.task_id,
+        furrow_hole_depth: null,
+        furrow_hole_depth_unit: null,
+      },
+    }),
+    getExpectedData: async () => {
+      return {
+        furrow_hole_depth: null,
+        furrow_hole_depth_unit: null,
+      };
+    },
+  },
+  switchWeightToVolume: {
+    getFakeCompletionData: (_initialData, associatedInitialData) => {
+      const { soilAmendmentTaskProduct, soilAmendmentTaskProductsPurposeRelationship } =
+        associatedInitialData;
+
+      const soilAmendmentProduct = {
+        ...soilAmendmentTaskProduct,
+        ...soilAmendmentTaskProductFakeCompletionData,
+        purpose_relationships: [soilAmendmentTaskProductsPurposeRelationship],
+      };
+
+      return { soil_amendment_task_products: [soilAmendmentProduct] };
+    },
+    extraExpect: async (taskId) => {
+      const soilAmendmentTaskProduct = await knex('soil_amendment_task_products')
+        .where({ task_id: taskId })
+        .first();
+
+      Object.entries(soilAmendmentTaskProductFakeCompletionData).forEach(([property, value]) => {
+        expect(soilAmendmentTaskProduct[property]).toBe(value);
+      });
+    },
+  },
+};
+
+export const taskCompletionFieldUpdateTestCases = {
+  'should update relevant fields': {
+    irrigation_task: [
+      { initialData: irrigationTaskInitialData, ...irrigationTaskTestCases.switchMeasuringType },
+    ],
+  },
+  'should remove irrelevant fields': {
+    cleaning_task: [
+      { initialData: cleaningTaskInitialData, ...cleaningTaskTestCases.nullOptionalFields },
+    ],
+    pest_control_task: [
+      {
+        initialData: pestControlTaskInitialData,
+        ...pestControlTaskTestCases.changeToMethodWithoutProduct,
+      },
+    ],
+    soil_amendment_task: [
+      {
+        initialData: soilAmendmentTaskInitialData,
+        ...soilAmendmentTaskTestCases.nullOptionalFields,
+      },
+      {
+        initialData: soilAmendmentTaskInitialData,
+        extraSetup: soilAmendmentTaskProductInitialDataSetup,
+        ...soilAmendmentTaskTestCases.switchWeightToVolume,
+      },
+    ],
+  },
+  'should add new type on completion': {
+    field_work_task: [{ initialData: {}, ...fieldWorkTaskTestCases.newFieldWorkType }],
+    irrigation_task: [{ initialData: {}, ...irrigationTaskTestCases.newIrrigationType }],
+  },
+};

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -240,3 +240,32 @@ export function expectTaskCompletionFields(
   expect(task.happiness).toBe(happiness);
   expect(task.completion_notes).toBe(completion_notes);
 }
+
+export const taskWithLocationFactory = async ({ userId, locationId, taskTypeId, farmId }) => {
+  if (!taskTypeId && farmId) {
+    const taskType = await mocks.task_typeFactory({
+      promisedFarm: Promise.resolve([{ farm_id: farmId }]),
+    });
+    taskTypeId = taskType[0].task_type_id;
+  }
+
+  const fakeTask = mocks.fakeTask({
+    task_type_id: taskTypeId,
+    owner_user_id: userId,
+    assignee_user_id: userId,
+  });
+
+  const [task] = await mocks.taskFactory(
+    {
+      promisedUser: Promise.resolve([{ user_id: userId }]),
+      promisedTaskType: Promise.resolve([{ task_type_id: taskTypeId }]),
+    },
+    fakeTask,
+  );
+  await mocks.location_tasksFactory({
+    promisedTask: Promise.resolve([task]),
+    promisedField: Promise.resolve([{ location_id: locationId }]),
+  });
+
+  return task;
+};

--- a/packages/api/tests/utils/testDataSetup.ts
+++ b/packages/api/tests/utils/testDataSetup.ts
@@ -13,6 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import knex from '../../src/util/knex.js';
 import mocks from '../mock.factories.js';
 import LocationModel from '../../src/models/locationModel.js';
 import { Farm, Location, User } from '../../src/models/types.js';
@@ -135,3 +136,51 @@ export async function createField(farm: Farm) {
 
   return field;
 }
+
+export const setupSoilAmendmentTaskDependencies = async ({
+  farmId,
+  taskId,
+  soilAmendmentTaskProductData = {},
+}: {
+  farmId: string;
+  taskId: string;
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  soilAmendmentTaskProductData: { [key: string]: any };
+}) => {
+  const [product] = await mocks.productFactory(
+    { promisedFarm: Promise.resolve([{ farm_id: farmId }]) },
+    mocks.fakeProduct({ type: 'soil_amendment_task' }),
+  );
+  // Make product details available
+  await mocks.soil_amendment_productFactory({
+    promisedProduct: Promise.resolve([product]),
+  });
+
+  const [soilAmendmentPurpose] = await mocks.soil_amendment_purposeFactory();
+
+  const fakeSoilAmendmentTaskProduct = mocks.fakeSoilAmendmentTaskProduct({
+    product_id: product.product_id,
+    ...soilAmendmentTaskProductData,
+  });
+
+  const [soilAmendmentTaskProduct] = await mocks.soil_amendment_task_productsFactory(
+    { promisedTask: Promise.resolve([{ task_id: taskId }]) },
+    fakeSoilAmendmentTaskProduct,
+  );
+
+  const soilAmendmentProduct = await knex('soil_amendment_product')
+    .where({ product_id: product.product_id })
+    .first();
+
+  const [soilAmendmentTaskProductsPurposeRelationship] = await knex(
+    'soil_amendment_task_products_purpose_relationship',
+  )
+    .insert({ task_products_id: soilAmendmentTaskProduct.id, purpose_id: soilAmendmentPurpose.id })
+    .returning('*');
+
+  return {
+    soilAmendmentProduct,
+    soilAmendmentTaskProduct,
+    soilAmendmentTaskProductsPurposeRelationship,
+  };
+};

--- a/packages/webapp/src/components/Task/CleaningTask/index.jsx
+++ b/packages/webapp/src/components/Task/CleaningTask/index.jsx
@@ -28,9 +28,9 @@ const PureCleaningTask = ({
 
   useEffect(() => {
     if (isCleaningAgentUsed === false && getValues('cleaning_task.product')) {
-      setValue('cleaning_task.product', null);
+      setValue('cleaning_task.product', undefined);
       setValue('cleaning_task.product_id', null);
-      setValue('cleaning_task.product_quantity', undefined);
+      setValue('cleaning_task.product_quantity', null);
       setValue('cleaning_task.product_quantity_unit', null, { shouldValidate: true });
     }
   }, [isCleaningAgentUsed]);

--- a/packages/webapp/src/components/Task/PestControlTask/index.jsx
+++ b/packages/webapp/src/components/Task/PestControlTask/index.jsx
@@ -50,9 +50,9 @@ const PurePestControlTask = ({
       controlMethodExposedValue?.value &&
       !productPests.includes(controlMethodExposedValue?.value)
     ) {
-      setValue('pest_control_task.product', null);
+      setValue('pest_control_task.product', undefined);
       setValue('pest_control_task.product_id', null);
-      setValue('pest_control_task.product_quantity', undefined);
+      setValue('pest_control_task.product_quantity', null);
       setValue('pest_control_task.product_quantity_unit', null, { shouldValidate: true });
     }
     if (controlMethodExposedValue?.value !== 'other') {

--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -30,6 +30,13 @@ const soilAmendmentContinueDisabled = (needsChange, isValid) => {
   return !isValid;
 };
 
+const getFieldsToKeep = (taskType) => {
+  if (!taskType || taskType.farm_id) {
+    return [];
+  }
+  return [taskType.task_translation_key.toLowerCase()];
+};
+
 export default function PureCompleteStepOne({
   persistedFormData,
   onContinue,
@@ -74,7 +81,7 @@ export default function PureCompleteStepOne({
   const {
     persistedData: { uploadedFiles },
     historyCancel,
-  } = useHookFormPersist(getValues);
+  } = useHookFormPersist(getValues, [], getFieldsToKeep(selectedTaskType));
 
   const CHANGES_NEEDED = 'need_changes';
   const changesRequired = watch(CHANGES_NEEDED);

--- a/packages/webapp/src/containers/hooks/useHookFormPersist/hookFormPersistSlice.js
+++ b/packages/webapp/src/containers/hooks/useHookFormPersist/hookFormPersistSlice.js
@@ -9,10 +9,13 @@ export const initialState = {
   isRedrawing: false,
 };
 
-const getCorrectedPayload = (payload) => {
-  const result = cloneObject(payload);
+const getCorrectedPayload = (payload, propertiesToKeep) => {
+  const result = structuredClone(payload);
   const removeNullValues = (object) => {
     for (const key in object) {
+      if (propertiesToKeep?.includes(key)) {
+        continue;
+      }
       if (object[key] !== null && typeof object[key] === 'object') {
         removeNullValues(object[key]);
       } else if (!object[key] && object[key] !== 0 && object[key] !== false) {
@@ -45,7 +48,8 @@ const hookFormPersistSlice = createSlice({
       Object.assign(state.formData, payload);
     },
     hookFormPersistUnMount: (state, { payload }) => {
-      Object.assign(state.formData, getCorrectedPayload(payload));
+      const { values, propertiesToKeep } = payload;
+      Object.assign(state.formData, getCorrectedPayload(values, propertiesToKeep));
     },
     setFormData: (state, { payload }) => {
       state.formData = payload;

--- a/packages/webapp/src/containers/hooks/useHookFormPersist/index.jsx
+++ b/packages/webapp/src/containers/hooks/useHookFormPersist/index.jsx
@@ -12,7 +12,19 @@ import {
 import { useCallback, useEffect, useLayoutEffect } from 'react';
 import history from '../../../history';
 
-export default function useHookFormPersist(getValues = () => ({}), persistedPathNames = []) {
+/**
+ * Persists form values when navigating between routes.
+ *
+ * @param {Function} getValues - Returns the current form values.
+ * @param {string[]} persistedPathNames - Route paths where form data should be preserved.
+ * @param {string[]} formFieldsToKeep - Field names that should not be removed during cleanup, even if null or empty.
+ * @returns {{ persistedData: any, historyCancel: Function }}
+ */
+export default function useHookFormPersist(
+  getValues = () => ({}),
+  persistedPathNames = [],
+  formFieldsToKeep = [],
+) {
   const dispatch = useDispatch();
 
   const historyStack = useSelector(hookFormPersistHistoryStackSelector);
@@ -36,7 +48,9 @@ export default function useHookFormPersist(getValues = () => ({}), persistedPath
         persistedPathsSet.has(history.location.pathname) ||
         persistedPathNames.includes(history.location.pathname)
       ) {
-        dispatch(hookFormPersistUnMount(getValues()));
+        dispatch(
+          hookFormPersistUnMount({ values: getValues(), propertiesToKeep: formFieldsToKeep }),
+        );
         switch (history.action) {
           case 'PUSH':
             dispatch(pushHistoryStack(history.location.pathname));


### PR DESCRIPTION
**Description**

This PR fixes an issue where null values were not being added (e.g. product-related fields in cleaning and pest control tasks) to the DB on task completion. The major cause was the frontend not sending null values. The backend has also been updated to accept them.

Details:
- Update `cleaningTaskModel` and `pestControlTaskModel` to accept `null` for `product_quantity`.
- Add tests for task completion. (`npm run test /task.test`)
- Update `CleaningTask` and `PestControlTask` components to properly clear product info when removed.
- Update `hookFormPersistUnMount` (triggered during page transitions) not to remove `null` values for specified properties. (`propertiesToKeep` parameter is added to the `getCorrectedPayload` function)

NOTE:
- For irrigation tasks, there's currently no logic on either frontend or backend to remove irrelevant fields based on the selected method type. These fields are hidden in the UI, so I'll leave this as is.
- I plan to add tests for plant and transplant tasks later when I work on task re-completion tests. (I didn't have the energy left for that in this PR...)

Jira link: https://lite-farm.atlassian.net/browse/LF-3134

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
