### PR TITLE
Lf 4973 add revision info to task card

### DIFF
--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { ReactComponent as CalendarIcon } from '../../../assets/images/task/Calendar.svg';
 import { ReactComponent as UnassignedIcon } from '../../../assets/images/task/Unassigned.svg';
@@ -35,6 +34,7 @@ export const taskStatusTranslateKey = {
 import { languageCodes } from '../../../hooks/useLanguageOptions';
 import { getIntlDate } from '../../../util/date-migrate-TS';
 import { getFirstNameWithLastInitial } from '../../../util';
+import RevisionInfoText from '../../RevisionInfoText';
 
 export const PureTaskCard = ({
   taskType,
@@ -53,6 +53,8 @@ export const PureTaskCard = ({
   isAdmin,
   isAssignee,
   language,
+  revision_date,
+  reviser,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -69,6 +71,8 @@ export const PureTaskCard = ({
 
   const isAssigneeInactive = assignee?.status === 'Inactive';
   const assigneeName = assignee ? getFirstNameWithLastInitial(assignee) : '';
+
+  const isRevised = !!revision_date;
 
   return (
     <CardWithStatus
@@ -153,6 +157,9 @@ export const PureTaskCard = ({
           )}
         </div>
       </div>
+      {isRevised && (
+        <RevisionInfoText revisionDate={revision_date} reviser={reviser} language={language} />
+      )}
     </CardWithStatus>
   );
 };

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -158,7 +158,9 @@ export const PureTaskCard = ({
         </div>
       </div>
       {isRevised && (
-        <RevisionInfoText revisionDate={revision_date} reviser={reviser} language={language} />
+        <div className={styles.revisionInfo}>
+          <RevisionInfoText revisionDate={revision_date} reviser={reviser} language={language} />
+        </div>
       )}
     </CardWithStatus>
   );

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/styles.module.scss
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/styles.module.scss
@@ -99,3 +99,15 @@
   background-color: var(--grey500);
   color: white;
 }
+
+.revisionInfo {
+  position: absolute;
+  bottom: 16px;
+  right: 8px;
+  color: var(--teal900);
+  text-align: right;
+
+  @include md-breakpoint {
+    visibility: hidden;
+  }
+}

--- a/packages/webapp/src/containers/Task/TaskCard/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCard/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { useDispatch, useSelector } from 'react-redux';
@@ -30,6 +30,8 @@ const TaskCard = ({
   happiness,
   classes = { card: {} },
   wage_at_moment,
+  revision_date,
+  revised_by_user_id,
   ...props
 }) => {
   const [showTaskAssignModal, setShowTaskAssignModal] = useState();
@@ -63,6 +65,7 @@ const TaskCard = ({
   } else {
     taskUnassigned = true;
   }
+  const getUserById = (id) => users.find((user) => user.user_id === id);
 
   return (
     <>
@@ -92,6 +95,8 @@ const TaskCard = ({
         isAdmin={isAdmin}
         isAssignee={isAssignee}
         language={language}
+        revision_date={revision_date}
+        reviser={getUserById(revised_by_user_id)}
       />
       {showTaskAssignModal && (
         <TaskQuickAssignModal

--- a/packages/webapp/src/containers/Task/taskCardContentSelector.js
+++ b/packages/webapp/src/containers/Task/taskCardContentSelector.js
@@ -24,6 +24,8 @@ const getTaskContents = (tasks, userFarmEntities, { farm_id }) => {
       abandon_date: task.abandon_date,
       date: task.abandon_date || task.complete_date || task.due_date,
       wage_at_moment: task.wage_at_moment,
+      revision_date: task.revision_date,
+      revised_by_user_id: task.revised_by_user_id,
     };
   });
 };


### PR DESCRIPTION
**Description**

This adds the revision info to the task card.

It is conditional on mobile view vs other views. If there is no revision it is not displayed.

DRAFT is waiting on resolution to UI issue where FAB overlaps the text:
<img width="960" height="438" alt="Screenshot 2025-10-06 at 11 21 09 AM" src="https://github.com/user-attachments/assets/17822e39-b183-4087-b118-1a5edace3ffb" />

Jira link: [LF-4973](https://lite-farm.atlassian.net/browse/LF-4973)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
