### PR TITLE
LF-4909 The user should be redirected to the IP view once he clicks on it through notifications

### DIFF
--- a/packages/webapp/src/containers/Notification/index.jsx
+++ b/packages/webapp/src/containers/Notification/index.jsx
@@ -64,7 +64,15 @@ export default function NotificationPage() {
           <NotificationCard
             key={notification.notification_id}
             variables={notification.variables}
-            onClick={() => dispatch(readNotification(notification.notification_id))}
+            onClick={() =>
+              dispatch(
+                readNotification({
+                  notificationId: notification.notification_id,
+                  notificationType: notification.context?.notification_type,
+                  redirectUrl: notification.ref?.url,
+                }),
+              )
+            }
             {...notification}
           />
         );

--- a/packages/webapp/src/containers/Notification/saga.js
+++ b/packages/webapp/src/containers/Notification/saga.js
@@ -39,17 +39,24 @@ export function* getNotificationSaga() {
 
 export const readNotification = createAction('readNotificationSaga');
 
-export function* readNotificationSaga({ payload }) {
+export function* readNotificationSaga({
+  payload: { notificationId, notificationType, redirectUrl },
+}) {
   const { user_id, farm_id } = yield select(userFarmSelector);
   const header = getHeader(user_id, farm_id);
   try {
     yield call(
       axios.patch,
       notificationsUrl,
-      { notification_ids: [payload], status: 'Read' },
+      { notification_ids: [notificationId], status: 'Read' },
       header,
     );
-    history.push(`/notifications/${payload}/read_only`);
+
+    if (notificationType === 'NEW_IRRIGATION_PRESCRIPTION' && redirectUrl) {
+      history.push(redirectUrl);
+    } else {
+      history.push(`/notifications/${notificationId}/read_only`);
+    }
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
**Description**

This PR removes the redirect through the `<NotificationReadOnly />` component (screenshot), and routes directly to the same URL as used by the "Take me there" button:

<img width="815" height="256" alt="Screenshot 2025-07-31 at 12 58 39 PM" src="https://github.com/user-attachments/assets/2cbd2f85-7224-4bab-95c8-674c87996997" />

This PR only affects IP notifications, but as the redirect defined is defined within a saga, this is actually a pretty easy behaviour to change for other types if we want to.

Jira link: https://lite-farm.atlassian.net/issues/?filter=-4&selectedIssue=LF-4909

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
