### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/api/db/migration/20200713160251_make_email_token_table.js
+++ b/packages/api/db/migration/20200713160251_make_email_token_table.js
@@ -15,7 +15,7 @@ export const up = function (knex) {
         .onDelete('CASCADE')
         .onUpdate('CASCADE')
         .notNullable();
-      table.string('token').notNullable();
+      table.string('token', 64).notNullable();
       table.boolean('is_used').defaultTo(false).notNullable();
       table.timestamps(false, true);
       table.primary(['user_id', 'farm_id']);

--- a/packages/api/db/migration/20201130123842_change_user_id_to_uuid.js
+++ b/packages/api/db/migration/20201130123842_change_user_id_to_uuid.js
@@ -1,6 +1,6 @@
 export const up = function (knex) {
   return Promise.all([
-    knex.raw('ALTER TABLE "users" ALTER COLUMN user_id SET DEFAULT uuid_generate_v1();'),
+    knex.raw('ALTER TABLE "users" ALTER COLUMN user_id SET DEFAULT uuid_generate_v4();'),
   ]);
 };
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `packages/api/db/migration/20201130123842_change_user_id_to_uuid.js:L3`

The migration sets `users.user_id` default to `uuid_generate_v1()`, which is time/MAC-based and more predictable than random UUIDs. If user IDs are exposed through APIs, this can increase enumeration risk and leak metadata about creation time/host characteristics.

## Solution

Use `uuid_generate_v4()` (or `gen_random_uuid()` in modern Postgres) for security-sensitive/public identifiers. Consider migrating existing externally exposed IDs to random UUIDs if feasible.

## Changes

- `packages/api/db/migration/20201130123842_change_user_id_to_uuid.js` (modified)
- `packages/api/db/migration/20200713160251_make_email_token_table.js` (modified)