### PR TITLE
LF-5230 Make farm note images available offline

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -100,6 +100,7 @@
     "uuid": "^8.3.2",
     "workbox-background-sync": "^7.4.0",
     "workbox-core": "^7.4.0",
+    "workbox-expiration": "^7.4.0",
     "workbox-precaching": "^7.4.0",
     "workbox-routing": "^7.4.0",
     "workbox-strategies": "^7.4.0"

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       workbox-core:
         specifier: ^7.4.0
         version: 7.4.0
+      workbox-expiration:
+        specifier: ^7.4.0
+        version: 7.4.0
       workbox-precaching:
         specifier: ^7.4.0
         version: 7.4.0
@@ -7412,6 +7415,9 @@ packages:
 
   workbox-expiration@6.6.0:
     resolution: {integrity: sha512-baplYXcDHbe8vAo7GYvyAmlS4f6998Jff513L4XvlzAOxcl8F620O91guoJ5EOf5qeXG4cGdNZHkkVAPouFCpw==}
+
+  workbox-expiration@7.4.0:
+    resolution: {integrity: sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==}
 
   workbox-google-analytics@6.6.0:
     resolution: {integrity: sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==}
@@ -16254,6 +16260,11 @@ snapshots:
     dependencies:
       idb: 7.1.1
       workbox-core: 6.6.0
+
+  workbox-expiration@7.4.0:
+    dependencies:
+      idb: 7.1.1
+      workbox-core: 7.4.0
 
   workbox-google-analytics@6.6.0:
     dependencies:

--- a/packages/webapp/src/containers/hooks/useMediaWithAuthentication.ts
+++ b/packages/webapp/src/containers/hooks/useMediaWithAuthentication.ts
@@ -88,26 +88,22 @@ export default function useMediaWithAuthentication({
             return;
           }
 
-          if (import.meta.env.VITE_ENV === 'development') {
-            if (subscribed) {
-              setMediaUrl(fileUrl);
-            }
-          } else {
-            const url = new URL(fileUrl);
+          const url = new URL(fileUrl);
+          if (import.meta.env.VITE_ENV !== 'development') {
             url.hostname = 'images.litefarm.workers.dev';
-
-            const response = await fetch(url.toString(), config);
-            const blobFile = await response.blob();
-            const nextBlobUrl = URL.createObjectURL(blobFile);
-
-            if (!subscribed) {
-              URL.revokeObjectURL(nextBlobUrl);
-              return;
-            }
-
-            blobUrl = nextBlobUrl;
-            setMediaUrl(nextBlobUrl);
           }
+
+          const response = await fetch(url.toString(), config);
+          const blobFile = await response.blob();
+          const nextBlobUrl = URL.createObjectURL(blobFile);
+
+          if (!subscribed) {
+            URL.revokeObjectURL(nextBlobUrl);
+            return;
+          }
+
+          blobUrl = nextBlobUrl;
+          setMediaUrl(nextBlobUrl);
         }
       } catch (e) {
         console.log(e);

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -20,6 +20,7 @@ import {
 } from 'workbox-precaching';
 import { registerRoute, NavigationRoute } from 'workbox-routing';
 import { CacheFirst, NetworkOnly } from 'workbox-strategies';
+import { ExpirationPlugin } from 'workbox-expiration';
 import { Queue } from 'workbox-background-sync';
 import { clientsClaim, cacheNames } from 'workbox-core';
 
@@ -52,6 +53,24 @@ async function validatePrecacheIntegrity() {
 registerRoute(
   ({ url }) => /\/assets\/(survey-vendor)-[^/]+\.(js|css)$/.test(url.pathname),
   new CacheFirst({ cacheName: 'dynamic-chunks' }),
+);
+
+// Farm note images served through the Cloudflare Worker proxy (beta/prod) or minio (dev)
+registerRoute(
+  ({ url, request }) =>
+    request.method === 'GET' &&
+    (url.hostname === 'images.litefarm.workers.dev' || url.pathname.includes('minio')) &&
+    url.pathname.includes('/farm_note/'),
+  new CacheFirst({
+    cacheName: 'farm-note-images',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+        purgeOnQuotaError: true,
+      }),
+    ],
+  }),
 );
 
 // SPA navigation handler


### PR DESCRIPTION
**Description**

This adds runtime caching of images to the Farm Notes feature in a new dedicated cache `farm-notes-images`. To keep this cache from accumulating stale images and growing out of control, the `workbox-expiration` plugin was used, and the cache images set to:

1. expire in 30 days
2. keep only up to 50 entries (oldest will get purged first)
3. `purgeOnQuotaError` <-- [documentation has nothing to say](https://developer.chrome.com/docs/workbox/modules/workbox-expiration#type-ExpirationPluginOptions) on what this is exactly, but Claude says

> If the browser hits its storage quota limit (the maximum amount of data the origin is allowed to store across all caches, IndexedDB, etc.), it's OK to delete this entire cache to free up space.

So that sounds like exactly what we want -- these images are the least important part of our cache compared to the request queue and `workbox-precache` application code.

With the imaginary compressed images, I was seeing quite small image files, and 50 entries is unlikely to be more than 3-5MB of total data 🙂 I'll add new cache-checking code below

Jira link: https://lite-farm.atlassian.net/browse/LF-5230

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I ran `pnpm build` and `pnpm preview` to create the cache on `localhost:4173`. As usual you can then go offline and reload to see the images subsequently served from cache.

Here is also new cache-inspecting code for the browser console which tallies per cache:

```js
 (async () => {
    const names = await caches.keys();
    for (const name of names) {
      const cache = await caches.open(name);
      const keys = await cache.keys();
      let totalBytes = 0;
      for (const req of keys) {
        const res = await cache.match(req);
        const blob = await res.blob();
        totalBytes += blob.size;
      }
      console.log(`${name}: ${keys.length} entries, ${(totalBytes / 1024 / 1024).toFixed(2)} MB`);
    }
  })();
  ```
 
 With that I was finding a _very_ modest cache size for my note images! 🎉
  
<img width="422" height="88" alt="Screenshot 2026-04-10 at 3 58 12 PM" src="https://github.com/user-attachments/assets/f051634b-f270-4bcd-a21c-679388045969" />


**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
