### PR TITLE
LF-5252:  Add farm token fetch on farm selection via selectFarmSaga

### DIFF
--- a/packages/webapp/src/containers/AddFarm/saga.js
+++ b/packages/webapp/src/containers/AddFarm/saga.js
@@ -20,12 +20,11 @@ import {
   patchFarmSuccess,
   patchRoleStepTwoSuccess,
   postFarmSuccess,
-  selectFarmSuccess,
   setLoadingEnd,
   setLoadingStart,
   userFarmSelector,
 } from '../userFarmSlice';
-import { axios, getHeader } from '../saga';
+import { axios, getHeader, selectFarm } from '../saga';
 import { createAction } from '@reduxjs/toolkit';
 import i18n from '../../locales/i18n';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
@@ -74,12 +73,8 @@ export function* postFarmSaga({ payload: { showFarmNameCharacterLimitExceededErr
         country_code: addFarmData.country,
       }),
     );
-    yield put(selectFarmSuccess({ farm_id }));
+    yield put(selectFarm({ farm_id }));
     history.push('/role_selection');
-    const {
-      data: { farm_token },
-    } = yield call(axios.get, `${url}/farm_token/farm/${farm_id}`, getHeader(user_id, farm_id));
-    localStorage.setItem('farm_token', farm_token);
   } catch (e) {
     yield put(setLoadingEnd());
     const isFarmNameError =

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -651,10 +651,6 @@ export function* fetchAllSaga() {
     put(api.endpoints.getAnimalUses.initiate()),
   ]);
 
-  const {
-    data: { farm_token },
-  } = yield call(axios.get, `${url}/farm_token/farm/${farm_id}`, getHeader(user_id, farm_id));
-  localStorage.setItem('farm_token', farm_token);
   const appVersion = yield select(appVersionSelector);
   if (appVersion !== APP_VERSION) {
     yield put(setAppVersion());
@@ -672,11 +668,27 @@ export function* clearOldFarmStateSaga() {
   yield put(setIsFetchingData(true));
 }
 
+export const selectFarm = createAction('selectFarmSaga');
+
+export function* selectFarmSaga({ payload: { farm_id } }) {
+  yield put(selectFarmSuccess({ farm_id }));
+  try {
+    const { user_id } = yield select(loginSelector);
+    const header = getHeader(user_id, farm_id);
+    const {
+      data: { farm_token },
+    } = yield call(axios.get, `${url}/farm_token/farm/${farm_id}`, header);
+    localStorage.setItem('farm_token', farm_token);
+  } catch (e) {
+    console.error('failed to fetch farm token', e);
+  }
+}
+
 export const selectFarmAndFetchAll = createAction('selectFarmAndFetchAllSaga');
 
 export function* selectFarmAndFetchAllSaga({ payload: farm }) {
   try {
-    yield put(selectFarmSuccess(farm));
+    yield call(selectFarmSaga, { payload: farm });
     const userFarm = yield select(userFarmSelector);
     if (!userFarm.has_consent) return history.push('/consent');
     history.push({ pathname: '/' });
@@ -718,6 +730,7 @@ export default function* getFarmIdSaga() {
   yield takeLatest(getManagementPlans.type, getManagementPlansSaga);
   yield takeLatest(getCrops.type, getCropsSaga);
   yield takeLatest(getCropVarieties.type, getCropVarietiesSaga);
+  yield takeLatest(selectFarm.type, selectFarmSaga);
   yield takeLatest(selectFarmAndFetchAll.type, selectFarmAndFetchAllSaga);
   yield takeLatest(onLoadingLocationStart.type, onLoadingLocationStartSaga);
   yield takeLatest(getLocationsSuccess.type, getLocationsSuccessSaga);


### PR DESCRIPTION
**Description**

Private image fetching in `useMediaWithAuthentication` fails after login or farm switch because `farm_token` hasn't always been set yet. This PR creates a saga that sets farm token right after selecting a farm.

- Add `selectFarmSaga` that dispatches `selectFarmSuccess` and fetches the farm token, storing it in `localStorage`.
   - `selectFarmAndFetchAllSaga` calls `selectFarmSaga` directly.
   - `postFarmSaga` (AddFarm) dispatches the new `selectFarm` action.


Jira link: https://lite-farm.atlassian.net/browse/LF-5252

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Open DevTools Network tab and verify `/farm_token` request completes before any image requests.

Before:
<img width="1101" height="589" alt="Screenshot 2026-04-20 at 2 12 01 PM" src="https://github.com/user-attachments/assets/e918eee7-43ce-47c9-9139-378e837fdbd7" />

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
