### PR TITLE
LF-5235 Fix 'Click to enlarge' button visibility after image deletion in Farm Note

### DIFF
--- a/packages/webapp/src/containers/hooks/useMediaWithAuthentication.ts
+++ b/packages/webapp/src/containers/hooks/useMediaWithAuthentication.ts
@@ -85,6 +85,7 @@ export default function useMediaWithAuthentication({
           const fileUrl = fileUrls[0];
 
           if (!fileUrl) {
+            setMediaUrl(undefined);
             return;
           }
 


### PR DESCRIPTION
**Description**

I missed this second part of how the `useMediaWithAuthentication()` hook needed adjust when working on #4105.

The `useEffect` was correctly re-running now when the `fileUrls` changed, but the early return from `fetchMediaUrls()` didn't update state, so the re-run didn't do anything in the case of `!fileUrl` 🙂

Jira link: https://lite-farm.atlassian.net/browse/LF-5235

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
