### PR TITLE
"Drag and drop" text in the file upload field is partially hidden or not visible in the support form.

### DIFF
--- a/packages/webapp/src/components/ImagePicker/styles.module.scss
+++ b/packages/webapp/src/components/ImagePicker/styles.module.scss
@@ -78,6 +78,7 @@
   background-color: var(--grey100);
   border: 1px dashed var(--grey500);
   border-radius: 4px;
+  color: initial;
 
   .cameraIcon {
     width: 40px;


### PR DESCRIPTION
**Description**

Text colour of `teal50` was being inherited from a parent, likely due to contrast settings from MUI theme as mentioned by @kathyavini in the Jira ticket. Simple solution was to just set colour to initial which is overrides the inheritance. 

Jira link: https://lite-farm.atlassian.net/browse/LF-4843

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
