### PR TITLE
LF-5231: Fix unread indicator missing for notes fetched after seen at is set

### DIFF
--- a/packages/api/db/migration/20260409180010_rename_farm_notes_read_last_read_at.js
+++ b/packages/api/db/migration/20260409180010_rename_farm_notes_read_last_read_at.js
@@ -13,28 +13,22 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import Model from './baseFormatModel.js';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  return knex.schema.alterTable('farm_notes_read', (table) => {
+    table.renameColumn('last_read_at', 'read_through');
+  });
+};
 
-class FarmNotesReadModel extends Model {
-  static get tableName() {
-    return 'farm_notes_read';
-  }
-
-  static get idColumn() {
-    return ['user_id', 'farm_id'];
-  }
-
-  static get jsonSchema() {
-    return {
-      type: 'object',
-      required: ['user_id', 'farm_id', 'read_through'],
-      properties: {
-        user_id: { type: 'string' },
-        farm_id: { type: 'string' },
-        read_through: { type: 'string', format: 'date-time' },
-      },
-    };
-  }
-}
-
-export default FarmNotesReadModel;
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  return knex.schema.table('farm_notes_read', (table) => {
+    table.renameColumn('read_through', 'last_read_at');
+  });
+};

--- a/packages/api/db/migration/20260409180010_rename_farm_notes_read_last_read_at.js
+++ b/packages/api/db/migration/20260409180010_rename_farm_notes_read_last_read_at.js
@@ -19,7 +19,7 @@
  */
 export const up = async function (knex) {
   return knex.schema.alterTable('farm_notes_read', (table) => {
-    table.renameColumn('last_read_at', 'read_through');
+    table.renameColumn('last_read_at', 'read_up_to');
   });
 };
 
