### PR TITLE
LF-5098 Silence 'legacy-js-api' warnings

### DIFF
--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
   },
   server: {
     port: 3000,
-    allowedHosts: true,
   },
   resolve: {
     alias: {

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -8,6 +8,15 @@ import svgrPlugin from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // see https://sass-lang.com/d/legacy-js-api
+        // api: 'modern-compiler' requires Vite 5.4+
+        silenceDeprecations: ['legacy-js-api'],
+      },
+    },
+  },
   plugins: [
     { enforce: 'pre', ...mdx({ providerImportSource: '@mdx-js/react' }) },
     react({
@@ -37,6 +46,7 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    allowedHosts: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
**Description**

After the torrent of SCSS warnings in the webapp console / build process were resolved in:

- #3983 (yay! ❤️)

There is now just the singular warning 

<img width="1339" height="775" alt="Screenshot 2025-12-18 at 11 38 37 AM" src="https://github.com/user-attachments/assets/ff326651-3d52-48b5-ae3a-ef962c5589b0" />

According to the provided link https://sass-lang.com/d/legacy-js-api the new API is supported by default in Vite 6 and as an option in Vite 5.4+. We are on Vite 4. Although we will need to upgrade at some point, this SASS deprecation will not the impetus/cause, so I am silencing it for now.

Jira link: https://lite-farm.atlassian.net/browse/LF-5098

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Webapp console inspected

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
