### PR TITLE
LF-5119 image when offline on crop details page leads to flickering and string of console errors

### DIFF
--- a/packages/webapp/src/components/CropTile/index.jsx
+++ b/packages/webapp/src/components/CropTile/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { StatusLabel } from '../CardWithStatus/StatusLabel';
 import { managementPlanStatusTranslateKey } from '../CardWithStatus/ManagementPlanCard/ManagementPlanCard';
 import { useTranslation } from 'react-i18next';
-import { useIsOffline } from '../../containers/hooks/useOfflineDetector/useIsOffline';
 
 export default function PureCropTile({
   className,
@@ -22,32 +21,23 @@ export default function PureCropTile({
   children,
   isSelected,
   status,
-  getIsOffline = useIsOffline,
 }) {
   const { active = 0, abandoned = 0, planned = 0, completed = 0, noPlans = 0 } = cropCount;
   const { t } = useTranslation();
-  const isOffline = getIsOffline();
-  const [hasError, setHasError] = useState();
-  const showImage = !(isOffline && hasError);
   const image = useMemo(() => {
-    if (showImage) {
-      return (
-        <img
-          src={src}
-          alt={alt}
-          loading="lazy"
-          className={styles.img}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = '/crop-images/default.jpg';
-            setHasError(true);
-          }}
-        />
-      );
-    } else {
-      return <div className={clsx(styles.img, styles.imgPlaceHolder)} />;
-    }
-  }, [showImage, src, alt, styles.img]);
+    return (
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        className={styles.img}
+        onError={(e) => {
+          e.target.onerror = null;
+          e.target.src = '/crop-images/default.jpg';
+        }}
+      />
+    );
+  }, [src, alt, styles.img]);
   return (
     <div
       data-cy="crop-tile"

--- a/packages/webapp/src/components/CropTile/styles.module.scss
+++ b/packages/webapp/src/components/CropTile/styles.module.scss
@@ -110,7 +110,3 @@
   margin-bottom: 2px;
   white-space: nowrap;
 }
-
-.imgPlaceHolder {
-  background-color: var(--grey200);
-}

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       cypress: true,
     }),
     VitePWA({
+      includeAssets: ['crop-images/default.jpg'],
       registerType: 'autoUpdate',
       strategies: 'injectManifest',
       srcDir: 'src',


### PR DESCRIPTION
**Description**

This was actually a bit fun to look into because you can trace the story of this attempt at fallback over 3+ years 😆

The cause of the error on the crop header page was this code, which is a very old pattern in our codebase (first use predates current devs) -- the idea is to fall back to the default crop image when the requested image is not found:

```jsx
<img
  src={crop_variety_photo_url}
  // ...
  onError={(e) => {
    e.target.onerror = null;
    e.target.src = '/crop-images/default.jpg';
  }}
/>
```

According to my [PR notes from 2023](https://github.com/LiteFarmOrg/LiteFarm/pull/2723) that fallback wasn't quite defined correctly in order to actually pull the default image from our built webapp, which was also leading to this flickering behaviour on local; that was adjusted in June 2023.

However, in lovely parallel to the investigation we just did on translations last week, that default image path is valid for our _built_ assets on webapp, but that doesn't mean that it's in our _cached_ assets in workbox precache (since as of integration right now, we don't precache any images). Therefore when offline, that `onError()` code runs, tries to fetch the image from the hosted webapp, fails, triggers the `onError()`, which tries to fetch the fallback... etc.

This PR adds the default image to our precache, so that the path resolves and that error cycle is broken.

Also somewhat interestingly, the original use of the `useIsOffline()` hook that we have recently revamped was in the `<CropTile />` and used to display a grey placeholder when offline. The original author Jimmy had noted [here on that PR](https://github.com/LiteFarmOrg/LiteFarm/pull/2460#issuecomment-1461165482):

> The crop tile change is just a walkaround. If app is installed, images are not cached by the browser and the phone is offline, the component will display a grey placeholder. Ideally, the offline placeholder should be svg/default crop image.

So I have completed that intention and removed the grey placeholder -- with the default image in our cache we can now show that when offline.

PS Jimmy also wrote, same comment

> Google maps can't be displayed offline. Maps should be replaced with open-source map leaflet so that tiles can be cached and locations can be displayed without tiles.

Haha... well, we _were_ warned.

Jira link: https://lite-farm.atlassian.net/browse/LF-5119

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Loaded app with app storage freshly cleared to make sure 

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
