### PR TITLE
LF-4814: Pre-fill task completion flow forms with previous values

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/HarvestComplete/HarvestUses.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/HarvestComplete/HarvestUses.jsx
@@ -13,6 +13,36 @@ import { cloneObject } from '../../../../util';
 import { colors } from '../../../../assets/theme';
 import PageBreak from '../../../PageBreak';
 
+const HARVEST_USE_QUANTITY_UNIT = 'quantity_unit';
+const HARVEST_USE_QUANTITY = 'quantity';
+const HARVEST_USE_TYPE = 'harvest_use_type_id';
+
+const formatHarvestUse = (harvestUse, harvestUseTypes, t) => {
+  const { quantity, quantity_unit, harvest_use_type_id } = harvestUse;
+  const useType = harvestUseTypes.find((type) => type.harvest_use_type_id === harvest_use_type_id);
+
+  return {
+    [HARVEST_USE_QUANTITY]: quantity,
+    [HARVEST_USE_QUANTITY_UNIT]: quantity_unit,
+    [HARVEST_USE_TYPE]: {
+      value: harvest_use_type_id,
+      label: t(`harvest_uses:${useType.harvest_use_type_translation_key}`),
+    },
+  };
+};
+
+const formatHarvestUses = (persistedFormData, task, harvestUseTypes, t) => {
+  if (persistedFormData?.harvest_uses) {
+    return persistedFormData.harvest_uses;
+  }
+
+  const isCompleted = !!task.complete_date;
+
+  return isCompleted
+    ? task.harvest_task.harvest_use.map((use) => formatHarvestUse(use, harvestUseTypes, t))
+    : [{}];
+};
+
 export default function PureHarvestUses({
   onContinue,
   onGoBack,
@@ -40,7 +70,7 @@ export default function PureHarvestUses({
     shouldUnregister: false,
     defaultValues: {
       ...persistedFormData,
-      harvest_uses: persistedFormData?.harvest_uses ?? [{}],
+      harvest_uses: formatHarvestUses(persistedFormData, task, harvestUseTypes, t),
       ...cloneObject(task),
     },
   });
@@ -48,10 +78,6 @@ export default function PureHarvestUses({
   const { historyCancel } = useHookFormPersist(getValues);
 
   const progress = 50;
-
-  const HARVEST_USE_QUANTITY_UNIT = 'quantity_unit';
-  const HARVEST_USE_QUANTITY = 'quantity';
-  const HARVEST_USE_TYPE = 'harvest_use_type_id';
 
   const { fields, append, remove, swap } = useFieldArray({
     control,

--- a/packages/webapp/src/components/Task/TaskComplete/HarvestComplete/HarvestUses.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/HarvestComplete/HarvestUses.jsx
@@ -1,4 +1,18 @@
-import React, { useMemo } from 'react';
+/*
+ *  Copyright 2021 - 2025 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+import { useMemo } from 'react';
 import MultiStepPageTitle from '../../../PageTitle/MultiStepPageTitle';
 import { useTranslation } from 'react-i18next';
 import Form from '../../../Form';
@@ -9,7 +23,6 @@ import Unit from '../../../Form/Unit';
 import { harvestAmounts, roundToTwoDecimal } from '../../../../util/convert-units/unit';
 import ReactSelect from '../../../Form/ReactSelect';
 import UnitLabel from './UnitLabel';
-import { cloneObject } from '../../../../util';
 import { colors } from '../../../../assets/theme';
 import PageBreak from '../../../PageBreak';
 
@@ -64,14 +77,14 @@ export default function PureHarvestUses({
     getValues,
     setValue,
     control,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm({
     mode: 'onChange',
     shouldUnregister: false,
     defaultValues: {
       ...persistedFormData,
       harvest_uses: formatHarvestUses(persistedFormData, task, harvestUseTypes, t),
-      ...cloneObject(task),
+      ...structuredClone(task),
     },
   });
 
@@ -88,7 +101,7 @@ export default function PureHarvestUses({
   const watchFields = watch('harvest_uses');
   const quantities = watchFields.map((field) => field[HARVEST_USE_QUANTITY]);
 
-  const { allocated_amount, amount_to_allocate } = useMemo(() => {
+  const { amount_to_allocate } = useMemo(() => {
     let allocated_amount = 0;
     for (let field of watchFields) {
       const quantity = field[HARVEST_USE_QUANTITY] || 0;
@@ -96,7 +109,7 @@ export default function PureHarvestUses({
         allocated_amount += quantity;
       }
     }
-    return { allocated_amount, amount_to_allocate: amount - allocated_amount };
+    return { amount_to_allocate: amount - allocated_amount };
   }, [quantities]);
 
   const harvestUseIds = watchFields.map((field) => field?.[HARVEST_USE_TYPE]?.value);

--- a/packages/webapp/src/components/Task/TaskComplete/HarvestComplete/Quantity.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/HarvestComplete/Quantity.jsx
@@ -18,6 +18,7 @@ export default function PureHarvestCompleteQuantity({
   useHookFormPersist,
 }) {
   const { t } = useTranslation();
+  const isCompleted = !!task.complete_date;
 
   const {
     register,
@@ -32,9 +33,14 @@ export default function PureHarvestCompleteQuantity({
     shouldUnregister: false,
     defaultValues: {
       ...persistedFormData,
-      actual_quantity: persistedFormData.actual_quantity || task.harvest_task.projected_quantity,
+      actual_quantity:
+        persistedFormData.actual_quantity ||
+        (isCompleted ? task.harvest_task.actual_quantity : task.harvest_task.projected_quantity),
       actual_quantity_unit:
-        persistedFormData.actual_quantity_unit || task.harvest_task.projected_quantity_unit,
+        persistedFormData.actual_quantity_unit ||
+        (isCompleted
+          ? task.harvest_task.actual_quantity_unit
+          : task.harvest_task.projected_quantity_unit),
     },
   });
 

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -18,6 +18,43 @@ import { isNotInFuture } from '../../Form/Input/utils';
 import { useIsTaskType } from '../../../containers/Task/useIsTaskType';
 import { ORIGINAL_DUE_DATE, TODAY_DUE_DATE, ANOTHER_DUE_DATE } from '../AbandonTask/constants';
 import { TASK_TYPE_PRODUCT_MAP } from '../../../containers/Task/constants';
+import { isSameDay } from '../../../util/date-migrate-TS';
+import { getLocalDateInYYYYDDMM } from '../../../util/date';
+
+const DURATION = 'duration';
+const COMPLETION_NOTES = 'completion_notes';
+const HAPPINESS = 'happiness';
+const PREFER_NOT_TO_SAY = 'prefer_not_to_say';
+const DATE_CHOICE = 'date_choice';
+const ANOTHER_DATE = 'date_another';
+
+const formatDefaultValues = (persistedFormData, dueDateDisabled) => {
+  if (persistedFormData[DATE_CHOICE]) {
+    return persistedFormData;
+  }
+
+  const completeDate = persistedFormData?.complete_date;
+  let dateChoice;
+  let anotherDate = '';
+
+  if (!completeDate) {
+    dateChoice = dueDateDisabled ? TODAY_DUE_DATE : ORIGINAL_DUE_DATE;
+  } else if (isSameDay(new Date(completeDate), new Date())) {
+    dateChoice = TODAY_DUE_DATE;
+  } else if (completeDate === persistedFormData.due_date) {
+    dateChoice = ORIGINAL_DUE_DATE;
+  } else {
+    dateChoice = ANOTHER_DUE_DATE;
+    anotherDate = getLocalDateInYYYYDDMM(new Date(completeDate));
+  }
+
+  return {
+    ...persistedFormData,
+    [DATE_CHOICE]: dateChoice,
+    [ANOTHER_DATE]: anotherDate,
+    [PREFER_NOT_TO_SAY]: !persistedFormData?.happiness,
+  };
+};
 
 export default function PureTaskComplete({
   onSave,
@@ -25,13 +62,6 @@ export default function PureTaskComplete({
   persistedFormData,
   useHookFormPersist,
 }) {
-  const DURATION = 'duration';
-  const COMPLETION_NOTES = 'completion_notes';
-  const HAPPINESS = 'happiness';
-  const PREFER_NOT_TO_SAY = 'prefer_not_to_say';
-  const DATE_CHOICE = 'date_choice';
-  const ANOTHER_DATE = 'date_another';
-
   const { t } = useTranslation();
 
   // Prepare dates
@@ -50,11 +80,7 @@ export default function PureTaskComplete({
   } = useForm({
     mode: 'onChange',
     shouldUnregister: false,
-    defaultValues: {
-      [DATE_CHOICE]: dueDateDisabled ? TODAY_DUE_DATE : ORIGINAL_DUE_DATE,
-      [ANOTHER_DATE]: '',
-      ...persistedFormData,
-    },
+    defaultValues: formatDefaultValues(persistedFormData, dueDateDisabled),
   });
 
   const date_choice = watch(DATE_CHOICE); // Radiobox Group choice


### PR DESCRIPTION
**Description**

Pre-fill `PureHarvestCompleteQuantity`, `HarvestUses`, `PureTaskComplete` for re-completion.

Jira link: https://lite-farm.atlassian.net/browse/LF-4814

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
