### PR TITLE
LF-4947:  Animals page and create task page display error screen when user is offline

### DIFF
--- a/packages/webapp/src/containers/Animals/Inventory/KPI/index.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/KPI/index.tsx
@@ -71,7 +71,11 @@ function KPI({ selectedTypeIds, onTypeClick }: KPIProps) {
     }
 
     const { defaultAnimalTypes, customAnimalTypes } = data;
-    const types = formatAnimalTypes([...defaultAnimalTypes, ...customAnimalTypes], onTypeClick, t);
+    const types = formatAnimalTypes(
+      [...(defaultAnimalTypes || []), ...(customAnimalTypes || [])],
+      onTypeClick,
+      t,
+    );
     types.sort(getComparator('asc', 'label'));
 
     return types;

--- a/packages/webapp/src/containers/Animals/Inventory/useAnimalsExist.tsx
+++ b/packages/webapp/src/containers/Animals/Inventory/useAnimalsExist.tsx
@@ -23,7 +23,9 @@ const useAnimalsExist = () => {
 
   const animalsExistOnFarm =
     !isLoading &&
-    [...data.animals, ...data.animalBatches].some((entity) => !entity.animal_removal_reason_id);
+    [...(data.animals || []), ...(data.animalBatches || [])].some(
+      (entity) => !entity.animal_removal_reason_id,
+    );
 
   return { animalsExistOnFarm };
 };


### PR DESCRIPTION
**Description**

Fix crashes offline by defaulting array values to `[]` when undefined.
Animals/batches/animal types might be pre-cached later, but this shouldn't hurt.

The fixes were tested on the offline POC branch mentioned in this [ticket](https://lite-farm.atlassian.net/browse/LF-4941).

(Offline testing was tricky with these bugs, so I decided to addressed them)

Jira link: https://lite-farm.atlassian.net/browse/LF-4947

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

I used Joyce's offline POC [branch](https://github.com/LiteFarmOrg/LiteFarm/tree/LF-4941-spike-technical-requirements-of-offline-capability).

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
