### PR TITLE
LF-5138 Remove "Add planting task" when crop plan creation is unavailable (offline / no connection)

### DIFF
--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -76,6 +76,7 @@ export const PureTaskTypeSelection = ({
   hasAnimals,
   hasSoilSampleLocations,
   hasSoilAmendmentProducts,
+  isOffline,
 }) => {
   const { t } = useTranslation();
   const { watch, getValues, register, setValue } = useForm({
@@ -128,6 +129,10 @@ export const PureTaskTypeSelection = ({
   const shouldDisplayTaskType = (taskType) => {
     const supportedTaskTypes = getSupportedTaskTypesSet(isAdmin, hasAnimals);
     const { farm_id, task_translation_key } = taskType;
+
+    if (isOffline && isTaskType(taskType, 'PLANT_TASK')) {
+      return false;
+    }
 
     if (farm_id === null && supportedTaskTypes.has(task_translation_key)) {
       // If trying to make a task through the crop management plan 'Add Task' link -- exclude animal tasks from selection for now

--- a/packages/webapp/src/containers/Task/TaskTypeSelection/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskTypeSelection/index.jsx
@@ -14,6 +14,7 @@ import { animalLocationsSelector } from '../../locationSlice';
 import { soilSampleLocationsSelector } from '../../soilSampleLocationSlice';
 import { hasAvailableProductsSelector } from '../../productSlice';
 import { TASK_TYPES } from '../constants';
+import { useIsOffline } from '../../hooks/useOfflineDetector/useIsOffline';
 
 function TaskTypeSelection() {
   const location = useLocation();
@@ -28,6 +29,7 @@ function TaskTypeSelection() {
   const { planting_task } = useSelector(showedSpotlightSelector);
   const isAdmin = useSelector(isAdminSelector);
   const { animalsExistOnFarm } = useAnimalsExist();
+  const isOffline = useIsOffline();
 
   useEffect(() => {
     dispatch(getTaskTypes());
@@ -77,6 +79,7 @@ function TaskTypeSelection() {
           hasAnimals={animalsExistOnFarm}
           hasSoilSampleLocations={hasSoilSampleLocations}
           hasSoilAmendmentProducts={hasSoilAmendmentProducts}
+          isOffline={isOffline}
         />
       </HookFormPersistProvider>
     </>


### PR DESCRIPTION
**Description**

Hides the planting task tile when offline. This is the flow that we observed in bug bash was merely a re-direct to crops and a complete dead-end offline. A separate follow-up ticket (not scoped for offline release) includes redesigning this flow.

Jira link: https://lite-farm.atlassian.net/browse/LF-5138

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
