### PR TITLE
Patch 3.8.1 - Bump version numbers

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litefarm-api",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litefarm-api",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.622.0",
         "@googlemaps/google-maps-services-js": "^3.4.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litefarm-api",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "LiteFarm API server",
   "main": "./api/src/server.js",
   "type": "module",

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -31,7 +31,7 @@ if (process.env.SENTRY_DSN && environment !== 'development') {
       // Automatically instrument Node.js libraries and frameworks
       ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
     ],
-    release: '3.8.0',
+    release: '3.8.1',
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litefarm-webapp",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "LiteFarm Web application",
   "type": "module",
   "devEngines": {

--- a/packages/webapp/src/main.jsx
+++ b/packages/webapp/src/main.jsx
@@ -87,7 +87,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     integrations: [new Integrations.BrowserTracing()],
-    release: '3.8.0',
+    release: '3.8.1',
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production


### PR DESCRIPTION
**Description**

Bump version numbers to `3.8.1`.

Jira link: [3.8.1 Release](https://lite-farm.atlassian.net/projects/LF/versions/10100/tab/release-report-all-issues)