### PR TITLE
LF-5243: Implement text length limit validation for farm notes

### DIFF
--- a/packages/api/src/models/farmNoteModel.js
+++ b/packages/api/src/models/farmNoteModel.js
@@ -37,7 +37,7 @@ class FarmNoteModel extends BaseModel {
         id: { type: 'string' },
         farm_id: { type: 'string' },
         user_id: { type: 'string' },
-        note: { type: 'string' },
+        note: { type: 'string', maxLength: 3000 },
         is_private: { type: 'boolean' },
         image_url: { type: ['string', 'null'] },
         ...this.baseProperties,

--- a/packages/webapp/src/components/FarmNotes/FarmNoteForm/index.tsx
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteForm/index.tsx
@@ -21,6 +21,9 @@ import TextArea from '../../Form/TextArea';
 import Switch from '../../Form/Switch';
 import InFormButtons from '../../Form/InFormButtons';
 import ImageUploadCapture from '../../ImageUploadCapture';
+import { getInputErrors } from '../../Form/Input';
+import { Error } from '../../Typography';
+import { hookFormMaxCharsValidation } from '../../Form/hookformValidationUtils';
 import { ReactComponent as LockIcon } from '../../../assets/images/icon-privacy.svg';
 import styles from './styles.module.scss';
 
@@ -51,7 +54,7 @@ export default function FarmNoteForm({
   const {
     register,
     handleSubmit,
-    formState: { isDirty, isValid, isSubmitting },
+    formState: { isDirty, isValid, isSubmitting, errors },
     setValue,
     watch,
   } = useForm<FarmNoteFormValues>({
@@ -83,19 +86,25 @@ export default function FarmNoteForm({
     onSubmit(data, imageFile);
   });
 
+  const noteError = getInputErrors(errors, FARM_NOTE_FIELDS.NOTE);
+
   return (
     <div className={styles.container}>
       <div className={styles.body}>
-        {/* @ts-expect-error */}
-        <TextArea
-          label={t('FARM_NOTE.NOTE_LABEL')}
-          placeholder={t('FARM_NOTE.NOTE_PLACEHOLDER')}
-          hookFormRegister={register(FARM_NOTE_FIELDS.NOTE, {
-            required: true,
-            setValueAs: (value) => value.trim(),
-          })}
-          rows={5}
-        />
+        <div className={styles.textAreaContainer}>
+          {/* @ts-expect-error */}
+          <TextArea
+            label={t('FARM_NOTE.NOTE_LABEL')}
+            placeholder={t('FARM_NOTE.NOTE_PLACEHOLDER')}
+            hookFormRegister={register(FARM_NOTE_FIELDS.NOTE, {
+              required: true,
+              setValueAs: (value) => value.trim(),
+              maxLength: hookFormMaxCharsValidation(3000),
+            })}
+            rows={5}
+          />
+          {noteError ? <Error>{noteError}</Error> : null}
+        </div>
 
         <ImageUploadCapture
           label={t('FARM_NOTE.ATTACH_PHOTO')}

--- a/packages/webapp/src/components/FarmNotes/FarmNoteForm/styles.module.scss
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteForm/styles.module.scss
@@ -37,6 +37,10 @@
   }
 }
 
+.textAreaContainer {
+  text-align: left;
+}
+
 .privacyRow {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**Description**

Add model and form validation for farm notes.

Jira link: https://lite-farm.atlassian.net/browse/LF-5243

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
