### PR TITLE
LF-5176 Increase maximum filesize to cache in VitePWA config

### DIFF
--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       filename: 'sw.js',
       injectManifest: {
         globPatterns: ['**/*.{js,css,html,svg}'],
+        maximumFileSizeToCacheInBytes: 3 * 1024 ** 2, // 3MB
       },
     }),
   ],


### PR DESCRIPTION
**Description**

This offline change is not urgent (i.e. not necessary for offline release), but I think it would be good to get in eventually.

This change prevents this error: `<entrypoint file> is [greater than 2MB] and won’t be precached`

<img width="1375" height="62" alt="Screenshot 2026-02-24 at 12 06 44 PM" src="https://github.com/user-attachments/assets/e9786e1c-ae39-4bb0-aeb2-fa143bb9a77e" />

An uncached entrypoint file means a complete application crash on reload when offline, as Duncan and I were seeing in local thanks to a larger entrypoint file.

However, even on beta (and so presumably on production) we are fairly close to that [2MB default limit](https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest):

<img width="1017" height="100" alt="Screenshot 2026-02-24 at 3 32 26 PM" src="https://github.com/user-attachments/assets/63301a22-dec4-40bc-91e8-4b7b3f812652" />


(Screenshot taken from [most recent deploy](https://github.com/LiteFarmOrg/LiteFarm/actions/runs/22370720322/job/64748614192))

If we ever miss that warning on `pnpm build` when deploying to production, we will break offline, so it makes more sense to increase our limit preemptively. There is no particular downside as it doesn't change anything about the size of the files, just allows a larger one to be cached. And no other cachable file is in the 2-3MB range other than our entrypoint file.

Jira link: https://lite-farm.atlassian.net/browse/LF-5176

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I've always needed this in my local; otherwise I get the error on pnpm build. I thought maybe it was my .env variable `VITE_ENABLE_SW_IN_DEV=true` but I actually have no idea where I got that value or what it does 😂 Nonetheless, my entrypoint is consistently 2.2MB instead of 1.7MB.
 
**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
