### PR TITLE
LF-4896 Water consumption is incorrectly showing as 0 for URI prescriptions with 0 to 360º arcs

### DIFF
--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -283,7 +283,7 @@ const calculateURIWaterConsumption = (
 
   let pivotAreaM2;
   if (startAngle !== undefined && endAngle !== undefined) {
-    const angleDiff = (startAngle - endAngle + 360) % 360;
+    const angleDiff = (startAngle - endAngle + 360) % 360 || 360;
     const proportion = angleDiff / 360;
     pivotAreaM2 = proportion * Math.PI * Math.pow(pivotRadius, 2);
   } else {

--- a/packages/api/tests/irrigation_prescription.test.ts
+++ b/packages/api/tests/irrigation_prescription.test.ts
@@ -422,9 +422,9 @@ describe('Get Irrigation Prescription Tests', () => {
         data: await generateMockPrescriptionDetails({
           farm_id: farm.farm_id,
           irrigationPrescriptionId: MOCK_ID,
-          applicationDepths: [20], // in mm
-          pivotRadius: 100, // in meters
-          pivotArc: { start_angle: '0', end_angle: '360' }, // counter-clockwise, in mathematical degrees (3/4 circle)
+          applicationDepths: [20],
+          pivotRadius: 100,
+          pivotArc: { start_angle: '0', end_angle: '360' },
         }),
       });
 


### PR DESCRIPTION
**Description**

The water consumption calculation was relying on `% 360` to calculate the proportion of the circle covered, and so incorrectly returned 0 for all full circles instead of 1. A test case was added.

Jira link: https://lite-farm.atlassian.net/browse/LF-4896

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
