### PR TITLE
LF-5123: Show readonly and disabled menu states when offline

### DIFF
--- a/packages/webapp/src/components/Navigation/SideMenu/index.jsx
+++ b/packages/webapp/src/components/Navigation/SideMenu/index.jsx
@@ -28,15 +28,10 @@ import styles from './styles.module.scss';
 import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 import { useIsOffline } from '../../../containers/hooks/useOfflineDetector/useIsOffline';
 
-const MenuItem = forwardRef(({ history, onClick, path, children, className, ariaLabel }, ref) => {
-  const isActive = matchPath(history.location.pathname, path);
+const MenuItem = forwardRef(({ history, onClick, path, children, ...props }, ref) => {
   return (
-    <ListItemButton
-      onClick={onClick ?? (() => history.push(path))}
-      className={clsx(styles.listItem, isActive && styles.active, className)}
-      ref={ref}
-      aria-label={ariaLabel}
-    >
+    <ListItemButton onClick={onClick ?? (() => history.push(path))} ref={ref} {...props}>
+      {/* Visibility controlled via props.classes passed to ListItemButton */}
       <span className={styles.eyeIconWrapper}>
         <FiEye aria-hidden="true" />
       </span>
@@ -95,17 +90,25 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
     resetExpanded();
   }, [isCompact]);
 
-  const getMenuItemProps = (key, label, className) => {
+  const getMenuItemProps = (key, label, path, className) => {
     const isViewOnly = offline && offlineViewOnlyPageKeys.has(key);
     const isDisabled = offline && offlineDisabledPageKeys.has(key);
+    const isActive = matchPath(history.location.pathname, path);
 
     return {
-      className: clsx(
-        className,
-        isViewOnly && styles.offlineViewOnly,
-        isDisabled && styles.offlineDisabled,
-      ),
-      ariaLabel: label + (isViewOnly ? ' - view only page' : ''),
+      history,
+      path,
+      'aria-label': label + (isViewOnly ? ' - view only page' : ''),
+      disabled: isDisabled,
+      classes: {
+        root: clsx(
+          className,
+          styles.listItem,
+          isActive && styles.active,
+          isViewOnly && styles.offlineViewOnly,
+        ),
+        disabled: styles.offlineDisabled,
+      },
     };
   };
 
@@ -132,11 +135,9 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
             return (
               <React.Fragment key={key}>
                 <MenuItem
-                  history={history}
                   onClick={() => toggleExpanded(key)}
-                  path={path}
                   ref={(el) => (expandableItemsRef.current[key] = el)}
-                  {...getMenuItemProps(key, label)}
+                  {...getMenuItemProps(key, label, path)}
                 >
                   <ListItemIcon className={styles.icon}>{icon}</ListItemIcon>
                   <ListItemText
@@ -169,13 +170,11 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
                   {subMenu.map(({ label: subMenuLabel, path: subMenuPath, key: subMenuKey }) => {
                     return (
                       <MenuItem
-                        history={history}
                         key={subMenuKey}
-                        path={subMenuPath}
                         onClick={() =>
                           isCompact ? onMenuItemClick(subMenuPath) : handleClick(subMenuPath)
                         }
-                        {...getMenuItemProps(subMenuKey, subMenuLabel, styles.subItem)}
+                        {...getMenuItemProps(subMenuKey, subMenuLabel, subMenuPath, styles.subItem)}
                       >
                         <ListItemText primary={subMenuLabel} className={styles.subItemText} />
                       </MenuItem>
@@ -188,11 +187,9 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
 
           return (
             <MenuItem
-              history={history}
               key={key}
-              path={path}
               onClick={() => onMenuItemClick(path)}
-              {...getMenuItemProps(key, label)}
+              {...getMenuItemProps(key, label, path)}
             >
               <ListItemIcon className={styles.icon}>{icon}</ListItemIcon>
               <ListItemText
@@ -212,11 +209,9 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
         {adminActions.map(({ icon, label, path, key }) => {
           return (
             <MenuItem
-              history={history}
               key={key}
-              path={path}
               onClick={() => onMenuItemClick(path)}
-              {...getMenuItemProps(key, label, styles.adminActionListItem)}
+              {...getMenuItemProps(key, label, path, styles.adminActionListItem)}
             >
               <ListItemIcon className={styles.icon}>{icon}</ListItemIcon>
               <ListItemText

--- a/packages/webapp/src/components/Navigation/SideMenu/index.jsx
+++ b/packages/webapp/src/components/Navigation/SideMenu/index.jsx
@@ -12,25 +12,34 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React, { forwardRef, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { matchPath } from 'react-router-dom';
+import { FiEye } from 'react-icons/fi';
 
 import useExpandable from '../../Expandable/useExpandableItem';
 import { ReactComponent as Logo } from '../../../assets/images/middle_logo.svg';
 import { ReactComponent as LogoOffline } from '../../../assets/images/middle_logo-offline.svg';
-import { useGetMenuItems } from '../../../hooks/useGetMenuItems';
+import {
+  useGetMenuItems,
+  offlineDisabledPageKeys,
+  offlineViewOnlyPageKeys,
+} from '../../../hooks/useGetMenuItems';
 import Drawer from '../../Drawer';
 import { ReactComponent as CollapseMenuIcon } from '../../../assets/images/nav/collapse-menu.svg';
 import styles from './styles.module.scss';
 import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 import { useIsOffline } from '../../../containers/hooks/useOfflineDetector/useIsOffline';
 
-const MenuItem = forwardRef(({ history, onClick, path, children, className }, ref) => {
+const MenuItem = forwardRef(({ history, onClick, path, children, className, ariaLabel }, ref) => {
   const isActive = matchPath(history.location.pathname, path);
   return (
     <ListItemButton
       onClick={onClick ?? (() => history.push(path))}
       className={clsx(styles.listItem, isActive && styles.active, className)}
       ref={ref}
+      aria-label={ariaLabel}
     >
+      <span className={styles.eyeIconWrapper}>
+        <FiEye aria-hidden="true" />
+      </span>
       {children}
     </ListItemButton>
   );
@@ -86,6 +95,20 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
     resetExpanded();
   }, [isCompact]);
 
+  const getMenuItemProps = (key, label, className) => {
+    const isViewOnly = offline && offlineViewOnlyPageKeys.has(key);
+    const isDisabled = offline && offlineDisabledPageKeys.has(key);
+
+    return {
+      className: clsx(
+        className,
+        isViewOnly && styles.offlineViewOnly,
+        isDisabled && styles.offlineDisabled,
+      ),
+      ariaLabel: label + (isViewOnly ? ' - view only page' : ''),
+    };
+  };
+
   return (
     <div
       role="presentation"
@@ -113,6 +136,7 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
                   onClick={() => toggleExpanded(key)}
                   path={path}
                   ref={(el) => (expandableItemsRef.current[key] = el)}
+                  {...getMenuItemProps(key, label)}
                 >
                   <ListItemIcon className={styles.icon}>{icon}</ListItemIcon>
                   <ListItemText
@@ -148,10 +172,10 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
                         history={history}
                         key={subMenuKey}
                         path={subMenuPath}
-                        className={styles.subItem}
                         onClick={() =>
                           isCompact ? onMenuItemClick(subMenuPath) : handleClick(subMenuPath)
                         }
+                        {...getMenuItemProps(subMenuKey, subMenuLabel, styles.subItem)}
                       >
                         <ListItemText primary={subMenuLabel} className={styles.subItemText} />
                       </MenuItem>
@@ -163,7 +187,13 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
           }
 
           return (
-            <MenuItem history={history} key={key} path={path} onClick={() => onMenuItemClick(path)}>
+            <MenuItem
+              history={history}
+              key={key}
+              path={path}
+              onClick={() => onMenuItemClick(path)}
+              {...getMenuItemProps(key, label)}
+            >
               <ListItemIcon className={styles.icon}>{icon}</ListItemIcon>
               <ListItemText
                 primary={label}
@@ -185,8 +215,8 @@ const SideMenuContent = ({ history, closeDrawer, isCompact, hasBeenExpanded }) =
               history={history}
               key={key}
               path={path}
-              className={styles.adminActionListItem}
               onClick={() => onMenuItemClick(path)}
+              {...getMenuItemProps(key, label, styles.adminActionListItem)}
             >
               <ListItemIcon className={styles.icon}>{icon}</ListItemIcon>
               <ListItemText

--- a/packages/webapp/src/components/Navigation/SideMenu/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/SideMenu/styles.module.scss
@@ -346,6 +346,10 @@
     display: flex;
     justify-content: flex-start;
 
+    .eyeIconWrapper {
+      display: none;
+    }
+
     &:first-child {
       border-color: var(--White);
     }
@@ -469,7 +473,7 @@
           }
         }
       }
-      border: none;
+      border-top: 1px solid var(--teal700);
 
       &.logoListItem {
         display: none;
@@ -503,6 +507,61 @@
 
     &:hover span {
       overflow: visible;
+    }
+
+    &.offlineDisabled.offlineDisabled {
+      cursor: default;
+      pointer-events: none;
+      background: var(--Colors-Neutral-Neutral-50);
+
+      span {
+        color: var(--Colors-Neutral-Neutral-200);
+      }
+
+      > div > svg path {
+        stroke: var(--Colors-Neutral-Neutral-200);
+      }
+    }
+
+    &.offlineViewOnly {
+      .eyeIconWrapper {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: 6px;
+        left: 5px;
+        width: 13px;
+        color: var(--Colors-Primary-Primary-teal-300);
+      }
+
+      &.subItem {
+        .eyeIconWrapper {
+          top: 4px;
+          left: 3px;
+
+          @include xs-breakpoint {
+            top: 14px;
+            right: 22px;
+            left: auto;
+          }
+        }
+      }
+
+      @include xs-breakpoint {
+        padding-right: 44px;
+
+        .eyeIconWrapper {
+          width: 20px;
+          height: 20px;
+          top: 18px;
+          right: 22px;
+          left: auto;
+          border-radius: 4px;
+          color: var(--Colors-Primary-Primary-teal-700);
+          background-color: var(--Colors-Primary-Primary-teal-300);
+        }
+      }
     }
   }
 

--- a/packages/webapp/src/components/Navigation/SideMenu/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/SideMenu/styles.module.scss
@@ -512,7 +512,7 @@
     &.offlineDisabled.offlineDisabled {
       cursor: default;
       pointer-events: none;
-      background: var(--Colors-Neutral-Neutral-50);
+      background-color: var(--Colors-Neutral-Neutral-50);
 
       span {
         color: var(--Colors-Neutral-Neutral-200);
@@ -520,6 +520,18 @@
 
       > div > svg path {
         stroke: var(--Colors-Neutral-Neutral-200);
+      }
+
+      @include xs-breakpoint {
+        span {
+          color: #9eb5bb;
+        }
+
+        > div > svg path {
+          stroke: #9eb5bb;
+        }
+
+        background-color: #c8d7d7;
       }
     }
 

--- a/packages/webapp/src/components/Navigation/SideMenu/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/SideMenu/styles.module.scss
@@ -509,25 +509,27 @@
       overflow: visible;
     }
 
-    &.offlineDisabled.offlineDisabled {
-      cursor: default;
-      pointer-events: none;
+    &.offlineDisabled,
+    &.offlineDisabled.subItem {
+      opacity: 1;
       background-color: var(--Colors-Neutral-Neutral-50);
 
-      span {
+      .listItemText,
+      .subItemText {
         color: var(--Colors-Neutral-Neutral-200);
       }
 
-      > div > svg path {
+      .icon > svg path {
         stroke: var(--Colors-Neutral-Neutral-200);
       }
 
       @include xs-breakpoint {
-        span {
+        .listItemText,
+        .subItemText {
           color: #9eb5bb;
         }
 
-        > div > svg path {
+        .icon > svg path {
           stroke: #9eb5bb;
         }
 

--- a/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
+++ b/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
@@ -88,6 +88,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
       icon: <MyInfoIcon />,
       label: t('PROFILE_FLOATER.INFO'),
       externalLink: false,
+      disabled: offline,
     },
     {
       id: 'farm-selection',
@@ -95,6 +96,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
       icon: <SwitchFarmIcon />,
       label: t('PROFILE_FLOATER.SWITCH'),
       externalLink: false,
+      disabled: offline,
     },
     {
       id: 'tutorials',
@@ -102,6 +104,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
       icon: <VideoIcon />,
       label: t('PROFILE_FLOATER.TUTORIALS'),
       externalLink: true,
+      disabled: offline,
     },
     {
       id: 'logout',
@@ -113,9 +116,14 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
   ];
 
   const menuItems = options.map((option) => {
-    const { id, onClick, icon, label, externalLink } = option;
+    const { id, onClick, icon, label, externalLink, disabled } = option;
     return (
-      <MenuItem key={id} onClick={onClick} classes={{ root: styles.menuItemRoot }}>
+      <MenuItem
+        key={id}
+        onClick={onClick}
+        classes={{ root: styles.menuItemRoot, disabled: styles.menuItemDisabled }}
+        disabled={disabled}
+      >
         <ListItemIcon classes={{ root: styles.listItemIconRoot }}>{icon}</ListItemIcon>
         <ListItemText classes={{ root: styles.itemTextRoot }}>{label}</ListItemText>
         {externalLink && <LaunchIcon />}

--- a/packages/webapp/src/components/Navigation/TopMenu/styles.module.scss
+++ b/packages/webapp/src/components/Navigation/TopMenu/styles.module.scss
@@ -104,3 +104,22 @@
 .sectionHeader {
   margin-left: 16px;
 }
+
+/* Disabled menu item style */
+.menuItemRoot.menuItemDisabled {
+  opacity: 1;
+  border-color: var(--White);
+  background: var(--Colors-Neutral-Neutral-50);
+
+  .listItemIconRoot svg path {
+    stroke: var(--Colors-Neutral-Neutral-200);
+  }
+
+  .itemTextRoot {
+    color: var(--Colors-Neutral-Neutral-200);
+  }
+
+  .itemTextRoot + svg path {
+    fill: var(--Colors-Neutral-Neutral-200);
+  }
+}

--- a/packages/webapp/src/containers/FeedbackSurvey/index.jsx
+++ b/packages/webapp/src/containers/FeedbackSurvey/index.jsx
@@ -14,12 +14,14 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
 import TextButton from '../../components/Form/Button/TextButton';
 import { ReactComponent as SendIcon } from '../../assets/images/send-icon.svg';
 import styles from './styles.module.scss';
 import Drawer, { DesktopDrawerVariants } from '../../components/Drawer';
 import HelpRequest from '../Help';
 import { useNavMenuControls } from '../../contexts/appContext';
+import { useIsOffline } from '../hooks/useOfflineDetector/useIsOffline';
 
 export default function FeedbackSurvey() {
   const { t } = useTranslation();
@@ -27,6 +29,7 @@ export default function FeedbackSurvey() {
     feedback: { isFeedbackSurveyOpen: isSurveyOpen, setFeedbackSurveyOpen: setIsSurveyOpen },
   } = useNavMenuControls();
   const toggleSurveyOpen = () => setIsSurveyOpen(!isSurveyOpen);
+  const isOffline = useIsOffline();
 
   const title = (
     <div className={styles.surveyTitleWrapper}>
@@ -43,7 +46,10 @@ export default function FeedbackSurvey() {
 
   return (
     <div>
-      <TextButton className={styles.surveyButton} onClick={toggleSurveyOpen}>
+      <TextButton
+        className={clsx(styles.surveyButton, isOffline && styles.offline)}
+        onClick={toggleSurveyOpen}
+      >
         <SendIcon />
       </TextButton>
       <Drawer

--- a/packages/webapp/src/containers/FeedbackSurvey/styles.module.scss
+++ b/packages/webapp/src/containers/FeedbackSurvey/styles.module.scss
@@ -36,6 +36,14 @@
     width: 32px;
     transition: width 100ms ease-out, background-color 100ms ease-out;
   }
+
+  &.offline {
+    cursor: default;
+    pointer-events: none;
+
+    background: var(--Colors-Neutral-Neutral-50);
+    @include svgColorFill(var(--Colors-Neutral-Neutral-200));
+  }
 }
 
 .surveyButtonTitleIcon {

--- a/packages/webapp/src/hooks/useGetMenuItems.jsx
+++ b/packages/webapp/src/hooks/useGetMenuItems.jsx
@@ -59,6 +59,27 @@ const MENU_KEYS = {
   CERTIFICATION: 'certification',
 };
 
+export const offlineViewOnlyPageKeys = new Set([
+  MENU_KEYS.MAP,
+  MENU_KEYS.CROPS,
+  MENU_KEYS.ANIMALS,
+  MENU_KEYS.FINANCES,
+  MENU_KEYS.TRANSACTIONS,
+  MENU_KEYS.INVENTORY,
+]);
+
+export const offlineDisabledPageKeys = new Set([
+  MENU_KEYS.OTHER_EXPENSE,
+  MENU_KEYS.LABOUR,
+  MENU_KEYS.ACTUAL_REVENUE,
+  MENU_KEYS.ESTIMATED_REVENUE,
+  MENU_KEYS.INSIGHTS,
+  MENU_KEYS.DOCUMENTS,
+  MENU_KEYS.FARM,
+  MENU_KEYS.PEOPLE,
+  MENU_KEYS.CERTIFICATION,
+]);
+
 export const useGetMenuItems = () => {
   const { t } = useTranslation();
   const isAdmin = useSelector(isAdminSelector);

--- a/packages/webapp/src/hooks/useGetMenuItems.jsx
+++ b/packages/webapp/src/hooks/useGetMenuItems.jsx
@@ -40,28 +40,52 @@ import {
 } from '../util/siteMapConstants';
 import Badge from '../components/Badge';
 
+const MENU_KEYS = {
+  MAP: 'map',
+  TASKS: 'tasks',
+  CROPS: 'crops',
+  ANIMALS: 'animals',
+  FINANCES: 'finances',
+  TRANSACTIONS: 'transactions',
+  OTHER_EXPENSE: 'other_expense',
+  LABOUR: 'labour',
+  ACTUAL_REVENUE: 'actual_revenue',
+  ESTIMATED_REVENUE: 'estimated_revenue',
+  INSIGHTS: 'insights',
+  DOCUMENTS: 'documents',
+  INVENTORY: 'inventory',
+  FARM: 'farm',
+  PEOPLE: 'people',
+  CERTIFICATION: 'certification',
+};
+
 export const useGetMenuItems = () => {
   const { t } = useTranslation();
   const isAdmin = useSelector(isAdminSelector);
 
   const mainActions = useMemo(() => {
     const list = [
-      { label: t('MENU.MAP'), icon: <MapIcon />, path: '/map', key: 'map' },
-      { label: t('MENU.TASKS'), icon: <TasksIcon />, path: '/tasks', key: 'tasks' },
+      { label: t('MENU.MAP'), icon: <MapIcon />, path: '/map', key: MENU_KEYS.MAP },
+      { label: t('MENU.TASKS'), icon: <TasksIcon />, path: '/tasks', key: MENU_KEYS.TASKS },
       {
         label: t('MENU.CROPS'),
         icon: <CropsIcon />,
         path: '/crop_catalogue',
-        key: 'crops',
+        key: MENU_KEYS.CROPS,
       },
       {
         label: t('MENU.ANIMALS'),
         icon: <AnimalsIcon />,
         path: ANIMALS_INVENTORY_URL,
-        key: 'animals',
+        key: MENU_KEYS.ANIMALS,
         badge: <Badge isMenuItem={true} title={t('BADGE.BETA.TITLE')} showIcon={false} />,
       },
-      { label: t('MENU.INSIGHTS'), icon: <InsightsIcon />, path: '/Insights', key: 'insights' },
+      {
+        label: t('MENU.INSIGHTS'),
+        icon: <InsightsIcon />,
+        path: '/Insights',
+        key: MENU_KEYS.INSIGHTS,
+      },
     ];
 
     if (isAdmin) {
@@ -69,28 +93,28 @@ export const useGetMenuItems = () => {
         label: t('MENU.FINANCES'),
         icon: <FinancesIcon />,
         path: FINANCES_URL,
-        key: 'finances',
+        key: MENU_KEYS.FINANCES,
         subMenu: [
           {
             label: t('MENU.TRANSACTION_LIST'),
             path: FINANCES_HOME_URL,
-            key: 'transactions',
+            key: MENU_KEYS.TRANSACTIONS,
           },
           {
             label: t('MENU.OTHER_EXPENSES'),
             path: OTHER_EXPENSE_URL,
-            key: 'other_expense',
+            key: MENU_KEYS.OTHER_EXPENSE,
           },
-          { label: t('MENU.LABOUR_EXPENSES'), path: LABOUR_URL, key: 'labour' },
+          { label: t('MENU.LABOUR_EXPENSES'), path: LABOUR_URL, key: MENU_KEYS.LABOUR },
           {
             label: t('MENU.ACTUAL_REVENUES'),
             path: ACTUAL_REVENUE_URL,
-            key: 'actual_revenue',
+            key: MENU_KEYS.ACTUAL_REVENUE,
           },
           {
             label: t('MENU.ESTIMATED_REVENUES'),
             path: ESTIMATED_REVENUE_URL,
-            key: 'estimated_revenue',
+            key: MENU_KEYS.ESTIMATED_REVENUE,
           },
         ],
       });
@@ -98,14 +122,14 @@ export const useGetMenuItems = () => {
         label: t('MENU.DOCUMENTS'),
         icon: <DocumentsIcon />,
         path: '/documents',
-        key: 'documents',
+        key: MENU_KEYS.DOCUMENTS,
       });
     }
     list.push({
       label: t('MENU.INVENTORY'),
       icon: <InventoryIcon />,
       path: PRODUCT_INVENTORY_URL,
-      key: 'inventory',
+      key: MENU_KEYS.INVENTORY,
       badge: <Badge isMenuItem={true} title={t('BADGE.BETA.TITLE')} showIcon={false} />,
     });
     return list;
@@ -119,14 +143,19 @@ export const useGetMenuItems = () => {
               label: t('MENU.FARM_SETTINGS'),
               icon: <FarmSettingsIcon />,
               path: '/farm_settings/',
-              key: 'farm',
+              key: MENU_KEYS.FARM,
             },
-            { label: t('MENU.PEOPLE'), icon: <PeopleIcon />, path: '/people', key: 'people' },
+            {
+              label: t('MENU.PEOPLE'),
+              icon: <PeopleIcon />,
+              path: '/people',
+              key: MENU_KEYS.PEOPLE,
+            },
             {
               label: t('MENU.CERTIFICATIONS'),
               icon: <CertificationsIcon />,
               path: '/certification',
-              key: 'certification',
+              key: MENU_KEYS.CERTIFICATION,
             },
           ]
         : [],

--- a/packages/webapp/src/stories/Navigation/NavBarDropdown.stories.jsx
+++ b/packages/webapp/src/stories/Navigation/NavBarDropdown.stories.jsx
@@ -1,24 +1,47 @@
+import { Provider } from 'react-redux';
+import { action } from '@storybook/addon-actions';
 import TopMenu from '../../components/Navigation/TopMenu/TopMenu';
 import {
   componentDecoratorsGreyBackground,
   navMenuControlDecorator,
 } from '../Pages/config/Decorators';
+import state from '../../../.storybook/state';
 
 export default {
   title: 'Components/Navbar/TopMenu',
   decorators: [...componentDecoratorsGreyBackground, ...navMenuControlDecorator],
   component: TopMenu,
+  args: {
+    history: {
+      push: () => {},
+      location: { pathname: '/home' },
+      replace: () => {},
+    },
+    isMobile: false,
+    showNavActions: true,
+    onClickBurger: () => {},
+    showNav: true,
+  },
 };
 
 export const NavbarTopMenu = ((args) => <TopMenu {...args} />).bind({});
-NavbarTopMenu.args = {
-  history: {
-    push: () => {},
-    location: { pathname: '/home' },
-    replace: () => {},
-  },
-  isMobile: false,
-  showNavActions: true,
-  onClickBurger: () => {},
-  showNav: true,
+
+const offlineStore = {
+  getState: () => ({
+    ...state,
+    tempStateReducer: {
+      offlineDetectorReducer: { isOffline: true },
+      homeReducer: { showHelpRequestModal: undefined },
+    },
+  }),
+  subscribe: () => 0,
+  dispatch: action('dispatch'),
+};
+
+export const NavbarTopMenuOffline = {
+  render: (args) => (
+    <Provider store={offlineStore}>
+      <TopMenu {...args} />
+    </Provider>
+  ),
 };

--- a/packages/webapp/src/stories/Navigation/NavBarSideMenu.stories.jsx
+++ b/packages/webapp/src/stories/Navigation/NavBarSideMenu.stories.jsx
@@ -13,7 +13,6 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import TopMenu from '../../components/Navigation/TopMenu/TopMenu';
 import {
   componentDecoratorsWithoutPadding,
   navMenuControlDecorator,
@@ -22,48 +21,74 @@ import SideMenu from '../../components/Navigation/SideMenu';
 import { Provider } from 'react-redux';
 import { action } from '@storybook/addon-actions';
 
+const adminEntitiesReducer = {
+  userFarmReducer: {
+    byFarmIdUserId: {
+      farm1: {
+        user1: {
+          farm_id: 'farm1',
+          user_id: 'user1',
+          role_id: 1,
+        },
+      },
+    },
+    farm_id: 'farm1',
+    user_id: 'user1',
+  },
+};
+
 const adminStore = {
   getState: () => {
     return {
-      entitiesReducer: {
-        userFarmReducer: {
-          byFarmIdUserId: {
-            farm1: {
-              user1: {
-                farm_id: 'farm1',
-                user_id: 'user1',
-                role_id: 1,
-              },
-            },
-          },
-          farm_id: 'farm1',
-          user_id: 'user1',
-        },
-      },
+      entitiesReducer: adminEntitiesReducer,
     };
   },
   subscribe: () => 0,
   dispatch: action('dispatch'),
 };
 
+const workerEntitiesReducer = {
+  userFarmReducer: {
+    byFarmIdUserId: {
+      farm1: {
+        user2: {
+          farm_id: 'farm1',
+          user_id: 'user2',
+          role_id: 3,
+        },
+      },
+    },
+    farm_id: 'farm1',
+    user_id: 'user2',
+  },
+};
+
 const workerStore = {
   getState: () => {
     return {
-      entitiesReducer: {
-        userFarmReducer: {
-          byFarmIdUserId: {
-            farm1: {
-              user2: {
-                farm_id: 'farm1',
-                user_id: 'user2',
-                role_id: 3,
-              },
-            },
-          },
-          farm_id: 'farm1',
-          user_id: 'user2',
-        },
-      },
+      entitiesReducer: workerEntitiesReducer,
+    };
+  },
+  subscribe: () => 0,
+  dispatch: action('dispatch'),
+};
+
+const offlineAdminStore = {
+  getState: () => {
+    return {
+      entitiesReducer: adminEntitiesReducer,
+      tempStateReducer: { offlineDetectorReducer: { isOffline: true } },
+    };
+  },
+  subscribe: () => 0,
+  dispatch: action('dispatch'),
+};
+
+const offlineWorkerStore = {
+  getState: () => {
+    return {
+      entitiesReducer: workerEntitiesReducer,
+      tempStateReducer: { offlineDetectorReducer: { isOffline: true } },
     };
   },
   subscribe: () => 0,
@@ -73,41 +98,49 @@ const workerStore = {
 export default {
   title: 'Components/Navbar/SideMenu',
   decorators: [...componentDecoratorsWithoutPadding, ...navMenuControlDecorator],
-  component: TopMenu,
+  component: SideMenu,
+  args: {
+    history: {
+      push: () => {},
+      location: { pathname: '/home' },
+      replace: () => {},
+    },
+    isMobile: false,
+    isDrawerOpen: true,
+    onDrawerClose: () => {},
+    isCompact: false,
+    setIsCompact: () => {},
+  },
 };
 
-export const WithAdminItems = ((args) => (
-  <Provider store={adminStore}>
-    <SideMenu {...args} />
-  </Provider>
-)).bind({});
-WithAdminItems.args = {
-  history: {
-    push: () => {},
-    location: { pathname: '/home' },
-    replace: () => {},
-  },
-  isMobile: false,
-  isDrawerOpen: true,
-  onDrawerClose: () => {},
-  isCompact: false,
-  setIsCompact: () => {},
+export const WithAdminItems = {
+  render: (args) => (
+    <Provider store={adminStore}>
+      <SideMenu {...args} />
+    </Provider>
+  ),
 };
 
-export const WithoutAdminItems = ((args) => (
-  <Provider store={workerStore}>
-    <SideMenu {...args} />
-  </Provider>
-)).bind({});
-WithoutAdminItems.args = {
-  history: {
-    push: () => {},
-    location: { pathname: '/home' },
-    replace: () => {},
-  },
-  isMobile: false,
-  isDrawerOpen: true,
-  onDrawerClose: () => {},
-  isCompact: false,
-  setIsCompact: () => {},
+export const WithoutAdminItems = {
+  render: (args) => (
+    <Provider store={workerStore}>
+      <SideMenu {...args} />
+    </Provider>
+  ),
+};
+
+export const WithAdminItemsOffline = {
+  render: (args) => (
+    <Provider store={offlineAdminStore}>
+      <SideMenu {...args} />
+    </Provider>
+  ),
+};
+
+export const WithoutAdminItemsOffline = {
+  render: (args) => (
+    <Provider store={offlineWorkerStore}>
+      <SideMenu {...args} />
+    </Provider>
+  ),
 };


### PR DESCRIPTION
**Description**

Add offline read-only / disabled menu styles to side and top menu.

- Side Menu
   - Modify `MenuItem` component to support offline states
      - Use Mui's `ListItemButton` `disabled` prop, which automatically applies the `classes.disabled` class name
      - Add `getMenuItemProps` helper function that generates props including:
         - `disabled` prop for disabled items
         - Class names for read-only/disabled visual styles
         - `aria-label` with " - view only page" suffix for read-only items (not translated since accessibility hasn't been fully implemented yet)
   - [Stories](http://localhost:6006/?path=/story/components-navbar-topmenu--navbar-top-menu-offline)
- Top Menu
   - Disable feedback button in offline mode
   - Apply disabled styles to dropdown menu items using `ListItemButton`'s `disabled` prop and `classes.disabled` prop
   - [Stories](http://localhost:6006/?path=/story/components-navbar-topmenu--navbar-top-menu-offline)

Jira link: https://lite-farm.atlassian.net/browse/LF-5123

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
