### PR TITLE
LF-4957 Rating, Notes, and Time Spent Not Persisted During Task Re-Completion

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -22,6 +22,23 @@ import PureMovementTask from '../MovementTask';
 import AnimalInventory, { View } from '../../../containers/Animals/Inventory';
 import { ANIMAL_IDS } from '../TaskAnimalInventory';
 import FilePicker from '../../FilePicker';
+import {
+  ANOTHER_DATE,
+  COMPLETION_NOTES,
+  DATE_CHOICE,
+  DURATION,
+  HAPPINESS,
+  PREFER_NOT_TO_SAY,
+} from '.';
+
+const COMPLETION_FIELDS = [
+  DURATION,
+  HAPPINESS,
+  COMPLETION_NOTES,
+  PREFER_NOT_TO_SAY,
+  DATE_CHOICE,
+  ANOTHER_DATE,
+];
 
 const soilAmendmentContinueDisabled = (needsChange, isValid) => {
   if (!needsChange) {
@@ -54,6 +71,13 @@ export default function PureCompleteStepOne({
   const defaultsToUse = formatTaskReadOnlyDefaultValues(
     persistedFormData.need_changes ? persistedFormData : selectedTask,
   );
+  const preserveCompletionFields = (persistedFormData) => {
+    // If `/complete` form is visited, duration will always be defined
+    if (persistedFormData.duration === undefined) {
+      return {};
+    }
+    return Object.fromEntries(COMPLETION_FIELDS.map((field) => [field, persistedFormData[field]]));
+  };
   const {
     register,
     handleSubmit,
@@ -71,6 +95,7 @@ export default function PureCompleteStepOne({
       need_changes: false,
       ...defaultsToUse,
       ...(persistedFormData[ANIMAL_IDS] && { [ANIMAL_IDS]: persistedFormData[ANIMAL_IDS] }),
+      ...preserveCompletionFields(persistedFormData),
       results_available: persistedFormData.uploadedFiles?.length ? true : false,
     },
   });

--- a/packages/webapp/src/components/Task/TaskComplete/index.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/index.jsx
@@ -21,12 +21,12 @@ import { TASK_TYPE_PRODUCT_MAP } from '../../../containers/Task/constants';
 import { isSameDay } from '../../../util/date-migrate-TS';
 import { getLocalDateInYYYYDDMM } from '../../../util/date';
 
-const DURATION = 'duration';
-const COMPLETION_NOTES = 'completion_notes';
-const HAPPINESS = 'happiness';
-const PREFER_NOT_TO_SAY = 'prefer_not_to_say';
-const DATE_CHOICE = 'date_choice';
-const ANOTHER_DATE = 'date_another';
+export const DURATION = 'duration';
+export const COMPLETION_NOTES = 'completion_notes';
+export const HAPPINESS = 'happiness';
+export const PREFER_NOT_TO_SAY = 'prefer_not_to_say';
+export const DATE_CHOICE = 'date_choice';
+export const ANOTHER_DATE = 'date_another';
 
 const formatDefaultValues = (persistedFormData, dueDateDisabled) => {
   if (persistedFormData[DATE_CHOICE]) {


### PR DESCRIPTION
**Description**

This one wasn't quite as smooth and fun a bugfix as the other, since everything with `hookFormPersist` completely confuses me 🤣 

But in a nutshell, the issue was that in `PureCompleteStepOne`, the default form values are taken from either the (database saved) `selectedTask` -or- the `persistedFormData`, based on `need_changes`:

```js
  const defaultsToUse = formatTaskReadOnlyDefaultValues(
    persistedFormData.need_changes ? persistedFormData : selectedTask,
  );
```

This is exactly the right behaviour for the task-specific details fields, but not for the complete fields, on which `need_changes` has no relevance (we always want the `persistedFormData` to take precedence if it exists).

When unmounting `/before_complete`, `useHookFormPersist` updates the persistedFormData will the current form values:

```js
  const {
    persistedData: { uploadedFiles },
    historyCancel,
  } = useHookFormPersist(getValues, [], getFieldsToKeep(selectedTaskType));
  ```
 
Because that logic has a step that removes `null` values (`getCorrectedPayload()` in `/hookFormPersistSlice.js`), it just so happened to always take the `/complete` form values, since complete fields are all null on `selectedTask` in the original complete flow.

In the re-complete flow, those values are NOT null, won't be discarded, and will overwrite anything that has been put in `persistedFormData` subsequently by the actual `/complete` form. I'm quite sure this is the cause although I'm not 100% sure this is the best code solution 😄 I just checked for one of the non-optional fields that is always populated once visiting the second step of the form, and if it was present, made sure the `persistedFormData` values always overwrite whatever was in the originally completed task as far as completion fields. I left the `need_changes` logic untouched as it is correct for the `/before_complete` fields.

Jira link: https://lite-farm.atlassian.net/browse/LF-4957

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
