### PR TITLE
LF-4817(2): Tests for revision date and revision author when re-completing a task

### DIFF
--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -1621,8 +1621,8 @@ async function harvest_taskFactory(
   { promisedTask = taskFactory() } = {},
   harvestLog = fakeHarvestTask(),
 ) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('harvest_task')
     .insert({ task_id, ...harvestLog })
     .returning('*');
@@ -1669,8 +1669,8 @@ async function plant_taskFactory(
   { promisedTask = taskFactory() } = {},
   plant_task = fakePlantTask(),
 ) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('plant_task')
     .insert({ task_id, ...plant_task })
     .returning('*');
@@ -1716,8 +1716,8 @@ async function field_work_taskFactory(
   { promisedTask = taskFactory() } = {},
   field_work_task = fakeFieldWorkTask(),
 ) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('field_work_task')
     .insert({ task_id, ...field_work_task })
     .returning('*');
@@ -1730,8 +1730,8 @@ function fakeFieldWorkTask(defaultData = {}) {
 }
 
 async function soil_taskFactory({ promisedTask = taskFactory() } = {}, soil_task = fakeSoilTask()) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('soil_task')
     .insert({ task_id, ...soil_task })
     .returning('*');
@@ -1782,8 +1782,8 @@ async function irrigation_taskFactory(
   { promisedTask = taskFactory() } = {},
   irrigationTask = fakeIrrigationTask(),
 ) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('irrigation_task')
     .insert({ task_id, ...irrigationTask })
     .returning('*');
@@ -1801,8 +1801,8 @@ async function scouting_taskFactory(
   { promisedTask = taskFactory() } = {},
   scouting_task = fakeScoutingTask(),
 ) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('scouting_task')
     .insert({ task_id, ...scouting_task })
     .returning('*');
