### PR TITLE
LF-5129: Transplant task creation offline causes crash on sync

### DIFF
--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -21,6 +21,7 @@ import {
   enqueueErrorSnackbar,
 } from '../../containers/Snackbar/snackbarSlice';
 import { getTasks } from '../../containers/Task/saga';
+import { getManagementPlans } from '../../containers/saga';
 import { invalidateTags } from '../../store/api/apiSlice';
 
 type SyncArea =
@@ -74,7 +75,10 @@ export function useServiceWorkerListener() {
             return invalidateTags(['IrrigationPrescriptions']);
           }
         },
-        refresh: getTasks,
+        refresh: () => {
+          dispatch(getManagementPlans());
+          dispatch(getTasks());
+        },
       },
       'tasks.complete': {
         successMessage: t('message:TASK.COMPLETE.SYNC.SUCCESS'),
@@ -89,14 +93,14 @@ export function useServiceWorkerListener() {
             return invalidateTags(['Animals', 'AnimalBatches']);
           }
         },
-        refresh: getTasks,
+        refresh: () => dispatch(getTasks()),
       },
       'tasks.abandon': {
         successMessage: t('message:TASK.ABANDON.SYNC.SUCCESS'),
         errors: {
           404: t('message:TASK.SYNC.NOT_FOUND'),
         },
-        refresh: getTasks,
+        refresh: () => dispatch(getTasks()),
       },
       'tasks.update': {
         successMessage: t('message:TASK.UPDATE.SYNC.SUCCESS'),
@@ -104,7 +108,7 @@ export function useServiceWorkerListener() {
           403: t('message:TASK.SYNC.UNAUTHORIZED'),
           404: t('message:TASK.SYNC.NOT_FOUND'),
         },
-        refresh: getTasks,
+        refresh: () => dispatch(getTasks()),
       },
       'tasks.delete': {
         successMessage: t('message:TASK.DELETE.SYNC.SUCCESS'),
@@ -116,10 +120,10 @@ export function useServiceWorkerListener() {
             return invalidateTags(['IrrigationPrescriptions']);
           }
         },
-        refresh: getTasks,
+        refresh: () => dispatch(getTasks()),
       },
     }),
-    [t],
+    [t, dispatch],
   );
 
   useEffect(() => {
@@ -156,7 +160,7 @@ export function useServiceWorkerListener() {
         }
 
         // Refresh data regardless of success/failure
-        dispatch(refresh());
+        refresh();
       } else if (type === 'SYNC_ITEM_FAILURE') {
         /*
          * This indicates a failure to reach the server (e.g. API down). It should be rare.


### PR DESCRIPTION
**Description**

A newly created transplant task needs to be combined with management plans in `transplantTaskEntitiesSelector`.
This PR updates `tasks.create`'s `refresh` in `syncConfig` so `getManagementPlans` is called after syncing.

Jira link: https://lite-farm.atlassian.net/browse/LF-5129

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
