### PR TITLE
LF-5111 Set up Redux state to store survey data

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1129,7 +1129,6 @@
       "INFO": "LiteFarm estimates labour happiness by averaging the satisfaction scores individuals enter when marking a task as completed.",
       "TITLE": "Labour Happiness"
     },
-    "NOT_FILLED": "Not filled",
     "PRICES": {
       "INFO": "We show you the trajectory of your sales prices against the sales prices for the same goods within a given distance of you, collected across the LiteFarm network.",
       "NEARBY_FARMS_one": "Network price is based on {{count}} farm in your local area",
@@ -1149,7 +1148,10 @@
       "TITLE": "Soil OM"
     },
     "TAPE": {
+      "COMPLETED": "Completed - See your results",
+      "IN_PROGRESS": "In progress",
       "NO_RESULTS": "No survey data available",
+      "NOT_FILLED": "Not filled",
       "RESULTS_TITLE": "Characterization of the Agroecological Transitions (CAET) Scores",
       "TITLE": "TAPE Survey (Tool for Agroecology Performance Evaluation)"
     },

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1153,7 +1153,8 @@
       "NO_RESULTS": "No survey data available",
       "NOT_FILLED": "Not filled",
       "RESULTS_TITLE": "Characterization of the Agroecological Transitions (CAET) Scores",
-      "TITLE": "TAPE Survey (Tool for Agroecology Performance Evaluation)"
+      "TITLE": "TAPE Survey (Tool for Agroecology Performance Evaluation)",
+      "UPDATE_ANSWERS": "Update your answers"
     },
     "TITLE": "Insights",
     "UNAVAILABLE": "Unavailable"

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1150,7 +1150,6 @@
     "TAPE": {
       "COMPLETED": "Completed - See your results",
       "IN_PROGRESS": "In progress",
-      "NO_RESULTS": "No survey data available",
       "NOT_FILLED": "Not filled",
       "RESULTS_TITLE": "Characterization of the Agroecological Transitions (CAET) Scores",
       "TITLE": "TAPE Survey (Tool for Agroecology Performance Evaluation)",

--- a/packages/webapp/src/components/SurveyComponent/index.tsx
+++ b/packages/webapp/src/components/SurveyComponent/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { Model } from 'survey-core';
 import { Survey } from 'survey-react-ui';
 import { DefaultLight } from 'survey-core/themes';
@@ -85,15 +85,29 @@ export default function SurveyComponent({
     [onValueChanged],
   );
 
-  survey.onComplete.add(handleComplete);
+  useEffect(() => {
+    survey.onComplete.add(handleComplete);
 
-  if (onCurrentPageChanged) {
-    survey.onCurrentPageChanged.add(handleCurrentPageChanged);
-  }
+    if (onCurrentPageChanged) {
+      survey.onCurrentPageChanged.add(handleCurrentPageChanged);
+    }
 
-  if (onValueChanged) {
-    survey.onValueChanged.add(handleValueChanged);
-  }
+    if (onValueChanged) {
+      survey.onValueChanged.add(handleValueChanged);
+    }
+
+    return () => {
+      survey.onComplete.remove(handleComplete);
+
+      if (onCurrentPageChanged) {
+        survey.onCurrentPageChanged.remove(handleCurrentPageChanged);
+      }
+
+      if (onValueChanged) {
+        survey.onValueChanged.remove(handleValueChanged);
+      }
+    };
+  }, [survey, handleComplete, handleCurrentPageChanged, handleValueChanged]);
 
   return <Survey model={survey} />;
 }

--- a/packages/webapp/src/components/SurveyComponent/index.tsx
+++ b/packages/webapp/src/components/SurveyComponent/index.tsx
@@ -21,12 +21,17 @@ import 'survey-core/survey-core.css';
 
 interface SurveyComponentProps {
   surveyJson: any; // Survey JSON schema object
-  onComplete: (surveyData: any) => void;
+  onComplete: (currentPageNo: number, surveyData: any) => void;
   initialData?: Record<string, any>;
   initialPageNo?: number;
   onCurrentPageChanged?: (currentPageNo: number, surveyData: Record<string, any>) => void;
   onValueChanged?: (currentPageNo: number, surveyData: Record<string, any>) => void;
 }
+
+const extractSurveyState = (model: Model) => ({
+  currentPageNo: model.currentPageNo,
+  surveyData: model.data,
+});
 
 export default function SurveyComponent({
   surveyJson,
@@ -58,16 +63,15 @@ export default function SurveyComponent({
   // https://surveyjs.io/form-library/documentation/get-started-react
   const handleComplete = useCallback(
     (surveyModel: Model) => {
-      const surveyData = surveyModel.data;
-      onComplete(surveyData);
+      const { currentPageNo, surveyData } = extractSurveyState(surveyModel);
+      onComplete(currentPageNo, surveyData);
     },
     [onComplete],
   );
 
   const handleCurrentPageChanged = useCallback(
     (surveyModel: Model) => {
-      const currentPageNo = surveyModel.currentPageNo;
-      const surveyData = surveyModel.data;
+      const { currentPageNo, surveyData } = extractSurveyState(surveyModel);
       onCurrentPageChanged?.(currentPageNo, surveyData);
     },
     [onCurrentPageChanged],
@@ -75,8 +79,7 @@ export default function SurveyComponent({
 
   const handleValueChanged = useCallback(
     (surveyModel: Model) => {
-      const currentPageNo = surveyModel.currentPageNo;
-      const surveyData = surveyModel.data;
+      const { currentPageNo, surveyData } = extractSurveyState(surveyModel);
       onValueChanged?.(currentPageNo, surveyData);
     },
     [onValueChanged],

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Radar } from 'react-chartjs-2';
 import {
@@ -25,6 +25,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import { tapeSurveyDataSelector } from './tapeSurveySlice';
 import styles from './styles.module.scss';
 import { Main, Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
@@ -90,8 +91,7 @@ interface TAPEDimension {
 
 function TAPEResults() {
   const { t } = useTranslation();
-  const location = useLocation<{ surveyData: any }>();
-  const surveyData = location.state?.surveyData;
+  const surveyData = useSelector(tapeSurveyDataSelector);
 
   const tapeData = analyzeTAPEData(surveyData);
 

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -131,7 +131,7 @@ function TAPEResults() {
       },
       tooltip: {
         callbacks: {
-          label: (context: any) => ` ${context.label}: ${context.parsed.r} %`,
+          label: (context: any) => ` ${context.label}: ${context.parsed.r}%`,
         },
       },
     },

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -158,12 +158,10 @@ function TAPEResults() {
         </Button>
       </div>
       <Semibold className={styles.titleText}>{t('INSIGHTS.TAPE.RESULTS_TITLE')}</Semibold>
-      {tapeData && tapeData.length > 0 ? (
+      {tapeData && tapeData.length > 0 && (
         <div className={styles.chartContainer}>
           <Radar data={chartData} options={options} />
         </div>
-      ) : (
-        <Main className={styles.titleText}>{t('INSIGHTS.TAPE.NO_RESULTS')}</Main>
       )}
     </>
   );

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { Radar } from 'react-chartjs-2';
@@ -26,7 +26,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import { tapeSurveyDataSelector } from './tapeSurveySlice';
+import { tapeSurveyDataSelector, reopenSurvey } from './tapeSurveySlice';
 import styles from './styles.module.scss';
 import { Main, Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
@@ -95,6 +95,7 @@ interface TAPEDimension {
 function TAPEResults() {
   const { t } = useTranslation();
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const surveyData = useSelector(tapeSurveyDataSelector);
 
@@ -143,6 +144,7 @@ function TAPEResults() {
   };
 
   const returnToSurvey = () => {
+    dispatch(reopenSurvey());
     history.push('/insights/tape');
   };
 

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -26,7 +26,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import { tapeSurveyDataSelector, reopenSurvey } from './tapeSurveySlice';
+import { tapeSurveySelector, reopenSurvey } from './tapeSurveySlice';
 import styles from './styles.module.scss';
 import { Main, Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
@@ -97,7 +97,7 @@ function TAPEResults() {
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const surveyData = useSelector(tapeSurveyDataSelector);
+  const { surveyData } = useSelector(tapeSurveySelector);
 
   const tapeData = analyzeTAPEData(surveyData);
 

--- a/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/TapeResults.tsx
@@ -15,6 +15,7 @@
 
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import { Radar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -31,6 +32,8 @@ import { Main, Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
 import TapeQuestions from './tapeQuestions.json';
 import { roundToOne } from '../../../util/rounding';
+import Button from '../../../components/Form/Button';
+import { ReactComponent as EditIcon } from '../../../assets/images/edit.svg';
 
 const CHART_COLOR = 'rgba(85, 143, 112, 1)'; // --Colors-Secondary-Secondary-green-700
 const CHART_FILL_COLOR = 'rgba(85, 143, 112, 0.2)'; // reduced opacity
@@ -91,6 +94,8 @@ interface TAPEDimension {
 
 function TAPEResults() {
   const { t } = useTranslation();
+  const history = useHistory();
+
   const surveyData = useSelector(tapeSurveyDataSelector);
 
   const tapeData = analyzeTAPEData(surveyData);
@@ -137,9 +142,19 @@ function TAPEResults() {
     },
   };
 
+  const returnToSurvey = () => {
+    history.push('/insights/tape');
+  };
+
   return (
     <>
       <PageTitle title={t('INSIGHTS.TAPE.TITLE')} backUrl="/Insights" />
+      <div className={styles.buttonContainer}>
+        <Button sm color="secondary-2" onClick={returnToSurvey}>
+          {t('INSIGHTS.TAPE.UPDATE_ANSWERS')}
+          <EditIcon className={styles.editIcon} />
+        </Button>
+      </div>
       <Semibold className={styles.titleText}>{t('INSIGHTS.TAPE.RESULTS_TITLE')}</Semibold>
       {tapeData && tapeData.length > 0 ? (
         <div className={styles.chartContainer}>

--- a/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
@@ -16,12 +16,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import {
-  saveSurveyProgress,
-  completeSurvey,
-  tapeSurveyDataSelector,
-  tapeSurveyCurrentPageNoSelector,
-} from './tapeSurveySlice';
+import { saveSurveyProgress, completeSurvey, tapeSurveySelector } from './tapeSurveySlice';
 import SurveyComponent from '../../../components/SurveyComponent';
 import surveyJson from './tapeQuestions.json';
 import PageTitle from '../../../components/PageTitle';
@@ -39,8 +34,7 @@ function TAPESurvey() {
     // Number of unique species in crop management plans
   };
 
-  const savedData = useSelector(tapeSurveyDataSelector);
-  const savedPageNo = useSelector(tapeSurveyCurrentPageNoSelector);
+  const { surveyData: savedData, currentPageNo: savedPageNo } = useSelector(tapeSurveySelector);
 
   const initialData = { ...prepopulatedData, ...savedData };
 

--- a/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
@@ -13,6 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -38,14 +39,14 @@ function TAPESurvey() {
 
   const initialData = { ...prepopulatedData, ...savedData };
 
-  const handleDataChange = (currentPageNo: number, surveyData: Record<string, any>) => {
+  const handleDataChange = useCallback((currentPageNo: number, surveyData: Record<string, any>) => {
     dispatch(saveSurveyProgress({ currentPageNo, surveyData }));
-  };
+  }, []);
 
-  const handleComplete = (currentPageNo: number, surveyData: any) => {
+  const handleComplete = useCallback((currentPageNo: number, surveyData: any) => {
     dispatch(completeSurvey({ currentPageNo, surveyData }));
     history.push('/insights/tape/results');
-  };
+  }, []);
 
   return (
     <>

--- a/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
@@ -13,8 +13,15 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import {
+  saveSurveyProgress,
+  completeSurvey,
+  tapeSurveyDataSelector,
+  tapeSurveyCurrentPageNoSelector,
+} from './tapeSurveySlice';
 import SurveyComponent from '../../../components/SurveyComponent';
 import surveyJson from './tapeQuestions.json';
 import PageTitle from '../../../components/PageTitle';
@@ -22,13 +29,23 @@ import PageTitle from '../../../components/PageTitle';
 function TAPESurvey() {
   const { t } = useTranslation();
   const history = useHistory();
+  const dispatch = useDispatch();
 
-  // TODO: Prepare prepopulated data
+  // TODO LF-5109: Prepare prepopulated data
   const prepopulatedData = {
     // Country
     // Lat / Lng
     // Do you raise animals
     // Number of unique species in crop management plans
+  };
+
+  const savedData = useSelector(tapeSurveyDataSelector);
+  const savedPageNo = useSelector(tapeSurveyCurrentPageNoSelector);
+
+  const initialData = { ...prepopulatedData, ...savedData };
+
+  const handleDataChange = (currentPageNo: number, surveyData: Record<string, any>) => {
+    dispatch(saveSurveyProgress({ currentPageNo, surveyData }));
   };
 
   const handleComplete = (surveyData: any) => {
@@ -41,7 +58,9 @@ function TAPESurvey() {
       <SurveyComponent
         surveyJson={surveyJson}
         onComplete={handleComplete}
-        initialData={prepopulatedData}
+        onValueChanged={handleDataChange}
+        initialData={initialData}
+        initialPageNo={savedPageNo}
       />
     </>
   );

--- a/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
@@ -49,7 +49,8 @@ function TAPESurvey() {
   };
 
   const handleComplete = (surveyData: any) => {
-    history.push('/insights/tape/results', { surveyData });
+    dispatch(completeSurvey(surveyData));
+    history.push('/insights/tape/results');
   };
 
   return (

--- a/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/index.tsx
@@ -42,8 +42,8 @@ function TAPESurvey() {
     dispatch(saveSurveyProgress({ currentPageNo, surveyData }));
   };
 
-  const handleComplete = (surveyData: any) => {
-    dispatch(completeSurvey(surveyData));
+  const handleComplete = (currentPageNo: number, surveyData: any) => {
+    dispatch(completeSurvey({ currentPageNo, surveyData }));
     history.push('/insights/tape/results');
   };
 

--- a/packages/webapp/src/containers/Insights/TapeSurvey/styles.module.scss
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/styles.module.scss
@@ -21,3 +21,12 @@
   height: 500px;
   width: 100%;
 }
+
+.buttonContainer {
+  padding-inline: 32px;
+
+  .editIcon {
+    margin-left: 4px;
+    width: 16px;
+  }
+}

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -16,24 +16,16 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 
-export interface TAPEDimension {
-  dimension: string;
-  score: number;
-  maxScore: number;
-}
-
 interface TapeSurveyState {
   currentPageNo: number;
   surveyData: Record<string, any>;
   isCompleted: boolean;
-  results: TAPEDimension[] | null;
 }
 
 const initialState: TapeSurveyState = {
   currentPageNo: 0,
   surveyData: {},
   isCompleted: false,
-  results: null,
 };
 
 const tapeSurveySlice = createSlice({
@@ -47,12 +39,8 @@ const tapeSurveySlice = createSlice({
       state.currentPageNo = action.payload.currentPageNo;
       state.surveyData = { ...state.surveyData, ...action.payload.surveyData };
     },
-    completeSurvey: (
-      state,
-      action: PayloadAction<{ surveyData: Record<string, any>; results: TAPEDimension[] }>,
-    ) => {
-      state.surveyData = action.payload.surveyData;
-      state.results = action.payload.results;
+    completeSurvey: (state, action: PayloadAction<Record<string, any>>) => {
+      state.surveyData = action.payload;
       state.isCompleted = true;
     },
     clearSurvey: () => initialState,
@@ -79,11 +67,6 @@ export const tapeSurveyCurrentPageNoSelector = createSelector(
 export const tapeSurveyIsCompletedSelector = createSelector(
   [tapeSurveyReducerSelector],
   (tapeSurvey) => tapeSurvey?.isCompleted || false,
-);
-
-export const tapeSurveyResultsSelector = createSelector(
-  [tapeSurveyReducerSelector],
-  (tapeSurvey) => tapeSurvey?.results || null,
 );
 
 export const tapeSurveyStatusSelector = createSelector(

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSelector } from 'reselect';
+
+export interface TAPEDimension {
+  dimension: string;
+  score: number;
+  maxScore: number;
+}
+
+interface TapeSurveyState {
+  currentPageNo: number;
+  surveyData: Record<string, any>;
+  isCompleted: boolean;
+  results: TAPEDimension[] | null;
+}
+
+const initialState: TapeSurveyState = {
+  currentPageNo: 0,
+  surveyData: {},
+  isCompleted: false,
+  results: null,
+};
+
+const tapeSurveySlice = createSlice({
+  name: 'tapeSurveyReducer',
+  initialState,
+  reducers: {
+    saveSurveyProgress: (
+      state,
+      action: PayloadAction<{ currentPageNo: number; surveyData: Record<string, any> }>,
+    ) => {
+      state.currentPageNo = action.payload.currentPageNo;
+      state.surveyData = { ...state.surveyData, ...action.payload.surveyData };
+    },
+    completeSurvey: (
+      state,
+      action: PayloadAction<{ surveyData: Record<string, any>; results: TAPEDimension[] }>,
+    ) => {
+      state.surveyData = action.payload.surveyData;
+      state.results = action.payload.results;
+      state.isCompleted = true;
+    },
+    clearSurvey: () => initialState,
+  },
+});
+
+export const { saveSurveyProgress, completeSurvey, clearSurvey } = tapeSurveySlice.actions;
+export default tapeSurveySlice.reducer;
+
+// Selectors
+export const tapeSurveyReducerSelector = (state: any) =>
+  state.entitiesReducer[tapeSurveySlice.name];
+
+export const tapeSurveyDataSelector = createSelector(
+  [tapeSurveyReducerSelector],
+  (tapeSurvey) => tapeSurvey?.surveyData || {},
+);
+
+export const tapeSurveyCurrentPageNoSelector = createSelector(
+  [tapeSurveyReducerSelector],
+  (tapeSurvey) => tapeSurvey?.currentPageNo || 0,
+);
+
+export const tapeSurveyIsCompletedSelector = createSelector(
+  [tapeSurveyReducerSelector],
+  (tapeSurvey) => tapeSurvey?.isCompleted || false,
+);
+
+export const tapeSurveyResultsSelector = createSelector(
+  [tapeSurveyReducerSelector],
+  (tapeSurvey) => tapeSurvey?.results || null,
+);
+
+export const tapeSurveyStatusSelector = createSelector(
+  [tapeSurveyReducerSelector],
+  (tapeSurvey) => ({
+    isCompleted: tapeSurvey?.isCompleted || false,
+    hasData: Object.keys(tapeSurvey?.surveyData || {}).length > 0,
+  }),
+);

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -43,7 +43,6 @@ const tapeSurveySlice = createSlice({
       state,
       action: PayloadAction<{ currentPageNo: number; surveyData: Record<string, any> }>,
     ) => {
-      debugger;
       state.currentPageNo = action.payload.currentPageNo;
       state.surveyData = action.payload.surveyData;
       state.isCompleted = true;

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -40,6 +40,7 @@ const tapeSurveySlice = createSlice({
       state.surveyData = { ...state.surveyData, ...action.payload.surveyData };
     },
     completeSurvey: (state, action: PayloadAction<Record<string, any>>) => {
+      debugger;
       state.surveyData = action.payload;
       state.isCompleted = true;
     },
@@ -55,28 +56,10 @@ export const { saveSurveyProgress, completeSurvey, reopenSurvey, clearSurvey } =
 export default tapeSurveySlice.reducer;
 
 // Selectors
-export const tapeSurveyReducerSelector = (state: any) =>
-  state.entitiesReducer[tapeSurveySlice.name];
+export const tapeSurveySelector = (state: any) =>
+  state.entitiesReducer[tapeSurveySlice.name] || initialState;
 
-export const tapeSurveyDataSelector = createSelector(
-  [tapeSurveyReducerSelector],
-  (tapeSurvey) => tapeSurvey?.surveyData || {},
-);
-
-export const tapeSurveyCurrentPageNoSelector = createSelector(
-  [tapeSurveyReducerSelector],
-  (tapeSurvey) => tapeSurvey?.currentPageNo || 0,
-);
-
-export const tapeSurveyIsCompletedSelector = createSelector(
-  [tapeSurveyReducerSelector],
-  (tapeSurvey) => tapeSurvey?.isCompleted || false,
-);
-
-export const tapeSurveyStatusSelector = createSelector(
-  [tapeSurveyReducerSelector],
-  (tapeSurvey) => ({
-    isCompleted: tapeSurvey?.isCompleted || false,
-    hasData: Object.keys(tapeSurvey?.surveyData || {}).length > 0,
-  }),
-);
+export const tapeSurveyStatusSelector = createSelector([tapeSurveySelector], (tapeSurvey) => ({
+  isCompleted: tapeSurvey.isCompleted,
+  hasData: Object.keys(tapeSurvey.surveyData).length > 0,
+}));

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -43,11 +43,15 @@ const tapeSurveySlice = createSlice({
       state.surveyData = action.payload;
       state.isCompleted = true;
     },
+    reopenSurvey: (state) => {
+      state.isCompleted = false;
+    },
     clearSurvey: () => initialState,
   },
 });
 
-export const { saveSurveyProgress, completeSurvey, clearSurvey } = tapeSurveySlice.actions;
+export const { saveSurveyProgress, completeSurvey, reopenSurvey, clearSurvey } =
+  tapeSurveySlice.actions;
 export default tapeSurveySlice.reducer;
 
 // Selectors

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -49,6 +49,7 @@ const tapeSurveySlice = createSlice({
     },
     reopenSurvey: (state) => {
       state.isCompleted = false;
+      state.currentPageNo = 0;
     },
     clearSurvey: () => initialState,
   },

--- a/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/tapeSurveySlice.ts
@@ -39,9 +39,13 @@ const tapeSurveySlice = createSlice({
       state.currentPageNo = action.payload.currentPageNo;
       state.surveyData = { ...state.surveyData, ...action.payload.surveyData };
     },
-    completeSurvey: (state, action: PayloadAction<Record<string, any>>) => {
+    completeSurvey: (
+      state,
+      action: PayloadAction<{ currentPageNo: number; surveyData: Record<string, any> }>,
+    ) => {
       debugger;
-      state.surveyData = action.payload;
+      state.currentPageNo = action.payload.currentPageNo;
+      state.surveyData = action.payload.surveyData;
       state.isCompleted = true;
     },
     reopenSurvey: (state) => {

--- a/packages/webapp/src/containers/Insights/index.jsx
+++ b/packages/webapp/src/containers/Insights/index.jsx
@@ -34,6 +34,7 @@ import {
   pricesSelector,
   soilOMSelector,
 } from './selectors';
+import { tapeSurveyStatusSelector } from './TapeSurvey/tapeSurveySlice';
 
 import InfoBoxComponent from '../../components/InfoBoxComponent';
 import { BsChevronRight } from 'react-icons/bs';
@@ -43,6 +44,7 @@ import { Semibold, Text, Title } from '../../components/Typography';
 const Insights = () => {
   const history = useHistory();
   const farm = useSelector(userFarmSelector);
+  const tapeStatus = useSelector(tapeSurveyStatusSelector);
   const pricesDistance = useSelector(pricesDistanceSelector);
   const soilOMData = useSelector(soilOMSelector);
   const labourHappinessData = useSelector(labourHappinessSelector);
@@ -56,7 +58,7 @@ const Insights = () => {
     {
       label: t('INSIGHTS.TAPE.TITLE'),
       image: tape_survey,
-      route: 'tape',
+      route: tapeStatus.isCompleted ? 'tape/results' : 'tape',
       data_point: 'TAPE',
     },
     {
@@ -122,7 +124,11 @@ const Insights = () => {
 
   const insightData = useMemo(() => {
     const insightData = {};
-    insightData['TAPE'] = t('INSIGHTS.NOT_FILLED');
+    insightData['TAPE'] = tapeStatus.isCompleted
+      ? t('INSIGHTS.TAPE.COMPLETED')
+      : tapeStatus.hasData
+        ? t('INSIGHTS.TAPE.IN_PROGRESS')
+        : t('INSIGHTS.TAPE.NOT_FILLED');
     insightData['SoilOM'] = (soilOMData.preview ?? '0') + '%';
     insightData['LabourHappiness'] = labourHappinessData.preview
       ? labourHappinessData.preview + '/5'
@@ -132,7 +138,7 @@ const Insights = () => {
       ? t('INSIGHTS.PRICES.PERCENT_OF_MARKET', { percentage: pricesData.preview })
       : t('INSIGHTS.UNAVAILABLE');
     return insightData;
-  }, [soilOMData, labourHappinessData, biodiversityData, pricesData]);
+  }, [tapeStatus, soilOMData, labourHappinessData, biodiversityData, pricesData]);
 
   const renderedItems = useMemo(() => {
     return (

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -85,6 +85,7 @@ import fieldWorkReducer from '../containers/fieldWorkSlice';
 import irrigationTaskReducer from '../containers/slice/taskSlice/irrigationTaskSlice';
 import irrigationTaskTypesReducer from '../containers/irrigationTaskTypesSlice';
 import revenueTypeReducer from '../containers/revenueTypeSlice';
+import tapeSurveyReducer from '../containers/Insights/TapeSurvey/tapeSurveySlice';
 
 import { ActionTypes } from './actionTypes';
 // all the initial state for the forms
@@ -207,6 +208,7 @@ const entitiesReducer = combineReducers({
   irrigationTaskReducer,
   irrigationTaskTypesReducer,
   revenueTypeReducer,
+  tapeSurveyReducer,
 });
 
 const farmStateReducer = combineReducers({


### PR DESCRIPTION
**Description**

Alright, that was a bit of an adventure! Took longer than expected.

This PR hooks the TAPE form up to Redux. Now the form can be resumed from any point, reloaded, and edited after completion. Insights tracks the state of the form and routes to either the survey or the results as applicable.

Code-wise, the PR does the following:
- create a Redux slice with selectors and actions for interacting with TAPE
  - this includes one action (`clearSurvey()`) which is not used yet in app; I personally think we might want a reset that is not logout now that there is so much saving (see below), but I'll leave that to Loïc to decide next week or for Hannah and co. to comment tomorrow
- add handlers to the general Survey component for `onValueChanged` and `onCurrentPageChanged` in addition to the original `onComplete`
  - in the case of TAPE I actually didn't end up using the `onCurrentPageChanged` -- I just go ahead and save to Redux `onValueChanged` (= `onBlur` of each input). However, I left it in, in case a different survey wanted to react to that event
  - all handlers now return the current state of the survey in terms of a) page number (so it can be resumed from the same place) and b) survey content
- add a bit of status state to the slice for use in `<Insights />` so the survey status and routing can be adjusted from that main Insight page (works pretty well, I think!)
-  adds the little button to return to the survey which also removes the "completed" state. This only matters for that Insight main page; I don't really do anything with completed or not in the results page. And actually I think the way the chart data logic was implemented (0 for skipped scores) means that if you navigate right to `/tape/results` with no data, you just see a chart with all values 0. I think that's totally fine so I removed the "No results" fallback and string

Jira link: https://lite-farm.atlassian.net/browse/LF-5111

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
