### PR TITLE
LF-5163: Incorrect sync state and conflicting snackbars after offline changes when app is closed

### DIFF
--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -167,10 +167,8 @@ export function useServiceWorkerListener() {
       } else if (type === 'SYNC_ITEM_FAILURE') {
         /*
          * This indicates a failure to reach the server (e.g. API down). It should be rare.
-         * The background-sync-api retries automatically with exponential backoff (approx. 5 min on Chrome).
-         * See: https://developer.chrome.com/docs/workbox/modules/workbox-background-sync
+         * We will manually replay when the app is re-rendered.
          */
-        // We will also manually replay when the app comes back online.
         switch (area) {
           case 'tasks.create':
             dispatch(enqueueErrorSnackbar(t('message:TASK.CREATE.SYNC.NETWORK_ERROR')));

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -137,10 +137,9 @@ export function useServiceWorkerListener() {
       const { type, payload } = event.data;
 
       const { method, status, url } = payload || {};
+      const area = resolveAreaFromUrl(method, url);
 
       if (type === 'SYNC_ITEM_SUCCESS') {
-        const area = resolveAreaFromUrl(method, url);
-
         const handler = syncConfig[area as SyncArea];
         if (!handler) return;
 
@@ -172,14 +171,16 @@ export function useServiceWorkerListener() {
          * See: https://developer.chrome.com/docs/workbox/modules/workbox-background-sync
          */
         // We will also manually replay when the app comes back online.
-        switch (method) {
-          case 'POST':
+        switch (area) {
+          case 'tasks.create':
             dispatch(enqueueErrorSnackbar(t('message:TASK.CREATE.SYNC.NETWORK_ERROR')));
             break;
-          case 'DELETE':
+          case 'tasks.delete':
             dispatch(enqueueErrorSnackbar(t('message:TASK.DELETE.SYNC.NETWORK_ERROR')));
             break;
-          case 'PATCH':
+          case 'tasks.complete':
+          case 'tasks.abandon':
+          case 'tasks.update':
             dispatch(enqueueErrorSnackbar(t('message:TASK.UPDATE.SYNC.NETWORK_ERROR')));
             break;
           default:

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -112,7 +112,8 @@ const BG_SYNC_QUEUE_NAME = 'background-sync';
 
 const backgroundSyncQueue = new Queue(BG_SYNC_QUEUE_NAME, {
   maxRetentionTime: 24 * 60, // 24 hours
-  onSync: createOnSyncHandler(),
+  // onSync is a no-op; the actual handler is createOnSyncHandler called from the message event listener below
+  onSync: () => ({}),
 });
 
 // Store queue references globally to allow manual replay
@@ -138,18 +139,15 @@ BG_SYNC_ROUTES.forEach(({ matcher, method }) => {
 
 // ——————————————————————————————
 self.addEventListener('message', async (event) => {
-  // Manually replay queues if background sync is not supported
-  if (!('sync' in self.registration)) {
-    if (event.data === 'replay_queue') {
-      Object.values(queues).forEach(async ({ queue }) => {
-        const handler = createOnSyncHandler();
-        try {
-          await handler({ queue });
-        } catch (err) {
-          // Ignore errors during manual replay; they are logged by the handler anyway
-        }
-      });
-    }
+  if (event.data === 'replay_queue') {
+    Object.values(queues).forEach(async ({ queue }) => {
+      const handler = createOnSyncHandler();
+      try {
+        await handler({ queue });
+      } catch (err) {
+        // Ignore errors during manual replay; they are logged by the handler anyway
+      }
+    });
   }
 
   if (event.data === 'clear_queue') {

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -140,14 +140,14 @@ BG_SYNC_ROUTES.forEach(({ matcher, method }) => {
 // ——————————————————————————————
 self.addEventListener('message', async (event) => {
   if (event.data === 'replay_queue') {
-    Object.values(queues).forEach(async ({ queue }) => {
+    for (let { queue } of Object.values(queues)) {
       const handler = createOnSyncHandler();
       try {
         await handler({ queue });
       } catch (err) {
         // Ignore errors during manual replay; they are logged by the handler anyway
       }
-    });
+    }
   }
 
   if (event.data === 'clear_queue') {


### PR DESCRIPTION
**Description**

My assumption is that the network stack isn't fully ready when automatic background sync fires on mobile Chrome, causing requests to fail.
This PR disables automatic background sync by setting onSync to a no-op.

Retry won't happen automatically, so "Sorry, we are down momentarily. We will retry your task update automatically" snackbar message now feels inaccurate. We can confirm this with Loïc later.
The queue is no longer for background sync, so we should rename variables.

Also, I addressed the [comment](https://github.com/LiteFarmOrg/LiteFarm/pull/4022#discussion_r2784744595) about the `switch` for areas, and converted the `forEach` in the message event listener to `for` loop since `forEach` doesn't wait for promises ([doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#description:~:text=forEach()%20expects%20a%20synchronous%20function%20%E2%80%94%20it%20does%20not%20wait%20for%20promises.%20Make%20sure%20you%20are%20aware%20of%20the%20implications%20while%20using%20promises%20(or%20async%20functions)%20as%20forEach%20callbacks.)). 

Jira link: https://lite-farm.atlassian.net/browse/LF-5163

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
