### PR TITLE
LF-4228: Product and supplier fields are not populated once user tries to complete soil amendment task with newly created product

### DIFF
--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -106,6 +106,7 @@ import {
   getEndpoint,
   getMovementTaskBody,
   getSoilSampleTaskBody,
+  postTaskRequestHasNewProduct,
 } from './sagaUtils';
 import { api } from '../../store/api/apiSlice';
 
@@ -647,18 +648,14 @@ export function* createTaskSaga({ payload }) {
       managementPlanWithCurrentLocationEntitiesSelector,
     );
     data = getCompleteCustomTaskTypeBody(data, task_translation_key);
-    const result = yield call(
-      axios.post,
-      `${taskUrl}/${endpoint}`,
-      getPostTaskReqBody(
-        data,
-        endpoint,
-        task_translation_key,
-        isCustomTask,
-        managementPlanWithCurrentLocationEntities,
-      ),
-      header,
+    const reqBody = getPostTaskReqBody(
+      data,
+      endpoint,
+      task_translation_key,
+      isCustomTask,
+      managementPlanWithCurrentLocationEntities,
     );
+    const result = yield call(axios.post, `${taskUrl}/${endpoint}`, reqBody, header);
     if (result) {
       const { task_id, taskType } =
         task_translation_key === 'HARVEST_TASK' ? result.data[0] : result.data;
@@ -667,6 +664,9 @@ export function* createTaskSaga({ payload }) {
         yield put(api.util.invalidateTags(['IrrigationPrescriptions']));
       }
       if (alreadyCompleted) {
+        if (postTaskRequestHasNewProduct(reqBody, task_translation_key)) {
+          yield call(getProductsSaga);
+        }
         const isCustomTaskWithAnimals =
           isCustomTask && (result.data.animals?.length || result.data.animal_batches?.length);
         yield call(onReqSuccessSaga, {

--- a/packages/webapp/src/containers/Task/sagaUtils.js
+++ b/packages/webapp/src/containers/Task/sagaUtils.js
@@ -121,7 +121,10 @@ export const postTaskRequestHasNewProduct = (reqBody, taskTypeTranslationKey) =>
     return false;
   }
 
-  const { product_id, name } = reqBody[taskType].product;
+  const {
+    product_id,
+    product: { name },
+  } = reqBody[taskType];
 
   return !!(!product_id && name);
 };

--- a/packages/webapp/src/containers/Task/sagaUtils.js
+++ b/packages/webapp/src/containers/Task/sagaUtils.js
@@ -114,3 +114,14 @@ export const getCompleteSoilSampleTaskBody = ({ taskData, uploadedFiles }) => {
     ...formatSoilSampleDocuments(uploadedFiles),
   };
 };
+
+export const postTaskRequestHasNewProduct = (reqBody, taskTypeTranslationKey) => {
+  const taskType = taskTypeTranslationKey.toLowerCase();
+  if (!reqBody[taskType]?.product) {
+    return false;
+  }
+
+  const { product_id, name } = reqBody[taskType].product;
+
+  return !!(!product_id && name);
+};

--- a/packages/webapp/src/tests/taskSagaUtils.test.js
+++ b/packages/webapp/src/tests/taskSagaUtils.test.js
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { expect, describe, test } from 'vitest';
+import { postTaskRequestHasNewProduct } from '../containers/Task/sagaUtils';
+
+const createFakeProduct = (productId, name) => {
+  return { product: { product_id: productId, name } };
+};
+
+describe('Task saga utils test', () => {
+  describe('postTaskRequestHasNewProduct', () => {
+    test('returns true when product has a name but no productId', () => {
+      expect(
+        postTaskRequestHasNewProduct(
+          { cleaning_task: createFakeProduct(undefined, 'New product') },
+          'CLEANING_TASK',
+        ),
+      ).toBe(true);
+
+      expect(
+        postTaskRequestHasNewProduct(
+          { pest_control_task: createFakeProduct(undefined, 'New product') },
+          'PEST_CONTROL_TASK',
+        ),
+      ).toBe(true);
+    });
+
+    test('returns false when product has a productId', () => {
+      expect(
+        postTaskRequestHasNewProduct({ cleaning_task: createFakeProduct('xxxx') }, 'CLEANING_TASK'),
+      ).toBe(false);
+    });
+
+    test('returns false when the task has no product', () => {
+      expect(postTaskRequestHasNewProduct({ irrigation_task: {} }, 'IRRIGATION_TASK')).toBe(false);
+    });
+  });
+});

--- a/packages/webapp/src/tests/taskSagaUtils.test.js
+++ b/packages/webapp/src/tests/taskSagaUtils.test.js
@@ -17,7 +17,7 @@ import { expect, describe, test } from 'vitest';
 import { postTaskRequestHasNewProduct } from '../containers/Task/sagaUtils';
 
 const createFakeProduct = (productId, name) => {
-  return { product: { product_id: productId, name } };
+  return { product: { name }, product_id: productId };
 };
 
 describe('Task saga utils test', () => {
@@ -40,7 +40,7 @@ describe('Task saga utils test', () => {
 
     test('returns false when product has a productId', () => {
       expect(
-        postTaskRequestHasNewProduct({ cleaning_task: createFakeProduct('xxxx') }, 'CLEANING_TASK'),
+        postTaskRequestHasNewProduct({ cleaning_task: createFakeProduct('xxxx', 'Existing Product') }, 'CLEANING_TASK'),
       ).toBe(false);
     });
 


### PR DESCRIPTION
**Description**

Call `getProductsSaga` when creating an already completed task with a new product (`createTaskSaga`).

- Add and use `postTaskRequestHasNewProduct` function to determine whether `getProductsSaga` should be called.
   Test: `npm run test taskSagaUtils`

Jira link: https://lite-farm.atlassian.net/browse/LF-4228

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
