### PR TITLE
LF-5145(2): Record offline logs

### DIFF
--- a/packages/api/db/migration/20260223184122_add_columns_to_offfline_event_log.js
+++ b/packages/api/db/migration/20260223184122_add_columns_to_offfline_event_log.js
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  return knex.schema.alterTable('offline_event_log', (table) => {
+    table.string('user_id').references('user_id').inTable('users').nullable();
+    table.integer('role_id').references('role_id').inTable('role').nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  return knex.schema.table('offline_event_log', (table) => {
+    table.dropColumn('user_id');
+    table.dropColumn('role_id');
+  });
+};

--- a/packages/api/src/controllers/offlineEventLogController.ts
+++ b/packages/api/src/controllers/offlineEventLogController.ts
@@ -42,6 +42,8 @@ const offlineEventLogController = {
           log_status: res.locals.log_status,
           app_version,
           went_online_at: wentOnlineAt,
+          user_id: res.locals.user_id,
+          role_id: res.locals.role_id,
         };
 
         const records = logs.map(({ event_name, event_at, status_code, url }, index) => {

--- a/packages/api/src/controllers/offlineEventLogController.ts
+++ b/packages/api/src/controllers/offlineEventLogController.ts
@@ -31,7 +31,26 @@ const offlineEventLogController = {
         const wentOnlineAt = went_online_at && new Date(went_online_at).toISOString();
         const ua = parser(req.headers['user-agent']);
 
-        const commonInfo = {
+        let indexToIncludeCommonInfo = 0;
+
+        const records: Record<string, unknown>[] = logs.map(
+          ({ event_name, event_at, status_code, url }, index) => {
+            if (event_name === 'session_start') {
+              indexToIncludeCommonInfo = index;
+            }
+
+            return {
+              session_id,
+              event_name,
+              status_code,
+              url,
+              event_at: event_at && new Date(event_at).toISOString(),
+            };
+          },
+        );
+
+        records[indexToIncludeCommonInfo] = {
+          ...records[indexToIncludeCommonInfo],
           country_id: res.locals.country_id,
           network,
           browser: ua.browser.name,
@@ -45,19 +64,6 @@ const offlineEventLogController = {
           user_id: res.locals.user_id,
           role_id: res.locals.role_id,
         };
-
-        const records = logs.map(({ event_name, event_at, status_code, url }, index) => {
-          const isFirst = index === 0;
-
-          return {
-            session_id,
-            event_name,
-            status_code,
-            url,
-            event_at: event_at && new Date(event_at).toISOString(),
-            ...(isFirst ? commonInfo : {}),
-          };
-        });
 
         await offlineEventLogModel.query().insert(records);
 

--- a/packages/api/src/controllers/offlineEventLogController.ts
+++ b/packages/api/src/controllers/offlineEventLogController.ts
@@ -65,7 +65,7 @@ const offlineEventLogController = {
           role_id: res.locals.role_id,
         };
 
-        await offlineEventLogModel.query().insert(records);
+        await offlineEventLogModel.query().insert(records).onConflict().ignore();
 
         return res.status(201).send();
       } catch (error: unknown) {

--- a/packages/api/src/middleware/validation/checkOfflineLogs.ts
+++ b/packages/api/src/middleware/validation/checkOfflineLogs.ts
@@ -20,6 +20,7 @@ import userModel from '../../models/userModel.js';
 import farmModel from '../../models/farmModel.js';
 import userFarmModel from '../../models/userFarmModel.js';
 import { HttpError, LiteFarmRequest } from '../../types.js';
+import { UserFarm } from '../../models/types.js';
 
 export interface OfflineEventLogReqBody {
   logs: {
@@ -99,13 +100,15 @@ export function checkOfflineLogs() {
         }
 
         if (res.locals.user_id) {
-          const userFarm = await userFarmModel
+          const userFarm = (await userFarmModel
             .query()
-            .findOne({ user_id: res.locals.user_id, farm_id });
+            .findOne({ user_id: res.locals.user_id, farm_id })) as UserFarm | undefined;
 
           if (!userFarm) {
             throw new Error('user_id and farm_id do not match');
           }
+
+          res.locals.role_id = userFarm.role_id;
         }
 
         res.locals.country_id = farm.country_id;

--- a/packages/api/src/models/offlineEventLogModel.js
+++ b/packages/api/src/models/offlineEventLogModel.js
@@ -33,7 +33,7 @@ class offlineEventLogModel extends Model {
         event_name: { type: 'string' },
         status_code: { type: ['integer', 'null'] },
         url: { type: ['string', 'null'] },
-        country_id: { type: ['number', 'null'] },
+        country_id: { type: ['integer', 'null'] },
         network: { type: ['string', 'null'] },
         browser: { type: ['string', 'null'] },
         browser_version: { type: ['string', 'null'] },
@@ -44,6 +44,8 @@ class offlineEventLogModel extends Model {
         log_status: { type: ['string', 'null'] },
         event_at: { type: 'string', format: 'date-time' },
         went_online_at: { type: ['string', 'null'], format: 'date-time' },
+        user_id: { type: ['string', 'null'] },
+        role_id: { type: ['integer', 'null'] },
       },
       additionalProperties: false,
     };

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -682,3 +682,28 @@ export interface MarketDirectoryPartnerPermissions extends BaseProperties {
   market_directory_info_id: string;
   market_directory_partner_id: number;
 }
+
+export interface UserFarm {
+  user_id: string;
+  farm_id: string;
+  role_id: number;
+  has_consent?: boolean;
+  status: 'Active' | 'Inactive' | 'Invited';
+  created_at: string;
+  consent_version: string;
+  wage?: {
+    type: 'hourly' | 'annually';
+    amount: { type?: number };
+  };
+  step_one?: boolean;
+  step_one_end?: string;
+  step_two?: boolean;
+  step_two_end?: string;
+  step_three?: boolean;
+  step_three_end?: string;
+  step_four?: boolean;
+  step_four_end?: string;
+  step_five?: boolean;
+  step_five_end?: string;
+  wage_do_not_ask_again?: boolean;
+}

--- a/packages/webapp/src/hooks/useOfflineActivityLogger.ts
+++ b/packages/webapp/src/hooks/useOfflineActivityLogger.ts
@@ -39,10 +39,7 @@ const useOfflineActivityLogger = () => {
       return;
     }
 
-    const token = localStorage.getItem('id_token');
-
     await recordOfflineEvent({
-      auth: token ? 'Bearer ' + token : undefined,
       farmId: farmIdRef.current,
       logs: activities.map(([timestamp, url, event]) => ({
         eventName: event || 'page_view',

--- a/packages/webapp/src/hooks/useOfflineReadiness/useOfflineReadiness.ts
+++ b/packages/webapp/src/hooks/useOfflineReadiness/useOfflineReadiness.ts
@@ -22,6 +22,7 @@ import {
   type CacheValidation,
 } from './offlineReadinessSlice';
 import { useIsOffline } from '../../containers/hooks/useOfflineDetector/useIsOffline';
+import { postEventLogs } from '../../util/offlineEventLogger';
 
 export interface UseOfflineReadinessResult {
   isReadyForOffline: boolean;
@@ -54,6 +55,9 @@ async function checkCacheStatus(): Promise<CacheValidation> {
 
 const reloadApp = () => {
   window.location.reload();
+  postEventLogs({
+    logs: [{ eventName: 'reload_app', eventAt: Date.now() }],
+  });
 };
 
 const resetApplication = async () => {
@@ -63,6 +67,9 @@ const resetApplication = async () => {
       await registration.unregister();
     }
   }
+  postEventLogs({
+    logs: [{ eventName: 'reset_app', eventAt: Date.now() }],
+  });
   window.location.reload();
 };
 

--- a/packages/webapp/src/hooks/useOfflineReadiness/useOfflineReadiness.ts
+++ b/packages/webapp/src/hooks/useOfflineReadiness/useOfflineReadiness.ts
@@ -23,6 +23,7 @@ import {
 } from './offlineReadinessSlice';
 import { useIsOffline } from '../../containers/hooks/useOfflineDetector/useIsOffline';
 import { postEventLogs } from '../../util/offlineEventLogger';
+import { userFarmSelector } from '../../containers/userFarmSlice';
 
 export interface UseOfflineReadinessResult {
   isReadyForOffline: boolean;
@@ -53,14 +54,15 @@ async function checkCacheStatus(): Promise<CacheValidation> {
   });
 }
 
-const reloadApp = () => {
+const reloadApp = (farmId?: string) => {
   window.location.reload();
   postEventLogs({
+    farmId,
     logs: [{ eventName: 'reload_app', eventAt: Date.now() }],
   });
 };
 
-const resetApplication = async () => {
+const resetApplication = async (farmId?: string) => {
   if (navigator.serviceWorker) {
     const registrations = await navigator.serviceWorker.getRegistrations();
     for (const registration of registrations) {
@@ -68,6 +70,7 @@ const resetApplication = async () => {
     }
   }
   postEventLogs({
+    farmId,
     logs: [{ eventName: 'reset_app', eventAt: Date.now() }],
   });
   window.location.reload();
@@ -84,6 +87,8 @@ export function useOfflineReadiness(): UseOfflineReadinessResult {
   // This check will not exclude localhost:3000, but will exclude browsers without SW support or other unsecured contexts
   // (e.g. hosted over the local network)
   const isServiceWorkerSupported = typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+
+  const farm: { farm_id?: string } = useSelector(userFarmSelector);
 
   const validateAndUpdateState = async () => {
     const validation = await checkCacheStatus();
@@ -130,6 +135,6 @@ export function useOfflineReadiness(): UseOfflineReadinessResult {
     isReadyForOffline,
     wentOfflineDuringSetup,
     isServiceWorkerSupported,
-    restoreCache: recoveryMode ? resetApplication : reloadApp,
+    restoreCache: () => (recoveryMode ? resetApplication : reloadApp)(farm?.farm_id),
   };
 }

--- a/packages/webapp/src/hooks/useOfflineReadiness/useOfflineReadiness.ts
+++ b/packages/webapp/src/hooks/useOfflineReadiness/useOfflineReadiness.ts
@@ -54,25 +54,17 @@ async function checkCacheStatus(): Promise<CacheValidation> {
   });
 }
 
-const reloadApp = (farmId?: string) => {
+const reloadApp = () => {
   window.location.reload();
-  postEventLogs({
-    farmId,
-    logs: [{ eventName: 'reload_app', eventAt: Date.now() }],
-  });
 };
 
-const resetApplication = async (farmId?: string) => {
+const resetApplication = async () => {
   if (navigator.serviceWorker) {
     const registrations = await navigator.serviceWorker.getRegistrations();
     for (const registration of registrations) {
       await registration.unregister();
     }
   }
-  postEventLogs({
-    farmId,
-    logs: [{ eventName: 'reset_app', eventAt: Date.now() }],
-  });
   window.location.reload();
 };
 
@@ -131,10 +123,19 @@ export function useOfflineReadiness(): UseOfflineReadinessResult {
     }
   }, [offline]);
 
+  const restoreCache = () => {
+    postEventLogs({
+      farmId: farm?.farm_id,
+      logs: [{ eventName: recoveryMode ? 'reset_app' : 'reload_app', eventAt: Date.now() }],
+    });
+
+    recoveryMode ? resetApplication() : reloadApp();
+  };
+
   return {
     isReadyForOffline,
     wentOfflineDuringSetup,
     isServiceWorkerSupported,
-    restoreCache: () => (recoveryMode ? resetApplication : reloadApp)(farm?.farm_id),
+    restoreCache,
   };
 }

--- a/packages/webapp/src/util/offlineEventLogger.ts
+++ b/packages/webapp/src/util/offlineEventLogger.ts
@@ -79,7 +79,7 @@ export const recordOfflineEvent = async ({ auth, farmId, logs }: OfflineEventPay
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: auth || id_token,
+      ...(auth || id_token ? { Authorization: auth || `Bearer ${id_token}` } : {}),
     },
     // https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive
     keepalive: true, // Attempt to send even when the page is unloading
@@ -101,11 +101,13 @@ export const recordOfflineEvent = async ({ auth, farmId, logs }: OfflineEventPay
 };
 
 export const postEventLogs = async ({ farmId, logs }: OfflineEventPayload) => {
+  const idToken = localStorage.getItem('id_token');
+
   return fetch(offlineEventLogUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: 'Bearer ' + localStorage.getItem('id_token'),
+      ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
     },
     // https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive
     keepalive: true, // Attempt to send even when the page is unloading

--- a/packages/webapp/src/util/offlineEventLogger.ts
+++ b/packages/webapp/src/util/offlineEventLogger.ts
@@ -99,3 +99,26 @@ export const recordOfflineEvent = async ({ auth, farmId, logs }: OfflineEventPay
     }),
   }).catch(() => {}); // Fire and forget
 };
+
+export const postEventLogs = async ({ farmId, logs }: OfflineEventPayload) => {
+  return fetch(offlineEventLogUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ' + localStorage.getItem('id_token'),
+    },
+    // https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive
+    keepalive: true, // Attempt to send even when the page is unloading
+    body: JSON.stringify({
+      app_version: APP_VERSION,
+      farm_id: farmId,
+      // @ts-expect-error -- connection exists
+      network: navigator?.connection?.effectiveType,
+      session_id: uuidv4(),
+      logs: logs.map(({ eventName, eventAt }) => ({
+        event_name: eventName,
+        event_at: eventAt,
+      })),
+    }),
+  }).catch(() => {}); // Fire and forget
+};


### PR DESCRIPTION
**Description**

- Save `user_id` and `role_id` in `offline_event_log` table
- Send 'reset_app' and 'reload_app' events from the client
- Prevent db operations from failing when the request contains duplicated logs (https://knexjs.org/guide/query-builder.html#onconflict:~:text=20)%22-,onConflict,-MS)
  
    <img width="614" height="180" alt="Screenshot 2026-02-23 at 12 09 37 PM" src="https://github.com/user-attachments/assets/397d1082-3ee0-4a9f-a8a4-52fcc70e6cf9" />

  - This happens when the user opens the app in multiple tabs.
  - In such cases, we'll have multiple `session_start`. I'd rather not clean it so that we'll know the session includes events from different tabs.

Jira link: https://lite-farm.atlassian.net/browse/LF-5145

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
