### PR TITLE
LF-5170: List the locations on the readonly view

### DIFF
--- a/packages/webapp/src/components/Task/TaskReadOnly/LocationList.tsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/LocationList.tsx
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <<https://www.gnu.org/licenses/>.>
+ */
+
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import { Location } from '../../../types';
+import styles from './styles.module.scss';
+import navStyles from '@navStyles';
+
+interface LocationListProps {
+  locations: Location[];
+  isTransplantTask: boolean;
+  selectedLocationIds?: Location['location_id'][];
+}
+
+export default function LocationList({
+  locations,
+  isTransplantTask,
+  selectedLocationIds,
+}: LocationListProps) {
+  const { t } = useTranslation();
+
+  if (!locations?.length) {
+    return null;
+  }
+
+  if (isTransplantTask) {
+    const transplantLocation = locations.find(
+      ({ location_id }) => location_id === selectedLocationIds?.[0],
+    );
+    // When transplanting to the same location, currentLocation becomes transplantLocation
+    const currentLocation =
+      locations.find(({ location_id }) => location_id !== selectedLocationIds?.[0]) ||
+      transplantLocation;
+
+    return (
+      <ul className={clsx(styles.locationList, navStyles.showWhenOffline)}>
+        <li>
+          {t('TASK.CURRENT')}: {currentLocation?.name}
+        </li>
+        <li>
+          {t('TASK.TRANSPLANT')}: {transplantLocation?.name}
+        </li>
+      </ul>
+    );
+  }
+
+  return (
+    <ul className={clsx(styles.locationList, navStyles.showWhenOffline)}>
+      {locations.map((location) => {
+        return <li key={location.location_id}>{location.name}</li>;
+      })}
+    </ul>
+  );
+}

--- a/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
+++ b/packages/webapp/src/components/Task/TaskReadOnly/index.jsx
@@ -69,6 +69,7 @@ import PureDocumentTile from '../../../containers/Documents/DocumentTile';
 import PureDocumentTileContainer from '../../../containers/Documents/DocumentTile/DocumentTileContainer';
 import RevisionPrompt from '../RevisionPrompt';
 import RevisionInfoText from '../../RevisionInfoText';
+import LocationList from './LocationList';
 
 export default function PureTaskReadOnly({
   onGoBack,
@@ -163,9 +164,9 @@ export default function PureTaskReadOnly({
   const isCurrent = !isCompleted && !isAbandoned;
   const taskStatus = getTaskStatus(task);
   const isRevised = !!task.revision_date;
+  const isTransplantTask = isTaskType(taskType, 'TRANSPLANT_TASK');
 
-  const showTaskNotes =
-    !isTaskType(taskType, 'PLANT_TASK') && !isTaskType(taskType, 'TRANSPLANT_TASK');
+  const showTaskNotes = !isTaskType(taskType, 'PLANT_TASK') && !isTransplantTask;
 
   const [showTaskAssignModal, setShowTaskAssignModal] = useState(false);
   const [showDueDateModal, setShowDueDateModal] = useState(false);
@@ -300,7 +301,12 @@ export default function PureTaskReadOnly({
       {showLocations ? (
         <>
           <Semibold className={styles.taskLocationsTitle}>{t('TASK.LOCATIONS')}</Semibold>
-          {isTaskType(taskType, 'TRANSPLANT_TASK') && (
+          <LocationList
+            isTransplantTask={isTransplantTask}
+            locations={task.locations}
+            selectedLocationIds={task.selectedLocationIds}
+          />
+          {isTransplantTask && (
             <TransplantLocationLabel
               locations={task.locations}
               selectedLocationId={task.selectedLocationIds[0]}

--- a/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
+++ b/packages/webapp/src/components/Task/TaskReadOnly/styles.module.scss
@@ -143,3 +143,8 @@
   font-style: italic;
   padding-top: 12px;
 }
+
+.locationList {
+  margin-bottom: 20px;
+  list-style-position: inside;
+}

--- a/packages/webapp/src/containers/Navigation/styles.module.scss
+++ b/packages/webapp/src/containers/Navigation/styles.module.scss
@@ -32,5 +32,13 @@
     .hideWhenOffline {
       display: none;
     }
+
+    .showWhenOffline {
+      display: block;
+    }
+  }
+
+  .showWhenOffline {
+    display: none;
   }
 }


### PR DESCRIPTION
**Description**
 
Show task location list in the task read-only view when offline.

- Add `showWhenOffline` class and style to `@navStyles`
- Add `LocationList` component

Jira link: https://lite-farm.atlassian.net/browse/LF-5170

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
