### PR TITLE
LF-5172 Fix Product Field Sync Issue for Offline Created and Completed Clean and Pest Control Tasks

### DIFF
--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -130,7 +130,10 @@ export function useServiceWorkerListener() {
             return invalidateTags(['Animals', 'AnimalBatches']);
           }
         },
-        refresh: () => dispatch(getTasks()),
+        refresh: () => {
+          dispatch(getProducts());
+          dispatch(getTasks());
+        },
       },
       'tasks.abandon': {
         successMessage: t('message:TASK.ABANDON.SYNC.SUCCESS'),

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -20,7 +20,7 @@ import {
   enqueueSuccessSnackbar,
   enqueueErrorSnackbar,
 } from '../../containers/Snackbar/snackbarSlice';
-import { getTasks } from '../../containers/Task/saga';
+import { getProducts, getTasks } from '../../containers/Task/saga';
 import { getManagementPlans } from '../../containers/saga';
 import { invalidateTags } from '../../store/api/apiSlice';
 import { OfflineEventPayload, recordOfflineEvent } from '../../util/offlineEventLogger';
@@ -113,6 +113,7 @@ export function useServiceWorkerListener() {
         },
         refresh: () => {
           dispatch(getManagementPlans());
+          dispatch(getProducts()); // cleaning and pest control task creation
           dispatch(getTasks());
         },
       },


### PR DESCRIPTION
**Description**

A quick fix. The product-creating middleware runs on sync and creates the product without issue, but we didn't fetch the new product down to show it in the task.

Note on reproduction: Original bug only visible if you don't yourself re-fetch the products, such as by reloading on the task list. You can see it if you navigate directly to the new task by clicking on its tile, or going via notifications.

Jira link: https://lite-farm.atlassian.net/browse/LF-5172

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Another `pnpm build` + `pnpm preview` testing situation, since we need the queue for this one.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
