### PR TITLE
LF-5237 Implement immediate validation for unsupported file formats on upload in Farm Note creation

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1109,7 +1109,7 @@
     "OVER_255_CHARS": "Text cannot exceed 255 characters"
   },
   "HELP": {
-    "ATTACHMENT_LABEL": "Upload screenshot or file",
+    "ATTACHMENT_LABEL": "Upload screenshot",
     "EMAIL": "Email",
     "FEEDBACK_INVITATION": "Get help or give us feedback",
     "MESSAGE_LABEL": "Message",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -2228,6 +2228,7 @@
     "CLICK_TO_UPLOAD": "Click to upload",
     "DRAG_DROP": "or drag and drop",
     "REMOVE_IMAGE": "Remove Image",
+    "UNSUPPORTED_FILE_TYPE": "Please upload a PNG, JPG, GIF, or WebP image",
     "UPLOAD_IMAGE": "Upload Image"
   },
   "WAGE": {

--- a/packages/webapp/src/components/ImagePicker/index.tsx
+++ b/packages/webapp/src/components/ImagePicker/index.tsx
@@ -15,6 +15,7 @@
 
 import { ChangeEvent, DragEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import clsx from 'clsx';
 import { AddLink } from '../Typography';
 import PureFilePickerWrapper from '../Form/FilePickerWrapper';
@@ -23,6 +24,8 @@ import InputBaseLabel from '../Form/InputBase/InputBaseLabel';
 import { ReactComponent as CameraIcon } from '../../assets/images/farm-profile/camera.svg';
 import { ReactComponent as TrashIcon } from '../../assets/images/farm-profile/trash.svg';
 import { ReactComponent as EditIcon } from '../../assets/images/farm-profile/edit.svg';
+import { enqueueErrorSnackbar } from '../../containers/Snackbar/snackbarSlice';
+import { isImageFile } from '../../util/validation';
 import styles from './styles.module.scss';
 import FileSizeExceedModal from '../Modals/FileSizeExceedModal';
 
@@ -90,6 +93,7 @@ export default function ImagePicker({
   const [previewUrl, setPreviewUrl] = useState(defaultUrl);
   const [showFileSizeExceedsModal, setShowFileSizeExceedsModal] = useState(false);
   const dropContainerRef = useRef<HTMLDivElement>(null);
+  const dispatch = useDispatch();
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -104,6 +108,11 @@ export default function ImagePicker({
   };
 
   const showImage = (file: File) => {
+    if (!isImageFile(file)) {
+      dispatch(enqueueErrorSnackbar(t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
+      return;
+    }
+
     if (file.size > 5e6) {
       setShowFileSizeExceedsModal(true);
       return;

--- a/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
+++ b/packages/webapp/src/components/ImagePicker/useImagePickerUpload.tsx
@@ -18,6 +18,7 @@ import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { enqueueErrorSnackbar } from '../../containers/Snackbar/snackbarSlice';
 import { uploadImage } from '../../containers/ImagePickerWrapper/saga';
+import { isImageFile } from '../../util/validation';
 import { FileEvent, OnFileUpload } from '.';
 
 export type GetOnFileUpload = (
@@ -75,9 +76,8 @@ export default function useImagePickerUpload(): { getOnFileUpload: GetOnFileUplo
         const onUploadFail = getOnUploadFail(onLoading);
         const onUploadSuccess = getOnUploadSuccess(setPreviewUrl, onSelectImage);
 
-        const isNotImage = !/^image\/.*/.test(blob.type);
-        if (isNotImage) {
-          dispatch(enqueueErrorSnackbar(t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
+        if (!isImageFile(blob)) {
+          dispatch(enqueueErrorSnackbar(t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
           onUploadFail('Not an image file');
         } else {
           if (blob.size > 5e6) {

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -15,6 +15,7 @@
 
 import { ChangeEvent, DragEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import clsx from 'clsx';
 import PureFilePickerWrapper from '../Form/FilePickerWrapper';
 import TextButton from '../Form/Button/TextButton';
@@ -24,7 +25,9 @@ import { ReactComponent as PhotoLibraryIcon } from '../../assets/images/imageCap
 import { ReactComponent as CameraIcon } from '../../assets/images/imageCapture/camera-btn.svg';
 import { ReactComponent as TrashIcon } from '../../assets/images/trash-03.svg';
 import { ReactComponent as EditIcon } from '../../assets/images/edit-02.svg';
+import { enqueueErrorSnackbar } from '../../containers/Snackbar/snackbarSlice';
 import getDeviceType from '../../util/getDeviceType';
+import { isImageFile } from '../../util/validation';
 import styles from './styles.module.scss';
 
 export type ImageUploadCaptureProps = {
@@ -49,6 +52,7 @@ export default function ImageUploadCapture({
   const [localUrl, setLocalUrl] = useState<string | null>(null);
   const [showFileSizeExceedsModal, setShowFileSizeExceedsModal] = useState(false);
   const dropContainerRef = useRef<HTMLDivElement>(null);
+  const dispatch = useDispatch();
 
   const previewUrl = localUrl ?? defaultUrl;
 
@@ -61,6 +65,11 @@ export default function ImageUploadCapture({
   }, [localUrl]);
 
   const handleFile = (file: File) => {
+    if (!isImageFile(file)) {
+      dispatch(enqueueErrorSnackbar(t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
+      return;
+    }
+
     if (file.size > 5e6) {
       setShowFileSizeExceedsModal(true);
       return;

--- a/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
+++ b/packages/webapp/src/containers/ImagePickerWrapper/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { uploadImage } from './saga';
 import i18n from '../../locales/i18n';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
+import { isImageFile } from '../../util/validation';
 
 const useStyles = makeStyles({
   inputContainer: {
@@ -48,9 +49,8 @@ export default function ImagePickerWrapper({
     onLoading?.(true);
     if (e?.target?.files?.[0]) {
       const blob = e.target.files[0];
-      const isNotImage = !/^image\/.*/.test(blob.type);
-      if (isNotImage) {
-        dispatch(enqueueErrorSnackbar(i18n.t('message:ATTACHMENTS.ERROR.FAILED_UPLOAD')));
+      if (!isImageFile(blob)) {
+        dispatch(enqueueErrorSnackbar(i18n.t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
         onUploadFail('Not an image file');
       } else if (blob.size < 200000) {
         dispatch(

--- a/packages/webapp/src/util/validation.ts
+++ b/packages/webapp/src/util/validation.ts
@@ -59,3 +59,9 @@ const isValidDomainNameFormat = (domain: string): boolean => {
     !!topLevelDomain && topLevelDomain.length >= 2 && labels.every((label) => label.length > 0)
   );
 };
+
+// Restrict to formats supported by h2non/imaginary
+export const isImageFile = (file: File) => {
+  if (file.type) return /^image\/.*/.test(file.type);
+  return /\.(png|jpe?g|gif|webp|svg|tiff?)$/i.test(file.name);
+};


### PR DESCRIPTION
**Description**

Despite the ticket title, this fix is applied to all image uploads throughout app in this PR

There were two existing patterns:
1. No check for / warning about filetype. This was the pattern in `<ImagePicker />`'s delayed upload flow (i.e. Farm Image, Help Request image), and inherited by `<ImageUploadCapture />` (Farm Notes), which was based on this flow
2. A check for image MIME-type, with an immediate "Failed to upload attachments" snackbar if the file wasn't an image. This was in the original `<ImagePickerWrapper />` (crop images) and in the immediate upload flow of `<ImagePicker />` using `useImagePicker` (e.g. animals, market directory). This was fundamentally sound but the snackbar was unhelpful as it didn't explain the cause of the upload error

This PR:
- Creates a single validator function to consolidate the MIME-type checks into a single shared function. It's slightly more permissive than the original checks as it allows specific file extensions if a MIME-type is not present
- Creates a more helpful snackbar that directs towards uploading the right kind of file
- Uses the validator + the snackbar across the various image upload situations in app (should now cover all of them)

Jira link: https://lite-farm.atlassian.net/browse/LF-5237

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files