### PR TITLE
LF- 5213: Farm notes offline support

### DIFF
--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -90,8 +90,6 @@
   },
   "FARM_NOTE": {
     "CREATE": {
-      "FAILED": "Failed to create note",
-      "SUCCESS": "Successfully created note",
       "SYNC": {
         "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note creation automatically",
         "ONLINE": "Note created. Will appear when you're back online",
@@ -99,8 +97,6 @@
       }
     },
     "DELETE": {
-      "FAILED": "Failed to delete note",
-      "SUCCESS": "Successfully deleted note",
       "SYNC": {
         "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note deletion automatically",
         "ONLINE": "Note deleted. Will save when you're back online",
@@ -108,8 +104,6 @@
       }
     },
     "EDIT": {
-      "FAILED": "Failed to update note",
-      "SUCCESS": "Successfully updated note",
       "SYNC": {
         "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note update automatically",
         "ONLINE": "Note updated. Will save when you're back online",

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -125,6 +125,11 @@
       "ADD": "Successfully saved note",
       "DELETE": "Successfully deleted note",
       "EDIT": "Successfully updated note"
+    },
+    "SYNC": {
+      "FAILED": "Task changes failed to save",
+      "NOT_FOUND": "Note failed to save: note no longer exists",
+      "UNAUTHORIZED": "Note failed to save: insufficient permissions"
     }
   },
   "HELP_REQUEST": {

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -89,6 +89,33 @@
     "SUCCESS_DISCONNECT_ADDON": "Successfully disconnected addon"
   },
   "FARM_NOTE": {
+    "CREATE": {
+      "FAILED": "Failed to create note",
+      "SUCCESS": "Successfully created note",
+      "SYNC": {
+        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note creation automatically",
+        "ONLINE": "Note created. Will appear when you're back online",
+        "SUCCESS": "Note created offline has been saved successfully"
+      }
+    },
+    "DELETE": {
+      "FAILED": "Failed to delete note",
+      "SUCCESS": "Successfully deleted note",
+      "SYNC": {
+        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note deletion automatically",
+        "ONLINE": "Note deleted. Will save when you're back online",
+        "SUCCESS": "Note deleted offline has been saved successfully"
+      }
+    },
+    "EDIT": {
+      "FAILED": "Failed to update note",
+      "SUCCESS": "Successfully updated note",
+      "SYNC": {
+        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note update automatically",
+        "ONLINE": "Note updated. Will save when you're back online",
+        "SUCCESS": "Note updated offline has been saved successfully"
+      }
+    },
     "ERROR": {
       "ADD": "Failed to save note",
       "DELETE": "Failed to delete note",

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -89,27 +89,6 @@
     "SUCCESS_DISCONNECT_ADDON": "Successfully disconnected addon"
   },
   "FARM_NOTE": {
-    "CREATE": {
-      "SYNC": {
-        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note creation automatically",
-        "ONLINE": "Note created. Will appear when you're back online",
-        "SUCCESS": "Note created offline has been saved successfully"
-      }
-    },
-    "DELETE": {
-      "SYNC": {
-        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note deletion automatically",
-        "ONLINE": "Note deleted. Will save when you're back online",
-        "SUCCESS": "Note deleted offline has been saved successfully"
-      }
-    },
-    "EDIT": {
-      "SYNC": {
-        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note update automatically",
-        "ONLINE": "Note updated. Will save when you're back online",
-        "SUCCESS": "Note updated offline has been saved successfully"
-      }
-    },
     "ERROR": {
       "ADD": "Failed to save note",
       "DELETE": "Failed to delete note",
@@ -121,6 +100,21 @@
       "EDIT": "Successfully updated note"
     },
     "SYNC": {
+      "ADD": {
+        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note creation automatically",
+        "ONLINE": "Note created. Will appear when you're back online",
+        "SUCCESS": "Note created offline has been saved successfully"
+      },
+      "DELETE": {
+        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note deletion automatically",
+        "ONLINE": "Note deleted. Will save when you're back online",
+        "SUCCESS": "Note deleted offline has been saved successfully"
+      },
+      "EDIT": {
+        "NETWORK_ERROR": "Sorry, we are down momentarily. We will retry your note update automatically",
+        "ONLINE": "Note updated. Will save when you're back online",
+        "SUCCESS": "Note updated offline has been saved successfully"
+      },
       "FAILED": "Task changes failed to save",
       "NOT_FOUND": "Note failed to save: note no longer exists",
       "UNAUTHORIZED": "Note failed to save: insufficient permissions"

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -115,7 +115,7 @@
         "ONLINE": "Note updated. Will save when you're back online",
         "SUCCESS": "Note updated offline has been saved successfully"
       },
-      "FAILED": "Task changes failed to save",
+      "FAILED": "Note changes failed to save",
       "NOT_FOUND": "Note failed to save: note no longer exists",
       "UNAUTHORIZED": "Note failed to save: insufficient permissions"
     }

--- a/packages/webapp/src/containers/FarmNotes/FarmNoteForm/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/FarmNoteForm/index.tsx
@@ -22,6 +22,7 @@ import PureFarmNoteForm, {
 } from '../../../components/FarmNotes/FarmNoteForm';
 import type { FarmNote } from '../../../store/api/types';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../../Snackbar/snackbarSlice';
+import { isNetworkError } from '../../../util/apiUtils';
 
 interface FarmNoteFormContainerProps {
   note?: FarmNote;
@@ -76,13 +77,17 @@ export default function FarmNoteFormContainer({
         ),
       );
       onSuccess();
-    } catch (error) {
-      console.error(error);
-      dispatch(
-        enqueueErrorSnackbar(
-          t(isEditMode ? 'message:FARM_NOTE.ERROR.EDIT' : 'message:FARM_NOTE.ERROR.ADD'),
-        ),
-      );
+    } catch (error: any) {
+      if (isNetworkError(error)) {
+        onSuccess();
+      } else {
+        console.error(error);
+        dispatch(
+          enqueueErrorSnackbar(
+            t(isEditMode ? 'message:FARM_NOTE.ERROR.EDIT' : 'message:FARM_NOTE.ERROR.ADD'),
+          ),
+        );
+      }
     }
   };
 

--- a/packages/webapp/src/containers/FarmNotes/FarmNoteForm/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/FarmNoteForm/index.tsx
@@ -26,15 +26,10 @@ import { isNetworkError } from '../../../util/apiUtils';
 
 interface FarmNoteFormContainerProps {
   note?: FarmNote;
-  onSuccess: () => void;
-  onCancel: () => void;
+  onClose: () => void;
 }
 
-export default function FarmNoteFormContainer({
-  note,
-  onSuccess,
-  onCancel,
-}: FarmNoteFormContainerProps) {
+export default function FarmNoteFormContainer({ note, onClose }: FarmNoteFormContainerProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [addFarmNote] = useAddFarmNoteMutation();
@@ -76,22 +71,22 @@ export default function FarmNoteFormContainer({
           t(isEditMode ? 'message:FARM_NOTE.SUCCESS.EDIT' : 'message:FARM_NOTE.SUCCESS.ADD'),
         ),
       );
-      onSuccess();
     } catch (error: any) {
-      if (isNetworkError(error)) {
-        onSuccess();
-      } else {
+      if (!isNetworkError(error)) {
         console.error(error);
         dispatch(
           enqueueErrorSnackbar(
             t(isEditMode ? 'message:FARM_NOTE.ERROR.EDIT' : 'message:FARM_NOTE.ERROR.ADD'),
           ),
         );
+        return;
       }
+      // Don't show error snackbar for network errors since it's handled in the api slice
     }
+    onClose();
   };
 
   return (
-    <PureFarmNoteForm defaultValues={defaultValues} onSubmit={handleSubmit} onCancel={onCancel} />
+    <PureFarmNoteForm defaultValues={defaultValues} onSubmit={handleSubmit} onCancel={onClose} />
   );
 }

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -34,6 +34,8 @@ import ImageLightbox from '../../components/ImageLightbox';
 import styles from './styles.module.scss';
 import type { UserFarm } from '../../types';
 import { isNetworkError } from '../../util/apiUtils';
+import { useIsOffline } from '../hooks/useOfflineDetector/useIsOffline';
+import { storeActivity } from '../../util/offlineEventLogger';
 
 type FormState = null | { mode: 'add' } | { mode: 'edit'; note: FarmNote };
 
@@ -42,6 +44,7 @@ export default function FarmNotes() {
   const dispatch = useDispatch();
   const userFarm = useSelector(userFarmSelector) as UserFarm;
   const userDisplayNameMap = useSelector(userDisplayNameMapSelector);
+  const isOffline = useIsOffline();
 
   const { data: farmNotes } = useGetFarmNotesQuery();
   const [deleteFarmNote] = useDeleteFarmNoteMutation();
@@ -57,6 +60,10 @@ export default function FarmNotes() {
   const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
     markFarmNotesRead();
+
+    if (isOffline) {
+      storeActivity('/', 'open_farm_notes');
+    }
   };
 
   const handleCloseDrawer = () => {

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -76,6 +76,7 @@ export default function FarmNotes() {
         console.error(error);
         dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.ERROR.DELETE')));
       }
+      // Don't show error snackbar for network errors since it's handled in the api slice
     }
     setNoteToDelete(null);
   };
@@ -118,8 +119,7 @@ export default function FarmNotes() {
         {isFormOpen ? (
           <FarmNoteFormContainer
             note={isEditState ? formState.note : undefined}
-            onSuccess={() => setFormState(null)}
-            onCancel={() => setFormState(null)}
+            onClose={() => setFormState(null)}
           />
         ) : (
           <FarmNoteList

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -33,6 +33,7 @@ import Drawer, { DesktopDrawerVariants } from '../../components/Drawer';
 import ImageLightbox from '../../components/ImageLightbox';
 import styles from './styles.module.scss';
 import type { UserFarm } from '../../types';
+import { isNetworkError } from '../../util/apiUtils';
 
 type FormState = null | { mode: 'add' } | { mode: 'edit'; note: FarmNote };
 
@@ -71,8 +72,10 @@ export default function FarmNotes() {
       await deleteFarmNote(noteToDelete.id).unwrap();
       dispatch(enqueueSuccessSnackbar(t('message:FARM_NOTE.SUCCESS.DELETE')));
     } catch (error) {
-      console.error(error);
-      dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.ERROR.DELETE')));
+      if (!isNetworkError(error)) {
+        console.error(error);
+        dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.ERROR.DELETE')));
+      }
     }
     setNoteToDelete(null);
   };

--- a/packages/webapp/src/containers/Task/saga.js
+++ b/packages/webapp/src/containers/Task/saga.js
@@ -169,9 +169,10 @@ export function* assignTaskSaga({ payload: { task_id, assignee_user_id } }) {
     if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.UPDATE.SYNC.ONLINE')
+        : i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR');
+      yield put(enqueueSuccessSnackbar(message));
 
       // Optimistic update for task update
       yield put(putTaskSuccess({ assignee_user_id, task_id }));
@@ -230,9 +231,10 @@ export function* changeTaskDateSaga({ payload: { task_id, due_date } }) {
     if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.UPDATE.SYNC.ONLINE')
+        : i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR');
+      yield put(enqueueSuccessSnackbar(message));
 
       // Optimistic update for task update
       yield put(putTaskSuccess({ due_date, task_id }));
@@ -259,9 +261,10 @@ export function* changeTaskWageSaga({
     if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.UPDATE.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.UPDATE.SYNC.ONLINE')
+        : i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR');
+      yield put(enqueueSuccessSnackbar(message));
 
       // Optimistic update for task wage update
       yield put(putTaskSuccess({ ...patchData, task_id }));
@@ -725,9 +728,10 @@ export function* createTaskSaga({ payload }) {
     } else if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueuePersistentSuccessSnackbar(i18n.t('message:TASK.CREATE.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.CREATE.SYNC.ONLINE')
+        : i18n.t('message:TASK.CREATE.SYNC.NETWORK_ERROR');
+      yield put(enqueuePersistentSuccessSnackbar(message));
 
       // No optimistic update for task creation
 
@@ -913,9 +917,10 @@ export function* completeTaskSaga({ payload: { task_id, data, returnPath } }) {
     if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.COMPLETE.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.COMPLETE.SYNC.ONLINE')
+        : i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR');
+      yield put(enqueueSuccessSnackbar(message));
 
       // Optimistic update for task completion
       const optimisticTaskData = taskData.task // i.e. harvest tasks
@@ -956,9 +961,10 @@ export function* abandonTaskSaga({ payload: data }) {
     if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.ABANDON.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.ABANDON.SYNC.ONLINE')
+        : i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR');
+      yield put(enqueueSuccessSnackbar(message));
 
       // Optimistic update for task abandonment
       yield put(
@@ -1105,9 +1111,10 @@ export function* deleteTaskSaga({ payload: data }) {
     if (e.code === 'ERR_NETWORK') {
       const isOffline = yield select(isOfflineSelector);
 
-      if (isOffline) {
-        yield put(enqueueSuccessSnackbar(i18n.t('message:TASK.DELETE.SYNC.ONLINE')));
-      }
+      const message = isOffline
+        ? i18n.t('message:TASK.DELETE.SYNC.ONLINE')
+        : i18n.t('message:TASK.DELETE.SYNC.NETWORK_ERROR');
+      yield put(enqueueSuccessSnackbar(message));
 
       // Optimistic update for task deletion
 

--- a/packages/webapp/src/hooks/useServiceWorkerListener/feedbackMessages.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/feedbackMessages.ts
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import i18n from '../../locales/i18n';
+import { FeedbackMessages } from './useServiceWorkerListener';
+
+export const feedbackMessages: FeedbackMessages = {
+  'tasks.create': {
+    successMessage: i18n.t('message:TASK.CREATE.SYNC.SUCCESS'),
+    errors: {
+      409: i18n.t('message:TASK.SYNC.LOCATION_DELETED'),
+    },
+    syncErrorMessage: i18n.t('message:TASK.CREATE.SYNC.NETWORK_ERROR'),
+  },
+  'tasks.complete': {
+    successMessage: i18n.t('message:TASK.COMPLETE.SYNC.SUCCESS'),
+    errors: {
+      403: i18n.t('message:TASK.SYNC.UNAUTHORIZED'),
+      404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
+      409: i18n.t('message:TASK.SYNC.LOCATION_DELETED'),
+    },
+    syncErrorMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
+  },
+  'tasks.abandon': {
+    successMessage: i18n.t('message:TASK.ABANDON.SYNC.SUCCESS'),
+    errors: {
+      404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
+    },
+    syncErrorMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
+  },
+  'tasks.update': {
+    successMessage: i18n.t('message:TASK.UPDATE.SYNC.SUCCESS'),
+    errors: {
+      403: i18n.t('message:TASK.SYNC.UNAUTHORIZED'),
+      404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
+    },
+    syncErrorMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
+  },
+  'tasks.delete': {
+    successMessage: i18n.t('message:TASK.DELETE.SYNC.SUCCESS'),
+    errors: {
+      404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
+    },
+    syncErrorMessage: i18n.t('message:TASK.DELETE.SYNC.NETWORK_ERROR'),
+  },
+  'farm_notes.create': {
+    successMessage: i18n.t('message:FARM_NOTE.SYNC.ADD.SUCCESS'),
+    errors: {},
+    syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.ADD.NETWORK_ERROR'),
+  },
+  'farm_notes.edit': {
+    successMessage: i18n.t('message:FARM_NOTE.SYNC.EDIT.SUCCESS'),
+    errors: {
+      403: i18n.t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
+      404: i18n.t('message:FARM_NOTE.SYNC.NOT_FOUND'),
+    },
+    syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.EDIT.NETWORK_ERROR'),
+  },
+  'farm_notes.delete': {
+    successMessage: i18n.t('message:FARM_NOTE.SYNC.DELETE.SUCCESS'),
+    errors: {
+      403: i18n.t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
+      404: i18n.t('message:FARM_NOTE.SYNC.NOT_FOUND'),
+    },
+    syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR'),
+  },
+  'farm_notes.patch': {
+    successMessage: undefined,
+    errors: null,
+    syncErrorMessage: null,
+  },
+};

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -24,6 +24,7 @@ import { getProducts, getTasks } from '../../containers/Task/saga';
 import { getManagementPlans } from '../../containers/saga';
 import { invalidateTags } from '../../store/api/apiSlice';
 import { OfflineEventPayload, recordOfflineEvent } from '../../util/offlineEventLogger';
+import { feedbackMessages } from './feedbackMessages';
 
 type SyncArea =
   | 'tasks.create'
@@ -36,9 +37,15 @@ type SyncArea =
   | 'farm_notes.delete'
   | 'farm_notes.patch';
 
-type SyncConfig = {
+interface Messages {
   successMessage?: string;
   errors: Record<number, string> | null;
+  syncErrorMessage?: string | null;
+}
+
+export type FeedbackMessages = Record<SyncArea, Messages>;
+
+type SyncConfig = {
   onSuccess?: (response: any) => any;
   refresh: () => any;
 };
@@ -121,10 +128,6 @@ export function useServiceWorkerListener() {
   const syncConfig = useMemo(
     (): Record<SyncArea, SyncConfig> => ({
       'tasks.create': {
-        successMessage: t('message:TASK.CREATE.SYNC.SUCCESS'),
-        errors: {
-          409: t('message:TASK.SYNC.LOCATION_DELETED'),
-        },
         onSuccess: (response) => {
           if (response?.taskType?.task_translation_key === 'IRRIGATION_TASK') {
             return invalidateTags(['IrrigationPrescriptions']);
@@ -137,12 +140,6 @@ export function useServiceWorkerListener() {
         },
       },
       'tasks.complete': {
-        successMessage: t('message:TASK.COMPLETE.SYNC.SUCCESS'),
-        errors: {
-          403: t('message:TASK.SYNC.UNAUTHORIZED'),
-          404: t('message:TASK.SYNC.NOT_FOUND'),
-          409: t('message:TASK.SYNC.LOCATION_DELETED'),
-        },
         onSuccess: (response) => {
           // taskType not returned in the completion API response
           if (response?.animal_movement_task) {
@@ -154,26 +151,9 @@ export function useServiceWorkerListener() {
           dispatch(getTasks());
         },
       },
-      'tasks.abandon': {
-        successMessage: t('message:TASK.ABANDON.SYNC.SUCCESS'),
-        errors: {
-          404: t('message:TASK.SYNC.NOT_FOUND'),
-        },
-        refresh: () => dispatch(getTasks()),
-      },
-      'tasks.update': {
-        successMessage: t('message:TASK.UPDATE.SYNC.SUCCESS'),
-        errors: {
-          403: t('message:TASK.SYNC.UNAUTHORIZED'),
-          404: t('message:TASK.SYNC.NOT_FOUND'),
-        },
-        refresh: () => dispatch(getTasks()),
-      },
+      'tasks.abandon': { refresh: () => dispatch(getTasks()) },
+      'tasks.update': { refresh: () => dispatch(getTasks()) },
       'tasks.delete': {
-        successMessage: t('message:TASK.DELETE.SYNC.SUCCESS'),
-        errors: {
-          404: t('message:TASK.SYNC.NOT_FOUND'),
-        },
         onSuccess: (response) => {
           if (response?.taskType?.task_translation_key === 'IRRIGATION_TASK') {
             return invalidateTags(['IrrigationPrescriptions']);
@@ -181,34 +161,12 @@ export function useServiceWorkerListener() {
         },
         refresh: () => dispatch(getTasks()),
       },
-      'farm_notes.create': {
-        successMessage: t('message:FARM_NOTE.SYNC.ADD.SUCCESS'),
-        errors: {},
-        refresh: () => dispatch(invalidateTags(['FarmNote'])),
-      },
-      'farm_notes.edit': {
-        successMessage: t('message:FARM_NOTE.SYNC.EDIT.SUCCESS'),
-        errors: {
-          403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
-          404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
-        },
-        refresh: () => dispatch(invalidateTags(['FarmNote'])),
-      },
-      'farm_notes.delete': {
-        successMessage: t('message:FARM_NOTE.SYNC.DELETE.SUCCESS'),
-        errors: {
-          403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
-          404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
-        },
-        refresh: () => dispatch(invalidateTags(['FarmNote'])),
-      },
-      'farm_notes.patch': {
-        successMessage: undefined,
-        errors: null,
-        refresh: () => dispatch(invalidateTags(['FarmNotesRead'])),
-      },
+      'farm_notes.create': { refresh: () => dispatch(invalidateTags(['FarmNote'])) },
+      'farm_notes.edit': { refresh: () => dispatch(invalidateTags(['FarmNote'])) },
+      'farm_notes.delete': { refresh: () => dispatch(invalidateTags(['FarmNote'])) },
+      'farm_notes.patch': { refresh: () => dispatch(invalidateTags(['FarmNotesRead'])) },
     }),
-    [t, dispatch],
+    [dispatch],
   );
 
   useEffect(() => {
@@ -219,12 +177,13 @@ export function useServiceWorkerListener() {
 
       const { method, status, url, queuedAt, auth, farm_id } = payload || {};
       const area = resolveAreaFromUrl(method, url);
+      const { successMessage, errors, syncErrorMessage } = feedbackMessages[area];
 
       if (type === 'SYNC_ITEM_SUCCESS') {
         const handler = syncConfig[area as SyncArea];
         if (!handler) return;
 
-        const { successMessage, errors, refresh, onSuccess } = handler;
+        const { refresh, onSuccess } = handler;
         const isSuccess = status >= 200 && status < 400;
 
         if (isSuccess) {
@@ -236,13 +195,9 @@ export function useServiceWorkerListener() {
           if (onSuccessAction) {
             dispatch(onSuccessAction);
           }
-        } else {
-          const errorMessage = errors?.[status];
-          if (errorMessage) {
-            dispatch(enqueueErrorSnackbar(errorMessage));
-          } else if (errors !== null) {
-            dispatch(enqueueErrorSnackbar(t('message:TASK.SYNC.FAILED')));
-          }
+        } else if (errors !== null) {
+          const errorMessage = errors?.[status] || t('message:TASK.SYNC.FAILED');
+          dispatch(errorMessage);
         }
 
         // Refresh data regardless of success/failure
@@ -266,31 +221,9 @@ export function useServiceWorkerListener() {
          * This indicates a failure to reach the server (e.g. API down). It should be rare.
          * We will manually replay when the app is re-rendered.
          */
-        switch (area) {
-          case 'tasks.create':
-            dispatch(enqueueErrorSnackbar(t('message:TASK.CREATE.SYNC.NETWORK_ERROR')));
-            break;
-          case 'tasks.delete':
-            dispatch(enqueueErrorSnackbar(t('message:TASK.DELETE.SYNC.NETWORK_ERROR')));
-            break;
-          case 'tasks.complete':
-          case 'tasks.abandon':
-          case 'tasks.update':
-            dispatch(enqueueErrorSnackbar(t('message:TASK.UPDATE.SYNC.NETWORK_ERROR')));
-            break;
-          case 'farm_notes.create':
-            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.SYNC.ADD.NETWORK_ERROR')));
-            break;
-          case 'farm_notes.edit':
-            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.SYNC.EDIT.NETWORK_ERROR')));
-            break;
-          case 'farm_notes.delete':
-            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR')));
-          case 'farm_notes.patch':
-            // No snackbar should appear
-            break;
-          default:
-            dispatch(enqueueErrorSnackbar(t('message:TASK.SYNC.NETWORK_ERROR')));
+        if (syncErrorMessage !== null) {
+          const message = syncErrorMessage || t('message:TASK.SYNC.NETWORK_ERROR');
+          dispatch(enqueueErrorSnackbar(message));
         }
       }
     };

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -182,12 +182,12 @@ export function useServiceWorkerListener() {
         refresh: () => dispatch(getTasks()),
       },
       'farm_notes.create': {
-        successMessage: t('message:FARM_NOTE.CREATE.SYNC.SUCCESS'),
+        successMessage: t('message:FARM_NOTE.SYNC.ADD.SUCCESS'),
         errors: {},
         refresh: () => dispatch(invalidateTags(['FarmNote'])),
       },
       'farm_notes.edit': {
-        successMessage: t('message:FARM_NOTE.EDIT.SYNC.SUCCESS'),
+        successMessage: t('message:FARM_NOTE.SYNC.EDIT.SUCCESS'),
         errors: {
           403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
           404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
@@ -195,7 +195,7 @@ export function useServiceWorkerListener() {
         refresh: () => dispatch(invalidateTags(['FarmNote'])),
       },
       'farm_notes.delete': {
-        successMessage: t('message:FARM_NOTE.DELETE.SYNC.SUCCESS'),
+        successMessage: t('message:FARM_NOTE.SYNC.DELETE.SUCCESS'),
         errors: {
           403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
           404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
@@ -279,12 +279,14 @@ export function useServiceWorkerListener() {
             dispatch(enqueueErrorSnackbar(t('message:TASK.UPDATE.SYNC.NETWORK_ERROR')));
             break;
           case 'farm_notes.create':
-            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.CREATE.SYNC.NETWORK_ERROR')));
+            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.SYNC.ADD.NETWORK_ERROR')));
             break;
           case 'farm_notes.edit':
-            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.EDIT.SYNC.NETWORK_ERROR')));
+            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.SYNC.EDIT.NETWORK_ERROR')));
             break;
           case 'farm_notes.delete':
+            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR')));
+          case 'farm_notes.patch':
             // No snackbar should appear
             break;
           default:

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -184,7 +184,7 @@ export function useServiceWorkerListener() {
       'farm_notes.create': {
         successMessage: t('message:FARM_NOTE.CREATE.SYNC.SUCCESS'),
         errors: {},
-        refresh: () => invalidateTags(['FarmNote']),
+        refresh: () => dispatch(invalidateTags(['FarmNote'])),
       },
       'farm_notes.edit': {
         successMessage: t('message:FARM_NOTE.EDIT.SYNC.SUCCESS'),
@@ -192,7 +192,7 @@ export function useServiceWorkerListener() {
           403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
           404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
         },
-        refresh: () => invalidateTags(['FarmNote']),
+        refresh: () => dispatch(invalidateTags(['FarmNote'])),
       },
       'farm_notes.delete': {
         successMessage: t('message:FARM_NOTE.DELETE.SYNC.SUCCESS'),
@@ -200,12 +200,12 @@ export function useServiceWorkerListener() {
           403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
           404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
         },
-        refresh: () => invalidateTags(['FarmNote']),
+        refresh: () => dispatch(invalidateTags(['FarmNote'])),
       },
       'farm_notes.patch': {
         successMessage: undefined,
         errors: null,
-        refresh: () => invalidateTags(['FarmNotesRead']),
+        refresh: () => dispatch(invalidateTags(['FarmNotesRead'])),
       },
     }),
     [t, dispatch],

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -24,68 +24,12 @@ import { getProducts, getTasks } from '../../containers/Task/saga';
 import { getManagementPlans } from '../../containers/saga';
 import { invalidateTags } from '../../store/api/apiSlice';
 import { OfflineEventPayload, recordOfflineEvent } from '../../util/offlineEventLogger';
-import { feedbackMessages } from './feedbackMessages';
-
-type SyncArea =
-  | 'tasks.create'
-  | 'tasks.complete'
-  | 'tasks.abandon'
-  | 'tasks.update' // Generic fallback; use for patching date and assignee as well
-  | 'tasks.delete'
-  | 'farm_notes.create'
-  | 'farm_notes.edit'
-  | 'farm_notes.delete'
-  | 'farm_notes.patch';
-
-interface Messages {
-  successMessage?: string;
-  errors: Record<number, string> | null;
-  syncErrorMessage?: string | null;
-}
-
-export type FeedbackMessages = Record<SyncArea, Messages>;
+import { feedbackMessages, resolveAreaFromUrl, SyncArea } from './utils';
 
 type SyncConfig = {
   onSuccess?: (response: any) => any;
   refresh: () => any;
 };
-
-/**
- * Resolve specific kinds of task operations from the URL and HTTP method.
- */
-function resolveAreaFromUrl(method: string, url: string): SyncArea {
-  // Farm notes detection (check these first before tasks)
-  if (method === 'POST' && url.includes('/farm_note')) {
-    return 'farm_notes.create';
-  }
-  if (method === 'PATCH' && url.includes('/farm_note/')) {
-    return 'farm_notes.edit';
-  }
-  if (method === 'DELETE' && url.includes('/farm_note/')) {
-    return 'farm_notes.delete';
-  }
-  if (method === 'PATCH' && url.includes('/farm_notes_read')) {
-    return 'farm_notes.patch';
-  }
-
-  // Tasks (existing logic)
-  if (method === 'POST') {
-    return 'tasks.create';
-  }
-
-  if (method === 'DELETE') {
-    return 'tasks.delete';
-  }
-
-  if (url.includes('/task/complete/')) {
-    return 'tasks.complete';
-  }
-  if (url.includes('/task/abandon/')) {
-    return 'tasks.abandon';
-  }
-
-  return 'tasks.update';
-}
 
 const LOG_BATCH_SIZE = 10;
 const LOG_BATCH_TIMEOUT_MS = 2000;

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -24,7 +24,7 @@ import { getProducts, getTasks } from '../../containers/Task/saga';
 import { getManagementPlans } from '../../containers/saga';
 import { invalidateTags } from '../../store/api/apiSlice';
 import { OfflineEventPayload, recordOfflineEvent } from '../../util/offlineEventLogger';
-import { feedbackMessages, resolveAreaFromUrl, SyncArea } from './utils';
+import { getFeedbackMessages, resolveAreaFromUrl, SyncArea } from './utils';
 
 type SyncConfig = {
   onSuccess?: (response: any) => any;
@@ -121,7 +121,7 @@ export function useServiceWorkerListener() {
 
       const { method, status, url, queuedAt, auth, farm_id } = payload || {};
       const area = resolveAreaFromUrl(method, url);
-      const { successMessage, errors, syncErrorMessage } = feedbackMessages[area];
+      const { successMessage, errors, retryMessage } = getFeedbackMessages()[area];
 
       if (type === 'SYNC_ITEM_SUCCESS') {
         const handler = syncConfig[area as SyncArea];
@@ -141,7 +141,7 @@ export function useServiceWorkerListener() {
           }
         } else if (errors !== null) {
           const errorMessage = errors?.[status] || t('message:TASK.SYNC.FAILED');
-          dispatch(errorMessage);
+          dispatch(enqueueErrorSnackbar(errorMessage));
         }
 
         // Refresh data regardless of success/failure
@@ -165,8 +165,8 @@ export function useServiceWorkerListener() {
          * This indicates a failure to reach the server (e.g. API down). It should be rare.
          * We will manually replay when the app is re-rendered.
          */
-        if (syncErrorMessage !== null) {
-          const message = syncErrorMessage || t('message:TASK.SYNC.NETWORK_ERROR');
+        if (retryMessage !== null) {
+          const message = retryMessage || t('message:TASK.SYNC.NETWORK_ERROR');
           dispatch(enqueueErrorSnackbar(message));
         }
       }

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -30,11 +30,15 @@ type SyncArea =
   | 'tasks.complete'
   | 'tasks.abandon'
   | 'tasks.update' // Generic fallback; use for patching date and assignee as well
-  | 'tasks.delete';
+  | 'tasks.delete'
+  | 'farm_notes.create'
+  | 'farm_notes.edit'
+  | 'farm_notes.delete'
+  | 'farm_notes.patch';
 
 type SyncConfig = {
-  successMessage: string;
-  errors: Record<number, string>;
+  successMessage?: string;
+  errors: Record<number, string> | null;
   onSuccess?: (response: any) => any;
   refresh: () => any;
 };
@@ -43,6 +47,21 @@ type SyncConfig = {
  * Resolve specific kinds of task operations from the URL and HTTP method.
  */
 function resolveAreaFromUrl(method: string, url: string): SyncArea {
+  // Farm notes detection (check these first before tasks)
+  if (method === 'POST' && url.includes('/farm_note')) {
+    return 'farm_notes.create';
+  }
+  if (method === 'PATCH' && url.includes('/farm_note/')) {
+    return 'farm_notes.edit';
+  }
+  if (method === 'DELETE' && url.includes('/farm_note/')) {
+    return 'farm_notes.delete';
+  }
+  if (method === 'PATCH' && url.includes('/farm_notes_read')) {
+    return 'farm_notes.patch';
+  }
+
+  // Tasks (existing logic)
   if (method === 'POST') {
     return 'tasks.create';
   }
@@ -162,6 +181,32 @@ export function useServiceWorkerListener() {
         },
         refresh: () => dispatch(getTasks()),
       },
+      'farm_notes.create': {
+        successMessage: t('message:FARM_NOTE.CREATE.SYNC.SUCCESS'),
+        errors: {},
+        refresh: () => invalidateTags(['FarmNote']),
+      },
+      'farm_notes.edit': {
+        successMessage: t('message:FARM_NOTE.EDIT.SYNC.SUCCESS'),
+        errors: {
+          403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
+          404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
+        },
+        refresh: () => invalidateTags(['FarmNote']),
+      },
+      'farm_notes.delete': {
+        successMessage: t('message:FARM_NOTE.DELETE.SYNC.SUCCESS'),
+        errors: {
+          403: t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
+          404: t('message:FARM_NOTE.SYNC.NOT_FOUND'),
+        },
+        refresh: () => invalidateTags(['FarmNote']),
+      },
+      'farm_notes.patch': {
+        successMessage: undefined,
+        errors: null,
+        refresh: () => invalidateTags(['FarmNotesRead']),
+      },
     }),
     [t, dispatch],
   );
@@ -183,17 +228,19 @@ export function useServiceWorkerListener() {
         const isSuccess = status >= 200 && status < 400;
 
         if (isSuccess) {
-          dispatch(enqueueSuccessSnackbar(successMessage));
+          if (successMessage) {
+            dispatch(enqueueSuccessSnackbar(successMessage));
+          }
 
           const onSuccessAction = onSuccess?.(payload.response);
           if (onSuccessAction) {
             dispatch(onSuccessAction);
           }
         } else {
-          const errorMessage = errors[status];
+          const errorMessage = errors?.[status];
           if (errorMessage) {
             dispatch(enqueueErrorSnackbar(errorMessage));
-          } else {
+          } else if (errors !== null) {
             dispatch(enqueueErrorSnackbar(t('message:TASK.SYNC.FAILED')));
           }
         }
@@ -230,6 +277,15 @@ export function useServiceWorkerListener() {
           case 'tasks.abandon':
           case 'tasks.update':
             dispatch(enqueueErrorSnackbar(t('message:TASK.UPDATE.SYNC.NETWORK_ERROR')));
+            break;
+          case 'farm_notes.create':
+            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.CREATE.SYNC.NETWORK_ERROR')));
+            break;
+          case 'farm_notes.edit':
+            dispatch(enqueueErrorSnackbar(t('message:FARM_NOTE.EDIT.SYNC.NETWORK_ERROR')));
+            break;
+          case 'farm_notes.delete':
+            // No snackbar should appear
             break;
           default:
             dispatch(enqueueErrorSnackbar(t('message:TASK.SYNC.NETWORK_ERROR')));

--- a/packages/webapp/src/hooks/useServiceWorkerListener/utils.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/utils.ts
@@ -14,7 +14,62 @@
  */
 
 import i18n from '../../locales/i18n';
-import { FeedbackMessages } from './useServiceWorkerListener';
+
+export type SyncArea =
+  | 'tasks.create'
+  | 'tasks.complete'
+  | 'tasks.abandon'
+  | 'tasks.update' // Generic fallback; use for patching date and assignee as well
+  | 'tasks.delete'
+  | 'farm_notes.create'
+  | 'farm_notes.edit'
+  | 'farm_notes.delete'
+  | 'farm_notes.patch';
+
+/**
+ * Resolve specific kinds of task operations from the URL and HTTP method.
+ */
+export function resolveAreaFromUrl(method: string, url: string): SyncArea {
+  // Farm notes detection (check these first before tasks)
+  if (method === 'POST' && url.includes('/farm_note')) {
+    return 'farm_notes.create';
+  }
+  if (method === 'PATCH' && url.includes('/farm_note/')) {
+    return 'farm_notes.edit';
+  }
+  if (method === 'DELETE' && url.includes('/farm_note/')) {
+    return 'farm_notes.delete';
+  }
+  if (method === 'PATCH' && url.includes('/farm_notes_read')) {
+    return 'farm_notes.patch';
+  }
+
+  // Tasks (existing logic)
+  if (method === 'POST') {
+    return 'tasks.create';
+  }
+
+  if (method === 'DELETE') {
+    return 'tasks.delete';
+  }
+
+  if (url.includes('/task/complete/')) {
+    return 'tasks.complete';
+  }
+  if (url.includes('/task/abandon/')) {
+    return 'tasks.abandon';
+  }
+
+  return 'tasks.update';
+}
+
+export interface Messages {
+  successMessage?: string | null;
+  errors: Record<number, string> | null;
+  syncErrorMessage?: string | null;
+}
+
+export type FeedbackMessages = Record<SyncArea, Messages>;
 
 export const feedbackMessages: FeedbackMessages = {
   'tasks.create': {
@@ -77,7 +132,7 @@ export const feedbackMessages: FeedbackMessages = {
     syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR'),
   },
   'farm_notes.patch': {
-    successMessage: undefined,
+    successMessage: null,
     errors: null,
     syncErrorMessage: null,
   },

--- a/packages/webapp/src/hooks/useServiceWorkerListener/utils.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/utils.ts
@@ -30,7 +30,6 @@ export type SyncArea =
  * Resolve specific kinds of task operations from the URL and HTTP method.
  */
 export function resolveAreaFromUrl(method: string, url: string): SyncArea {
-  // Farm notes detection (check these first before tasks)
   if (method === 'POST' && url.includes('/farm_note')) {
     return 'farm_notes.create';
   }
@@ -66,18 +65,18 @@ export function resolveAreaFromUrl(method: string, url: string): SyncArea {
 export interface Messages {
   successMessage?: string | null;
   errors: Record<number, string> | null;
-  syncErrorMessage?: string | null;
+  retryMessage?: string | null;
 }
 
 export type FeedbackMessages = Record<SyncArea, Messages>;
 
-export const feedbackMessages: FeedbackMessages = {
+export const getFeedbackMessages = (): FeedbackMessages => ({
   'tasks.create': {
     successMessage: i18n.t('message:TASK.CREATE.SYNC.SUCCESS'),
     errors: {
       409: i18n.t('message:TASK.SYNC.LOCATION_DELETED'),
     },
-    syncErrorMessage: i18n.t('message:TASK.CREATE.SYNC.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:TASK.CREATE.SYNC.NETWORK_ERROR'),
   },
   'tasks.complete': {
     successMessage: i18n.t('message:TASK.COMPLETE.SYNC.SUCCESS'),
@@ -86,14 +85,14 @@ export const feedbackMessages: FeedbackMessages = {
       404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
       409: i18n.t('message:TASK.SYNC.LOCATION_DELETED'),
     },
-    syncErrorMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
   },
   'tasks.abandon': {
     successMessage: i18n.t('message:TASK.ABANDON.SYNC.SUCCESS'),
     errors: {
       404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
     },
-    syncErrorMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
   },
   'tasks.update': {
     successMessage: i18n.t('message:TASK.UPDATE.SYNC.SUCCESS'),
@@ -101,19 +100,19 @@ export const feedbackMessages: FeedbackMessages = {
       403: i18n.t('message:TASK.SYNC.UNAUTHORIZED'),
       404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
     },
-    syncErrorMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:TASK.UPDATE.SYNC.NETWORK_ERROR'),
   },
   'tasks.delete': {
     successMessage: i18n.t('message:TASK.DELETE.SYNC.SUCCESS'),
     errors: {
       404: i18n.t('message:TASK.SYNC.NOT_FOUND'),
     },
-    syncErrorMessage: i18n.t('message:TASK.DELETE.SYNC.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:TASK.DELETE.SYNC.NETWORK_ERROR'),
   },
   'farm_notes.create': {
     successMessage: i18n.t('message:FARM_NOTE.SYNC.ADD.SUCCESS'),
     errors: {},
-    syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.ADD.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:FARM_NOTE.SYNC.ADD.NETWORK_ERROR'),
   },
   'farm_notes.edit': {
     successMessage: i18n.t('message:FARM_NOTE.SYNC.EDIT.SUCCESS'),
@@ -121,7 +120,7 @@ export const feedbackMessages: FeedbackMessages = {
       403: i18n.t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
       404: i18n.t('message:FARM_NOTE.SYNC.NOT_FOUND'),
     },
-    syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.EDIT.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:FARM_NOTE.SYNC.EDIT.NETWORK_ERROR'),
   },
   'farm_notes.delete': {
     successMessage: i18n.t('message:FARM_NOTE.SYNC.DELETE.SUCCESS'),
@@ -129,11 +128,11 @@ export const feedbackMessages: FeedbackMessages = {
       403: i18n.t('message:FARM_NOTE.SYNC.UNAUTHORIZED'),
       404: i18n.t('message:FARM_NOTE.SYNC.NOT_FOUND'),
     },
-    syncErrorMessage: i18n.t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR'),
+    retryMessage: i18n.t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR'),
   },
   'farm_notes.patch': {
     successMessage: null,
     errors: null,
-    syncErrorMessage: null,
+    retryMessage: null,
   },
-};
+});

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -19,10 +19,10 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { api } from './apiSlice';
 import { farmNoteUrl } from '../../apiConfig';
 import { FarmNote } from './types';
-import {
-  enqueueErrorSnackbar,
-  enqueueSuccessSnackbar,
-} from '../../containers/Snackbar/snackbarSlice';
+import { enqueueSuccessSnackbar } from '../../containers/Snackbar/snackbarSlice';
+import { isOfflineSelector } from '../../containers/hooks/useOfflineDetector/offlineDetectorSlice';
+import { loginSelector } from '../../containers/userFarmSlice';
+import { isNetworkError } from '../../util/apiUtils';
 import { RootState } from '../store';
 
 type QueryResult<T> = { data: T } | { error: FetchBaseQueryError };
@@ -50,7 +50,7 @@ export const farmNoteApi = api.injectEndpoints({
     getFarmNotes: build.query<FarmNote[], void>({
       queryFn: async (_, { getState }, __, baseQuery): Promise<QueryResult<FarmNote[]>> => {
         const state = getState() as RootState;
-        if (state.tempStateReducer?.offlineDetectorReducer?.isOffline) {
+        if (isOfflineSelector(state)) {
           const existingData = selectFarmNoteResult(state);
           if (existingData.data) {
             return { data: existingData.data };
@@ -76,42 +76,34 @@ export const farmNoteApi = api.injectEndpoints({
         };
       },
       async onQueryStarted({ file, data }, { dispatch, queryFulfilled, getState }) {
+        const state = getState() as RootState;
+        const userFarm = loginSelector(state);
+
+        const optimisticNote: FarmNote = {
+          id: uuidv4(),
+          farm_id: userFarm.farm_id!,
+          user_id: userFarm.user_id!,
+          note: data.note,
+          is_private: data.is_private,
+          image_url: file ? 'pending' : undefined,
+          updated_at: new Date().toISOString(),
+          to_sync: true,
+        };
+
+        const patchResult = dispatch(
+          farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
+            draft.unshift(optimisticNote);
+          }),
+        );
+
         try {
           await queryFulfilled;
         } catch (error: any) {
-          // Check if this is a network error (FETCH_ERROR) vs server error
-          // In RTK Query, network errors result in undefined status or specific error structure
-          const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
-
-          if (isNetworkError) {
-            // Network failure: inject optimistic note with to_sync flag
-            const state = getState() as any;
-            const userFarm = state.entitiesReducer.userFarmReducer;
-
-            const optimisticNote: FarmNote = {
-              id: uuidv4(),
-              farm_id: userFarm.farm_id,
-              user_id: userFarm.user_id,
-              note: data.note,
-              is_private: data.is_private,
-              image_url: file ? 'pending' : undefined,
-              updated_at: new Date().toISOString(),
-              to_sync: true,
-            };
-
-            // Patch the getFarmNotes cache with optimistic update
-            dispatch(
-              farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
-                draft.unshift(optimisticNote);
-              }),
-            );
-
-            // Show offline queue snackbar
+          if (isNetworkError(error)) {
             dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.CREATE.SYNC.ONLINE')));
           } else {
-            // Server error: show error snackbar (no optimistic update to rollback)
-            console.error(error);
-            dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.CREATE.FAILED')));
+            // Server error: rollback the optimistic updateconsole.error(error);
+            patchResult.undo();
           }
         }
       },
@@ -150,23 +142,13 @@ export const farmNoteApi = api.injectEndpoints({
 
         try {
           await queryFulfilled;
-
-          // TODO: success snackbar? Check the API call in the component and adjust
         } catch (error: any) {
-          const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
-
-          if (isNetworkError) {
-            // Show offline queue snackbar
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.EDIT.SYNC.SUCCESS')));
+          if (isNetworkError(error)) {
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.EDIT.SYNC.ONLINE')));
           } else {
             // Server error: rollback the optimistic update
             patchResult.undo();
-            dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.EDIT.FAILED')));
-
-            // TODO: Check the API call in the component and adjust
-            throw error;
           }
-          // On FETCH_ERROR: keep the to_sync flag, snackbar already shown
         }
       },
       invalidatesTags: ['FarmNote'],
@@ -188,22 +170,13 @@ export const farmNoteApi = api.injectEndpoints({
 
         try {
           await queryFulfilled;
-
-          // TODO: success snackbar? Check the API call in the component and adjust
         } catch (error: any) {
-          const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
-
-          if (isNetworkError) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.DELETE.SYNC.SUCCESS')));
+          if (isNetworkError(error)) {
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.DELETE.SYNC.ONLINE')));
           } else {
             // Server error: rollback the deletion
             patchResult.undo();
-            dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.DELETE.FAILED')));
-
-            // TODO: Check the API call in the component and adjust
-            throw error;
           }
-          // On FETCH_ERROR: keep deleted, SW will replay
         }
       },
       invalidatesTags: ['FarmNote'],

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -47,6 +47,8 @@ export const farmNoteApi = api.injectEndpoints({
     getFarmNotes: build.query<FarmNote[], void>({
       queryFn: async (_, { getState }, __, baseQuery): Promise<QueryResult<FarmNote[]>> => {
         const state = getState() as RootState;
+        // When offline, return cached data directly instead of making a network request.
+        // This keeps the query in 'fulfilled' status, which is required for optimistic updates to remain visible in the UI.
         if (isOfflineSelector(state)) {
           const existingData = selectFarmNoteResult(state);
           if (existingData.data) {

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -103,7 +103,7 @@ export const farmNoteApi = api.injectEndpoints({
           if (isNetworkError(error)) {
             dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.ADD.ONLINE')));
           } else {
-            // Server error: rollback the optimistic updateconsole.error(error);
+            // Server error: rollback the optimistic update
             patchResult.undo();
           }
         }

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -15,6 +15,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import i18n from 'i18next';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { api } from './apiSlice';
 import { farmNoteUrl } from '../../apiConfig';
 import { FarmNote } from './types';
@@ -22,6 +23,9 @@ import {
   enqueueErrorSnackbar,
   enqueueSuccessSnackbar,
 } from '../../containers/Snackbar/snackbarSlice';
+import { RootState } from '../store';
+
+type QueryResult<T> = { data: T } | { error: FetchBaseQueryError };
 
 type FarmNoteData = {
   note: string;
@@ -44,10 +48,16 @@ interface EditFarmNoteReqBody {
 export const farmNoteApi = api.injectEndpoints({
   endpoints: (build) => ({
     getFarmNotes: build.query<FarmNote[], void>({
-      query: () => ({
-        url: farmNoteUrl,
-        method: 'GET',
-      }),
+      queryFn: async (_, { getState }, __, baseQuery): Promise<QueryResult<FarmNote[]>> => {
+        const state = getState() as RootState;
+        if (state.tempStateReducer?.offlineDetectorReducer?.isOffline) {
+          const existingData = selectFarmNoteResult(state);
+          if (existingData.data) {
+            return { data: existingData.data };
+          }
+        }
+        return baseQuery({ url: farmNoteUrl, method: 'GET' }) as QueryResult<FarmNote[]>;
+      },
       providesTags: ['FarmNote'],
     }),
     addFarmNote: build.mutation<FarmNote, AddFarmNoteReqBody>({
@@ -200,6 +210,8 @@ export const farmNoteApi = api.injectEndpoints({
     }),
   }),
 });
+
+export const selectFarmNoteResult = farmNoteApi.endpoints.getFarmNotes.select();
 
 export const {
   useGetFarmNotesQuery,

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -101,7 +101,12 @@ export const farmNoteApi = api.injectEndpoints({
           await queryFulfilled;
         } catch (error: any) {
           if (isNetworkError(error)) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.ADD.ONLINE')));
+            const isOffline = isOfflineSelector(getState() as RootState);
+            const message = isOffline
+              ? i18n.t('message:FARM_NOTE.SYNC.ADD.ONLINE')
+              : i18n.t('message:FARM_NOTE.SYNC.ADD.NETWORK_ERROR');
+
+            dispatch(enqueueSuccessSnackbar(message));
           } else {
             // Server error: rollback the optimistic update
             patchResult.undo();
@@ -124,7 +129,7 @@ export const farmNoteApi = api.injectEndpoints({
           body: formData,
         };
       },
-      async onQueryStarted({ id, file, data }, { dispatch, queryFulfilled }) {
+      async onQueryStarted({ id, file, data }, { dispatch, queryFulfilled, getState }) {
         const patchResult = dispatch(
           farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
             const noteIndex = draft.findIndex((note) => note.id === id);
@@ -145,7 +150,12 @@ export const farmNoteApi = api.injectEndpoints({
           await queryFulfilled;
         } catch (error: any) {
           if (isNetworkError(error)) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.EDIT.ONLINE')));
+            const isOffline = isOfflineSelector(getState() as RootState);
+            const message = isOffline
+              ? i18n.t('message:FARM_NOTE.SYNC.EDIT.ONLINE')
+              : i18n.t('message:FARM_NOTE.SYNC.EDIT.NETWORK_ERROR');
+
+            dispatch(enqueueSuccessSnackbar(message));
           } else {
             // Server error: rollback the optimistic update
             patchResult.undo();
@@ -159,7 +169,7 @@ export const farmNoteApi = api.injectEndpoints({
         url: `${farmNoteUrl}/${id}`,
         method: 'DELETE',
       }),
-      async onQueryStarted(id, { dispatch, queryFulfilled }) {
+      async onQueryStarted(id, { dispatch, queryFulfilled, getState }) {
         const patchResult = dispatch(
           farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
             const noteIndex = draft.findIndex((note) => note.id === id);
@@ -173,7 +183,12 @@ export const farmNoteApi = api.injectEndpoints({
           await queryFulfilled;
         } catch (error: any) {
           if (isNetworkError(error)) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.DELETE.ONLINE')));
+            const isOffline = isOfflineSelector(getState() as RootState);
+            const message = isOffline
+              ? i18n.t('message:FARM_NOTE.SYNC.DELETE.ONLINE')
+              : i18n.t('message:FARM_NOTE.SYNC.DELETE.NETWORK_ERROR');
+
+            dispatch(enqueueSuccessSnackbar(message));
           } else {
             // Server error: rollback the deletion
             patchResult.undo();

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -13,9 +13,15 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { v4 as uuidv4 } from 'uuid';
+import i18n from 'i18next';
 import { api } from './apiSlice';
 import { farmNoteUrl } from '../../apiConfig';
 import { FarmNote } from './types';
+import {
+  enqueueErrorSnackbar,
+  enqueueSuccessSnackbar,
+} from '../../containers/Snackbar/snackbarSlice';
 
 type FarmNoteData = {
   note: string;
@@ -58,6 +64,46 @@ export const farmNoteApi = api.injectEndpoints({
           method: 'POST',
           body: formData,
         };
+      },
+      async onQueryStarted({ file, data }, { dispatch, queryFulfilled, getState }) {
+        try {
+          await queryFulfilled;
+        } catch (error: any) {
+          // Check if this is a network error (FETCH_ERROR) vs server error
+          // In RTK Query, network errors result in undefined status or specific error structure
+          const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
+
+          if (isNetworkError) {
+            // Network failure: inject optimistic note with to_sync flag
+            const state = getState() as any;
+            const userFarm = state.entitiesReducer.userFarmReducer;
+
+            const optimisticNote: FarmNote = {
+              id: uuidv4(),
+              farm_id: userFarm.farm_id,
+              user_id: userFarm.user_id,
+              note: data.note,
+              is_private: data.is_private,
+              image_url: file ? 'pending' : undefined,
+              updated_at: new Date().toISOString(),
+              to_sync: true,
+            };
+
+            // Patch the getFarmNotes cache with optimistic update
+            dispatch(
+              farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
+                draft.unshift(optimisticNote);
+              }),
+            );
+
+            // Show offline queue snackbar
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.CREATE.SYNC.ONLINE')));
+          } else {
+            // Server error: show error snackbar (no optimistic update to rollback)
+            console.error(error);
+            dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.CREATE.FAILED')));
+          }
+        }
       },
       invalidatesTags: ['FarmNote'],
     }),

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -47,9 +47,11 @@ export const farmNoteApi = api.injectEndpoints({
     getFarmNotes: build.query<FarmNote[], void>({
       queryFn: async (_, { getState }, __, baseQuery): Promise<QueryResult<FarmNote[]>> => {
         const state = getState() as RootState;
+        const isOffline = isOfflineSelector(state);
+
         // When offline, return cached data directly instead of making a network request.
         // This keeps the query in 'fulfilled' status, which is required for optimistic updates to remain visible in the UI.
-        if (isOfflineSelector(state)) {
+        if (isOffline) {
           const existingData = selectFarmNoteResult(state);
           if (existingData.data) {
             return { data: existingData.data };

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -100,7 +100,7 @@ export const farmNoteApi = api.injectEndpoints({
           await queryFulfilled;
         } catch (error: any) {
           if (isNetworkError(error)) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.CREATE.SYNC.ONLINE')));
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.ADD.ONLINE')));
           } else {
             // Server error: rollback the optimistic updateconsole.error(error);
             patchResult.undo();
@@ -144,7 +144,7 @@ export const farmNoteApi = api.injectEndpoints({
           await queryFulfilled;
         } catch (error: any) {
           if (isNetworkError(error)) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.EDIT.SYNC.ONLINE')));
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.EDIT.ONLINE')));
           } else {
             // Server error: rollback the optimistic update
             patchResult.undo();
@@ -172,7 +172,7 @@ export const farmNoteApi = api.injectEndpoints({
           await queryFulfilled;
         } catch (error: any) {
           if (isNetworkError(error)) {
-            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.DELETE.SYNC.ONLINE')));
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.SYNC.DELETE.ONLINE')));
           } else {
             // Server error: rollback the deletion
             patchResult.undo();

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -15,17 +15,14 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import i18n from 'i18next';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { api } from './apiSlice';
 import { farmNoteUrl } from '../../apiConfig';
 import { FarmNote } from './types';
 import { enqueueSuccessSnackbar } from '../../containers/Snackbar/snackbarSlice';
 import { isOfflineSelector } from '../../containers/hooks/useOfflineDetector/offlineDetectorSlice';
 import { loginSelector } from '../../containers/userFarmSlice';
-import { isNetworkError } from '../../util/apiUtils';
+import { isNetworkError, QueryResult } from '../../util/apiUtils';
 import { RootState } from '../store';
-
-type QueryResult<T> = { data: T } | { error: FetchBaseQueryError };
 
 type FarmNoteData = {
   note: string;

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -121,6 +121,42 @@ export const farmNoteApi = api.injectEndpoints({
           body: formData,
         };
       },
+      async onQueryStarted({ id, file, data }, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
+            const noteIndex = draft.findIndex((note) => note.id === id);
+            if (noteIndex !== -1) {
+              draft[noteIndex] = {
+                ...draft[noteIndex],
+                note: data.note,
+                is_private: data.is_private,
+                image_url: file ? 'pending' : data.image_url ?? draft[noteIndex].image_url,
+                updated_at: new Date().toISOString(),
+                to_sync: true,
+              };
+            }
+          }),
+        );
+
+        try {
+          await queryFulfilled;
+
+          // TODO: Check the API call in the component and adjust
+          dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.EDIT.SYNC.SUCCESS')));
+        } catch (error: any) {
+          const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
+
+          if (!isNetworkError) {
+            // Server error: rollback the optimistic update
+            patchResult.undo();
+            dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.EDIT.FAILED')));
+
+            // TODO: Check the API call in the component and adjust
+            throw error;
+          }
+          // On FETCH_ERROR: keep the to_sync flag, snackbar already shown
+        }
+      },
       invalidatesTags: ['FarmNote'],
     }),
     deleteFarmNote: build.mutation<void, string>({
@@ -128,6 +164,35 @@ export const farmNoteApi = api.injectEndpoints({
         url: `${farmNoteUrl}/${id}`,
         method: 'DELETE',
       }),
+      async onQueryStarted(id, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          farmNoteApi.util.updateQueryData('getFarmNotes', undefined, (draft) => {
+            const noteIndex = draft.findIndex((note) => note.id === id);
+            if (noteIndex !== -1) {
+              draft.splice(noteIndex, 1);
+            }
+          }),
+        );
+
+        try {
+          await queryFulfilled;
+
+          // TODO: Check the API call in the component and adjust
+          dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.DELETE.SYNC.SUCCESS')));
+        } catch (error: any) {
+          const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
+
+          if (!isNetworkError) {
+            // Server error: rollback the deletion
+            patchResult.undo();
+            dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.DELETE.FAILED')));
+
+            // TODO: Check the API call in the component and adjust
+            throw error;
+          }
+          // On FETCH_ERROR: keep deleted, SW will replay
+        }
+      },
       invalidatesTags: ['FarmNote'],
     }),
   }),

--- a/packages/webapp/src/store/api/farmNoteApi.ts
+++ b/packages/webapp/src/store/api/farmNoteApi.ts
@@ -141,12 +141,14 @@ export const farmNoteApi = api.injectEndpoints({
         try {
           await queryFulfilled;
 
-          // TODO: Check the API call in the component and adjust
-          dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.EDIT.SYNC.SUCCESS')));
+          // TODO: success snackbar? Check the API call in the component and adjust
         } catch (error: any) {
           const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
 
-          if (!isNetworkError) {
+          if (isNetworkError) {
+            // Show offline queue snackbar
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.EDIT.SYNC.SUCCESS')));
+          } else {
             // Server error: rollback the optimistic update
             patchResult.undo();
             dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.EDIT.FAILED')));
@@ -177,12 +179,13 @@ export const farmNoteApi = api.injectEndpoints({
         try {
           await queryFulfilled;
 
-          // TODO: Check the API call in the component and adjust
-          dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.DELETE.SYNC.SUCCESS')));
+          // TODO: success snackbar? Check the API call in the component and adjust
         } catch (error: any) {
           const isNetworkError = !error.status || error.status === 'FETCH_ERROR';
 
-          if (!isNetworkError) {
+          if (isNetworkError) {
+            dispatch(enqueueSuccessSnackbar(i18n.t('message:FARM_NOTE.DELETE.SYNC.SUCCESS')));
+          } else {
             // Server error: rollback the deletion
             patchResult.undo();
             dispatch(enqueueErrorSnackbar(i18n.t('message:FARM_NOTE.DELETE.FAILED')));

--- a/packages/webapp/src/store/api/farmNotesReadApi.ts
+++ b/packages/webapp/src/store/api/farmNotesReadApi.ts
@@ -31,6 +31,21 @@ export const farmNotesReadApi = api.injectEndpoints({
         url: farmNotesReadUrl,
         method: 'PATCH',
       }),
+      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+        // Always optimistic: update cache immediately with current timestamp
+        dispatch(
+          farmNotesReadApi.util.updateQueryData('getFarmNotesRead', undefined, (draft) => {
+            draft.last_read_at = new Date().toISOString();
+          }),
+        );
+
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          // Even on network error, keep the optimistic update (marking as read is not critical)
+          // SW will queue the PATCH and replay it
+        }
+      },
       invalidatesTags: ['FarmNotesRead'],
     }),
   }),

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -131,6 +131,23 @@ const RETRY_ROUTES = [
     matcher: ({ url }) => url.pathname.includes('/task/'),
     method: 'DELETE',
   },
+  {
+    matcher: ({ url }) => url.pathname.includes('/farm_note'),
+    method: 'POST',
+  },
+  {
+    // This matcher will include farm_note/{uuid} paths
+    matcher: ({ url }) => url.pathname.includes('/farm_note'),
+    method: 'PATCH',
+  },
+  {
+    matcher: ({ url }) => url.pathname.includes('/farm_note'),
+    method: 'DELETE',
+  },
+  {
+    matcher: ({ url }) => url.pathname.includes('/farm_notes_read'),
+    method: 'PATCH',
+  },
 ];
 
 const RETRY_QUEUE_NAME = 'retry-requests';

--- a/packages/webapp/src/util/apiUtils.ts
+++ b/packages/webapp/src/util/apiUtils.ts
@@ -13,5 +13,9 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+
+export type QueryResult<T> = { data: T } | { error: FetchBaseQueryError };
+
 // In RTK Query, network errors result in undefined status or specific error structure
 export const isNetworkError = (error: any) => !error.status || error.status === 'FETCH_ERROR';

--- a/packages/webapp/src/util/apiUtils.ts
+++ b/packages/webapp/src/util/apiUtils.ts
@@ -17,5 +17,7 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 
 export type QueryResult<T> = { data: T } | { error: FetchBaseQueryError };
 
-// In RTK Query, network errors result in undefined status or specific error structure
-export const isNetworkError = (error: any) => !error.status || error.status === 'FETCH_ERROR';
+export const isNetworkError = (error: any) => {
+  const status = error?.error?.status ?? error?.status;
+  return status === 'FETCH_ERROR';
+};

--- a/packages/webapp/src/util/apiUtils.ts
+++ b/packages/webapp/src/util/apiUtils.ts
@@ -1,0 +1,17 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+// In RTK Query, network errors result in undefined status or specific error structure
+export const isNetworkError = (error: any) => !error.status || error.status === 'FETCH_ERROR';


### PR DESCRIPTION
**Description**

- Update API error handling in the components
   - Prevent error snackbars from showing for network errors. (network errors are handled in the API slices)
- Add optimistic UI for farm notes and the farm notes unread dot
- Update `getFarmNotes` endpoint
   - When offline, `queryFn` returns the cached data to keep the query in "fulfilled" status; otherwise optimistic updates won't appear on the UI once the query moves to "rejected".
- Sync farm notes
  - Update `useServiceWorkerListener` to handle farm note routes, consolidating snackbar messages in one place.
  - Add farm note routes to `RETRY_ROUTES` in `sw.js`.

Jira link: https://lite-farm.atlassian.net/browse/LF-5213

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
