### PR TITLE
LF-5246 Fix Farm Notes Modal Remaining Open After Navigation

### DIFF
--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
@@ -54,6 +54,12 @@ export default function FarmNotes() {
   const [markFarmNotesRead] = useMarkFarmNotesReadMutation();
 
   const { isOpen: isDrawerOpen, openDrawer, closeDrawer } = useDrawerState('farmNotes');
+
+  useEffect(() => {
+    return () => {
+      closeDrawer();
+    };
+  }, []);
 
   const [formState, setFormState] = useState<FormState>(null);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);

--- a/packages/webapp/src/containers/ProductInventory/index.tsx
+++ b/packages/webapp/src/containers/ProductInventory/index.tsx
@@ -76,6 +76,12 @@ export default function ProductInventory() {
     dispatch(getProducts());
   }, []);
 
+  useEffect(() => {
+    return () => {
+      closeFormDrawer();
+    };
+  }, []);
+
   const productInventory = useSelector(productInventorySelector);
 
   const inventory = productInventory


### PR DESCRIPTION
**Description**

This PR closes the Farm Notes drawer (i.e. sets the `activeDrawer` to `null`) when unmounting the component. I should have thought to add this in the PR that created `activeDrawer`! 😬

Cleaning up the drawer state on unmount is closer to how the components behaved originally (with local `isOpen` state), and is a good default for drawers participating in the global drawer state in the future. Note of course that this isn't true for ALL drawers; some (like Feedback Form) are meant to remain open, and others (like Profile Menu) have a click away listeners built-in that handle the close anyway -- oh, and also they don't umount!

Of the other two drawers, though (Farm Notes and Product Form), I think they should both have this cleanup. Product Form was actually remaining the active drawer just like in Farm Notes, but because the local component states `mode` etc. were being reset on remount, and because both `isFormOpen` and local component state determine whether to show that drawer:

```tsx
<Drawer
  isOpen={isFormOpen && !!productFormType && !!mode && modalType === ModalType.NONE}
```

the overall effect was the drawer mounting closed, despite still being the active drawer. Not a problem currently, but it seemed a little bit more consistent/predictable to instead clean up the drawer state on unmount.

Jira link: https://lite-farm.atlassian.net/browse/LF-5246

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
