### PR TITLE
LF-5149 Cannot complete Soil Sample task in offline mode when you try to add an image of your Soil Sample

### DIFF
--- a/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
+++ b/packages/webapp/src/components/Task/TaskComplete/StepOne.jsx
@@ -30,6 +30,7 @@ import {
   HAPPINESS,
   PREFER_NOT_TO_SAY,
 } from '.';
+import { useIsOffline } from '../../../containers/hooks/useOfflineDetector/useIsOffline';
 
 const COMPLETION_FIELDS = [
   DURATION,
@@ -68,6 +69,7 @@ export default function PureCompleteStepOne({
   isUploading,
 }) {
   const { t } = useTranslation();
+  const isOffline = useIsOffline();
   const defaultsToUse = formatTaskReadOnlyDefaultValues(
     persistedFormData.need_changes ? persistedFormData : selectedTask,
   );
@@ -237,7 +239,7 @@ export default function PureCompleteStepOne({
             locations: selectedTask.locations,
           })
         : null}
-      {taskType === 'SOIL_SAMPLE_TASK' && (
+      {taskType === 'SOIL_SAMPLE_TASK' && !isOffline && (
         <div>
           <Main style={{ marginBottom: '24px' }}>{t('TASK.DID_YOU_GET_RESULTS')}</Main>
           <RadioGroup hookFormControl={control} required name={RESULTS_AVAILABLE} />


### PR DESCRIPTION
**Description**

Hide the option to add lab results when offline.

Note: I went with hiding the whole radio (and not just the upload link) because we don't store the actual radio value in our backend; just the document association. So selecting "yes" but not uploading a file (if we changed the code to permit that, at least while offline) would end up being the same as selecting "no" when later viewing that task.

Saw some other issues in this part of the code I want to fix -- particularly that a worker will get logged out with 403 when uploading a results file (!) -- but will do it on a separate branch to keep things tidy.

Jira link: https://lite-farm.atlassian.net/browse/LF-5149

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
