### PR TITLE
LF-5233: Prevent duplicate farm notes on rapid save button clicks

### DIFF
--- a/packages/webapp/src/components/FarmNotes/FarmNoteForm/index.tsx
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteForm/index.tsx
@@ -127,6 +127,7 @@ export default function FarmNoteForm({
         onCancel={onCancel}
         onConfirm={handleFormSubmit}
         isDisabled={isSaveDisabled}
+        isCancelDisabled={isSubmitting || isLoading}
       />
     </div>
   );

--- a/packages/webapp/src/components/FarmNotes/FarmNoteForm/index.tsx
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteForm/index.tsx
@@ -38,9 +38,15 @@ export type FarmNoteFormProps = {
   defaultValues?: Partial<FarmNoteFormValues> & { image_url?: string };
   onSubmit: (data: FarmNoteFormValues, imageFile: File | null | undefined) => void;
   onCancel: () => void;
+  isLoading: boolean;
 };
 
-export default function FarmNoteForm({ defaultValues, onSubmit, onCancel }: FarmNoteFormProps) {
+export default function FarmNoteForm({
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isLoading,
+}: FarmNoteFormProps) {
   const { t } = useTranslation();
   const {
     register,
@@ -71,7 +77,7 @@ export default function FarmNoteForm({ defaultValues, onSubmit, onCancel }: Farm
     setImageChanged(true);
   };
 
-  const isSaveDisabled = !isValid || (!isDirty && !imageChanged) || isSubmitting;
+  const isSaveDisabled = !isValid || (!isDirty && !imageChanged) || isSubmitting || isLoading;
 
   const handleFormSubmit = handleSubmit((data) => {
     onSubmit(data, imageFile);

--- a/packages/webapp/src/components/Modals/DeleteFarmNoteModal/index.tsx
+++ b/packages/webapp/src/components/Modals/DeleteFarmNoteModal/index.tsx
@@ -20,11 +20,13 @@ import Button from '../../Form/Button';
 interface DeleteFarmNoteModalProps {
   dismissModal: () => void;
   handleDelete: () => void;
+  isLoading: boolean;
 }
 
 export default function DeleteFarmNoteModal({
   dismissModal,
   handleDelete,
+  isLoading,
 }: DeleteFarmNoteModalProps) {
   const { t } = useTranslation(['translation', 'common']);
 
@@ -34,10 +36,10 @@ export default function DeleteFarmNoteModal({
       dismissModal={dismissModal}
       buttonGroup={
         <>
-          <Button onClick={dismissModal} color="secondary-cta" sm>
+          <Button onClick={dismissModal} color="secondary-cta" sm disabled={isLoading}>
             {t('common:CANCEL')}
           </Button>
-          <Button onClick={handleDelete} color="primary" sm>
+          <Button onClick={handleDelete} color="primary" sm disabled={isLoading}>
             {t('common:DELETE')}
           </Button>
         </>

--- a/packages/webapp/src/containers/FarmNotes/FarmNoteForm/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/FarmNoteForm/index.tsx
@@ -32,8 +32,8 @@ interface FarmNoteFormContainerProps {
 export default function FarmNoteFormContainer({ note, onClose }: FarmNoteFormContainerProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const [addFarmNote] = useAddFarmNoteMutation();
-  const [editFarmNote] = useEditFarmNoteMutation();
+  const [addFarmNote, { isLoading: isAdding }] = useAddFarmNoteMutation();
+  const [editFarmNote, { isLoading: isEditing }] = useEditFarmNoteMutation();
 
   const isEditMode = !!note;
 
@@ -87,6 +87,11 @@ export default function FarmNoteFormContainer({ note, onClose }: FarmNoteFormCon
   };
 
   return (
-    <PureFarmNoteForm defaultValues={defaultValues} onSubmit={handleSubmit} onCancel={onClose} />
+    <PureFarmNoteForm
+      defaultValues={defaultValues}
+      onSubmit={handleSubmit}
+      onCancel={onClose}
+      isLoading={isAdding || isEditing}
+    />
   );
 }

--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -48,7 +48,7 @@ export default function FarmNotes() {
   const isOffline = useIsOffline();
 
   const { data: farmNotes } = useGetFarmNotesQuery();
-  const [deleteFarmNote] = useDeleteFarmNoteMutation();
+  const [deleteFarmNote, { isLoading }] = useDeleteFarmNoteMutation();
 
   const { data: farmNotesRead } = useGetFarmNotesReadQuery();
   const [markFarmNotesRead] = useMarkFarmNotesReadMutation();
@@ -153,6 +153,7 @@ export default function FarmNotes() {
         <DeleteFarmNoteModal
           dismissModal={() => setNoteToDelete(null)}
           handleDelete={handleConfirmDelete}
+          isLoading={isLoading}
         />
       )}
     </>


### PR DESCRIPTION
**Description**

Disable "Save note", "Delete" and "Cancel" buttons while loading.

(I was able to use the mutation results this time, but here is the code where buttons are disabled "manually".)

https://github.com/LiteFarmOrg/LiteFarm/blob/987cfb3729f7f73a5270895b0ce463a84690abd2/packages/webapp/src/components/Form/ContextForm/WithStepperProgressBar.tsx#L176-L191

https://github.com/LiteFarmOrg/LiteFarm/blob/987cfb3729f7f73a5270895b0ce463a84690abd2/packages/webapp/src/containers/ProductInventory/ProductForm/index.tsx#L115-L128

Jira link: https://lite-farm.atlassian.net/browse/LF-5233

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