@@ -1832,8 +1832,8 @@ async function animal_movement_taskFactory(
   { promisedTask = taskFactory() } = {},
   animal_movement_task = fakeAnimalMovementTask(),
 ) {
-  const [activity] = await Promise.all([promisedTask]);
-  const [{ task_id }] = activity;
+  const [task] = await Promise.all([promisedTask]);
+  const [{ task_id }] = task;
   return knex('animal_movement_task')
     .insert({ task_id, ...animal_movement_task })
     .returning('*');

--- a/packages/api/tests/task.test.js
+++ b/packages/api/tests/task.test.js
@@ -3087,7 +3087,11 @@ describe('Task tests', () => {
             const expectedTaskTypeData = (await getExpectedTaskTypeData?.()) || {};
 
             Object.entries(expectedTaskTypeData).forEach(([property, value]) => {
-              expect(completedTaskTypeDataInDB[property]).toBe(value);
+              if (typeof value === 'object') {
+                expect(completedTaskTypeDataInDB[property]).toEqual(value);
+              } else {
+                expect(completedTaskTypeDataInDB[property]).toBe(value);
+              }
             });
 
             await testCase.extraExpect?.(task_id);

--- a/packages/api/tests/utils/taskCompletionTestCases.js
+++ b/packages/api/tests/utils/taskCompletionTestCases.js
@@ -19,10 +19,8 @@ import { setupSoilAmendmentTaskDependencies } from './testDataSetup.js';
 import mocks from '../mock.factories.js';
 
 // field_work_task
-const fieldWorkName = faker.lorem.word();
-const fieldWorkTaskTestCases = {
-  newFieldWorkType: {
-    initialData: undefined, // No initial data passed; use factory default
+const getFieldWorkTaskNewTypeTestCase = (fieldWorkName) => {
+  return {
     getFakeCompletionData: (initialData) => ({
       field_work_task: {
         task_id: initialData.task_id,
@@ -40,6 +38,12 @@ const fieldWorkTaskTestCases = {
 
       return { field_work_type_id };
     },
+  };
+};
+const fieldWorkTaskTestCases = {
+  newFieldWorkType: {
+    initialData: undefined, // No initial data passed; use factory default
+    ...getFieldWorkTaskNewTypeTestCase(faker.lorem.word()),
   },
 };
 
@@ -114,7 +118,27 @@ const cleaningTaskTestCases = {
 };
 
 // irrigation_task
-const irrigationTypeName = faker.lorem.word();
+const getIrrigationTaskNewTypeTestCase = (irrigationTypeName) => {
+  return {
+    getFakeCompletionData: (initialData) => ({
+      irrigation_task: {
+        task_id: initialData.task_id,
+        irrigation_type_name: irrigationTypeName,
+        measuring_type: 'VOLUME',
+      },
+    }),
+    getExpectedData: async () => {
+      const { irrigation_type_id } = await knex('irrigation_type')
+        .where({ irrigation_type_name: irrigationTypeName })
+        .first();
+
+      return {
+        irrigation_type_id,
+        irrigation_type_name: irrigationTypeName,
+      };
+    },
+  };
+};
 const irrigationTaskInitialData = {
   irrigation_type_name: 'irrigation type name',
   measuring_type: 'VOLUME',
@@ -136,23 +160,7 @@ const irrigationTaskFakeCompletionData = {
 const irrigationTaskTestCases = {
   newIrrigationType: {
     initialData: undefined, // No initial data passed; use factory default
-    getFakeCompletionData: (initialData) => ({
-      irrigation_task: {
-        task_id: initialData.task_id,
-        irrigation_type_name: irrigationTypeName,
-        measuring_type: 'VOLUME',
-      },
-    }),
-    getExpectedData: async () => {
-      const { irrigation_type_id } = await knex('irrigation_type')
-        .where({ irrigation_type_name: irrigationTypeName })
-        .first();
-
-      return {
-        irrigation_type_id,
-        irrigation_type_name: irrigationTypeName,
-      };
-    },
+    ...getIrrigationTaskNewTypeTestCase(faker.lorem.word()),
   },
   switchMeasuringType: {
     initialData: irrigationTaskInitialData,

--- a/packages/api/tests/utils/taskCompletionTestCases.js
+++ b/packages/api/tests/utils/taskCompletionTestCases.js
@@ -115,6 +115,7 @@ const cleaningTaskTestCases = {
 // irrigation_task
 const irrigationTypeName = faker.lorem.word();
 const irrigationTaskInitialData = {
+  irrigation_type_name: 'irrigation type name',
   measuring_type: 'VOLUME',
   estimated_duration: 60,
   estimated_duration_unit: 'minutes',
@@ -125,7 +126,6 @@ const irrigationTaskInitialData = {
 };
 const irrigationTaskFakeCompletionData = {
   measuring_type: 'DEPTH',
-  irrigation_type_name: 'HAND_WATERING',
   percent_of_location_irrigated: 3,
   application_depth_unit: 'mm',
   application_depth: 0.002,

--- a/packages/api/tests/utils/taskCompletionTestCases.js
+++ b/packages/api/tests/utils/taskCompletionTestCases.js
@@ -16,6 +16,7 @@
 import { faker } from '@faker-js/faker';
 import knex from '../../src/util/knex.js';
 import { setupSoilAmendmentTaskDependencies } from './testDataSetup.js';
+import mocks from '../mock.factories.js';
 
 // field_work_task
 const fieldWorkName = faker.lorem.word();
@@ -248,9 +249,25 @@ const soilAmendmentTaskTestCases = {
   },
 };
 
+// soil_sample_task
+const soilSampleTaskFakeCompletionData = mocks.fakeSoilSampleTask();
+const soilSampleTaskTestCases = {
+  updateFields: {
+    initialData: undefined,
+    getFakeCompletionData: (initialData) => ({
+      soil_sample_task: {
+        task_id: initialData.task_id,
+        ...soilSampleTaskFakeCompletionData,
+      },
+    }),
+    getExpectedData: async () => soilSampleTaskFakeCompletionData,
+  },
+};
+
 export const taskCompletionFieldUpdateTestCases = {
   'should update relevant fields': {
     irrigation_task: [irrigationTaskTestCases.switchMeasuringType],
+    soil_sample_task: [soilSampleTaskTestCases.updateFields],
   },
   'should remove irrelevant fields': {
     cleaning_task: [cleaningTaskTestCases.nullOptionalFields],

--- a/packages/api/tests/utils/taskCompletionTestCases.js
+++ b/packages/api/tests/utils/taskCompletionTestCases.js
@@ -290,3 +290,37 @@ export const taskCompletionFieldUpdateTestCases = {
     irrigation_task: [irrigationTaskTestCases.newIrrigationType],
   },
 };
+
+export const taskRecompletionTestCases = {
+  irrigation_task: {
+    initialData: irrigationTaskInitialData,
+    recompletionData: [
+      irrigationTaskTestCases.switchMeasuringType,
+      getIrrigationTaskNewTypeTestCase(faker.lorem.word()),
+    ],
+  },
+  cleaning_task: {
+    initialData: cleaningTaskInitialDataWithProduct,
+    recompletionData: [cleaningTaskTestCases.nullOptionalFields],
+  },
+  pest_control_task: {
+    initialData: pestControlTaskInitialDataWithProduct,
+    recompletionData: [pestControlTaskTestCases.changeToMethodWithoutProduct],
+  },
+  soil_amendment_task: {
+    initialData: soilAmendmentTaskInitialData,
+    extraSetup: soilAmendmentTaskProductInitialDataSetup,
+    recompletionData: [
+      soilAmendmentTaskTestCases.nullOptionalFields,
+      soilAmendmentTaskTestCases.switchWeightToVolume,
+    ],
+  },
+  field_work_task: {
+    initialData: undefined,
+    recompletionData: [getFieldWorkTaskNewTypeTestCase(faker.lorem.word())],
+  },
+  soil_sample_task: {
+    initialData: undefined,
+    recompletionData: [soilSampleTaskTestCases.updateFields],
+  },
+};

--- a/packages/api/tests/utils/taskUtils.js
+++ b/packages/api/tests/utils/taskUtils.js
@@ -59,6 +59,17 @@ export const abandonTaskBody = {
   abandon_date: new Date(),
 };
 
+export const commonTaskTypes = [
+  'scouting_task',
+  'soil_task',
+  'field_work_task',
+  'pest_control_task',
+  'cleaning_task',
+  'irrigation_task',
+  'soil_amendment_task',
+  'soil_sample_task',
+];
+
 export async function postTaskRequest({ user_id, farm_id }, type, data) {
   return chai
     .request(server)


### PR DESCRIPTION
**Description**

Add tests for task re-completion and update task completion tests.

- mock.factories
   - Rename `activity` (task's old name) to `task`
   - Update `irrigation_taskFactory` to include `irrigation_type_id` by default
     - Although `null` is allowed, but it never actually becomes `null`
     - This change addresses Joyce's [comment](https://github.com/LiteFarmOrg/LiteFarm/pull/3839#discussion_r2237687757) on irrigation task completion tests and should help write cleaner tests
- task.test
   - replace the `for` loop in the task completion tests with `test.each` to fix strange debugger behaviour ([reference](https://github.com/LiteFarmOrg/LiteFarm/pull/3839#pullrequestreview-3064358642))
     - Test cases were formatted first; besides that, the only change is to make the last `expect` more flexible to handle objects
     - Add tests for task re-completion
- taskCompletionTestCases
   - add tests for soil sample tasks
   - add helper functions to create test cases for field and irrigation tasks to avoid reusing field work type and irrigation type names, which causes re-completion test failures
   - Add re-completion test cases

Jira link: https://lite-farm.atlassian.net/browse/LF-4817

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
