### PR TITLE
LF-5140: No animals are shown after creating them and going offline

### DIFF
--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -168,7 +168,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimals.initiate());
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
         } catch (err) {
           // handled in component
         }
@@ -186,7 +188,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimalBatches.initiate());
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
         } catch (err) {
           // handled in component
         }
@@ -204,7 +208,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimals.initiate());
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
         } catch (err) {
           // handled in component
         }
@@ -222,7 +228,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimalBatches.initiate());
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
         } catch (err) {
           // handled in component
         }
@@ -240,7 +248,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimals.initiate());
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
         } catch (err) {
           // handled in component
@@ -259,7 +269,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimalBatches.initiate());
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
         } catch (err) {
           // handled in component
@@ -279,7 +291,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimals.initiate());
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
         } catch (err) {
           // handled in component
@@ -294,7 +308,9 @@ export const api = createApi({
           const { data } = await queryFulfilled;
           await dispatch(api.endpoints.getAnimalBatches.initiate());
           await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate('?count=true'));
           await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
         } catch (err) {
           // handled in component

--- a/packages/webapp/src/store/api/apiSlice.ts
+++ b/packages/webapp/src/store/api/apiSlice.ts
@@ -163,6 +163,16 @@ export const api = createApi({
         method: 'PATCH',
         body: patch,
       }),
+      async onQueryStarted(patch, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimals.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: ['Animals', 'CustomAnimalTypes', 'DefaultAnimalTypes'],
     }),
     removeAnimalBatches: build.mutation<AnimalBatch[], Partial<AnimalBatch>[]>({
@@ -171,6 +181,16 @@ export const api = createApi({
         method: 'PATCH',
         body: patch,
       }),
+      async onQueryStarted(patch, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimalBatches.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: ['AnimalBatches', 'CustomAnimalTypes', 'DefaultAnimalTypes'],
     }),
     deleteAnimals: build.mutation<Animal[], number[]>({
@@ -179,6 +199,16 @@ export const api = createApi({
         method: 'DELETE',
         params: del,
       }),
+      async onQueryStarted(del, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimals.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: ['Animals', 'CustomAnimalTypes', 'DefaultAnimalTypes'],
     }),
     deleteAnimalBatches: build.mutation<AnimalBatch[], number[]>({
@@ -187,6 +217,16 @@ export const api = createApi({
         method: 'DELETE',
         params: del,
       }),
+      async onQueryStarted(del, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimalBatches.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: ['AnimalBatches', 'CustomAnimalTypes', 'DefaultAnimalTypes'],
     }),
     addAnimals: build.mutation<Animal[], Partial<Animal>[]>({
@@ -195,6 +235,17 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimals.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: ['Animals', 'DefaultAnimalTypes', 'CustomAnimalTypes', 'CustomAnimalBreeds'],
     }),
     addAnimalBatches: build.mutation<AnimalBatch[], Partial<AnimalBatch>[]>({
@@ -203,6 +254,17 @@ export const api = createApi({
         method: 'POST',
         body,
       }),
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimalBatches.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: [
         'AnimalBatches',
         'DefaultAnimalTypes',
@@ -212,10 +274,32 @@ export const api = createApi({
     }),
     updateAnimals: build.mutation<void, Partial<Animal>[]>({
       query: (body) => ({ url: `${animalsUrl}`, method: 'PATCH', body }),
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimals.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: ['Animals', 'DefaultAnimalTypes', 'CustomAnimalTypes', 'CustomAnimalBreeds'],
     }),
     updateAnimalBatches: build.mutation<void, Partial<AnimalBatch>[]>({
       query: (body) => ({ url: `${animalBatchesUrl}`, method: 'PATCH', body }),
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await dispatch(api.endpoints.getAnimalBatches.initiate());
+          await dispatch(api.endpoints.getDefaultAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalTypes.initiate());
+          await dispatch(api.endpoints.getCustomAnimalBreeds.initiate());
+        } catch (err) {
+          // handled in component
+        }
+      },
       invalidatesTags: [
         'AnimalBatches',
         'DefaultAnimalTypes',


### PR DESCRIPTION
**Description**

### Problem

After adding animals, the data wasn't being refetched because the component that calls `useGetAnimalsQuery` wasn't currently rendered. This caused issues when:

1. Add animals (online)
2. Go offline
3. Navigate to Animals page
4. Page shows no data because the query fails offline and the cache wasn't populated

Tag invalidation alone doesn't trigger refetches when no component is currently subscribed to the query.

### Solution

Proactively fetch all invalidated queries in `onQueryStarted` after the mutation succeeds. This populates the cache while still online, ensuring data is available when navigating to animal pages offline.

We have separate caches for queries with different params:
- `getCustomAnimalTypes()` and `getCustomAnimalTypes('?count=true')`
- `getDefaultAnimalTypes()` and `getDefaultAnimalTypes('?count=true')`

So we need to call each API twice to populate both cache entries.

### Additional Fix

In Beta, editing animal/batch → go offline → navigate to Animals page showed no KPIs. This issue is also addressed.


Reference:
- https://github.com/reduxjs/redux-toolkit/issues/1509
- https://redux-toolkit.js.org/rtk-query/api/createApi#onquerystarted

Jira link: https://lite-farm.atlassian.net/browse/LF-5140

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
