### PR TITLE
LF-5155 Fix persisting success snackbars behavior in offline mode

### DIFF
--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -170,7 +170,7 @@ export function* assignTaskSaga({ payload: { task_id, assignee_user_id } }) {
       const isOffline = yield select(isOfflineSelector);
 
       if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
+        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
       }
 
       // Optimistic update for task update
@@ -231,7 +231,7 @@ export function* changeTaskDateSaga({ payload: { task_id, due_date } }) {
       const isOffline = yield select(isOfflineSelector);
 
       if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
+        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
       }
 
       // Optimistic update for task update
@@ -260,7 +260,7 @@ export function* changeTaskWageSaga({
       const isOffline = yield select(isOfflineSelector);
 
       if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
+        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
       }
 
       // Optimistic update for task wage update
@@ -914,7 +914,7 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
       const isOffline = yield select(isOfflineSelector);
 
       if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.COMPLETE.SYNC.ONLINE')));
+        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.COMPLETE.SYNC.ONLINE')));
       }
 
       // Optimistic update for task completion
@@ -957,7 +957,7 @@ export function* abandonTaskSaga({ payload: data }) {
       const isOffline = yield select(isOfflineSelector);
 
       if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.ABANDON.SYNC.ONLINE')));
+        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.ABANDON.SYNC.ONLINE')));
       }
 
       // Optimistic update for task abandonment
@@ -1106,7 +1106,7 @@ export function* deleteTaskSaga({ payload: data }) {
       const isOffline = yield select(isOfflineSelector);
 
       if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.DELETE.SYNC.ONLINE')));
+        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.DELETE.SYNC.ONLINE')));
       }
 
       // Optimistic update for task deletion


### PR DESCRIPTION
**Description**

It was decided only offline task creation requires a persistent snackbar, since it lacks an optimistic update. All other task actions while offline have an optimistic update and their snackbars don't require persistence.

(Creation itself, if the nice-to-have ticket for optimistic update is completed, will not need one either).

Jira link: https://lite-farm.atlassian.net/browse/LF-5155

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
