### PR TITLE
LF-5103: Frontload data that is currently loaded on demand

### DIFF
--- a/packages/webapp/src/App.jsx
+++ b/packages/webapp/src/App.jsx
@@ -26,6 +26,7 @@ import { ANIMALS_URL, MAP_URL, SENSORS_URL } from './util/siteMapConstants';
 import { NavMenuControlsContext } from './contexts/appContext';
 import { useOfflineDetector } from './containers/hooks/useOfflineDetector/useOfflineDetector';
 import { useServiceWorkerListener } from './hooks/useServiceWorkerListener/useServiceWorkerListener';
+import { useGoogleMapsLoader } from './hooks/useGoogleMapsLoader';
 
 function App() {
   const location = useLocation();
@@ -36,6 +37,7 @@ function App() {
 
   useOfflineDetector();
   useServiceWorkerListener();
+  useGoogleMapsLoader();
 
   return (
     <div className={clsx(styles.container)}>

--- a/packages/webapp/src/containers/Finances/saga.js
+++ b/packages/webapp/src/containers/Finances/saga.js
@@ -151,7 +151,7 @@ export function* getExpenseSaga() {
       yield put(setExpense(result.data));
     }
   } catch (e) {
-    if (e.response.status === 404) {
+    if (e.response?.status === 404) {
       yield put(setExpense([]));
     }
     console.log('failed to fetch expenses from database');

--- a/packages/webapp/src/containers/fieldWorkSlice.js
+++ b/packages/webapp/src/containers/fieldWorkSlice.js
@@ -18,7 +18,6 @@ const fieldWorkSlice = createSlice({
     fieldWorkLoading: (state, action) => {
       Object.assign(state, {
         loading: true,
-        fieldWorkTypes: [],
       });
     },
     fieldWorkSuccess: (state, { payload }) => {

--- a/packages/webapp/src/containers/fieldWorkSlice.js
+++ b/packages/webapp/src/containers/fieldWorkSlice.js
@@ -31,7 +31,6 @@ const fieldWorkSlice = createSlice({
     },
     fieldWorkFailure: (state, action) => {
       state.loading = true;
-      state.fieldWorkTypes = [];
     },
   },
 });

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -157,6 +157,8 @@ import {
   getSoilSampleLocationsSuccess,
   onLoadingSoilSampleLocationFail,
 } from './soilSampleLocationSlice';
+import { getFieldWorkTypes } from './Task/FieldWorkTask/saga';
+import { getIrrigationTaskTypes } from './Task/IrrigationTaskTypes/saga';
 
 const logUserInfoUrl = () => `${url}/userLog`;
 const getCropsByFarmIdUrl = (farm_id) => `${url}/crop/farm/${farm_id}`;
@@ -613,11 +615,32 @@ export function* fetchAllSaga() {
     put(getRoles()),
     put(getManagementPlansAndTasks()),
     call(getAllUserFarmsByFarmIDSaga),
+    put(getFieldWorkTypes()),
+    put(getIrrigationTaskTypes()),
+    put(api.endpoints.getSoilAmendmentMethods.initiate()),
+    put(api.endpoints.getSoilAmendmentPurposes.initiate()),
+    put(api.endpoints.getSoilAmendmentFertiliserTypes.initiate()),
   ];
 
   yield all(isAdmin ? [...tasks, ...adminTasks] : tasks);
 
   yield put(fetchAllFinanceData());
+
+  // Animals
+  yield all([
+    put(api.endpoints.getAnimals.initiate()),
+    put(api.endpoints.getAnimalBatches.initiate()),
+    put(api.endpoints.getDefaultAnimalTypes.initiate()),
+    put(api.endpoints.getDefaultAnimalBreeds.initiate()),
+    put(api.endpoints.getCustomAnimalTypes.initiate()),
+    put(api.endpoints.getCustomAnimalBreeds.initiate()),
+    put(api.endpoints.getAnimalSexes.initiate()),
+    put(api.endpoints.getAnimalIdentifierTypes.initiate()),
+    put(api.endpoints.getAnimalIdentifierColors.initiate()),
+    put(api.endpoints.getAnimalMovementPurposes.initiate()),
+    put(api.endpoints.getAnimalOrigins.initiate()),
+    put(api.endpoints.getAnimalUses.initiate()),
+  ]);
 
   const {
     data: { farm_token },

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -91,6 +91,7 @@ import { getFencesSuccess, onLoadingFenceFail, onLoadingFenceStart } from './fen
 import { getFieldsSuccess, onLoadingFieldFail, onLoadingFieldStart } from './fieldSlice';
 import { resetTasksFilter } from './filterSlice';
 import { resetDateRange, setIsFetchingData } from './Finances/actions.js';
+import { fetchAllData as fetchAllFinanceData } from './Finances/saga';
 import { getGardensSuccess, onLoadingGardenFail, onLoadingGardenStart } from './gardenSlice';
 import { getGatesSuccess, onLoadingGateFail, onLoadingGateStart } from './gateSlice';
 import {
@@ -615,6 +616,8 @@ export function* fetchAllSaga() {
   ];
 
   yield all(isAdmin ? [...tasks, ...adminTasks] : tasks);
+
+  yield put(fetchAllFinanceData());
 
   const {
     data: { farm_token },

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -620,6 +620,7 @@ export function* fetchAllSaga() {
     put(api.endpoints.getSoilAmendmentMethods.initiate()),
     put(api.endpoints.getSoilAmendmentPurposes.initiate()),
     put(api.endpoints.getSoilAmendmentFertiliserTypes.initiate()),
+    put(api.endpoints.getAnimalMovementPurposes.initiate()),
   ];
 
   yield all(isAdmin ? [...tasks, ...adminTasks] : tasks);

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -100,6 +100,8 @@ export const api = createApi({
     responseHandler: 'content-type',
   }),
   tagTypes: API_TAGS,
+  keepUnusedDataFor: 60 * 60 * 24 * 7, // 7 days
+  refetchOnMountOrArgChange: 60,
   endpoints: (build) => ({
     // redux-toolkit.js.org/rtk-query/usage-with-typescript#typing-query-and-mutation-endpoints
     // <ResultType, QueryArg>


### PR DESCRIPTION
**Description**

- Call `useGoogleMapsLoader` in `App.jsx` to ensure maps can render offline without requiring an initial online visit to the map page
- Add null check for `e.response` in finances saga (I believe this was the cause of infinite loading on the transactions page)
- Update `fieldWorkFailure` and `fieldWorkLoading` reducers to avoid resetting `fieldWorkTypes` to `[]`, which was preventing field work types from being available offline
- Pre-fetch required data in `fetchAllSaga` for offline task creation and read-only views:
   - Field work tasks
   - Irrigation tasks
   - Soil amendment tasks
   - Animal movement tasks
   - Finance transactions (read-only)
   - Animals (read-only etc.)
- Configure RTK Query caching at the API level:
   - `keepUnusedDataFor`: 7 days
   - `refetchOnMountOrArgChange`: 60 seconds

### RTK Query Cache Configuration

#### Why change the defaults?

With RTK Query's default settings, cached data expires 60 seconds after the component using it unmounts. For example, if you visit the animals page, go offline, navigate away, and return after 60 seconds, the cached data will be gone and you won't see any data while offline. To support offline functionality, we need to adjust the cache configuration.

#### New Configuration

`keepUnusedDataFor`: 7 days ([docs](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#reducing-subscription-time-with-keepunuseddatafor))
- Retains cached data for 7 days (matching our token lifetime)
- Previously: Cache expired 60 seconds after leaving the component

`refetchOnMountOrArgChange`: 60 seconds ([docs](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#encouraging-re-fetching-with-refetchonmountorargchange))
- Automatically refetches if the last request was more than 60 seconds ago
- Previously: Only refetched when cache was empty

#### Impact

Example scenario: You visit the animals page, stay for an hour, navigate away, then immediately return.

- Old behaviour: No refetch (you returned within 60 seconds of leaving, so cache is still valid)
- New behaviour: Refetch happens (the last API call was over 60 seconds ago _- an hour -_ so data is considered stale)

This configuration is applied globally at the API level rather than per-endpoint. This approach:
1. Eliminates the need to configure caching for each individual endpoint required for offline functionality
2. Ensures consistent behaviour for future APIs without additional configuration

Note: 
With `refetchOnReconnect: true` ([docs](https://redux-toolkit.js.org/rtk-query/api/createApi#refetchonreconnect)) , queries should automatically refetch when going back online, but I wasn't able to test this successfully. Claude says there are known bugs with this feature in our `@reduxjs/toolkit` version, which might be the cause. (The newer version have breaking changes. I created a [ticket](https://lite-farm.atlassian.net/browse/LF-5128) for the upgrade)
The app should work fine without this feature due to the cache configuration, but I'm documenting this for future reference in case we need automatic refetching on reconnection.

Jira link: https://lite-farm.atlassian.net/browse/LF-5103

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
