### PR TITLE
LF-5160: Fix replay queue order (Ticket title: Fix error message shown when deleting a task after toggling assignee offline)

### DIFF
--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -39,11 +39,15 @@ type SyncConfig = {
 };
 
 /**
- * Resolve specific kinds of task patch operations from the URL
+ * Resolve specific kinds of task operations from the URL and HTTP method.
  */
-function resolveAreaFromUrl(area: string, url: string): SyncArea {
-  if (area !== 'tasks.update') {
-    return area as SyncArea;
+function resolveAreaFromUrl(method: string, url: string): SyncArea {
+  if (method === 'POST') {
+    return 'tasks.create';
+  }
+
+  if (method === 'DELETE') {
+    return 'tasks.delete';
   }
 
   if (url.includes('/task/complete/')) {
@@ -132,10 +136,10 @@ export function useServiceWorkerListener() {
 
       const { type, payload } = event.data;
 
-      const { area: rawArea, status, url } = payload || {};
+      const { method, status, url } = payload || {};
 
       if (type === 'SYNC_ITEM_SUCCESS') {
-        const area = resolveAreaFromUrl(rawArea, url);
+        const area = resolveAreaFromUrl(method, url);
 
         const handler = syncConfig[area as SyncArea];
         if (!handler) return;
@@ -168,16 +172,14 @@ export function useServiceWorkerListener() {
          * See: https://developer.chrome.com/docs/workbox/modules/workbox-background-sync
          */
         // We will also manually replay when the app comes back online.
-        switch (rawArea) {
-          case 'tasks.create':
+        switch (method) {
+          case 'POST':
             dispatch(enqueueErrorSnackbar(t('message:TASK.CREATE.SYNC.NETWORK_ERROR')));
             break;
-          case 'tasks.delete':
+          case 'DELETE':
             dispatch(enqueueErrorSnackbar(t('message:TASK.DELETE.SYNC.NETWORK_ERROR')));
             break;
-          case 'tasks.complete':
-          case 'tasks.abandon':
-          case 'tasks.update':
+          case 'PATCH':
             dispatch(enqueueErrorSnackbar(t('message:TASK.UPDATE.SYNC.NETWORK_ERROR')));
             break;
           default:

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -39,7 +39,7 @@ registerRoute(new NavigationRoute(createHandlerBoundToURL('index.html')));
  * Higher-order function for onSync callbacks.
  * Replays requests and sends per-item success/failure messages to clients.
  */
-const createOnSyncHandler = (area) => {
+const createOnSyncHandler = () => {
   return async ({ queue }) => {
     let entry;
     while ((entry = await queue.shiftRequest())) {
@@ -64,8 +64,8 @@ const createOnSyncHandler = (area) => {
           client.postMessage({
             type: 'SYNC_ITEM_SUCCESS',
             payload: {
-              area,
               url: entry.request.url,
+              method: entry.request.method,
               status: response.status,
               response: responseContent,
             },
@@ -79,8 +79,8 @@ const createOnSyncHandler = (area) => {
           client.postMessage({
             type: 'SYNC_ITEM_FAILURE',
             payload: {
-              area,
               url: entry.request.url,
+              method: entry.request.method,
               error: error.message,
             },
           }),
@@ -94,41 +94,37 @@ const createOnSyncHandler = (area) => {
 
 const BG_SYNC_ROUTES = [
   {
-    queueName: 'create-task-queue',
     matcher: ({ url }) => url.pathname.includes('/task/'),
-    area: 'tasks.create',
     method: 'POST',
   },
   {
-    queueName: 'patch-task-queue',
     // This matcher as written will include task/patch_due_date, task/assign, task/abandon, etc.
     matcher: ({ url }) => url.pathname.includes('/task/'),
-    area: 'tasks.update',
     method: 'PATCH',
   },
   {
-    queueName: 'delete-task-queue',
     matcher: ({ url }) => url.pathname.includes('/task/'),
-    area: 'tasks.delete',
     method: 'DELETE',
   },
 ];
 
+const BG_SYNC_QUEUE_NAME = 'background-sync';
+
+const backgroundSyncQueue = new Queue(BG_SYNC_QUEUE_NAME, {
+  maxRetentionTime: 24 * 60, // 24 hours
+  onSync: createOnSyncHandler(),
+});
+
 // Store queue references globally to allow manual replay
-const queues = {};
+const queues = {
+  [BG_SYNC_QUEUE_NAME]: { queue: backgroundSyncQueue },
+};
 
-BG_SYNC_ROUTES.forEach(({ queueName, matcher, area, method }) => {
-  const queue = new Queue(queueName, {
-    maxRetentionTime: 24 * 60, // 24 hours
-    onSync: createOnSyncHandler(area),
-  });
-
-  queues[queueName] = { queue, area };
-
+BG_SYNC_ROUTES.forEach(({ matcher, method }) => {
   // Push to our queue on failure
   const bgSyncPlugin = {
     fetchDidFail: async ({ request }) => {
-      await queue.pushRequest({
+      await backgroundSyncQueue.pushRequest({
         request,
         metadata: {
           timestamp: Date.now(),
@@ -145,8 +141,8 @@ self.addEventListener('message', async (event) => {
   // Manually replay queues if background sync is not supported
   if (!('sync' in self.registration)) {
     if (event.data === 'replay_queue') {
-      Object.values(queues).forEach(async ({ queue, area }) => {
-        const handler = createOnSyncHandler(area);
+      Object.values(queues).forEach(async ({ queue }) => {
+        const handler = createOnSyncHandler();
         try {
           await handler({ queue });
         } catch (err) {


### PR DESCRIPTION
**Description**

Replaced multiple background sync queues with a single queue to fix request replay ordering issues. Requests now replay in FIFO order regardless of type.

Changes:
- Consolidate three separate queues into one 'background-sync' queue
- Update `onSync` handler to send method instead of area
- Area resolution now happens in App's `resolveAreaFromUrl`

@kathyavini Please let me know if this approach is different from what you were expecting!

Jira link: https://lite-farm.atlassian.net/browse/LF-5160

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
