### PR TITLE
LF-5110 Process survey for metadata and return scores from data

### DIFF
--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -28,9 +28,32 @@ import {
 import styles from './styles.module.scss';
 import { Main, Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
+import TapeQuestions from './tapeQuestions.json';
 
 const CHART_COLOR = 'rgba(85, 143, 112, 1)'; // --Colors-Secondary-Secondary-green-700
 const CHART_FILL_COLOR = 'rgba(85, 143, 112, 0.2)'; // reduced opacity
+const MAX_SCORE = 4;
+
+const getChartTitleFromSurveyTitle = (surveyTitle: unknown) => {
+  if (!surveyTitle || typeof surveyTitle !== 'string') return '';
+
+  // Remove the section number from the title
+  const titleWithoutSectionNumber = surveyTitle.split(/\s+/).slice(1).join(' ');
+
+  if (titleWithoutSectionNumber === '') return '';
+
+  return (
+    titleWithoutSectionNumber.charAt(0).toUpperCase() +
+    titleWithoutSectionNumber.slice(1).toLowerCase()
+  );
+};
+
+const getAnswerKeys = (element: any): string[] => {
+  if (Array.isArray(element.elements)) {
+    return element.elements.flatMap(getAnswerKeys);
+  }
+  return element.name ? [element.name] : [];
+};
 
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
 
@@ -71,9 +94,9 @@ function TAPEResults() {
           display: true,
         },
         suggestedMin: 0,
-        suggestedMax: 100,
+        suggestedMax: MAX_SCORE,
         ticks: {
-          stepSize: 20,
+          stepSize: 1,
         },
       },
     },
@@ -103,23 +126,48 @@ function TAPEResults() {
     </>
   );
 }
+interface ChartSection {
+  dimension: string;
+  answerKeys: string[];
+  maxScore: number;
+}
 
 const analyzeTAPEData = (data: any): TAPEDimension[] => {
   if (!data) return [];
 
-  // TODO: Replace with actual TAPE scoring logic summed over sections; sections below are accurate. Comments indicate the naming structure in the actual survey data
-  return [
-    { dimension: 'Diversity', score: 75, maxScore: 100 }, // diversity_1
-    { dimension: 'Synergy', score: 82, maxScore: 100 }, // synergy_2
-    { dimension: 'Recycling', score: 68, maxScore: 100 }, // recycling_3
-    { dimension: 'Efficiency', score: 90, maxScore: 100 }, // efficiency_4
-    { dimension: 'Resilience', score: 90, maxScore: 100 }, // resilience_5
-    { dimension: 'Culture and food traditions', score: 85, maxScore: 100 }, // culture_6
-    { dimension: 'Co-creation and sharing of knowledge', score: 78, maxScore: 100 }, // knowledge_7
-    { dimension: 'Human and social values', score: 72, maxScore: 100 }, // human_8
-    { dimension: 'Circular economy and solidarity', score: 88, maxScore: 100 }, // circular_9
-    { dimension: 'Responsible governance', score: 95, maxScore: 100 }, // governance_10
+  const sectionNames = [
+    'diversity',
+    'synergy',
+    'recycling',
+    'efficiency',
+    'resilience',
+    'culture_and_food',
+    'cocreation_and_knowledge',
+    'human_and_social',
+    'responsible_governance',
   ];
+  const titleAndAnswerKeys = TapeQuestions.pages.reduce<ChartSection[]>((acc, cv) => {
+    if (sectionNames.includes(cv.name)) {
+      acc.push({
+        dimension: getChartTitleFromSurveyTitle(cv.title),
+        answerKeys: getAnswerKeys(cv),
+        maxScore: MAX_SCORE,
+      });
+      return acc;
+    }
+    return acc;
+  }, []);
+
+  return titleAndAnswerKeys.map(({ dimension, answerKeys, maxScore }) => {
+    return {
+      dimension,
+      score:
+        answerKeys.reduce<number>((acc, cv) => {
+          return data[cv] ? acc + Number(data[cv]) : acc;
+        }, 0) / answerKeys.length, // simple average
+      maxScore,
+    };
+  });
 };
 
 export default TAPEResults;

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -29,10 +29,11 @@ import styles from './styles.module.scss';
 import { Main, Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
 import TapeQuestions from './tapeQuestions.json';
+import { roundToOne } from '../../../util/rounding';
 
 const CHART_COLOR = 'rgba(85, 143, 112, 1)'; // --Colors-Secondary-Secondary-green-700
 const CHART_FILL_COLOR = 'rgba(85, 143, 112, 0.2)'; // reduced opacity
-const MAX_SCORE = 4;
+const MAX_SCORE = 100;
 
 const getChartTitleFromSurveyTitle = (surveyTitle: unknown) => {
   if (!surveyTitle || typeof surveyTitle !== 'string') return '';
@@ -99,7 +100,7 @@ function TAPEResults() {
     datasets: [
       {
         label: 'Your Farm',
-        data: tapeData.map((d) => d.score),
+        data: tapeData.map((d) => roundToOne(d.score)),
         backgroundColor: CHART_FILL_COLOR,
         borderColor: CHART_COLOR,
         borderWidth: 2,
@@ -120,7 +121,7 @@ function TAPEResults() {
         suggestedMin: 0,
         suggestedMax: MAX_SCORE,
         ticks: {
-          stepSize: 1,
+          stepSize: 20,
         },
       },
     },
@@ -130,7 +131,7 @@ function TAPEResults() {
       },
       tooltip: {
         callbacks: {
-          label: (context: any) => `${context.label}: ${context.parsed.r}/100`,
+          label: (context: any) => ` ${context.label}: ${context.parsed.r} %`,
         },
       },
     },
@@ -163,9 +164,11 @@ const analyzeTAPEData = (data: any): TAPEDimension[] => {
     return {
       dimension,
       score:
-        answerKeys.reduce<number>((acc, cv) => {
+        25 *
+        (answerKeys.reduce<number>((acc, cv) => {
           return data[cv] ? acc + Number(data[cv]) : acc;
-        }, 0) / answerKeys.length, // simple average
+        }, 0) /
+          answerKeys.length), // simple average
       maxScore,
     };
   });

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -55,6 +55,30 @@ const getAnswerKeys = (element: any): string[] => {
   return element.name ? [element.name] : [];
 };
 
+const CHOSEN_SECTION_NAMES = [
+  'diversity',
+  'synergy',
+  'recycling',
+  'efficiency',
+  'resilience',
+  'culture_and_food',
+  'cocreation_and_knowledge',
+  'human_and_social',
+  'responsible_governance',
+];
+
+const CHART_SECTION_DATA = TapeQuestions.pages.reduce<ChartSection[]>((acc, cv) => {
+  if (CHOSEN_SECTION_NAMES.includes(cv.name)) {
+    acc.push({
+      dimension: getChartTitleFromSurveyTitle(cv.title),
+      answerKeys: getAnswerKeys(cv),
+      maxScore: MAX_SCORE,
+    });
+    return acc;
+  }
+  return acc;
+}, []);
+
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
 
 interface TAPEDimension {
@@ -135,30 +159,7 @@ interface ChartSection {
 const analyzeTAPEData = (data: any): TAPEDimension[] => {
   if (!data) return [];
 
-  const sectionNames = [
-    'diversity',
-    'synergy',
-    'recycling',
-    'efficiency',
-    'resilience',
-    'culture_and_food',
-    'cocreation_and_knowledge',
-    'human_and_social',
-    'responsible_governance',
-  ];
-  const titleAndAnswerKeys = TapeQuestions.pages.reduce<ChartSection[]>((acc, cv) => {
-    if (sectionNames.includes(cv.name)) {
-      acc.push({
-        dimension: getChartTitleFromSurveyTitle(cv.title),
-        answerKeys: getAnswerKeys(cv),
-        maxScore: MAX_SCORE,
-      });
-      return acc;
-    }
-    return acc;
-  }, []);
-
-  return titleAndAnswerKeys.map(({ dimension, answerKeys, maxScore }) => {
+  return CHART_SECTION_DATA.map(({ dimension, answerKeys, maxScore }) => {
     return {
       dimension,
       score:


### PR DESCRIPTION
**Description**

This calculates the chart data.

~~@kathyavini This ticket mentions adding the redux state, but I think you already did that. I could change it to a more stable store variable not based on -- but I guess not~~

Jira link: [LF-5110](https://lite-farm.atlassian.net/browse/LF-5110)

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files


[LF-5110]: https://lite-farm.atlassian.net/browse/LF-5110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