@@ -29,6 +29,6 @@ export const up = async function (knex) {
  */
 export const down = async function (knex) {
   return knex.schema.table('farm_notes_read', (table) => {
-    table.renameColumn('read_through', 'last_read_at');
+    table.renameColumn('read_up_to', 'last_read_at');
   });
 };

--- a/packages/api/src/controllers/farmNotesReadController.ts
+++ b/packages/api/src/controllers/farmNotesReadController.ts
@@ -15,6 +15,7 @@
 
 import { Response } from 'express';
 import FarmNotesReadModel from '../models/farmNotesReadModel.js';
+import { FarmNoteReadBody } from '../middleware/validation/checkFarmNotesRead.js';
 import { HttpError, LiteFarmRequest } from '../types.js';
 
 interface FarmNotesReadModelType {
@@ -45,16 +46,20 @@ const farmNotesReadController = {
   },
 
   markFarmNotesRead() {
-    return async (req: LiteFarmRequest, res: Response) => {
+    return async (
+      req: LiteFarmRequest<unknown, unknown, unknown, FarmNoteReadBody>,
+      res: Response,
+    ) => {
       try {
         const { user_id } = req.auth!;
         const { farm_id } = req.headers;
+        const { read_through } = req.body;
 
         await FarmNotesReadModel.query()
           .insert({
             user_id,
             farm_id,
-            read_through: new Date().toISOString(),
+            read_through: new Date(read_through).toISOString(),
           })
           .onConflict(['user_id', 'farm_id'])
           .merge();

--- a/packages/api/src/controllers/farmNotesReadController.ts
+++ b/packages/api/src/controllers/farmNotesReadController.ts
@@ -21,7 +21,7 @@ import { HttpError, LiteFarmRequest } from '../types.js';
 interface FarmNotesReadModelType {
   user_id: string;
   farm_id: string;
-  read_through: string;
+  read_up_to: string;
 }
 
 const farmNotesReadController = {
@@ -35,7 +35,7 @@ const farmNotesReadController = {
           | FarmNotesReadModelType
           | undefined;
 
-        return res.status(200).json({ read_through: row ? row.read_through : null });
+        return res.status(200).json({ read_up_to: row ? row.read_up_to : null });
       } catch (error: unknown) {
         console.error(error);
         const err = error as HttpError;
@@ -53,13 +53,13 @@ const farmNotesReadController = {
       try {
         const { user_id } = req.auth!;
         const { farm_id } = req.headers;
-        const { read_through } = req.body;
+        const { read_up_to } = req.body;
 
         await FarmNotesReadModel.query()
           .insert({
             user_id,
             farm_id,
-            read_through: new Date(read_through).toISOString(),
+            read_up_to: new Date(read_up_to).toISOString(),
           })
           .onConflict(['user_id', 'farm_id'])
           .merge();

--- a/packages/api/src/controllers/farmNotesReadController.ts
+++ b/packages/api/src/controllers/farmNotesReadController.ts
@@ -20,7 +20,7 @@ import { HttpError, LiteFarmRequest } from '../types.js';
 interface FarmNotesReadModelType {
   user_id: string;
   farm_id: string;
-  last_read_at: string;
+  read_through: string;
 }
 
 const farmNotesReadController = {
@@ -34,7 +34,7 @@ const farmNotesReadController = {
           | FarmNotesReadModelType
           | undefined;
 
-        return res.status(200).json({ last_read_at: row ? row.last_read_at : null });
+        return res.status(200).json({ read_through: row ? row.read_through : null });
       } catch (error: unknown) {
         console.error(error);
         const err = error as HttpError;
@@ -54,7 +54,7 @@ const farmNotesReadController = {
           .insert({
             user_id,
             farm_id,
-            last_read_at: new Date().toISOString(),
+            read_through: new Date().toISOString(),
           })
           .onConflict(['user_id', 'farm_id'])
           .merge();

--- a/packages/api/src/middleware/validation/checkFarmNotesRead.ts
+++ b/packages/api/src/middleware/validation/checkFarmNotesRead.ts
@@ -17,7 +17,7 @@ import { NextFunction, Response } from 'express';
 import { LiteFarmRequest } from '../../types.js';
 
 export interface FarmNoteReadBody {
-  read_through: string;
+  read_up_to: string;
 }
 
 export const checkFarmNotesRead = async (
@@ -25,13 +25,13 @@ export const checkFarmNotesRead = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const { read_through } = req.body;
+  const { read_up_to } = req.body;
 
-  if (!read_through) {
-    return res.status(400).json({ error: 'read_through is required' });
+  if (!read_up_to) {
+    return res.status(400).json({ error: 'read_up_to is required' });
   }
-  if (isNaN(Date.parse(read_through))) {
-    return res.status(400).json({ error: 'Invalid read_through' });
+  if (isNaN(Date.parse(read_up_to))) {
+    return res.status(400).json({ error: 'Invalid read_up_to' });
   }
 
   next();

--- a/packages/api/src/middleware/validation/checkFarmNotesRead.ts
+++ b/packages/api/src/middleware/validation/checkFarmNotesRead.ts
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { NextFunction, Response } from 'express';
+import { LiteFarmRequest } from '../../types.js';
+
+export interface FarmNoteReadBody {
+  read_through: string;
+}
+
+export const checkFarmNotesRead = async (
+  req: LiteFarmRequest<unknown, unknown, unknown, FarmNoteReadBody>,
+  res: Response,
+  next: NextFunction,
+) => {
+  const { read_through } = req.body;
+
+  if (!read_through) {
+    return res.status(400).json({ error: 'read_through is required' });
+  }
+  if (isNaN(Date.parse(read_through))) {
+    return res.status(400).json({ error: 'Invalid read_through' });
+  }
+
+  next();
+};

--- a/packages/api/src/models/farmNotesReadModel.js
+++ b/packages/api/src/models/farmNotesReadModel.js
@@ -27,11 +27,11 @@ class FarmNotesReadModel extends Model {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['user_id', 'farm_id', 'read_through'],
+      required: ['user_id', 'farm_id', 'read_up_to'],
       properties: {
         user_id: { type: 'string' },
         farm_id: { type: 'string' },
-        read_through: { type: 'string', format: 'date-time' },
+        read_up_to: { type: 'string', format: 'date-time' },
       },
     };
   }

--- a/packages/api/src/routes/farmNotesReadRoute.js
+++ b/packages/api/src/routes/farmNotesReadRoute.js
@@ -16,10 +16,16 @@
 import express from 'express';
 import checkScope from '../middleware/acl/checkScope.js';
 import controller from '../controllers/farmNotesReadController.js';
+import { checkFarmNotesRead } from '../middleware/validation/checkFarmNotesRead.js';
 
 const router = express.Router();
 
 router.get('/', checkScope(['get:farm_notes']), controller.getFarmNotesRead());
-router.patch('/', checkScope(['get:farm_notes']), controller.markFarmNotesRead());
+router.patch(
+  '/',
+  checkScope(['get:farm_notes']),
+  checkFarmNotesRead,
+  controller.markFarmNotesRead(),
+);
 
 export default router;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -365,7 +365,7 @@ app
   .use('/market_directory_partners', marketDirectoryPartnerRoute)
   .use('/offline_event_log', offlineEventLogRoute)
   .use('/tape_survey', tapeSurveyRoute)
-  .use('/farm_note', farmNoteRoute)
+  .use('/farm_notes', farmNoteRoute)
   .use('/farm_notes_read', farmNotesReadRoute);
 
 // Allow a 1MB limit on sensors to match incoming Ensemble data

--- a/packages/api/tests/farmNote.test.js
+++ b/packages/api/tests/farmNote.test.js
@@ -47,13 +47,13 @@ jest.mock('@aws-sdk/client-s3', () => ({
 }));
 
 async function getRequest({ user_id, farm_id }) {
-  return chai.request(server).get('/farm_note').set('user_id', user_id).set('farm_id', farm_id);
+  return chai.request(server).get('/farm_notes').set('user_id', user_id).set('farm_id', farm_id);
 }
 
 async function postRequest(data, file, { user_id, farm_id }) {
   const request = chai
     .request(server)
-    .post('/farm_note')
+    .post('/farm_notes')
     .set('user_id', user_id)
     .set('farm_id', farm_id)
     .field('data', JSON.stringify(data));
@@ -68,7 +68,7 @@ async function postRequest(data, file, { user_id, farm_id }) {
 async function patchRequest(id, data, file, { user_id, farm_id }) {
   const request = chai
     .request(server)
-    .patch(`/farm_note/${id}`)
+    .patch(`/farm_notes/${id}`)
     .set('user_id', user_id)
     .set('farm_id', farm_id);
 
@@ -85,7 +85,7 @@ async function patchRequest(id, data, file, { user_id, farm_id }) {
 async function deleteRequest(id, { user_id, farm_id }) {
   return chai
     .request(server)
-    .delete(`/farm_note/${id}`)
+    .delete(`/farm_notes/${id}`)
     .set('user_id', user_id)
     .set('farm_id', farm_id);
 }
@@ -103,7 +103,7 @@ describe('Farm Note tests', () => {
     await knex.destroy();
   });
 
-  describe('GET /farm_note', () => {
+  describe('GET /farm_notes', () => {
     test('Returns public notes for any farm member', async () => {
       const { user_id: author_id, farm_id } = await createUserFarmIds(1);
       const farmNote = { note: 'Public note', is_private: false };
@@ -200,7 +200,7 @@ describe('Farm Note tests', () => {
     });
   });
 
-  describe('POST /farm_note', () => {
+  describe('POST /farm_notes', () => {
     test('Creates a note without file', async () => {
       const userFarmIds = await createUserFarmIds(1);
       const farmNote = { note: 'Test create note', is_private: false };
@@ -249,7 +249,7 @@ describe('Farm Note tests', () => {
     });
   });
 
-  describe('PATCH /farm_note/:id', () => {
+  describe('PATCH /farm_notes/:id', () => {
     test('Author can update note text and is_private', async () => {
       const userFarmIds = await createUserFarmIds(1);
       const originalNote = { note: 'Original text', is_private: false };
@@ -340,7 +340,7 @@ describe('Farm Note tests', () => {
     });
   });
 
-  describe('DELETE /farm_note/:id', () => {
+  describe('DELETE /farm_notes/:id', () => {
     test('Author can soft-delete their note', async () => {
       const userFarmIds = await createUserFarmIds(1);
       const [createdNote] = await mocks.farm_noteFactory(

--- a/packages/api/tests/farmNotesRead.test.js
+++ b/packages/api/tests/farmNotesRead.test.js
@@ -34,7 +34,7 @@ jest.mock('../src/middleware/acl/checkJwt.js', () =>
 
 const setFarmNoteRead = async ({ farm_id, user_id }) => {
   return await knex('farm_notes_read')
-    .insert({ user_id, farm_id, last_read_at: new Date().toISOString() })
+    .insert({ user_id, farm_id, read_through: new Date().toISOString() })
     .onConflict(['user_id', 'farm_id'])
     .merge();
 };
@@ -63,26 +63,26 @@ describe('Farm Notes Read tests', () => {
 
   describe('GET /farm_notes_read', () => {
     test.each([1, 2, 3, 5])(
-      'Returns { last_read_at: null } when no record exists (role %i)',
+      'Returns { read_through: null } when no record exists (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
 
         const res = await getRequest(userFarmIds);
         expect(res.status).toBe(200);
-        expect(res.body).toEqual({ last_read_at: null });
+        expect(res.body).toEqual({ read_through: null });
       },
     );
 
     test.each([1, 2, 3, 5])(
-      'Returns { last_read_at: <timestamp> } after mark-read (role %i)',
+      'Returns { read_through: <timestamp> } after mark-read (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
         await setFarmNoteRead(userFarmIds);
 
         const res = await getRequest(userFarmIds);
         expect(res.status).toBe(200);
-        expect(res.body.last_read_at).not.toBeNull();
-        expect(typeof res.body.last_read_at).toBe('string');
+        expect(res.body.read_through).not.toBeNull();
+        expect(typeof res.body.read_through).toBe('string');
       },
     );
 
@@ -97,7 +97,7 @@ describe('Farm Notes Read tests', () => {
 
   describe('PATCH /farm_notes_read', () => {
     test.each([1, 2, 3, 5])(
-      'Creates a row when none exists and sets last_read_at (role %i)',
+      'Creates a row when none exists and sets read_through (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
 
@@ -106,12 +106,12 @@ describe('Farm Notes Read tests', () => {
 
         const row = await knex('farm_notes_read').where(userFarmIds).first();
         expect(row).toBeDefined();
-        expect(row.last_read_at).toBeDefined();
+        expect(row.read_through).toBeDefined();
       },
     );
 
     test.each([1, 2, 3, 5])(
-      'Updates last_read_at when a row already exists (role %i)',
+      'Updates read_through when a row already exists (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
 
@@ -128,8 +128,8 @@ describe('Farm Notes Read tests', () => {
 
         const second = await knex('farm_notes_read').where(userFarmIds).first();
 
-        expect(new Date(second.last_read_at).getTime()).toBeGreaterThanOrEqual(
-          new Date(first.last_read_at).getTime(),
+        expect(new Date(second.read_through).getTime()).toBeGreaterThanOrEqual(
+          new Date(first.read_through).getTime(),
         );
       },
     );

--- a/packages/api/tests/farmNotesRead.test.js
+++ b/packages/api/tests/farmNotesRead.test.js
@@ -34,7 +34,7 @@ jest.mock('../src/middleware/acl/checkJwt.js', () =>
 
 const setFarmNoteRead = async ({ farm_id, user_id }) => {
   return await knex('farm_notes_read')
-    .insert({ user_id, farm_id, read_through: new Date().toISOString() })
+    .insert({ user_id, farm_id, read_up_to: new Date().toISOString() })
     .onConflict(['user_id', 'farm_id'])
     .merge();
 };
@@ -53,7 +53,7 @@ async function patchRequest({ user_id, farm_id }) {
     .patch('/farm_notes_read')
     .set('user_id', user_id)
     .set('farm_id', farm_id)
-    .send({ read_through: new Date().toISOString() });
+    .send({ read_up_to: new Date().toISOString() });
 }
 
 describe('Farm Notes Read tests', () => {
@@ -64,26 +64,26 @@ describe('Farm Notes Read tests', () => {
 
   describe('GET /farm_notes_read', () => {
     test.each([1, 2, 3, 5])(
-      'Returns { read_through: null } when no record exists (role %i)',
+      'Returns { read_up_to: null } when no record exists (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
 
         const res = await getRequest(userFarmIds);
         expect(res.status).toBe(200);
-        expect(res.body).toEqual({ read_through: null });
+        expect(res.body).toEqual({ read_up_to: null });
       },
     );
 
     test.each([1, 2, 3, 5])(
-      'Returns { read_through: <timestamp> } after mark-read (role %i)',
+      'Returns { read_up_to: <timestamp> } after mark-read (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
         await setFarmNoteRead(userFarmIds);
 
         const res = await getRequest(userFarmIds);
         expect(res.status).toBe(200);
-        expect(res.body.read_through).not.toBeNull();
-        expect(typeof res.body.read_through).toBe('string');
+        expect(res.body.read_up_to).not.toBeNull();
+        expect(typeof res.body.read_up_to).toBe('string');
       },
     );
 
@@ -98,7 +98,7 @@ describe('Farm Notes Read tests', () => {
 
   describe('PATCH /farm_notes_read', () => {
     test.each([1, 2, 3, 5])(
-      'Creates a row when none exists and sets read_through (role %i)',
+      'Creates a row when none exists and sets read_up_to (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
 
@@ -107,12 +107,12 @@ describe('Farm Notes Read tests', () => {
 
         const row = await knex('farm_notes_read').where(userFarmIds).first();
         expect(row).toBeDefined();
-        expect(row.read_through).toBeDefined();
+        expect(row.read_up_to).toBeDefined();
       },
     );
 
     test.each([1, 2, 3, 5])(
-      'Updates read_through when a row already exists (role %i)',
+      'Updates read_up_to when a row already exists (role %i)',
       async (role) => {
         const userFarmIds = await createUserFarmIds(role);
 
@@ -129,8 +129,8 @@ describe('Farm Notes Read tests', () => {
 
         const second = await knex('farm_notes_read').where(userFarmIds).first();
 
-        expect(new Date(second.read_through).getTime()).toBeGreaterThanOrEqual(
-          new Date(first.read_through).getTime(),
+        expect(new Date(second.read_up_to).getTime()).toBeGreaterThanOrEqual(
+          new Date(first.read_up_to).getTime(),
         );
       },
     );

--- a/packages/api/tests/farmNotesRead.test.js
+++ b/packages/api/tests/farmNotesRead.test.js
@@ -52,7 +52,8 @@ async function patchRequest({ user_id, farm_id }) {
     .request(server)
     .patch('/farm_notes_read')
     .set('user_id', user_id)
-    .set('farm_id', farm_id);
+    .set('farm_id', farm_id)
+    .send({ read_through: new Date().toISOString() });
 }
 
 describe('Farm Notes Read tests', () => {

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -99,7 +99,7 @@ export const marketDirectoryPartnersUrl = `${URI}/market_directory_partners`;
 export const supportTicketUrl = `${URI}/support_ticket`;
 export const offlineEventLogUrl = `${URI}/offline_event_log`;
 export const tapeSurveyUrl = `${URI}/tape_survey`;
-export const farmNoteUrl = `${URI}/farm_note`;
+export const farmNoteUrl = `${URI}/farm_notes`;
 export const farmNotesReadUrl = `${URI}/farm_notes_read`;
 
 export const url = URI;

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -56,7 +56,7 @@ export default function FarmNotes() {
 
   const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
-    markFarmNotesRead();
+    markFarmNotesRead({ read_through: new Date().toISOString() });
   };
 
   const handleCloseDrawer = () => {

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -59,17 +59,17 @@ export default function FarmNotes() {
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const [noteToDelete, setNoteToDelete] = useState<FarmNote | null>(null);
 
-  const readThrough = farmNotesRead?.read_through;
+  const readUpTo = farmNotesRead?.read_up_to;
   const latestOtherUserNote = farmNotes?.find((note) => note.user_id !== userFarm?.user_id);
   const hasUnread =
     !!latestOtherUserNote &&
-    (!readThrough || new Date(latestOtherUserNote.updated_at) > new Date(readThrough));
+    (!readUpTo || new Date(latestOtherUserNote.updated_at) > new Date(readUpTo));
 
   const handleOpenDrawer = () => {
     openDrawer();
 
     if (hasUnread) {
-      markFarmNotesRead({ read_through: latestOtherUserNote.updated_at });
+      markFarmNotesRead({ read_up_to: latestOtherUserNote.updated_at });
     }
 
     if (isOffline) {

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -54,9 +54,17 @@ export default function FarmNotes() {
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const [noteToDelete, setNoteToDelete] = useState<FarmNote | null>(null);
 
+  const readThrough = farmNotesRead?.read_through;
+  const latestSomeoneElsesNote = farmNotes?.find((note) => note.user_id !== userFarm?.user_id);
+  const hasUnread =
+    latestSomeoneElsesNote &&
+    (!readThrough || new Date(latestSomeoneElsesNote.updated_at) > new Date(readThrough));
+
   const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
-    markFarmNotesRead({ read_through: new Date().toISOString() });
+    if (hasUnread) {
+      markFarmNotesRead({ read_through: new Date().toISOString() });
+    }
   };
 
   const handleCloseDrawer = () => {
@@ -84,13 +92,6 @@ export default function FarmNotes() {
   const isFormOpen = formState !== null;
   const isEditState = formState?.mode === 'edit';
   const formTitle = isEditState ? t('FARM_NOTE.EDIT_NOTE') : t('FARM_NOTE.NEW_NOTE');
-
-  const lastReadAt = farmNotesRead?.read_through;
-  const hasUnread = farmNotes?.some(
-    (note) =>
-      note.user_id !== userFarm?.user_id &&
-      (!lastReadAt || new Date(note.updated_at) > new Date(lastReadAt)),
-  );
 
   return (
     <>

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -55,15 +55,15 @@ export default function FarmNotes() {
   const [noteToDelete, setNoteToDelete] = useState<FarmNote | null>(null);
 
   const readThrough = farmNotesRead?.read_through;
-  const latestSomeoneElsesNote = farmNotes?.find((note) => note.user_id !== userFarm?.user_id);
+  const latestOtherUserNote = farmNotes?.find((note) => note.user_id !== userFarm?.user_id);
   const hasUnread =
-    latestSomeoneElsesNote &&
-    (!readThrough || new Date(latestSomeoneElsesNote.updated_at) > new Date(readThrough));
+    !!latestOtherUserNote &&
+    (!readThrough || new Date(latestOtherUserNote.updated_at) > new Date(readThrough));
 
   const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
     if (hasUnread) {
-      markFarmNotesRead({ read_through: new Date().toISOString() });
+      markFarmNotesRead({ read_through: latestOtherUserNote.updated_at });
     }
   };
 

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -85,7 +85,7 @@ export default function FarmNotes() {
   const isEditState = formState?.mode === 'edit';
   const formTitle = isEditState ? t('FARM_NOTE.EDIT_NOTE') : t('FARM_NOTE.NEW_NOTE');
 
-  const lastReadAt = farmNotesRead?.last_read_at;
+  const lastReadAt = farmNotesRead?.read_through;
   const hasUnread = farmNotes?.some(
     (note) =>
       note.user_id !== userFarm?.user_id &&

--- a/packages/webapp/src/hooks/useServiceWorkerListener/utils.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/utils.ts
@@ -30,13 +30,13 @@ export type SyncArea =
  * Resolve specific kinds of task operations from the URL and HTTP method.
  */
 export function resolveAreaFromUrl(method: string, url: string): SyncArea {
-  if (method === 'POST' && url.includes('/farm_note')) {
+  if (method === 'POST' && url.includes('/farm_notes')) {
     return 'farm_notes.create';
   }
-  if (method === 'PATCH' && url.includes('/farm_note/')) {
+  if (method === 'PATCH' && url.includes('/farm_notes/')) {
     return 'farm_notes.edit';
   }
-  if (method === 'DELETE' && url.includes('/farm_note/')) {
+  if (method === 'DELETE' && url.includes('/farm_notes/')) {
     return 'farm_notes.delete';
   }
   if (method === 'PATCH' && url.includes('/farm_notes_read')) {

--- a/packages/webapp/src/store/api/farmNotesReadApi.ts
+++ b/packages/webapp/src/store/api/farmNotesReadApi.ts
@@ -26,16 +26,17 @@ export const farmNotesReadApi = api.injectEndpoints({
       }),
       providesTags: ['FarmNotesRead'],
     }),
-    markFarmNotesRead: build.mutation<void, void>({
-      query: () => ({
+    markFarmNotesRead: build.mutation<void, { read_through: string }>({
+      query: ({ read_through }) => ({
         url: farmNotesReadUrl,
         method: 'PATCH',
+        body: { read_through },
       }),
-      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+      async onQueryStarted({ read_through }, { dispatch, queryFulfilled }) {
         // Always optimistic: update cache immediately with current timestamp
         dispatch(
           farmNotesReadApi.util.updateQueryData('getFarmNotesRead', undefined, (draft) => {
-            draft.read_through = new Date().toISOString();
+            draft.read_through = read_through;
           }),
         );
 

--- a/packages/webapp/src/store/api/farmNotesReadApi.ts
+++ b/packages/webapp/src/store/api/farmNotesReadApi.ts
@@ -26,17 +26,17 @@ export const farmNotesReadApi = api.injectEndpoints({
       }),
       providesTags: ['FarmNotesRead'],
     }),
-    markFarmNotesRead: build.mutation<void, { read_through: string }>({
-      query: ({ read_through }) => ({
+    markFarmNotesRead: build.mutation<void, { read_up_to: string }>({
+      query: ({ read_up_to }) => ({
         url: farmNotesReadUrl,
         method: 'PATCH',
-        body: { read_through },
+        body: { read_up_to },
       }),
-      async onQueryStarted({ read_through }, { dispatch, queryFulfilled }) {
+      async onQueryStarted({ read_up_to }, { dispatch, queryFulfilled }) {
         // Always optimistic: update cache immediately with current timestamp
         dispatch(
           farmNotesReadApi.util.updateQueryData('getFarmNotesRead', undefined, (draft) => {
-            draft.read_through = read_through;
+            draft.read_up_to = read_up_to;
           }),
         );
 

--- a/packages/webapp/src/store/api/farmNotesReadApi.ts
+++ b/packages/webapp/src/store/api/farmNotesReadApi.ts
@@ -35,7 +35,7 @@ export const farmNotesReadApi = api.injectEndpoints({
         // Always optimistic: update cache immediately with current timestamp
         dispatch(
           farmNotesReadApi.util.updateQueryData('getFarmNotesRead', undefined, (draft) => {
-            draft.last_read_at = new Date().toISOString();
+            draft.read_through = new Date().toISOString();
           }),
         );
 

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -426,5 +426,5 @@ export interface FarmNote {
 }
 
 export interface FarmNotesRead {
-  last_read_at: string | null;
+  read_through: string | null;
 }

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -426,5 +426,5 @@ export interface FarmNote {
 }
 
 export interface FarmNotesRead {
-  read_through: string | null;
+  read_up_to: string | null;
 }

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -132,16 +132,16 @@ const RETRY_ROUTES = [
     method: 'DELETE',
   },
   {
-    matcher: ({ url }) => url.pathname.includes('/farm_note'),
+    matcher: ({ url }) => url.pathname.includes('/farm_notes'),
     method: 'POST',
   },
   {
     // This matcher will include farm_note/{uuid} paths
-    matcher: ({ url }) => url.pathname.includes('/farm_note'),
+    matcher: ({ url }) => url.pathname.includes('/farm_notes'),
     method: 'PATCH',
   },
   {
-    matcher: ({ url }) => url.pathname.includes('/farm_note'),
+    matcher: ({ url }) => url.pathname.includes('/farm_notes'),
     method: 'DELETE',
   },
   {

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -155,12 +155,12 @@ const RETRY_ROUTES = [
     method: 'POST',
   },
   {
-    // This matcher will include farm_note/{uuid} paths
-    matcher: ({ url }) => url.pathname.includes('/farm_notes'),
+    // This matcher will include farm_notes/{uuid} paths
+    matcher: ({ url }) => url.pathname.includes('/farm_notes/'),
     method: 'PATCH',
   },
   {
-    matcher: ({ url }) => url.pathname.includes('/farm_notes'),
+    matcher: ({ url }) => url.pathname.includes('/farm_notes/'),
     method: 'DELETE',
   },
   {


### PR DESCRIPTION
**Description**

- Update the farm note API URL from `/farm_note` to `/farm_notes`.
- Rename `last_seen_at` in `farm_notes_read` table to `read_through`.
- Save latest other user note's `updated_at` as `read_through`.
- Avoid sending `markFarmNotesRead` request when notes have been read.

Jira link: https://lite-farm.atlassian.net/browse/LF-5231

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
