### PR TITLE
Routes cleanup

### DIFF
--- a/packages/webapp/src/routes/Onboarding.jsx
+++ b/packages/webapp/src/routes/Onboarding.jsx
@@ -14,12 +14,11 @@
  */
 
 /* eslint-disable react/no-children-prop */
-import React, { Suspense } from 'react';
+import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { useSelector } from 'react-redux';
 import { userFarmLengthSelector } from '../containers/userFarmSlice';
-import Spinner from '../components/Spinner';
 import { hookFormPersistSelector } from '../containers/hooks/useHookFormPersist/hookFormPersistSlice';
 
 const RoleSelection = React.lazy(() => import('../containers/RoleSelection'));

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -1159,7 +1159,6 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
                     <Route path="/" exact children={<Home />} />
                     <Route path="/home" exact children={<Home />} />
                     <Route path="/profile" exact children={<Account />} />
-                    <Route path="/farm" exact children={<Farm />} />
                     <Route path="/consent" exact children={<ConsentForm />} />
                     <Route path="/crop_catalogue" exact children={<CropCatalogue />} />
                     <Route

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -264,7 +264,7 @@ const TaskCompleteStepOne = React.lazy(() => import('../containers/Task/TaskComp
 const TaskReadOnly = React.lazy(() => import('../containers/Task/TaskReadOnly'));
 const EditCustomTask = React.lazy(() => import('../containers/Task/EditCustomTask'));
 const TaskAbandon = React.lazy(() => import('../containers/Task/TaskAbandon'));
-const EditCustomTaskUpdate = React.lazy(() => import('../containers/Task/EditCustomTaskUpdate'));
+// const EditCustomTaskUpdate = React.lazy(() => import('../containers/Task/EditCustomTaskUpdate'));
 const TaskTransplantMethod = React.lazy(() =>
   import('../containers/Task/TaskTransplantMethod/TaskTransplantMethod'),
 );
@@ -708,11 +708,11 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
                     />
                     <Route path="/add_task/add_custom_task" exact children={<AddCustomTask />} />
                     <Route path="/add_task/edit_custom_task" exact children={<EditCustomTask />} />
-                    <Route
+                    {/* <Route
                       path="/add_task/edit_custom_task_update"
                       exact
                       children={<EditCustomTaskUpdate />}
-                    />
+                    /> */}
                     <Route
                       path="/add_task/planting_method"
                       exact
@@ -1111,11 +1111,11 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
                     />
                     <Route path="/add_task/add_custom_task" exact children={<AddCustomTask />} />
                     <Route path="/add_task/edit_custom_task" exact children={<EditCustomTask />} />
-                    <Route
+                    {/* <Route
                       path="/add_task/edit_custom_task_update"
                       exact
                       children={<EditCustomTaskUpdate />}
-                    />
+                    /> */}
                     <Route
                       path="/add_task/planting_method"
                       exact
@@ -1266,11 +1266,11 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
                     />
                     <Route path="/add_task/add_custom_task" exact children={<AddCustomTask />} />
                     <Route path="/add_task/edit_custom_task" exact children={<EditCustomTask />} />
-                    <Route
+                    {/* <Route
                       path="/add_task/edit_custom_task_update"
                       exact
                       children={<EditCustomTaskUpdate />}
-                    />
+                    /> */}
                     <Route
                       path="/add_task/planting_method"
                       exact

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -1159,7 +1159,6 @@ const Routes = ({ isCompactSideMenu, isFeedbackSurveyOpen, setFeedbackSurveyOpen
                     <Route path="/" exact children={<Home />} />
                     <Route path="/home" exact children={<Home />} />
                     <Route path="/profile" exact children={<Account />} />
-                    <Route path="/people" exact children={<People />} />
                     <Route path="/farm" exact children={<Farm />} />
                     <Route path="/consent" exact children={<ConsentForm />} />
                     <Route path="/crop_catalogue" exact children={<CropCatalogue />} />


### PR DESCRIPTION
**Description**

I noticed while upgrading `react-router-dom` that users could access routes that should be hidden.
This PR:
- removes `/people` and `/farm` for worker accounts (sidebar navs are hidden)
- comments out `/add_task/edit_custom_task_update` (this should've been hidden as part of "Comment out route for edit custom task type" [ticket](https://lite-farm.atlassian.net/browse/ST-367))
- remove unused imports (address Joyce's [comment](https://github.com/LiteFarmOrg/LiteFarm/pull/3862#discussion_r2325858604), thank you!! 🙏)

Jira link:
- https://lite-farm.atlassian.net/browse/LF-4922
- https://lite-farm.atlassian.net/browse/LF-4923
- https://lite-farm.atlassian.net/browse/LF-4940

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
