### PR TITLE
LF-5143: Error snackbar appears when offline on reload

### DIFF
--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -204,7 +204,10 @@ export function useServiceWorkerListener() {
       window.addEventListener('online', replayQueue);
 
       // Also replay queue on startup
-      replayQueue();
+      // Do not use Redux isOnline state here - it may not reflect the actual network status on initial render
+      if (window.navigator.onLine) {
+        replayQueue();
+      }
     }
 
     return () => {

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -121,19 +121,19 @@ const queues = {
   [RETRY_QUEUE_NAME]: { queue: retryQueue },
 };
 
-// Push to our queue on failure
-const queueOnFailurePlugin = {
-  fetchDidFail: async ({ request }) => {
-    await retryQueue.pushRequest({
-      request,
-      metadata: {
-        timestamp: Date.now(),
-      },
-    });
-  },
-};
-
 RETRY_ROUTES.forEach(({ matcher, method }) => {
+  // Push to our queue on failure
+  const queueOnFailurePlugin = {
+    fetchDidFail: async ({ request }) => {
+      await retryQueue.pushRequest({
+        request,
+        metadata: {
+          timestamp: Date.now(),
+        },
+      });
+    },
+  };
+
   registerRoute(matcher, new NetworkOnly({ plugins: [queueOnFailurePlugin] }), method);
 });
 

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -92,7 +92,7 @@ const createOnSyncHandler = () => {
   };
 };
 
-const BG_SYNC_ROUTES = [
+const RETRY_ROUTES = [
   {
     matcher: ({ url }) => url.pathname.includes('/task/'),
     method: 'POST',
@@ -108,9 +108,9 @@ const BG_SYNC_ROUTES = [
   },
 ];
 
-const BG_SYNC_QUEUE_NAME = 'background-sync';
+const RETRY_QUEUE_NAME = 'retry-requests';
 
-const backgroundSyncQueue = new Queue(BG_SYNC_QUEUE_NAME, {
+const retryQueue = new Queue(RETRY_QUEUE_NAME, {
   maxRetentionTime: 24 * 60, // 24 hours
   // onSync is a no-op; the actual handler is createOnSyncHandler called from the message event listener below
   onSync: () => ({}),
@@ -118,23 +118,23 @@ const backgroundSyncQueue = new Queue(BG_SYNC_QUEUE_NAME, {
 
 // Store queue references globally to allow manual replay
 const queues = {
-  [BG_SYNC_QUEUE_NAME]: { queue: backgroundSyncQueue },
+  [RETRY_QUEUE_NAME]: { queue: retryQueue },
 };
 
-BG_SYNC_ROUTES.forEach(({ matcher, method }) => {
-  // Push to our queue on failure
-  const bgSyncPlugin = {
-    fetchDidFail: async ({ request }) => {
-      await backgroundSyncQueue.pushRequest({
-        request,
-        metadata: {
-          timestamp: Date.now(),
-        },
-      });
-    },
-  };
+// Push to our queue on failure
+const queueOnFailurePlugin = {
+  fetchDidFail: async ({ request }) => {
+    await retryQueue.pushRequest({
+      request,
+      metadata: {
+        timestamp: Date.now(),
+      },
+    });
+  },
+};
 
-  registerRoute(matcher, new NetworkOnly({ plugins: [bgSyncPlugin] }), method);
+RETRY_ROUTES.forEach(({ matcher, method }) => {
+  registerRoute(matcher, new NetworkOnly({ plugins: [queueOnFailurePlugin] }), method);
 });
 
 // ——————————————————————————————


### PR DESCRIPTION
**Description**

- Replay queue only when online to avoid triggering API calls that could show incorrect error snackbar.
- Adjust background-sync-related variable names.

Jira link: https://lite-farm.atlassian.net/browse/LF-5143

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
