### PR TITLE
LF-5135: User is not able to abandon or complete the task after he changes the assignee of the task in offline

### DIFF
--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -142,15 +142,18 @@ BG_SYNC_ROUTES.forEach(({ queueName, matcher, area, method }) => {
 
 // ——————————————————————————————
 self.addEventListener('message', async (event) => {
-  if (event.data === 'replay_queue') {
-    Object.values(queues).forEach(async ({ queue, area }) => {
-      const handler = createOnSyncHandler(area);
-      try {
-        await handler({ queue });
-      } catch (err) {
-        // Ignore errors during manual replay; they are logged by the handler anyway
-      }
-    });
+  // Manually replay queues if background sync is not supported
+  if (!('sync' in self.registration)) {
+    if (event.data === 'replay_queue') {
+      Object.values(queues).forEach(async ({ queue, area }) => {
+        const handler = createOnSyncHandler(area);
+        try {
+          await handler({ queue });
+        } catch (err) {
+          // Ignore errors during manual replay; they are logged by the handler anyway
+        }
+      });
+    }
   }
 
   if (event.data === 'clear_queue') {


### PR DESCRIPTION
**Description**

As expected, manual queue replay was happening in addition to background sync.
This PR prevents manual queue replay in browsers with Background Sync support.

I wasn't able to test offline on Safari and Firefox, but confirmed that the check for Background Sync support (`'sync' in self.registration`) ([reference](https://stackoverflow.com/a/60958564)) correctly returns `false` in those browsers as expected.

I'm not sure if additional fixes are needed for assignment + abandonment/completion, but I'd like to test it in Beta and go from there.


Jira link: https://lite-farm.atlassian.net/browse/LF-5135

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
