### PR TITLE
LF-5254: Fix deleted notes reappearing after going online

### DIFF
--- a/packages/api/src/controllers/farmNoteController.ts
+++ b/packages/api/src/controllers/farmNoteController.ts
@@ -40,6 +40,7 @@ const farmNoteController = {
           .where('updated_at', '>', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)) // last 30 days
           .orderBy('updated_at', 'desc');
 
+        await new Promise((resolve) => setTimeout(resolve, 2000));
         return res.status(200).json(notes);
       } catch (error: unknown) {
         console.error(error);

--- a/packages/api/src/controllers/farmNoteController.ts
+++ b/packages/api/src/controllers/farmNoteController.ts
@@ -40,7 +40,6 @@ const farmNoteController = {
           .where('updated_at', '>', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)) // last 30 days
           .orderBy('updated_at', 'desc');
 
-        await new Promise((resolve) => setTimeout(resolve, 2000));
         return res.status(200).json(notes);
       } catch (error: unknown) {
         console.error(error);

--- a/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
+++ b/packages/webapp/src/hooks/useServiceWorkerListener/useServiceWorkerListener.ts
@@ -23,6 +23,7 @@ import {
 import { getProducts, getTasks } from '../../containers/Task/saga';
 import { getManagementPlans } from '../../containers/saga';
 import { invalidateTags } from '../../store/api/apiSlice';
+import { farmNoteApi } from '../../store/api/farmNoteApi';
 import { OfflineEventPayload, recordOfflineEvent } from '../../util/offlineEventLogger';
 import { getFeedbackMessages, resolveAreaFromUrl, SyncArea } from './utils';
 
@@ -46,6 +47,7 @@ export function useServiceWorkerListener() {
   const { t } = useTranslation();
 
   const logTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingFarmNoteRequestRef = useRef<{ abort: () => void } | null>(null);
   const logBufferRef = useRef<OfflineEventBuffer>({
     logs: [],
     auth: '',
@@ -67,6 +69,26 @@ export function useServiceWorkerListener() {
     }
 
     recordOfflineEvent({ auth, farmId, logs });
+  };
+
+  // RTK Query deduplicates in-flight requests, so if a previous getFarmNotes request is still
+  // in-flight when a new SW sync message arrives, the new request would subscribe to the old one
+  // instead of firing a fresh fetch — potentially returning stale data that predates the latest sync.
+  // To avoid this, we abort the in-flight request and await its settlement before firing a new one.
+  // RTK Query does not natively support aborting in-flight requests on invalidation (as of 2026).
+  // See: https://github.com/reduxjs/redux-toolkit/issues/2444
+  const refreshFarmNotes = async () => {
+    const pending = pendingFarmNoteRequestRef.current;
+    pendingFarmNoteRequestRef.current = null;
+    if (pending) {
+      pending.abort(); // trigger cancellation
+      try {
+        await (pending as any); // wait for cancellation to complete
+      } catch {}
+    }
+    pendingFarmNoteRequestRef.current = dispatch(
+      farmNoteApi.endpoints.getFarmNotes.initiate(undefined, { forceRefetch: true }),
+    ) as unknown as { abort: () => void };
   };
 
   const syncConfig = useMemo(
@@ -105,9 +127,9 @@ export function useServiceWorkerListener() {
         },
         refresh: () => dispatch(getTasks()),
       },
-      'farm_notes.create': { refresh: () => dispatch(invalidateTags(['FarmNote'])) },
-      'farm_notes.edit': { refresh: () => dispatch(invalidateTags(['FarmNote'])) },
-      'farm_notes.delete': { refresh: () => dispatch(invalidateTags(['FarmNote'])) },
+      'farm_notes.create': { refresh: () => refreshFarmNotes() },
+      'farm_notes.edit': { refresh: () => refreshFarmNotes() },
+      'farm_notes.delete': { refresh: () => refreshFarmNotes() },
       'farm_notes.patch': { refresh: () => dispatch(invalidateTags(['FarmNotesRead'])) },
     }),
     [dispatch],


### PR DESCRIPTION
**Description**

When farm notes are synced offline, `getFarmNotes` is triggered for each operation (update, delete, etc.). If a previous `getFarmNotes` request is still in-flight, RTK Query deduplicates — the second call subscribes to the in-flight request instead of firing a new fetch. Since the in-flight request was initiated before the latest sync completed, it can return stale data.

Depending on timing, one of the following is observed (~5% reproduction rate locally, higher on Beta):

- `getFarmNotes` is called once and returns correct data (no race)
- `getFarmNotes` is called once and returns stale data that includes the deleted note ← bug
- `getFarmNotes` is called twice and returns correct data on the second call

**Solution**

Abort any in-flight getFarmNotes request before firing a new one, ensuring the response always reflects the latest server state.

Jira link: https://lite-farm.atlassian.net/browse/LF-5254

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Since the race condition is timing-dependent (~5% locally), the abort isn't easily observable without slowing things down. To verify, apply a commit that delays `getFarmNotes` by 2 seconds:

`git cherry-pick --no-commit 1a5b655f4` (https://github.com/LiteFarmOrg/LiteFarm/commit/1a5b655f4f7096827c72c555e398cf396bcef660)

With the delay applied, the network tab should show one canceled request followed by one successful one.

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files