### PR TITLE
LF-5242 Fix issue where Cross button automatically highlights the feedback icon

### DIFF
--- a/packages/webapp/src/containers/FeedbackSurvey/styles.module.scss
+++ b/packages/webapp/src/containers/FeedbackSurvey/styles.module.scss
@@ -26,7 +26,15 @@
   background-color: var(--Colors-Accent---singles-Blue-light);
   @include svgColorFill(var(--Colors-Accent---singles-Blue-full));
 
-  &:hover {
+  @media (hover: hover) {
+    &:hover {
+      width: 48px;
+      background-color: var(--Colors-Accent---singles-Blue-full);
+      @include svgColorFill(var(--White));
+    }
+  }
+
+  &:active {
     width: 48px;
     background-color: var(--Colors-Accent---singles-Blue-full);
     @include svgColorFill(var(--White));


### PR DESCRIPTION
**Description**

On iOS the tap's pseudo-click was was triggering a sticky `:hover` state on the element behind the close button. [MDN writes](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:hover) about mobile `:hover`:

> Note: The :hover pseudo-class is problematic on touchscreens. Depending on the browser, the :hover pseudo-class might never match, match only for a moment after touching an element, or continue to match even after the user has stopped touching and until the user touches another element.

Gating the `:hover` styles behind a

```scss
@media (hover: hover) {
```

has fixed this bug. @SayakaOno I see you have already known to use this media query in places! But I have not reached for it before. It probably would be a good pattern moving forward for _all_ our buttons. That said, Loïc gives us pretty subtle `:active` states that might not make any sense without the hover to contrast with. I have added this as a topic to next week's dev-design because I would like to get this pattern straight!

Jira link: https://lite-farm.atlassian.net/browse/LF-5242

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Tested on iPadOS Safari and double-checked for regressions on Android phone.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
