### PR TITLE
LF-4901: Clear All button overlaps the continue button on the footer of the app

### DIFF
--- a/packages/webapp/src/components/Task/MovementTask/styles.module.scss
+++ b/packages/webapp/src/components/Task/MovementTask/styles.module.scss
@@ -17,7 +17,6 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  margin-bottom: -8px;
   z-index: 1; // make sure clear all remains clickable
 }
 


### PR DESCRIPTION
**Description**

Resolve button overlap by removing the negative `margin-bottom`.

The negative margin was likely added for the task creation view:
<img width="668" height="246" alt="Screenshot 2025-07-31 at 2 01 58 PM" src="https://github.com/user-attachments/assets/defbbd4a-ca24-4329-bdb8-60ebe858ce3c" />

Here's the completion view with the fix. It's still not ideal especially on mobile devices:
<img width="670" height="174" alt="Screenshot 2025-07-31 at 2 00 34 PM" src="https://github.com/user-attachments/assets/e660f2d4-adaa-4bd4-82f1-a83a20bee32e" />

Adding a positive margin would make the creation view look awkward, so the current fix is just to remove the negative margin 😔 Please let me know if there's a better approach!

Both the clear button not being included in React Select’s height and the way the form layout is implemented are tricky to work with...

Jira link: https://lite-farm.atlassian.net/browse/LF-4901

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
