### PR TITLE
LF-4812: Show button to re-trigger completion in read only task view

### DIFF
--- a/packages/webapp/public/locales/en/common.json
+++ b/packages/webapp/public/locales/en/common.json
@@ -42,7 +42,6 @@
   "EXPORT": "Export",
   "FETCHING_YOUR_DATA": "Sit back, we’re fetching your {{dataName}} data",
   "FINISH": "Finish",
-  "FIX_IT_NOW": "Fix it now",
   "FROM": "from",
   "GO_BACK": "Go back",
   "GOT_IT": "Got it!",

--- a/packages/webapp/public/locales/en/common.json
+++ b/packages/webapp/public/locales/en/common.json
@@ -42,6 +42,7 @@
   "EXPORT": "Export",
   "FETCHING_YOUR_DATA": "Sit back, we’re fetching your {{dataName}} data",
   "FINISH": "Finish",
+  "FIX_IT_NOW": "Fix it now",
   "FROM": "from",
   "GO_BACK": "Go back",
   "GOT_IT": "Got it!",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1707,6 +1707,7 @@
     }
   },
   "REVISION_PROMPT": {
+    "FIX_IT_NOW": "Fix it now",
     "NOTICED_SOMETHING_OFF": "Noticed something off?",
     "UPDATE_THIS_TASK": "You can revisit and update the info you submitted for this task."
   },

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1706,6 +1706,10 @@
       "REVENUE_TYPE": "Revenue type"
     }
   },
+  "REVISION_PROMPT": {
+    "NOTICED_SOMETHING_OFF": "Noticed something off?",
+    "REVISIT_AND_UPDATE_THIS_ENTITY": "You can revisit and update the info you submitted for {{entity}}."
+  },
   "ROLE_SELECTION": {
     "FARM_EO": "Extension Officer",
     "FARM_MANAGER": "Farm Manager",
@@ -2039,6 +2043,7 @@
     "TASK": "task",
     "TASKS_COUNT_one": "{{count}} task",
     "TASKS_COUNT_other": "{{count}} tasks",
+    "THIS_TASK": "this task",
     "TRANSPLANT": "Transplant",
     "TRANSPLANT_LOCATIONS": "Select a transplant location",
     "UNASSIGNED": "Unassigned",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1708,7 +1708,7 @@
   },
   "REVISION_PROMPT": {
     "NOTICED_SOMETHING_OFF": "Noticed something off?",
-    "REVISIT_AND_UPDATE_THIS_ENTITY": "You can revisit and update the info you submitted for {{entity}}."
+    "UPDATE_THIS_TASK": "You can revisit and update the info you submitted for this task."
   },
   "ROLE_SELECTION": {
     "FARM_EO": "Extension Officer",
@@ -2043,7 +2043,6 @@
     "TASK": "task",
     "TASKS_COUNT_one": "{{count}} task",
     "TASKS_COUNT_other": "{{count}} tasks",
-    "THIS_TASK": "this task",
     "TRANSPLANT": "Transplant",
     "TRANSPLANT_LOCATIONS": "Select a transplant location",
     "UNASSIGNED": "Unassigned",

--- a/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
+++ b/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
@@ -32,7 +32,7 @@ const RevisionPrompt = ({ text, onClick }: RevisionPromptProps) => {
         <p>{text}</p>
       </div>
       <Button className={styles.button} type="button" sm color="secondary-2" onClick={onClick}>
-        {t('common:FIX_IT_NOW')}
+        {t('REVISION_PROMPT.FIX_IT_NOW')}
       </Button>
     </div>
   );

--- a/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
+++ b/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+import Button from '../../Form/Button';
+import styles from './styles.module.scss';
+
+interface RevisionPromptProps {
+  entityName: string;
+  onClick: () => void;
+}
+
+const RevisionPrompt = ({ entityName, onClick }: RevisionPromptProps) => {
+  const { t } = useTranslation(['translation', 'common']);
+
+  return (
+    <div className={styles.revisionPrompt}>
+      <div>
+        <h3>{t('REVISION_PROMPT.NOTICED_SOMETHING_OFF')}</h3>
+        <p>{t('REVISION_PROMPT.REVISIT_AND_UPDATE_THIS_ENTITY', { entity: entityName })}</p>
+      </div>
+      <Button type="button" sm color="secondary-2" onClick={onClick}>
+        {t('common:FIX_IT_NOW')}
+      </Button>
+    </div>
+  );
+};
+
+export default RevisionPrompt;

--- a/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
+++ b/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
@@ -18,18 +18,18 @@ import Button from '../../Form/Button';
 import styles from './styles.module.scss';
 
 interface RevisionPromptProps {
-  entityName: string;
+  text: string;
   onClick: () => void;
 }
 
-const RevisionPrompt = ({ entityName, onClick }: RevisionPromptProps) => {
+const RevisionPrompt = ({ text, onClick }: RevisionPromptProps) => {
   const { t } = useTranslation(['translation', 'common']);
 
   return (
     <div className={styles.revisionPrompt}>
       <div>
         <h3>{t('REVISION_PROMPT.NOTICED_SOMETHING_OFF')}</h3>
-        <p>{t('REVISION_PROMPT.REVISIT_AND_UPDATE_THIS_ENTITY', { entity: entityName })}</p>
+        <p>{text}</p>
       </div>
       <Button className={styles.button} type="button" sm color="secondary-2" onClick={onClick}>
         {t('common:FIX_IT_NOW')}

--- a/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
+++ b/packages/webapp/src/components/Task/RevisionPrompt/index.tsx
@@ -31,7 +31,7 @@ const RevisionPrompt = ({ entityName, onClick }: RevisionPromptProps) => {
         <h3>{t('REVISION_PROMPT.NOTICED_SOMETHING_OFF')}</h3>
         <p>{t('REVISION_PROMPT.REVISIT_AND_UPDATE_THIS_ENTITY', { entity: entityName })}</p>
       </div>
-      <Button type="button" sm color="secondary-2" onClick={onClick}>
+      <Button className={styles.button} type="button" sm color="secondary-2" onClick={onClick}>
         {t('common:FIX_IT_NOW')}
       </Button>
     </div>

--- a/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
+++ b/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
@@ -25,6 +25,7 @@
 
   border-radius: 4px;
   border: 1px solid var(--Colors-Neutral-Neutral-50);
+  background-color: var(--White);
 
   h3,
   p {
@@ -37,8 +38,15 @@
   }
 
   @include md-breakpoint {
-    flex-direction: column;
-    align-items: start;
-    gap: 8px;
+    padding: 8px;
+
+    h3,
+    p {
+      font-size: 14px;
+    }
+
+    p {
+      padding-bottom: 16px;
+    }
   }
 }

--- a/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
+++ b/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
@@ -44,9 +44,5 @@
     p {
       font-size: 14px;
     }
-
-    p {
-      padding-bottom: 16px;
-    }
   }
 }

--- a/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
+++ b/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
@@ -33,6 +33,10 @@
     font-size: 16px;
   }
 
+  h3 {
+    padding-bottom: 4px;
+  }
+
   .button {
     white-space: nowrap;
   }

--- a/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
+++ b/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+.revisionPrompt {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  margin-bottom: 40px;
+
+  border-radius: 4px;
+  border: 1px solid var(--Colors-Neutral-Neutral-50);
+
+  h3,
+  p {
+    color: #000;
+    font-size: 16px;
+  }
+}

--- a/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
+++ b/packages/webapp/src/components/Task/RevisionPrompt/styles.module.scss
@@ -12,6 +12,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
+
+@import '@assets/mixin.scss';
+
 .revisionPrompt {
   display: flex;
   justify-content: space-between;
@@ -27,5 +30,15 @@
   p {
     color: #000;
     font-size: 16px;
+  }
+
+  .button {
+    white-space: nowrap;
+  }
+
+  @include md-breakpoint {
+    flex-direction: column;
+    align-items: start;
+    gap: 8px;
   }
 }

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -63,7 +63,7 @@ import AnimalInventory, { View } from '../../../containers/Animals/Inventory';
 import PureIrrigationPrescription from '../../IrrigationPrescription';
 import PureDocumentTile from '../../../containers/Documents/DocumentTile';
 import PureDocumentTileContainer from '../../../containers/Documents/DocumentTile/DocumentTileContainer';
-import RecompletePrompt from '../RevisionPrompt';
+import RevisionPrompt from '../RevisionPrompt';
 
 export default function PureTaskReadOnly({
   onGoBack,
@@ -223,7 +223,7 @@ export default function PureTaskReadOnly({
         }
       />
       {isCompleted && canCompleteTask && (
-        <RecompletePrompt onClick={onComplete} entityName={t('TASK.THIS_TASK')} />
+        <RevisionPrompt onClick={onComplete} entityName={t('TASK.THIS_TASK')} />
       )}
       <div className={styles.editableContainer}>
         <Input

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -554,6 +554,9 @@ export default function PureTaskReadOnly({
           primaryButtonLabel={t('TASK.DELETE.CONFIRM_DELETION')}
         />
       )}
+
+      {isCompleted && canCompleteTask && <Button onClick={onComplete}>Re-complete</Button>}
+
       {showTaskAssignModal && (
         <TaskQuickAssignModal
           task_id={task.task_id}

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -63,6 +63,7 @@ import AnimalInventory, { View } from '../../../containers/Animals/Inventory';
 import PureIrrigationPrescription from '../../IrrigationPrescription';
 import PureDocumentTile from '../../../containers/Documents/DocumentTile';
 import PureDocumentTileContainer from '../../../containers/Documents/DocumentTile/DocumentTileContainer';
+import RecompletePrompt from '../RevisionPrompt';
 
 export default function PureTaskReadOnly({
   onGoBack,
@@ -221,6 +222,9 @@ export default function PureTaskReadOnly({
           />
         }
       />
+      {isCompleted && canCompleteTask && (
+        <RecompletePrompt onClick={onComplete} entityName={t('TASK.THIS_TASK')} />
+      )}
       <div className={styles.editableContainer}>
         <Input
           label={t('ADD_TASK.ASSIGNEE')}
@@ -554,8 +558,6 @@ export default function PureTaskReadOnly({
           primaryButtonLabel={t('TASK.DELETE.CONFIRM_DELETION')}
         />
       )}
-
-      {isCompleted && canCompleteTask && <Button onClick={onComplete}>Re-complete</Button>}
 
       {showTaskAssignModal && (
         <TaskQuickAssignModal

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -223,7 +223,7 @@ export default function PureTaskReadOnly({
         }
       />
       {isCompleted && canCompleteTask && (
-        <RevisionPrompt onClick={onComplete} entityName={t('TASK.THIS_TASK')} />
+        <RevisionPrompt onClick={onComplete} text={t('REVISION_PROMPT.UPDATE_THIS_TASK')} />
       )}
       <div className={styles.editableContainer}>
         <Input

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -558,7 +558,6 @@ export default function PureTaskReadOnly({
           primaryButtonLabel={t('TASK.DELETE.CONFIRM_DELETION')}
         />
       )}
-
       {showTaskAssignModal && (
         <TaskQuickAssignModal
           task_id={task.task_id}


### PR DESCRIPTION
**Description**

Add `RevisionPrompt` component and show it in task read-only view when the task has been completed and the user can complete the task.


Jira link: https://lite-farm.atlassian.net/browse/LF-4812

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
