### PR TITLE
LF-5158 Prevent submitting unchanged 'no' task wage updates

### DIFF
--- a/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
+++ b/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
@@ -57,11 +57,13 @@ export default function EditTaskWageModal({
     control,
     watch,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors, isValid, isDirty },
   } = useForm<EditTaskWageFormFields>({
     mode: 'onChange',
     defaultValues: {
-      [HOURLY_WAGE_ACTION]: hasTaskWageOverride ? hourlyWageActions.FOR_THIS_TASK : '',
+      [HOURLY_WAGE_ACTION]: hasTaskWageOverride
+        ? hourlyWageActions.FOR_THIS_TASK
+        : hourlyWageActions.NO,
       [HOURLY_WAGE]: hasTaskWageOverride ? wage_at_moment : null,
     },
   });
@@ -93,7 +95,12 @@ export default function EditTaskWageModal({
           <Button onClick={dismissModal} color="secondary" sm>
             {t('common:CANCEL')}
           </Button>
-          <Button onClick={handleSubmit(onSubmit)} disabled={!isValid} color="primary" sm>
+          <Button
+            onClick={handleSubmit(onSubmit)}
+            disabled={!isValid || !isDirty}
+            color="primary"
+            sm
+          >
             {t('common:SAVE')}
           </Button>
         </>

--- a/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
+++ b/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
@@ -18,15 +18,11 @@ import { useTranslation } from 'react-i18next';
 import ModalComponent from '../ModalComponent/v2';
 import Button from '../../Form/Button';
 import HourlyWageInputs from '../../Task/AssignTask/HourlyWageInputs';
-import {
-  HOURLY_WAGE,
-  HOURLY_WAGE_ACTION,
-  hourlyWageActions,
-} from '../../Task/AssignTask/constants';
+import { HOURLY_WAGE, HOURLY_WAGE_ACTION, HourlyWageAction } from '../../Task/AssignTask/constants';
 import { roundToTwo } from '../../../util/rounding';
 
 interface EditTaskWageFormFields {
-  [HOURLY_WAGE_ACTION]: string;
+  [HOURLY_WAGE_ACTION]: HourlyWageAction;
   [HOURLY_WAGE]: number | null;
 }
 
@@ -44,7 +40,7 @@ interface EditTaskWageModalProps {
 
 interface WageActionChangeEvent {
   target: {
-    value: typeof hourlyWageActions.FOR_THIS_TASK | typeof hourlyWageActions.NO;
+    value: HourlyWageAction;
   };
 }
 
@@ -69,28 +65,28 @@ export default function EditTaskWageModal({
     mode: 'onChange',
     defaultValues: {
       [HOURLY_WAGE_ACTION]: hasTaskWageOverride
-        ? hourlyWageActions.FOR_THIS_TASK
-        : hourlyWageActions.NO,
+        ? HourlyWageAction.FOR_THIS_TASK
+        : HourlyWageAction.NO,
       [HOURLY_WAGE]: hasTaskWageOverride ? wage_at_moment : null,
     },
   });
 
   const selectedHourlyWageAction = watch(HOURLY_WAGE_ACTION);
-  const shouldSetWage = selectedHourlyWageAction === hourlyWageActions.FOR_THIS_TASK;
+  const shouldSetWage = selectedHourlyWageAction === HourlyWageAction.FOR_THIS_TASK;
 
   const handleWageChange = ({ target }: WageActionChangeEvent) => {
-    if (target?.value === hourlyWageActions.NO) {
+    if (target?.value === HourlyWageAction.NO) {
       resetField(HOURLY_WAGE);
     }
   };
 
   const onSubmit = (data: EditTaskWageFormFields) => {
-    if (data[HOURLY_WAGE_ACTION] === hourlyWageActions.FOR_THIS_TASK) {
+    if (data[HOURLY_WAGE_ACTION] === HourlyWageAction.FOR_THIS_TASK) {
       onSave({
         wage_at_moment: roundToTwo(data[HOURLY_WAGE]),
         override_hourly_wage: true,
       });
-    } else if (data[HOURLY_WAGE_ACTION] === hourlyWageActions.NO) {
+    } else if (data[HOURLY_WAGE_ACTION] === HourlyWageAction.NO) {
       onSave({
         wage_at_moment: null,
         override_hourly_wage: false,

--- a/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
+++ b/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
@@ -13,7 +13,6 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import ModalComponent from '../ModalComponent/v2';
@@ -41,6 +40,12 @@ interface EditTaskWageModalProps {
   onSave: (data: TaskWagePatch) => void;
   wage_at_moment: number | null;
   override_hourly_wage: boolean;
+}
+
+interface WageActionChangeEvent {
+  target: {
+    value: typeof hourlyWageActions.FOR_THIS_TASK | typeof hourlyWageActions.NO;
+  };
 }
 
 export default function EditTaskWageModal({
@@ -73,11 +78,11 @@ export default function EditTaskWageModal({
   const selectedHourlyWageAction = watch(HOURLY_WAGE_ACTION);
   const shouldSetWage = selectedHourlyWageAction === hourlyWageActions.FOR_THIS_TASK;
 
-  useEffect(() => {
-    if (selectedHourlyWageAction === hourlyWageActions.NO) {
+  const handleWageChange = ({ target }: WageActionChangeEvent) => {
+    if (target?.value === hourlyWageActions.NO) {
       resetField(HOURLY_WAGE);
     }
-  }, [selectedHourlyWageAction]);
+  };
 
   const onSubmit = (data: EditTaskWageFormFields) => {
     if (data[HOURLY_WAGE_ACTION] === hourlyWageActions.FOR_THIS_TASK) {
@@ -119,6 +124,7 @@ export default function EditTaskWageModal({
         control={control}
         errors={errors}
         shouldSetWage={shouldSetWage}
+        onHourlyWageActionChange={handleWageChange}
       />
     </ModalComponent>
   );

--- a/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
+++ b/packages/webapp/src/components/Modals/EditTaskWageModal/index.tsx
@@ -13,6 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import ModalComponent from '../ModalComponent/v2';
@@ -57,6 +58,7 @@ export default function EditTaskWageModal({
     control,
     watch,
     handleSubmit,
+    resetField,
     formState: { errors, isValid, isDirty },
   } = useForm<EditTaskWageFormFields>({
     mode: 'onChange',
@@ -70,6 +72,12 @@ export default function EditTaskWageModal({
 
   const selectedHourlyWageAction = watch(HOURLY_WAGE_ACTION);
   const shouldSetWage = selectedHourlyWageAction === hourlyWageActions.FOR_THIS_TASK;
+
+  useEffect(() => {
+    if (selectedHourlyWageAction === hourlyWageActions.NO) {
+      resetField(HOURLY_WAGE);
+    }
+  }, [selectedHourlyWageAction]);
 
   const onSubmit = (data: EditTaskWageFormFields) => {
     if (data[HOURLY_WAGE_ACTION] === hourlyWageActions.FOR_THIS_TASK) {

--- a/packages/webapp/src/components/Task/AssignTask/HourlyWageInputs.jsx
+++ b/packages/webapp/src/components/Task/AssignTask/HourlyWageInputs.jsx
@@ -20,7 +20,13 @@ import { HOURLY_WAGE, HOURLY_WAGE_ACTION, hourlyWageActions } from './constants'
 import styles from './styles.module.scss';
 import { useCurrencySymbol } from '../../../containers/hooks/useCurrencySymbol';
 
-const HourlyWageInputs = ({ register, control, errors, shouldSetWage }) => {
+const HourlyWageInputs = ({
+  register,
+  control,
+  errors,
+  shouldSetWage,
+  onHourlyWageActionChange,
+}) => {
   const { t } = useTranslation(['translation']);
 
   const currencySymbol = useCurrencySymbol();
@@ -48,6 +54,7 @@ const HourlyWageInputs = ({ register, control, errors, shouldSetWage }) => {
         data-cy="hourlyWageInputs-action"
         style={{ marginBottom: '20px' }}
         row
+        onChange={onHourlyWageActionChange}
       />
       {shouldSetWage && (
         <Input

--- a/packages/webapp/src/components/Task/AssignTask/HourlyWageInputs.jsx
+++ b/packages/webapp/src/components/Task/AssignTask/HourlyWageInputs.jsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { Main } from '../../Typography';
 import RadioGroup from '../../Form/RadioGroup';
 import Input, { numberOnKeyDown } from '../../Form/Input';
-import { HOURLY_WAGE, HOURLY_WAGE_ACTION, hourlyWageActions } from './constants';
+import { HOURLY_WAGE, HOURLY_WAGE_ACTION, HourlyWageAction } from './constants';
 import styles from './styles.module.scss';
 import { useCurrencySymbol } from '../../../containers/hooks/useCurrencySymbol';
 
@@ -34,11 +34,11 @@ const HourlyWageInputs = ({
   const radioOptions = [
     {
       label: t('common:YES'),
-      value: hourlyWageActions.FOR_THIS_TASK,
+      value: HourlyWageAction.FOR_THIS_TASK,
     },
     {
       label: t('common:NO'),
-      value: hourlyWageActions.NO,
+      value: HourlyWageAction.NO,
     },
   ];
 

--- a/packages/webapp/src/components/Task/AssignTask/constants.ts
+++ b/packages/webapp/src/components/Task/AssignTask/constants.ts
@@ -18,9 +18,9 @@ export const HOURLY_WAGE_ACTION = 'hourly_wage_action';
 export const ASSIGN_ALL = 'assign_all';
 export const ALREADY_COMPLETED = 'already_completed';
 
-export const hourlyWageActions = {
-  FOR_THIS_TASK: 'for_this_task',
-  NO: 'no',
-};
+export enum HourlyWageAction {
+  FOR_THIS_TASK = 'for_this_task',
+  NO = 'no',
+}
 
 export const assignTaskFields = [ASSIGNEE, HOURLY_WAGE, HOURLY_WAGE_ACTION, ASSIGN_ALL];

--- a/packages/webapp/src/components/Task/AssignTask/useTaskAssignForm.jsx
+++ b/packages/webapp/src/components/Task/AssignTask/useTaskAssignForm.jsx
@@ -15,10 +15,10 @@
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
-import { ASSIGNEE, HOURLY_WAGE, HOURLY_WAGE_ACTION, hourlyWageActions } from './constants';
+import { ASSIGNEE, HOURLY_WAGE, HOURLY_WAGE_ACTION, HourlyWageAction } from './constants';
 
 const isYesOptionSelected = (option) => {
-  return option === hourlyWageActions.FOR_THIS_TASK;
+  return option === HourlyWageAction.FOR_THIS_TASK;
 };
 
 /**

--- a/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
+++ b/packages/webapp/src/containers/Task/TaskAssignment/index.jsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { cloneObject } from '../../../util';
 import useTaskAssignForm from '../../../components/Task/AssignTask/useTaskAssignForm';
 import {
-  hourlyWageActions,
+  HourlyWageAction,
   assignTaskFields,
   ASSIGNEE,
   ALREADY_COMPLETED,
@@ -70,7 +70,7 @@ export default function TaskAssignment() {
   const onSubmit = (data) => {
     const { hourly_wage_action, assignee, hourly_wage, already_completed } = data;
 
-    const shouldSetTaskWage = hourly_wage_action === hourlyWageActions.FOR_THIS_TASK;
+    const shouldSetTaskWage = hourly_wage_action === HourlyWageAction.FOR_THIS_TASK;
 
     const postData = {
       ...persistedFormData,


### PR DESCRIPTION
**Description**

This PR fixes two issues with the new EditTaskWageModal form:

1. The default value should be "no" when there is no task wage, not blank / empty string
2. The form should only be submittable when dirtied

To support (2) the hourly wage input is now also reset to default when "no" is selected -- this is to prevent the form from reading as dirtied (and submittable) just because a hourly wage was added, if the radio selection is then returned to "no"

To support _this_ I made the `hourlyWageActions` object an enum (and updating its naming to enum convention, i.e. `HourlyWageAction`), so I could use it in the new TS file as a type. I guess this is another use case for an enum -- when you want to use an existing JS object as a type in new files 🙂 

Jira link: https://lite-farm.atlassian.net/browse/LF-5158

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
