### PR TITLE
LF-5120 Show appropriate UI updates for non POST task actions

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -2151,7 +2151,8 @@
     "TRANSPLANT": "Transplant",
     "TRANSPLANT_LOCATIONS": "Select a transplant location",
     "UNASSIGNED": "Unassigned",
-    "UPLOAD_LAB_DOCUMENT": "Upload lab document"
+    "UPLOAD_LAB_DOCUMENT": "Upload lab document",
+    "WILL_SAVE_ONLINE": "Will save when online"
   },
   "UNIT": {
     "TIME": {

--- a/packages/webapp/src/components/CardWithStatus/StatusLabel/index.tsx
+++ b/packages/webapp/src/components/CardWithStatus/StatusLabel/index.tsx
@@ -59,6 +59,18 @@ const useStyles = makeStyles({
     height: '16px',
     fontSize: '11px',
   },
+  toSyncCompleted: {
+    margin: '8px',
+    border: '1px dashed var(--Colors-Primary-Primary-teal-500)',
+    background: 'var(--Colors-Primary-Primary-teal-100)',
+    color: 'var(--Colors-Primary-Primary-teal-500)',
+  },
+  toSyncAbandoned: {
+    margin: '8px',
+    border: '1px dashed var(--Colors-Neutral-Neutral-400)',
+    background: 'var(--Colors-Neutral-Neutral-100)',
+    color: 'var(--Colors-Neutral-Neutral-700)',
+  },
 });
 
 export enum TaskStatus {
@@ -74,6 +86,7 @@ type StatusLabelProps = {
   color: TaskStatus;
   label: string;
   sm?: boolean;
+  to_sync?: boolean;
   children?: React.ReactNode;
   props?: HTMLAttributes<HTMLDivElement>;
 };
@@ -82,14 +95,26 @@ export const StatusLabel = ({
   color = TaskStatus.ACTIVE,
   label,
   sm,
+  to_sync = false,
   children,
   ...props
 }: StatusLabelProps): React.ReactNode => {
   const classes = useStyles();
+
+  const getStatusClass = () => {
+    if (to_sync && color === TaskStatus.COMPLETED) {
+      return classes.toSyncCompleted;
+    }
+    if (to_sync && color === TaskStatus.ABANDONED) {
+      return classes.toSyncAbandoned;
+    }
+    return classes[color];
+  };
+
   return (
     <div
       data-cy="status-label"
-      className={clsx(classes.container, classes[color], sm && classes.sm)}
+      className={clsx(classes.container, getStatusClass(), sm && classes.sm)}
       {...props}
     >
       {label}

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -55,6 +55,7 @@ export const PureTaskCard = ({
   language,
   revision_date,
   reviser,
+  to_sync = false,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -77,10 +78,11 @@ export const PureTaskCard = ({
   return (
     <CardWithStatus
       data-cy="taskCard"
-      color={selected ? activeCardColorMap[status] : statusColorMap[status]}
+      color={to_sync ? 'completed' : selected ? activeCardColorMap[status] : statusColorMap[status]}
       style={style}
       status={status}
       label={t(`TASK.STATUS.${taskStatusTranslateKey[status]}`)}
+      className={clsx(to_sync && styles.cardAwaitingSync)}
       classes={{
         ...classes,
         card: {
@@ -92,8 +94,9 @@ export const PureTaskCard = ({
           ...classes.card,
         },
       }}
-      onClick={onClick}
+      onClick={to_sync ? undefined : onClick}
       score={happiness}
+      to_sync={to_sync}
     >
       <TaskIcon className={styles.taskIcon} />
       <div className={styles.info}>
@@ -162,6 +165,7 @@ export const PureTaskCard = ({
           <RevisionInfoText revisionDate={revision_date} reviser={reviser} language={language} />
         </div>
       )}
+      {to_sync && <div className={styles.willSaveText}>{t('TASK.WILL_SAVE_ONLINE')}</div>}
     </CardWithStatus>
   );
 };
@@ -181,4 +185,5 @@ PureTaskCard.propTypes = {
   onClickCompleteOrDueDate: PropTypes.func,
   selected: PropTypes.bool,
   language: PropTypes.oneOf(languageCodes),
+  to_sync: PropTypes.bool,
 };

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/TaskCard.jsx
@@ -78,7 +78,7 @@ export const PureTaskCard = ({
   return (
     <CardWithStatus
       data-cy="taskCard"
-      color={to_sync ? 'completed' : selected ? activeCardColorMap[status] : statusColorMap[status]}
+      color={selected ? activeCardColorMap[status] : statusColorMap[status]}
       style={style}
       status={status}
       label={t(`TASK.STATUS.${taskStatusTranslateKey[status]}`)}
@@ -165,7 +165,7 @@ export const PureTaskCard = ({
           <RevisionInfoText revisionDate={revision_date} reviser={reviser} language={language} />
         </div>
       )}
-      {to_sync && <div className={styles.willSaveText}>{t('TASK.WILL_SAVE_ONLINE')}</div>}
+      {to_sync && <span className={styles.willSaveText}>{t('TASK.WILL_SAVE_ONLINE')}</span>}
     </CardWithStatus>
   );
 };

--- a/packages/webapp/src/components/CardWithStatus/TaskCard/styles.module.scss
+++ b/packages/webapp/src/components/CardWithStatus/TaskCard/styles.module.scss
@@ -111,3 +111,21 @@
     visibility: hidden;
   }
 }
+
+.cardAwaitingSync {
+  border: 1px solid var(--Colors-Secondary-Secondary-green-100);
+  background: var(--Box-bg);
+  box-shadow: 0 1px 0 0 var(--Colors-Neutral-Neutral-50);
+
+  cursor: default;
+}
+
+.willSaveText {
+  position: absolute;
+  top: 32px;
+  right: 8px;
+
+  color: var(--Colors-Accent---singles-Brown-full);
+  font-size: 10px;
+  font-style: italic;
+}

--- a/packages/webapp/src/components/CardWithStatus/index.jsx
+++ b/packages/webapp/src/components/CardWithStatus/index.jsx
@@ -3,6 +3,7 @@ import styles from './styles.module.scss';
 import PropTypes from 'prop-types';
 import Card from '../Card';
 import { StatusLabel } from './StatusLabel';
+import clsx from 'clsx';
 
 import Rating from '../Rating';
 
@@ -15,17 +16,22 @@ export function CardWithStatus({
   score,
   color,
   children,
+  to_sync = false,
+  className,
   ...props
 }) {
+  const hasRating = [0, 1, 2, 3, 4, 5].includes(score);
+
   return (
     <div className={styles.cardContainer} style={{ ...classes.container, ...style }}>
       <div className={styles.statusLabel}>
-        <StatusLabel color={status} label={label} />
-        {[0, 1, 2, 3, 4, 5].includes(score) && <Rating stars={score} viewOnly />}
+        <StatusLabel color={status} label={label} to_sync={to_sync} />
+        {hasRating && <Rating stars={score} viewOnly />}
       </div>
       <Card
         color={color}
         onClick={onClick}
+        className={className}
         style={{
           cursor: onClick && color !== 'disabled' ? 'pointer' : 'default',
           ...classes.card,
@@ -47,4 +53,6 @@ CardWithStatus.propTypes = {
   onClick: PropTypes.func,
   score: PropTypes.oneOf([1, 2, 3, 4, 5, 0]),
   children: PropTypes.node,
+  to_sync: PropTypes.bool,
+  className: PropTypes.string,
 };

--- a/packages/webapp/src/components/CardWithStatus/index.jsx
+++ b/packages/webapp/src/components/CardWithStatus/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styles from './styles.module.scss';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import Card from '../Card';
 import { StatusLabel } from './StatusLabel';
-import clsx from 'clsx';
 
 import Rating from '../Rating';
 

--- a/packages/webapp/src/containers/Task/TaskCard/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskCard/index.jsx
@@ -32,6 +32,7 @@ const TaskCard = ({
   wage_at_moment,
   revision_date,
   revised_by_user_id,
+  to_sync = false,
   ...props
 }) => {
   const [showTaskAssignModal, setShowTaskAssignModal] = useState();
@@ -97,6 +98,7 @@ const TaskCard = ({
         language={language}
         revision_date={revision_date}
         reviser={reviser}
+        to_sync={to_sync}
       />
       {showTaskAssignModal && (
         <TaskQuickAssignModal

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -918,9 +918,13 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
       }
 
       // Optimistic update for task completion
+      const optimisticTaskData = taskData.task // i.e. harvest tasks
+        ? { ...taskData, ...taskData.task }
+        : taskData;
+
       yield put(
         putTaskSuccess({
-          ...taskData, // note: will not create the proper object for details view
+          ...optimisticTaskData, // note: will not create the proper object for details view
           task_id,
           to_sync: true, // For visual indicator on to-be-synced tasks
         }),

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -729,7 +729,7 @@ export function* createTaskSaga({ payload }) {
         yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.CREATE.SYNC.ONLINE')));
       }
 
-      // No optimstic update for task creation
+      // No optimistic update for task creation
 
       history.push(returnPath ?? '/tasks');
     } else {
@@ -922,7 +922,7 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
         putTaskSuccess({
           ...taskData, // note: will not create the proper object for details view
           task_id,
-          to_sync: true, // For LF-5120 visual indicator on to-be-synced tasks
+          to_sync: true, // For visual indicator on to-be-synced tasks
         }),
       );
 
@@ -961,7 +961,7 @@ export function* abandonTaskSaga({ payload: data }) {
         putTaskSuccess({
           ...patchData, // will create the proper object for details view
           task_id,
-          to_sync: true, // For LF-5120 - visual indicator on to-be-synced tasks
+          to_sync: true, // For visual indicator on to-be-synced tasks
         }),
       );
 

--- a/packages/webapp/src/containers/Task/taskCardContentSelector.js
+++ b/packages/webapp/src/containers/Task/taskCardContentSelector.js
@@ -26,12 +26,17 @@ const getTaskContents = (tasks, userFarmEntities, { farm_id }) => {
       wage_at_moment: task.wage_at_moment,
       revision_date: task.revision_date,
       revised_by_user_id: task.revised_by_user_id,
+      to_sync: task.to_sync,
     };
   });
 };
 
 export const sortTaskCardContent = (taskCardContents, isAscending = true) =>
   taskCardContents.sort((taskA, taskB) => {
+    // to_sync tasks always go to the top
+    if (taskA.to_sync && !taskB.to_sync) return -1;
+    if (!taskA.to_sync && taskB.to_sync) return 1;
+
     const order = isAscending ? 1 : -1;
     const bottomTwoStatus = ['completed', 'abandoned'];
     if (!bottomTwoStatus.includes(taskA.status) && bottomTwoStatus.includes(taskB.status)) {

--- a/packages/webapp/src/stories/TaskCard/TaskCard.stories.jsx
+++ b/packages/webapp/src/stories/TaskCard/TaskCard.stories.jsx
@@ -122,3 +122,26 @@ WithRevisionDate.args = {
     last_name: 'Last',
   },
 };
+
+export const ToSyncCompleted = Template.bind({});
+ToSyncCompleted.args = {
+  ...templateData,
+  status: 'completed',
+  to_sync: true,
+};
+
+export const ToSyncAbandoned = Template.bind({});
+ToSyncAbandoned.args = {
+  ...templateData,
+  status: 'abandoned',
+  abandonDate: '2023-04-12T00:00:00.000',
+  to_sync: true,
+};
+
+export const ToSyncCompletedWithRating = Template.bind({});
+ToSyncCompletedWithRating.args = {
+  ...templateData,
+  status: 'completed',
+  happiness: 4,
+  to_sync: true,
+};


### PR DESCRIPTION
**Description**

Adds the optimistic update (the read-only task card tiles with special status labels) for tasks completed and abandoned offline. Updated Storybook stories [here](http://localhost:6006/?path=/story/components-taskcard--to-sync-completed-with-rating).

Jira link: https://lite-farm.atlassian.net/browse/LF-5120

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
