### PR TITLE
LF-4888 Modify task deletion to accept IP id and update task status on deletion

### DIFF
--- a/packages/api/src/controllers/taskController.js
+++ b/packages/api/src/controllers/taskController.js
@@ -38,7 +38,7 @@ import AnimalMovementPurposeModel from '../models/animalMovementPurposeModel.js'
 import { ANIMAL_TASKS } from '../util/animal.js';
 import { CUSTOM_TASK } from '../util/task.js';
 import { customError } from '../util/customErrors.js';
-import { triggerPostTaskCreatedActions } from '../services/task.js';
+import { triggerPostTaskCreatedActions, triggerPostTaskDeletedActions } from '../services/task.js';
 import {
   checkCompleteTaskDocument,
   checkCreateTaskDocument,
@@ -1063,7 +1063,15 @@ const taskController = {
         farm_id,
       );
 
-      return res.status(200).send(result);
+      res.status(200).send(result);
+
+      triggerPostTaskDeletedActions(
+        result.taskType.farm_id
+          ? 'custom_task'
+          : result.taskType.task_translation_key.toLowerCase(),
+        result,
+        farm_id,
+      );
     } catch (error) {
       console.error(error);
       return res.status(400).json({ error });

--- a/packages/api/src/models/taskModel.js
+++ b/packages/api/src/models/taskModel.js
@@ -519,6 +519,7 @@ class TaskModel extends BaseModel {
 
     const relatedProductTable = `${taskTypeKey}_products`;
 
+    let response;
     if (!farm_id && taskTypesWithProducts.includes(taskTypeKey)) {
       // Mark related products as deleted
       await TaskModel.relatedQuery(relatedProductTable, trx)
@@ -526,14 +527,16 @@ class TaskModel extends BaseModel {
         .context(user)
         .patch({ deleted: true });
       // Mark the task itself as deleted and fetch the updated task
-      return await TaskModel.query(trx)
+      response = await TaskModel.query(trx)
         .withGraphFetched(relatedProductTable)
         .context({ ...user, showHidden: true })
         .patchAndFetchById(task_id, { deleted: true });
     } else {
       // If the task is custom or does not have associated product, delete just the task
-      return TaskModel.deleteTask(task_id, user, trx);
+      response = await TaskModel.deleteTask(task_id, user, trx);
     }
+    response.taskType = taskType;
+    return response;
   }
 
   static async getTaskIdsWithAnimalAndBatchIds(trx, taskIds) {

--- a/packages/api/src/services/task.ts
+++ b/packages/api/src/services/task.ts
@@ -13,15 +13,17 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import TaskModel from '../models/taskModel.js';
 import {
   safeGetFarmEnsembleAddonIds,
   patchIrrigationPrescriptionApproval,
 } from '../util/ensembleService.js';
 import { IRRIGATION_TASK, TASK_TYPES } from '../util/task.js';
+import type { Task as BaseTask } from '../models/types.js';
 
 type TaskType = (typeof TASK_TYPES)[number];
 
-interface Task {
+interface Task extends BaseTask {
   irrigation_task?: {
     irrigation_prescription_external_id?: number;
   };
@@ -48,6 +50,46 @@ export async function triggerPostTaskCreatedActions(
               return;
             }
             await patchIrrigationPrescriptionApproval(esciExternalId, farmAddon.org_pk, true);
+          }
+        }
+        break;
+
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+/**
+ * Non‑blocking post‑response side effects; do not send HTTP responses here
+ */
+export async function triggerPostTaskDeletedActions(
+  typeOfTask: TaskType,
+  deletedTask: Task,
+  farm_id: string,
+) {
+  try {
+    switch (typeOfTask) {
+      case IRRIGATION_TASK:
+        {
+          const { irrigation_prescription_external_id: esciExternalId } =
+            (await TaskModel
+              // @ts-expect-error known issue on models
+              .query()
+              .joinRelated('irrigation_task')
+              .select('irrigation_task.irrigation_prescription_external_id')
+              .where('task.task_id', deletedTask.task_id)
+              .first()) || {};
+
+          if (esciExternalId) {
+            const farmAddon = await safeGetFarmEnsembleAddonIds(farm_id);
+            if (!farmAddon) {
+              console.error(`Ensemble organization not found for farm ${farm_id}`);
+              return;
+            }
+            await patchIrrigationPrescriptionApproval(esciExternalId, farmAddon.org_pk, false);
           }
         }
         break;

--- a/packages/api/src/services/task.ts
+++ b/packages/api/src/services/task.ts
@@ -47,7 +47,7 @@ export async function triggerPostTaskCreatedActions(
               console.error(`Ensemble organization not found for farm ${farm_id}`);
               return;
             }
-            await patchIrrigationPrescriptionApproval(esciExternalId, farmAddon.org_pk);
+            await patchIrrigationPrescriptionApproval(esciExternalId, farmAddon.org_pk, true);
           }
         }
         break;

--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -466,13 +466,17 @@ function selectCropData(managementPlan: ManagementPlan) {
   ];
 }
 
-/* Update Ensemble to indicate an irrigation prescription has been approved */
-export async function patchIrrigationPrescriptionApproval(id: number, org_pk: number) {
+/* Update Ensemble to indicate an irrigation prescription has been approved or un-approved */
+export async function patchIrrigationPrescriptionApproval(
+  id: number,
+  org_pk: number,
+  approved: boolean,
+) {
   try {
     const axiosObject = {
       method: 'patch',
       data: {
-        approved: true,
+        approved,
       },
       url: `${ensembleAPI}/organizations/${org_pk}/prescriptions/${id}/`,
     };

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -1324,8 +1324,11 @@ function fakePesticide(defaultData = {}) {
 }
 
 function fakeTaskType(defaultData = {}) {
+  const task_name = faker.lorem.word();
+  const task_translation_key = defaultData.task_translation_key ?? task_name;
   return {
-    task_name: faker.lorem.word(),
+    task_name,
+    task_translation_key,
     ...defaultData,
   };
 }

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -38,6 +38,7 @@ import {
   expectTaskCompletionFields,
   irrigationTaskGenerator,
   completeTaskRequest as completeTaskRequestAsync,
+  deleteTaskRequest as deleteTaskRequestAsync,
   taskWithLocationFactory,
 } from './utils/taskUtils.js';
 import { setupFarmEnvironment } from './utils/testDataSetup.js';
@@ -3513,11 +3514,10 @@ describe('Task tests', () => {
         },
       });
 
-      const res = await chai
-        .request(server)
-        .delete(`/task/${task.task_id}`)
-        .set('user_id', user.user_id)
-        .set('farm_id', farm.farm_id);
+      const res = await deleteTaskRequestAsync(
+        { user_id: user.user_id, farm_id: farm.farm_id },
+        task.task_id,
+      );
 
       expect(res.status).toBe(200);
 

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -221,23 +221,12 @@ export const irrigationTaskGenerator = async ({ farm, user, field, irrigation })
     },
   );
 
-  // Insert the main task record
-  const [task] = await mocks.taskFactory(
-    {
-      promisedUser: Promise.resolve([user]),
-      promisedFarm: Promise.resolve([farm]),
-      promisedTaskType: Promise.resolve([irrgationTaskType]),
-    },
-    mocks.fakeTask({
-      task_type_id: irrgationTaskType.task_type_id,
-      owner_user_id: user.user_id,
-    }),
-  );
-
-  // Insert to location_tasks
-  await mocks.location_tasksFactory({
-    promisedTask: Promise.resolve([task]),
-    promisedField: Promise.resolve([field]),
+  // Insert the main task record + location_tasks record
+  const task = await taskWithLocationFactory({
+    userId: user.user_id,
+    locationId: field.location_id,
+    taskTypeId: irrgationTaskType.task_type_id,
+    farmId: farm.farm_id,
   });
 
   // Insert the irrigation_task record

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -210,6 +210,45 @@ export const animalTaskGenerator = async (taskData) => {
   return createdTask;
 };
 
+export const irrigationTaskGenerator = async ({ farm, user, field, irrigation }) => {
+  // Generate the irrigation task type
+  const [irrgationTaskType] = await mocks.task_typeFactory(
+    { promisedFarm: Promise.resolve([farm]) },
+    {
+      farm_id: null,
+      task_name: 'Irrigation',
+      task_translation_key: 'IRRIGATION_TASK',
+    },
+  );
+
+  // Insert the main task record
+  const [task] = await mocks.taskFactory(
+    {
+      promisedUser: Promise.resolve([user]),
+      promisedFarm: Promise.resolve([farm]),
+      promisedTaskType: Promise.resolve([irrgationTaskType]),
+    },
+    mocks.fakeTask({
+      task_type_id: irrgationTaskType.task_type_id,
+      owner_user_id: user.user_id,
+    }),
+  );
+
+  // Insert to location_tasks
+  await mocks.location_tasksFactory({
+    promisedTask: Promise.resolve([task]),
+    promisedField: Promise.resolve([field]),
+  });
+
+  // Insert the irrigation_task record
+  const [irrigationTask] = await mocks.irrigation_taskFactory(
+    { promisedTask: Promise.resolve([task]) },
+    irrigation,
+  );
+
+  return { task, irrigationTask };
+};
+
 export const generateUserFarms = async (number) => {
   const userFarms = [];
   const [user] = await mocks.usersFactory();

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -212,7 +212,7 @@ export const animalTaskGenerator = async (taskData) => {
 
 export const irrigationTaskGenerator = async ({ farm, user, field, irrigation }) => {
   // Generate the irrigation task type
-  const [irrgationTaskType] = await mocks.task_typeFactory(
+  const [irrigationTaskType] = await mocks.task_typeFactory(
     { promisedFarm: Promise.resolve([farm]) },
     {
       farm_id: null,
@@ -225,7 +225,7 @@ export const irrigationTaskGenerator = async ({ farm, user, field, irrigation })
   const task = await taskWithLocationFactory({
     userId: user.user_id,
     locationId: field.location_id,
-    taskTypeId: irrgationTaskType.task_type_id,
+    taskTypeId: irrigationTaskType.task_type_id,
     farmId: farm.farm_id,
   });
 

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -103,6 +103,14 @@ export async function abandonTaskRequest({ user_id, farm_id }, data, task_id) {
     .send(data);
 }
 
+export async function deleteTaskRequest({ user_id, farm_id }, task_id) {
+  return chai
+    .request(server)
+    .delete(`/task/${task_id}`)
+    .set('user_id', user_id)
+    .set('farm_id', farm_id);
+}
+
 export function fakeUserFarm(role = 1) {
   return { ...mocks.fakeUserFarm(), role_id: role };
 }

--- a/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskReadOnly/index.jsx
@@ -65,7 +65,7 @@ function TaskReadOnly({ history, match, location }) {
   if (externalIrrigationPrescription?.prescription?.vriData?.file_url) {
     files.push({ url: externalIrrigationPrescription.prescription.vriData.file_url });
   }
-  if (task.documents?.length) {
+  if (task?.documents?.length) {
     const documentFiles = task.documents.flatMap((doc) => doc.files);
     files.push(...documentFiles);
   }


### PR DESCRIPTION
**Description**

This PR adds patching an Ensemble IP as `approved: false` after we delete a task that had an `irrigation_prescription_external_id` associated with it, keeping the Ensemble state in sync with LiteFarm.

The PR includes:
- tiny update to `patchIrrigationPrescriptionApproval()` so we can use it for passing both kinds of patch
- the `triggerPostTaskDeletedActions()` side-effect function that mirrors `triggerPostTaskCreatedActions`
  - The logic is slightly more involved only because the deleted task (unlike the created task) is not returned with the whole graph of task type + task type-specific tables
  - this missing graph is also the reason for the slight modification of the `deleteTaskAndTaskProduct` model method, to return some task type information
- test case + one supporting utility function for it
- two minor bug fixes I'll indicate in-line. Neither are specific to this feature, but I noticed both while working on it

Jira link: https://lite-farm.atlassian.net/browse/LF-4888

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

The call to Ensemble is silent from the app perspective, but you can debugger on the `onError` of the patch request, or watch your API console to see the 400 error that (currently) results from this request, which happens to be

```json
{
    "detail": "Prescription already approved"
}
```

Ultimately we expect a 200 or 204 from this once they update their endpoint.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
