### PR TITLE
LF-5232 Fix farm notes modal not closing when clicking my profile icon or feedback button

### DIFF
--- a/packages/webapp/src/App.jsx
+++ b/packages/webapp/src/App.jsx
@@ -32,7 +32,7 @@ import useOfflineActivityLogger from './hooks/useOfflineActivityLogger';
 function App() {
   const location = useLocation();
   const [isCompactSideMenu, setIsCompactSideMenu] = useState(false);
-  const [isFeedbackSurveyOpen, setFeedbackSurveyOpen] = useState(false);
+  const [activeDrawer, setActiveDrawer] = useState(null);
   const FULL_WIDTH_ROUTES = [MAP_URL, ANIMALS_URL, SENSORS_URL];
   const isFullWidth = FULL_WIDTH_ROUTES.some((path) => matchPath(location.pathname, path));
 
@@ -45,7 +45,8 @@ function App() {
     <div className={clsx(styles.container)}>
       <AppUIContext.Provider
         value={{
-          feedback: { isFeedbackSurveyOpen, setFeedbackSurveyOpen },
+          activeDrawer,
+          setActiveDrawer,
           maps: { isLoaded },
         }}
       >

--- a/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
+++ b/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
@@ -36,7 +36,7 @@ import clsx from 'clsx';
 import styles from './styles.module.scss';
 import FeedbackSurvey from '../../../containers/FeedbackSurvey';
 import { useIsOffline } from '../../../containers/hooks/useOfflineDetector/useIsOffline';
-import { useAppUIContext } from '../../../contexts/appContext';
+import { useDrawerState } from '../../../contexts/appContext';
 import OfflineLogOutWarningModal from './OfflineLogoutWarningModal';
 import { storeActivity } from '../../../util/offlineEventLogger';
 
@@ -47,17 +47,13 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
   const { t } = useTranslation(['translation']);
   const profileIconRef = useRef(null);
   const sectionHeader = useSectionHeader(history.location.pathname);
-  const { activeDrawer, setActiveDrawer } = useAppUIContext();
+  const {
+    isOpen: openMenu,
+    toggleDrawer: toggleMenu,
+    closeDrawer: closeMenu,
+  } = useDrawerState('profileMenu');
 
-  const openMenu = activeDrawer === 'profileMenu';
   const [showOfflineLogoutWarning, setShowOfflineLogoutWarning] = useState(false);
-
-  const toggleMenu = () => {
-    setActiveDrawer(openMenu ? null : 'profileMenu');
-  };
-  const closeMenu = () => {
-    setActiveDrawer(null);
-  };
 
   const handleClick = (link) => {
     closeMenu();
@@ -183,7 +179,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
     <Drawer
       anchor={'bottom'}
       open={openMenu}
-      onClose={() => setActiveDrawer(null)}
+      onClose={closeMenu}
       classes={{ paper: styles.drawerMenuPaper }}
     >
       <MenuList
@@ -195,7 +191,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
         classes={{ list: styles.drawerMenuList, paper: styles.drawerMenuPaper }}
       >
         <ListSubheader classes={{ root: styles.drawerListSubheader }}>
-          <CloseX onClick={() => setActiveDrawer(null)} />
+          <CloseX onClick={closeMenu} />
         </ListSubheader>
         {menuItems}
       </MenuList>

--- a/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
+++ b/packages/webapp/src/components/Navigation/TopMenu/TopMenu.jsx
@@ -36,6 +36,7 @@ import clsx from 'clsx';
 import styles from './styles.module.scss';
 import FeedbackSurvey from '../../../containers/FeedbackSurvey';
 import { useIsOffline } from '../../../containers/hooks/useOfflineDetector/useIsOffline';
+import { useAppUIContext } from '../../../contexts/appContext';
 import OfflineLogOutWarningModal from './OfflineLogoutWarningModal';
 import { storeActivity } from '../../../util/offlineEventLogger';
 
@@ -46,15 +47,16 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
   const { t } = useTranslation(['translation']);
   const profileIconRef = useRef(null);
   const sectionHeader = useSectionHeader(history.location.pathname);
+  const { activeDrawer, setActiveDrawer } = useAppUIContext();
 
-  const [openMenu, setOpenMenu] = useState(false);
+  const openMenu = activeDrawer === 'profileMenu';
   const [showOfflineLogoutWarning, setShowOfflineLogoutWarning] = useState(false);
 
   const toggleMenu = () => {
-    setOpenMenu((prev) => !prev);
+    setActiveDrawer(openMenu ? null : 'profileMenu');
   };
   const closeMenu = () => {
-    setOpenMenu(false);
+    setActiveDrawer(null);
   };
 
   const handleClick = (link) => {
@@ -181,7 +183,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
     <Drawer
       anchor={'bottom'}
       open={openMenu}
-      onClose={() => setOpenMenu(false)}
+      onClose={() => setActiveDrawer(null)}
       classes={{ paper: styles.drawerMenuPaper }}
     >
       <MenuList
@@ -193,7 +195,7 @@ const TopMenu = ({ history, isMobile, showNavActions, onClickBurger, showNav }) 
         classes={{ list: styles.drawerMenuList, paper: styles.drawerMenuPaper }}
       >
         <ListSubheader classes={{ root: styles.drawerListSubheader }}>
-          <CloseX onClick={() => setOpenMenu(false)} />
+          <CloseX onClick={() => setActiveDrawer(null)} />
         </ListSubheader>
         {menuItems}
       </MenuList>

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -31,6 +31,7 @@ import FarmNotesFloatingButton from '../../components/FarmNotes/FarmNotesFloatin
 import DeleteFarmNoteModal from '../../components/Modals/DeleteFarmNoteModal';
 import Drawer, { DesktopDrawerVariants } from '../../components/Drawer';
 import ImageLightbox from '../../components/ImageLightbox';
+import { useAppUIContext } from '../../contexts/appContext';
 import styles from './styles.module.scss';
 import type { UserFarm } from '../../types';
 
@@ -48,18 +49,20 @@ export default function FarmNotes() {
   const { data: farmNotesRead } = useGetFarmNotesReadQuery();
   const [markFarmNotesRead] = useMarkFarmNotesReadMutation();
 
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { activeDrawer, setActiveDrawer } = useAppUIContext();
+  const isDrawerOpen = activeDrawer === 'farmNotes';
+
   const [formState, setFormState] = useState<FormState>(null);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const [noteToDelete, setNoteToDelete] = useState<FarmNote | null>(null);
 
   const handleOpenDrawer = () => {
-    setIsDrawerOpen(true);
+    setActiveDrawer('farmNotes');
     markFarmNotesRead();
   };
 
   const handleCloseDrawer = () => {
-    setIsDrawerOpen(false);
+    setActiveDrawer(null);
     setFormState(null);
   };
 

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -31,7 +31,7 @@ import FarmNotesFloatingButton from '../../components/FarmNotes/FarmNotesFloatin
 import DeleteFarmNoteModal from '../../components/Modals/DeleteFarmNoteModal';
 import Drawer, { DesktopDrawerVariants } from '../../components/Drawer';
 import ImageLightbox from '../../components/ImageLightbox';
-import { useAppUIContext } from '../../contexts/appContext';
+import { useDrawerState } from '../../contexts/appContext';
 import styles from './styles.module.scss';
 import type { UserFarm } from '../../types';
 
@@ -49,20 +49,19 @@ export default function FarmNotes() {
   const { data: farmNotesRead } = useGetFarmNotesReadQuery();
   const [markFarmNotesRead] = useMarkFarmNotesReadMutation();
 
-  const { activeDrawer, setActiveDrawer } = useAppUIContext();
-  const isDrawerOpen = activeDrawer === 'farmNotes';
+  const { isOpen: isDrawerOpen, openDrawer, closeDrawer } = useDrawerState('farmNotes');
 
   const [formState, setFormState] = useState<FormState>(null);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const [noteToDelete, setNoteToDelete] = useState<FarmNote | null>(null);
 
   const handleOpenDrawer = () => {
-    setActiveDrawer('farmNotes');
+    openDrawer();
     markFarmNotesRead();
   };
 
   const handleCloseDrawer = () => {
-    setActiveDrawer(null);
+    closeDrawer();
     setFormState(null);
   };
 

--- a/packages/webapp/src/containers/FeedbackSurvey/index.jsx
+++ b/packages/webapp/src/containers/FeedbackSurvey/index.jsx
@@ -20,14 +20,16 @@ import { ReactComponent as SendIcon } from '../../assets/images/send-icon.svg';
 import styles from './styles.module.scss';
 import Drawer, { DesktopDrawerVariants } from '../../components/Drawer';
 import HelpRequest from '../Help';
-import { useAppUIContext } from '../../contexts/appContext';
+import { useDrawerState } from '../../contexts/appContext';
 import { useIsOffline } from '../hooks/useOfflineDetector/useIsOffline';
 
 export default function FeedbackSurvey() {
   const { t } = useTranslation();
-  const { activeDrawer, setActiveDrawer } = useAppUIContext();
-  const isSurveyOpen = activeDrawer === 'feedbackSurvey';
-  const toggleSurveyOpen = () => setActiveDrawer(isSurveyOpen ? null : 'feedbackSurvey');
+  const {
+    isOpen: isSurveyOpen,
+    toggleDrawer: toggleSurveyOpen,
+    closeDrawer,
+  } = useDrawerState('feedbackSurvey');
   const isOffline = useIsOffline();
 
   const title = (
@@ -39,7 +41,7 @@ export default function FeedbackSurvey() {
 
   const drawerContent = (
     <div className={styles.content}>
-      <HelpRequest closeDrawer={() => setActiveDrawer(null)} />
+      <HelpRequest closeDrawer={closeDrawer} />
     </div>
   );
 
@@ -53,7 +55,7 @@ export default function FeedbackSurvey() {
       </TextButton>
       <Drawer
         isOpen={isSurveyOpen}
-        onClose={() => setActiveDrawer(null)}
+        onClose={closeDrawer}
         title={title}
         addBackdrop={false}
         desktopVariant={DesktopDrawerVariants.SIDE_DRAWER}

--- a/packages/webapp/src/containers/FeedbackSurvey/index.jsx
+++ b/packages/webapp/src/containers/FeedbackSurvey/index.jsx
@@ -25,10 +25,9 @@ import { useIsOffline } from '../hooks/useOfflineDetector/useIsOffline';
 
 export default function FeedbackSurvey() {
   const { t } = useTranslation();
-  const {
-    feedback: { isFeedbackSurveyOpen: isSurveyOpen, setFeedbackSurveyOpen: setIsSurveyOpen },
-  } = useAppUIContext();
-  const toggleSurveyOpen = () => setIsSurveyOpen(!isSurveyOpen);
+  const { activeDrawer, setActiveDrawer } = useAppUIContext();
+  const isSurveyOpen = activeDrawer === 'feedbackSurvey';
+  const toggleSurveyOpen = () => setActiveDrawer(isSurveyOpen ? null : 'feedbackSurvey');
   const isOffline = useIsOffline();
 
   const title = (
@@ -40,7 +39,7 @@ export default function FeedbackSurvey() {
 
   const drawerContent = (
     <div className={styles.content}>
-      <HelpRequest closeDrawer={() => setIsSurveyOpen(false)} />
+      <HelpRequest closeDrawer={() => setActiveDrawer(null)} />
     </div>
   );
 
@@ -54,7 +53,7 @@ export default function FeedbackSurvey() {
       </TextButton>
       <Drawer
         isOpen={isSurveyOpen}
-        onClose={() => setIsSurveyOpen(false)}
+        onClose={() => setActiveDrawer(null)}
         title={title}
         addBackdrop={false}
         desktopVariant={DesktopDrawerVariants.SIDE_DRAWER}

--- a/packages/webapp/src/containers/ProductInventory/index.tsx
+++ b/packages/webapp/src/containers/ProductInventory/index.tsx
@@ -36,6 +36,7 @@ import { isFilterCurrentlyActiveSelector, resetInventoryFilter } from '../filter
 import { useFilteredInventory } from './useFilteredInventory';
 import { useSectionHeader } from '../../components/Navigation/useSectionHeaders';
 import BetaSpotlight from '../Spotlights/BetaSpotlight';
+import { useAppUIContext } from '../../contexts/appContext';
 
 export type TableProduct = SoilAmendmentProduct & {
   id: Extract<Product['product_id'], number>;
@@ -61,6 +62,8 @@ export default function ProductInventory() {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
 
+  const { activeDrawer, setActiveDrawer } = useAppUIContext();
+
   const zIndexBase = theme.zIndex.drawer;
 
   const sectionHeaderTitle = useSectionHeader(history.location.pathname) || '';
@@ -85,7 +88,7 @@ export default function ProductInventory() {
   const isFilterActive = useSelector(isFilterCurrentlyActiveSelector('inventory'));
   const clearFilters = () => dispatch(resetInventoryFilter());
 
-  const [isFormOpen, setIsFormOpen] = useState(false);
+  const isFormOpen = activeDrawer === 'productForm';
   const [formMode, setFormMode] = useState<FormMode | null>(null);
   const [productFormType, setProductFormType] = useState<Product['type'] | null>(null);
 
@@ -123,7 +126,7 @@ export default function ProductInventory() {
     setSelectedIds([row.id]);
     setFormMode(FormMode.READ_ONLY);
     setProductFormType(row.type);
-    setIsFormOpen(true);
+    setActiveDrawer('productForm');
   };
 
   const productColumns = useMemo(
@@ -175,15 +178,24 @@ export default function ProductInventory() {
   const onAddMenuItemClick = (type: Product['type']) => {
     setFormMode(FormMode.CREATE);
     setProductFormType(type);
-    setIsFormOpen(true);
+    setActiveDrawer('productForm');
   };
 
   const onCancel = () => {
     setSelectedIds([]);
     setFormMode(null);
     setProductFormType(null);
-    setIsFormOpen(false);
+    setActiveDrawer(null);
   };
+
+  // Reset local form state when drawer is closed externally (another drawer opened)
+  useEffect(() => {
+    if (!isFormOpen) {
+      setSelectedIds([]);
+      setFormMode(null);
+      setProductFormType(null);
+    }
+  }, [isFormOpen]);
 
   return (
     <BetaSpotlight spotlight={'inventory_beta'}>

--- a/packages/webapp/src/containers/ProductInventory/index.tsx
+++ b/packages/webapp/src/containers/ProductInventory/index.tsx
@@ -36,7 +36,7 @@ import { isFilterCurrentlyActiveSelector, resetInventoryFilter } from '../filter
 import { useFilteredInventory } from './useFilteredInventory';
 import { useSectionHeader } from '../../components/Navigation/useSectionHeaders';
 import BetaSpotlight from '../Spotlights/BetaSpotlight';
-import { useAppUIContext } from '../../contexts/appContext';
+import { useDrawerState } from '../../contexts/appContext';
 
 export type TableProduct = SoilAmendmentProduct & {
   id: Extract<Product['product_id'], number>;
@@ -62,7 +62,11 @@ export default function ProductInventory() {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
 
-  const { activeDrawer, setActiveDrawer } = useAppUIContext();
+  const {
+    isOpen: isFormOpen,
+    openDrawer: openFormDrawer,
+    closeDrawer: closeFormDrawer,
+  } = useDrawerState('productForm');
 
   const zIndexBase = theme.zIndex.drawer;
 
@@ -88,7 +92,6 @@ export default function ProductInventory() {
   const isFilterActive = useSelector(isFilterCurrentlyActiveSelector('inventory'));
   const clearFilters = () => dispatch(resetInventoryFilter());
 
-  const isFormOpen = activeDrawer === 'productForm';
   const [formMode, setFormMode] = useState<FormMode | null>(null);
   const [productFormType, setProductFormType] = useState<Product['type'] | null>(null);
 
@@ -126,7 +129,7 @@ export default function ProductInventory() {
     setSelectedIds([row.id]);
     setFormMode(FormMode.READ_ONLY);
     setProductFormType(row.type);
-    setActiveDrawer('productForm');
+    openFormDrawer();
   };
 
   const productColumns = useMemo(
@@ -178,14 +181,14 @@ export default function ProductInventory() {
   const onAddMenuItemClick = (type: Product['type']) => {
     setFormMode(FormMode.CREATE);
     setProductFormType(type);
-    setActiveDrawer('productForm');
+    openFormDrawer();
   };
 
   const onCancel = () => {
     setSelectedIds([]);
     setFormMode(null);
     setProductFormType(null);
-    setActiveDrawer(null);
+    closeFormDrawer();
   };
 
   // Reset local form state when drawer is closed externally (another drawer opened)

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Consent/index.tsx
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Consent/index.tsx
@@ -51,7 +51,7 @@ const MarketDirectoryConsent = ({
 }: MarketDirectoryConsentProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const { feedback: feedbackFormControls } = useAppUIContext();
+  const { setActiveDrawer } = useAppUIContext();
 
   const savedConsent = marketDirectoryInfo?.[CONSENTED_TO_SHARE] || false;
 
@@ -169,7 +169,7 @@ const MarketDirectoryConsent = ({
             );
           })}
           <MarketplaceSuggestionTile
-            onClick={() => feedbackFormControls.setFeedbackSurveyOpen(true)}
+            onClick={() => setActiveDrawer('feedbackSurvey')}
             noPartner={marketDirectoryPartners.length === 0}
           />
         </div>

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Consent/index.tsx
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Consent/index.tsx
@@ -35,7 +35,7 @@ import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../../../../Snackb
 import { areSetsEqual } from '../../../../../util/comparisons';
 import { MarketDirectoryInfo, MarketDirectoryPartner } from '../../../../../store/api/types';
 import styles from './styles.module.scss';
-import { useAppUIContext } from '../../../../../contexts/appContext';
+import { useDrawerState } from '../../../../../contexts/appContext';
 
 interface MarketDirectoryConsentProps {
   canConsent: boolean;
@@ -51,7 +51,7 @@ const MarketDirectoryConsent = ({
 }: MarketDirectoryConsentProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const { setActiveDrawer } = useAppUIContext();
+  const { openDrawer: openFeedbackSurvey } = useDrawerState('feedbackSurvey');
 
   const savedConsent = marketDirectoryInfo?.[CONSENTED_TO_SHARE] || false;
 
@@ -169,7 +169,7 @@ const MarketDirectoryConsent = ({
             );
           })}
           <MarketplaceSuggestionTile
-            onClick={() => setActiveDrawer('feedbackSurvey')}
+            onClick={openFeedbackSurvey}
             noPartner={marketDirectoryPartners.length === 0}
           />
         </div>

--- a/packages/webapp/src/containers/Spotlights/BetaSpotlight.tsx
+++ b/packages/webapp/src/containers/Spotlights/BetaSpotlight.tsx
@@ -37,7 +37,7 @@ export default function BetaSpotlight({ children, spotlight }: BetaSpotlightProp
   const spotlights = useSelector(showedSpotlightSelector);
   const onFinish = () => dispatch(setSpotlightToShown(spotlight));
   const upperCaseSpotlightKey = spotlight.toUpperCase();
-  const { feedback: feedbackControls } = useAppUIContext();
+  const { setActiveDrawer } = useAppUIContext();
 
   return (
     <TourProviderWrapper
@@ -75,7 +75,7 @@ export default function BetaSpotlight({ children, spotlight }: BetaSpotlightProp
           buttonProps: {
             color: 'secondary',
           },
-          onNext: () => feedbackControls.setFeedbackSurveyOpen(true),
+          onNext: () => setActiveDrawer('feedbackSurvey'),
         },
       ]}
       onFinish={onFinish}

--- a/packages/webapp/src/containers/Spotlights/BetaSpotlight.tsx
+++ b/packages/webapp/src/containers/Spotlights/BetaSpotlight.tsx
@@ -24,7 +24,7 @@ import { ReactComponent as SendIcon } from '../../assets/images/send-icon.svg';
 import styles from './styles.module.scss';
 import { BETA_BADGE_LINK } from '../../util/constants';
 import { ReactElement } from 'react';
-import { useAppUIContext } from '../../contexts/appContext';
+import { useDrawerState } from '../../contexts/appContext';
 
 type BetaSpotlightProps = {
   children: ReactElement;
@@ -37,7 +37,7 @@ export default function BetaSpotlight({ children, spotlight }: BetaSpotlightProp
   const spotlights = useSelector(showedSpotlightSelector);
   const onFinish = () => dispatch(setSpotlightToShown(spotlight));
   const upperCaseSpotlightKey = spotlight.toUpperCase();
-  const { setActiveDrawer } = useAppUIContext();
+  const { openDrawer: openFeedbackSurvey } = useDrawerState('feedbackSurvey');
 
   return (
     <TourProviderWrapper
@@ -75,7 +75,7 @@ export default function BetaSpotlight({ children, spotlight }: BetaSpotlightProp
           buttonProps: {
             color: 'secondary',
           },
-          onNext: () => setActiveDrawer('feedbackSurvey'),
+          onNext: openFeedbackSurvey,
         },
       ]}
       onFinish={onFinish}

--- a/packages/webapp/src/contexts/appContext.ts
+++ b/packages/webapp/src/contexts/appContext.ts
@@ -35,3 +35,26 @@ export const useAppUIContext = () => {
     return AppUIData;
   }
 };
+
+export const useDrawerState = (drawerName: DrawerName) => {
+  const { activeDrawer, setActiveDrawer } = useAppUIContext();
+
+  const isOpen = activeDrawer === drawerName;
+
+  const openDrawer = () => setActiveDrawer(drawerName);
+
+  /**
+   * Safely closes this specific drawer.
+   * Can safely be used even as the onClose triggered by ClickAway listeners
+   * because it verifies it is still the active drawer before applying `null`.
+   */
+  const closeDrawer = () => {
+    setActiveDrawer((prev) => (prev === drawerName ? null : prev));
+  };
+
+  const toggleDrawer = () => {
+    setActiveDrawer((prev) => (prev === drawerName ? null : drawerName));
+  };
+
+  return { isOpen, openDrawer, closeDrawer, toggleDrawer };
+};

--- a/packages/webapp/src/contexts/appContext.ts
+++ b/packages/webapp/src/contexts/appContext.ts
@@ -15,11 +15,11 @@
 
 import { createContext, Dispatch, SetStateAction, useContext } from 'react';
 
+export type DrawerName = 'feedbackSurvey' | 'farmNotes' | 'productForm' | 'profileMenu';
+
 export type AppUIData = {
-  feedback: {
-    isFeedbackSurveyOpen: boolean;
-    setFeedbackSurveyOpen: Dispatch<SetStateAction<boolean>>;
-  };
+  activeDrawer: DrawerName | null;
+  setActiveDrawer: Dispatch<SetStateAction<DrawerName | null>>;
   maps: {
     isLoaded: boolean;
   };

--- a/packages/webapp/src/stories/Pages/config/Decorators.jsx
+++ b/packages/webapp/src/stories/Pages/config/Decorators.jsx
@@ -12,7 +12,7 @@ const setIdToken = () => {
 
 export default [
   (story) => {
-    const [isFeedbackSurveyOpen, setFeedbackSurveyOpen] = useState(false);
+    const [activeDrawer, setActiveDrawer] = useState(null);
     setIdToken();
     return (
       <div
@@ -25,7 +25,8 @@ export default [
       >
         <AppUIContext.Provider
           value={{
-            feedback: { isFeedbackSurveyOpen, setFeedbackSurveyOpen },
+            activeDrawer,
+            setActiveDrawer,
             maps: { isLoaded: true },
           }}
         >
@@ -50,7 +51,7 @@ export default [
 
 export const authenticatedDecorators = [
   (story) => {
-    const [isFeedbackSurveyOpen, setFeedbackSurveyOpen] = useState(false);
+    const [activeDrawer, setActiveDrawer] = useState(null);
     setIdToken();
     return (
       <div
@@ -63,7 +64,8 @@ export const authenticatedDecorators = [
       >
         <AppUIContext.Provider
           value={{
-            feedback: { isFeedbackSurveyOpen, setFeedbackSurveyOpen },
+            activeDrawer,
+            setActiveDrawer,
             maps: { isLoaded: true },
           }}
         >
@@ -134,11 +136,12 @@ export const v2TableDecorator = [
 
 export const navMenuControlDecorator = [
   (story) => {
-    const [isFeedbackSurveyOpen, setFeedbackSurveyOpen] = useState(false);
+    const [activeDrawer, setActiveDrawer] = useState(null);
     return (
       <AppUIContext.Provider
         value={{
-          feedback: { isFeedbackSurveyOpen, setFeedbackSurveyOpen },
+          activeDrawer,
+          setActiveDrawer,
         }}
       >
         {story()}


### PR DESCRIPTION
**Description**

This PR centralizes the visibility state for all the right side-drawers and the TopMenu Profile Menu into a single global value `activeDrawer`, so that a most a single drawer (or menu) can be opened at a time.

Each individual's drawer (or menu)'s open state is then derived from the global `activeDrawer`:

```ts
const isOpen = activeDrawer === drawerName;
```

The existing `AppUIContext` (which previously tracked `isFeedbackFormOpen`, `setIsFeedBackFormOpen`), was already perfect for holding this state, and a common exported hook (`useDrawerState`) can now replace localized `[isOpen, setIsOpen]` style state in each component.

### Extending the pattern to future drawers

Now to create a new drawer that participates in this mutually exclusive application state, register the name in the `appContext.ts` type:

```ts
type DrawerName = 'feedbackSurvey' | 'farmNotes' | /*... */ | 'newDrawer'
```

and interact with it like this in the component, destructuring only the needed values

```ts
const { isOpen, openDrawer, closeDrawer, toggleDrawer } = useDrawerState('newDrawer');
```

Jira link: https://lite-farm.atlassian.net/browse/LF-5232

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
