### PR TITLE
LF-5247: Add hover state and visual boundaries to delete note button

### DIFF
--- a/packages/webapp/src/assets/colors.scss
+++ b/packages/webapp/src/assets/colors.scss
@@ -104,6 +104,7 @@
   --Colors-Neutral-Neutral-500: #66738a;
   --Colors-Neutral-Neutral-600: #5d697e;
   --Colors-Neutral-Neutral-700: #485262;
+  --Colors-Neutral-Neutral-800: #383f4c;
   --Colors-Neutral-Neutral-900: #2b303a;
 
   --Btn-primary-pristine: #ffcf54;

--- a/packages/webapp/src/components/FarmNotes/FarmNoteItem/index.tsx
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteItem/index.tsx
@@ -96,10 +96,10 @@ export default function FarmNoteItem({
         {/* Author actions */}
         {isAuthor && (
           <div className={styles.actions}>
-            <TextButton className={styles.deleteButton} type="button" onClick={onDelete}>
+            <Button color="link-btn" type="button" onClick={onDelete} sm>
               <TrashIcon />
               <span>{t('translation:FARM_NOTE.DELETE_NOTE')}</span>
-            </TextButton>
+            </Button>
             <Button color="secondary" type="button" onClick={onEdit} sm>
               <EditIcon />
               <span>{t('translation:FARM_NOTE.EDIT_NOTE')}</span>

--- a/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
@@ -229,17 +229,9 @@
 
   button {
     min-width: 0;
-    display: flex;
     flex: 1 1 0;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--Colors-Neutral-Neutral-500);
 
     span {
-      @include fontFamily();
       @include truncateText();
     }
   }

--- a/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
@@ -252,9 +252,3 @@
     }
   }
 }
-
-/* ──── Focus outline styles ──── */
-.deleteButton {
-  padding: 8px 12px;
-  border-radius: 4px;
-}

--- a/packages/webapp/src/components/Form/Button/button.module.scss
+++ b/packages/webapp/src/components/Form/Button/button.module.scss
@@ -80,6 +80,38 @@
   --focus-box-shadow: none;
 }
 
+.btn.secondary-red {
+  --background: var(--White);
+  --border: 1px solid #ffa9a6;
+  --color: var(--Colors-Accent---singles-Red-full);
+
+  --hover-background: var(--White);
+  --hover-border: 1px solid var(--Colors-Accent---singles-Red-full);
+  --hover-box-shadow: 0px 1px 2px 0px var(--Colors-Neutral-Neutral-500);
+  --hover-color: var(--Colors-Accent---singles-Red-full);
+
+  --active-background: var(--Colors-Accent---singles-Red-light, #ffdad9);
+  --active-border: 1px solid var(--Colors-Accent---singles-Red-full);
+  --active-color: var(--Colors-Accent---singles-Red-full);
+
+  --focus-border: 1px solid #ffa9a6;
+  --focus-outline: none;
+  --focus-box-shadow: none;
+}
+
+.btn.link-btn {
+  --background: none;
+  --border: none;
+  --color: var(--Colors-Neutral-Neutral-500);
+
+  --hover-color: var(--Colors-Neutral-Neutral-800);
+
+  --active-color: var(--Colors-Neutral-Neutral-900);
+
+  --focus-outline: 2px solid var(--Colors-Neutral-Neutral-500, #66738a);
+  --focus-box-shadow: none;
+}
+
 .btn.accent {
   --background: var(--White);
   --border: none;

--- a/packages/webapp/src/components/Form/Button/index.tsx
+++ b/packages/webapp/src/components/Form/Button/index.tsx
@@ -23,6 +23,8 @@ export type ButtonProps = {
     | 'secondary'
     | 'secondary-2'
     | 'secondary-cta'
+    | 'secondary-red'
+    | 'link-btn'
     | 'accent'
     | 'warning'
     | 'error'

--- a/packages/webapp/src/stories/Button/Button.stories.jsx
+++ b/packages/webapp/src/stories/Button/Button.stories.jsx
@@ -45,6 +45,18 @@ SecondaryCTA.args = {
   children: 'Secondary-CTA',
 };
 
+export const SecondaryRed = Template.bind({});
+SecondaryRed.args = {
+  color: 'secondary-red',
+  children: 'Secondary-Red',
+};
+
+export const LinkBtn = Template.bind({});
+LinkBtn.args = {
+  color: 'link-btn',
+  children: 'Link-btn',
+};
+
 export const Disabled = Template.bind({});
 Disabled.args = {
   color: 'primary',


### PR DESCRIPTION
**Description**

- Add `secondary-red` and `link-btn` as options for the `<Button />`'s `color` prop.
- Add [stories](http://localhost:6006/?path=/story/components-button--link-btn).
- Replace farm note's delete `<TextButton />` with `<Button />`.

Jira link: https://lite-farm.atlassian.net/browse/LF-5247

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
