### PR TITLE
LF-5245 Farm notes date field is blue on iPadOS

### DIFF
--- a/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
@@ -64,6 +64,7 @@
     gap: 4px;
     border-bottom: solid 1px var(--Colors-Primary-Primary-teal-700);
     padding-bottom: 1px;
+    color: var(--Colors-Neutral-Neutral-900);
   }
 
   .today {


### PR DESCRIPTION
**Description**

Neither a very exciting problem nor a very exciting fix. iPadOS Safari was adding a blue colour to `<button>` text. Not so in other environments, including Desktop or iOS Safari 🤷

Jira link: https://lite-farm.atlassian.net/browse/LF-5245

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
