### PR TITLE
LF-5165 Add new strings for the offline readiness indicator

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1628,7 +1628,7 @@
     },
     "NOT_READY_BADGE": {
       "TITLE": "Info",
-      "TOOLTIP_CONTENT": "Litefarm needs to download data to work offline.<br><br>Complete this process when online."
+      "TOOLTIP_CONTENT": "LiteFarm needs to download data to work offline.<br><br>Complete this process when online."
     },
     "NOT_READY_WARNING": "LiteFarm hasn’t finished preparing offline data.",
     "PREPARE_TO_WORK_OFFLINE": "Prepare LiteFarm to work offline next time.",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1623,9 +1623,16 @@
     },
     "CHANGES_WILL_SYNC": "Any changes you make will sync when you're back online.",
     "LOG_OUT_MODAL": {
-      "INFO": "You won't be able to log back in while offline. All changes made while offline will be lost after logging out.",
+      "INFO": "You won't be able to log back in while offline. All changes made while offline will be lost after logging out.",
       "TITLE": "Are you sure you want to logout?"
-    }
+    },
+    "NOT_READY_BADGE": {
+      "TITLE": "Info",
+      "TOOLTIP_CONTENT": "Litefarm needs to download data to work offline.<br><br>Complete this process when online."
+    },
+    "NOT_READY_WARNING": "LiteFarm hasn’t finished preparing offline data.",
+    "PREPARE_TO_WORK_OFFLINE": "Prepare LiteFarm to work offline next time.",
+    "REFRESH": "Refresh"
   },
   "OUTRO": {
     "ALL_DONE": "Great! You're all done. Ready to get your hands dirty?",


### PR DESCRIPTION
**Description**

This is just the strings for the offline readiness indicator so they can be pushed to CrowdIn.

Jira link: https://lite-farm.atlassian.net/browse/LF-5165

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
