### PR TITLE
LF-5239 Menus visible after clearing cookies and logging in without selecting a farm

### DIFF
--- a/packages/webapp/src/containers/userFarmSlice.ts
+++ b/packages/webapp/src/containers/userFarmSlice.ts
@@ -103,6 +103,7 @@ const userFarmSlice = createSlice({
     onLoadingUserFarmsFail: onLoadingFail,
     loginSuccess: (state, { payload: { user_id } }) => {
       state.user_id = user_id;
+      state.farm_id = undefined;
     },
     selectFarmSuccess: (state, { payload: { farm_id } }) => {
       state.farm_id = farm_id;


### PR DESCRIPTION
_I think it would be good to get this in before bug bash, only because our bug bashers are traditionally some of the worst offenders in terms of manual cookies and site data clear_ 🤣 It will break farm note images in the way I describe below.

**Description**

On beta/prod (or local app with `pnpm build` + `pnpm preview`), if you clear site data via either Chrome's clear cookies and site data, or through "clear site data" within the application tab, you get to this broken view where you have the logged-in menus AND the farm selection screen at the same time:

<img width="400" height="752" alt="Screenshot 2026-04-14 at 12 45 55 PM" src="https://github.com/user-attachments/assets/257516d3-3fdf-4cb3-9b85-a6f2a8bdc278" />


### Why a fix is needed now (before bug bashing farm notes)
I've seen this forever and mostly ignored it since it 1) requires manual site data clear to generate and 2) for the most part doesn't affect application behaviour -- you can ignore the farm selection entirely and interact with the application normally and it will behave as though you have selected a farm (the one you were on before cookies clear). I'll explain why below.

HOWEVER, if you don't use the farm login/farm switch flow, you will never generate a `farm_token`. That local storage value is used specifically to generate the auth header for authenticated images, and the result is that zero authenticated images will work for you. Denis ran into this during testing today of Farm Notes and concluded that the feature was broken. To prevent other bug bashers, who are notorious for using cookies + site data clear unnecessarily (e.g. when reload or logout is more appropriate 😂) from similarly getting stuck, I would like to fix this edge case bug now.

### Cause of the bug

You can inspect the cause of the bug by observing local storage while clearing cookies + site data. Clearing site data will wipe all the local storage entries (plus cache, plus service worker), but it doesn't clear in-memory Redux. As soon as the store is modified (and on hosted app or built app I believe that's immediately due to the `offlineReadinessReducer` responding to the service worker lifecycle), the `persist:root` is regenerated with the full store data:


https://github.com/user-attachments/assets/53a1c670-59b8-4b53-80e0-dec196debffd



The true logout flow, in contrast, uses `purgeState()` so the Redux store is also cleared. (As a side note, you _can_ see it on localhost:3000 as well but it's much harder to reproduce; I suppose you would need to get lucky with the timing of something like an alert reducer to write to the Redux store?)

Once the `persist:root` is created, it is going to feed the full Redux store (including `farm_id`, indicating a "farm selected" state), back into the login flow, and we get the bug.

### Solution

There were two possibilities I considered and I took the more minimal one. One would be manually calling `purgeState()` in the login sagas right before login, something like:

```js
export function* loginWithGoogleSaga({ payload: google_id_token }) {
  try {
    // ...
    } else {
      purgeState();
      yield put(loginSuccess(user));
```

The disadvantage is that something like 3+ different login sagas would need the adjust, and we would need to make sure they stay updated.

Instead, since all login flows call `loginSuccess`, the solution in PR just clears `farm_id` at that time, which has the advantage of covering all login sagas in one go. The disadvantage is that it doesn't manually clear all the other farm state data, but without `farm_id`, it's not possible to bypass Farm Selection, and once a farm is selected, that flow correctly does all the store resetting necessary. So I think the more minimal fix is fine of these two.

Ultimately the most correct fix would want to not regenerate that `persist:root` at all when there is no `id_token` (not simply clear it later in login) because I don't love that `persist:root` surviving "Clear site data" -- it basically means site data wasn't really cleared. I think for the current timeframe and feature (Farm Notes) this is at least an improvement to prevent the failure of all note images for our bug bashers via this edge case, but easily reproduced, flow.

Jira link: https://lite-farm.atlassian.net/browse/LF-5239

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I did use to the built local app to get that immediate `persist:root` regeneration.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
