### PR TITLE
LF-4958 "I prefer not to say" Option Is Preselected by Default When Starting Task Completion

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -52,7 +52,7 @@ const formatDefaultValues = (persistedFormData, dueDateDisabled) => {
     ...persistedFormData,
     [DATE_CHOICE]: dateChoice,
     [ANOTHER_DATE]: anotherDate,
-    [PREFER_NOT_TO_SAY]: !persistedFormData?.happiness,
+    [PREFER_NOT_TO_SAY]: completeDate && !persistedFormData?.happiness,
   };
 };
 


### PR DESCRIPTION
**Description**

I was in the mood for a lightweight bug 😂🙏 Missed this completely the other day, sorry 🙇 

`null` happiness is indeed the right data model for having selected "I prefer not to say", but only on a task that has already been completed.

Jira link: https://lite-farm.atlassian.net/browse/LF-4958

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
