### PR TITLE
LF-5105: Detect offline state and pass to relevant components

### DIFF
--- a/packages/webapp/src/containers/hooks/useOfflineDetector/OfflineDetector.jsx
+++ b/packages/webapp/src/containers/hooks/useOfflineDetector/OfflineDetector.jsx
@@ -10,6 +10,13 @@ export function OfflineDetector() {
   const goOnline = () => dispatch(updateOfflineStatus(false));
   const goOffline = () => dispatch(updateOfflineStatus(true));
   useEffect(() => {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine
+    if (window.navigator.onLine) {
+      goOnline();
+    } else {
+      goOffline();
+    }
+
     window.addEventListener('online', goOnline);
     window.addEventListener('offline', goOffline);
     return () => {

--- a/packages/webapp/src/containers/hooks/useOfflineDetector/offlineDetectorSlice.ts
+++ b/packages/webapp/src/containers/hooks/useOfflineDetector/offlineDetectorSlice.ts
@@ -4,7 +4,7 @@ const initialState = {
   isOffline: false,
 };
 
-const hookFormPersistSlice = createSlice({
+const offlineDetectorSlice = createSlice({
   name: 'offlineDetectorReducer',
   initialState,
   reducers: {
@@ -13,5 +13,5 @@ const hookFormPersistSlice = createSlice({
     },
   },
 });
-export const { updateOfflineStatus } = hookFormPersistSlice.actions;
-export default hookFormPersistSlice.reducer;
+export const { updateOfflineStatus } = offlineDetectorSlice.actions;
+export default offlineDetectorSlice.reducer;


### PR DESCRIPTION
**Description**

This PR ensures the offline/online state is set correctly on browser reload.

Listeners for online/offline seem to be working fine. I think I once saw the offline banner not appear when Joyce checked "offline" on  [LF-5114 branch](https://github.com/LiteFarmOrg/LiteFarm/tree/LF-5114-create-and-show-the-offline-badge-icon), but I wasn't able to reproduce it.

Please let me know if there's a way to reproduce the issue!

Jira link: https://lite-farm.atlassian.net/browse/LF-5105

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature? (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Used Joyce's [LF-5114 branch](https://github.com/LiteFarmOrg/LiteFarm/tree/LF-5114-create-and-show-the-offline-badge-icon).

1. Navigate to a page where a crash happens, and go offline
2. Go back to the previous page and reload

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
