### PR TITLE
LF-4903: It is not quite clear how you are going to override wage

### DIFF
--- a/packages/webapp/src/components/Form/Input/index.jsx
+++ b/packages/webapp/src/components/Form/Input/index.jsx
@@ -150,13 +150,13 @@ const Input = ({
             onClick={setVisibility}
           />
         ))}
-      {unit && <div className={styles.unit}>{unit}</div>}
       {currency && (
         <div ref={currencyRef} className={styles.currency}>
           {currency}
         </div>
       )}
       <div className={styles.inputWrapper}>
+        {unit && <div className={styles.unit}>{unit}</div>}
         {showError && !unit && showCross && (
           <Cross
             className={clsx(styles.clearIcon, inputType === 'date' && styles.date)}

--- a/packages/webapp/src/components/Form/Input/input.module.scss
+++ b/packages/webapp/src/components/Form/Input/input.module.scss
@@ -129,7 +129,7 @@ input:focus::placeholder {
   @include fontFamily();
   position: absolute;
   right: 0;
-  transform: translate(-8px, 33px);
+  transform: translate(-8px, 14px);
 }
 
 .currency {

--- a/packages/webapp/src/stories/Form/Input/Input.stories.jsx
+++ b/packages/webapp/src/stories/Form/Input/Input.stories.jsx
@@ -103,6 +103,12 @@ WithUnit.args = {
   unit: 'unit',
 };
 
+export const WithUnitWithoutLabel = Template.bind({});
+WithUnitWithoutLabel.args = {
+  type: 'number',
+  unit: 'unit',
+};
+
 export const WithCurrency = Template.bind({});
 WithCurrency.args = {
   label: 'number',


### PR DESCRIPTION
**Description**

Fix the input component to display unit.
This bug was introduced in [v3.6.0](https://github.com/LiteFarmOrg/LiteFarm/releases/tag/v3.6.0) (Jan 4, 2024) when a background-color was added to the input ([change](https://github.com/LiteFarmOrg/LiteFarm/commit/188ea18033955eeb73e01c160e66b853eba3b332#diff-5a6c95d26a738de469dde15213a917c5371419433cca79068b676e5dd4541766)).

Previously, the unit was positioned absolutely relative to the container with the label, which caused it to be hidden by the background colour.
Without a label, this would cause the unit to be misaligned, similar to the clear button issue (https://github.com/LiteFarmOrg/LiteFarm/pull/3764).
Even though this issue hasn't seen in the app,  I **moved the unit to the input wrapper and adjusted its position** instead of relying on `z-index`.
- [Unit without label story](http://localhost:6006/?path=/story/components-input--with-unit-without-label)

Jira link: https://lite-farm.atlassian.net/browse/LF-4903

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
