### PR TITLE
LF-5182: Survey is not available for new farms

### DIFF
--- a/packages/webapp/src/containers/AddFarm/saga.js
+++ b/packages/webapp/src/containers/AddFarm/saga.js
@@ -71,6 +71,7 @@ export function* postFarmSaga({ payload: { showFarmNameCharacterLimitExceededErr
         ...farm,
         ...step,
         country: addFarmData.country,
+        country_code: addFarmData.country,
       }),
     );
     yield put(selectFarmSuccess({ farm_id }));


### PR DESCRIPTION
**Description**

The userFarm in Redux only gets `country_code` when switching farms (L617), so a newly created farm won't have one.

https://github.com/LiteFarmOrg/LiteFarm/blob/29af9386b226e937d3b40f3cf1f021f550e2a015/packages/webapp/src/containers/saga.js#L602-L624


This caused the TAPE survey to not be available right after creating a farm.
This fix adds `country_code` to the userFarm stored in Redux when a farm is created.

Jira link: (https://lite-farm.atlassian.net/browse/LF-5182)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
