### PR TITLE
LF-5139 Let users know they have to go online to add the task dependencies location crops products that block those flows

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -221,6 +221,10 @@
     "NO_SOIL_SAMPLE_LOCATION": "No eligible soil sample locations",
     "NOTES_LABEL": "Anything specific to add related to this task?",
     "NOTES_PLACEHOLDER": "Add any instructions or specifics for the assignee",
+    "OFFLINE_NOTICE": {
+      "CANNOT_ADD_NEW": "You can use existing locations, crops and products in your tasks, but you cannot add new ones while offline.",
+      "YOURE_OFFLINE": "You're offline"
+    },
     "PEST_CONTROL_VIEW": {
       "BIOLOGICAL_CONTROL": "Biological control",
       "FLAME_WEEDING": "Flame weeding",

--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/PureTaskTypeSelection.jsx
@@ -161,6 +161,13 @@ export const PureTaskTypeSelection = ({
 
         <Main style={{ paddingBottom: '20px' }}>{t('ADD_TASK.SELECT_TASK_TYPE')}</Main>
 
+        {isOffline && (
+          <div className={styles.offlineNotice}>
+            <h3>{t('ADD_TASK.OFFLINE_NOTICE.YOURE_OFFLINE')}</h3>
+            <p>{t('ADD_TASK.OFFLINE_NOTICE.CANNOT_ADD_NEW')}</p>
+          </div>
+        )}
+
         <div style={{ paddingBottom: '20px' }} className={styles.matrixContainer}>
           {taskTypes
             ?.filter(shouldDisplayTaskType)

--- a/packages/webapp/src/components/Task/PureTaskTypeSelection/styles.module.scss
+++ b/packages/webapp/src/components/Task/PureTaskTypeSelection/styles.module.scss
@@ -72,3 +72,21 @@
   padding-top: 24px;
   padding-bottom: 72px;
 }
+
+.offlineNotice {
+  padding: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  border-radius: 4px;
+  background: var(--Box-bg);
+
+  color: var(--Colors-Primary-Primary-teal-700);
+
+  h3 {
+    font-size: 14px;
+    font-weight: 700;
+  }
+}


### PR DESCRIPTION
**Description**

This PR adds the offline-only note to Task Type Selection that we looked at together in Sprint Planning last week.

Jira link: https://lite-farm.atlassian.net/browse/LF-5139

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [z] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
