### PR TITLE
LF-5248: Improve User Experience for Image Upload in Farm Notes by Early File Size Notification and UI Enhancements

### DIFF
--- a/packages/api/src/middleware/image/uploadFarmNoteImage.ts
+++ b/packages/api/src/middleware/image/uploadFarmNoteImage.ts
@@ -69,7 +69,7 @@ export default function uploadFarmNoteImage() {
       console.error(error);
 
       const err = error as HttpError;
-      const status = err.status || err.code || 500;
+      const status = err.status ?? (typeof err.code === 'number' ? err.code : 500);
       return res.status(status).json({ error: err.message || err });
     }
   };

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -30,6 +30,35 @@ import getDeviceType from '../../util/getDeviceType';
 import { isImageFile } from '../../util/validation';
 import styles from './styles.module.scss';
 
+const compressImage = async (file: File): Promise<Blob> => {
+  if (file.size <= 5e6) {
+    return file;
+  }
+
+  let quality = 0.8;
+  let compressedFile: Blob = file;
+
+  while (quality > 0) {
+    compressedFile = await compressImageWithQuality(file, quality);
+    if (compressedFile.size < 5e6) {
+      return compressedFile;
+    }
+    quality -= 0.2;
+  }
+  return compressedFile; // return the best effort compressed image even if it still exceeds max size
+};
+
+const compressImageWithQuality = async (file: File, quality: number): Promise<Blob> => {
+  const Compressor = await import('compressorjs').then((compressor) => compressor.default);
+  return new Promise((resolve, reject) => {
+    new Compressor(file, {
+      quality,
+      success: resolve,
+      error: reject,
+    });
+  });
+};
+
 export type ImageUploadCaptureProps = {
   onSelectImage: (file: File) => void;
   onRemoveImage: () => void;
@@ -64,26 +93,44 @@ export default function ImageUploadCapture({
     };
   }, [localUrl]);
 
-  const handleFile = (file: File) => {
+  const handleFile = async (file: File, option?: { compress?: boolean }) => {
     if (!isImageFile(file)) {
       dispatch(enqueueErrorSnackbar(t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
       return;
     }
 
+    let imageFile: File = file;
+
     if (file.size > 5e6) {
-      setShowFileSizeExceedsModal(true);
-      return;
+      if (option?.compress) {
+        try {
+          const blob = await compressImage(file);
+
+          if (blob.size > 5e6) {
+            setShowFileSizeExceedsModal(true);
+            return;
+          }
+
+          imageFile = new File([blob], file.name, { type: blob.type });
+        } catch {
+          console.error('Image compression failed');
+          return;
+        }
+      } else {
+        setShowFileSizeExceedsModal(true);
+        return;
+      }
     }
-    const url = URL.createObjectURL(file);
+    const url = URL.createObjectURL(imageFile);
     setLocalUrl(url);
-    onSelectImage(file);
+    onSelectImage(imageFile);
   };
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>, option?: { compress?: boolean }) => {
     if (!e.target.files?.length) {
       return;
     }
-    handleFile(e.target.files[0]);
+    handleFile(e.target.files[0], option);
     e.target.value = '';
   };
 
@@ -170,7 +217,7 @@ export default function ImageUploadCapture({
                 <PureFilePickerWrapper
                   accept="image/*"
                   capture="environment"
-                  onChange={handleChange}
+                  onChange={(e) => handleChange(e, { compress: true })}
                   className={styles.photoBtnWrapper}
                 >
                   <div className={styles.photoBtn}>

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -102,7 +102,7 @@ export default function ImageUploadCapture({
     let imageFile: File = file;
 
     if (file.size > 5e6) {
-      if (true) {
+      if (option?.compress) {
         try {
           const blob = await compressImage(file);
 
@@ -112,9 +112,6 @@ export default function ImageUploadCapture({
           }
 
           imageFile = new File([blob], file.name, { type: blob.type });
-          console.log(
-            `Image compressed from ${(file.size / 1e6).toFixed(2)} MB to ${(imageFile.size / 1e6).toFixed(2)} MB`,
-          );
         } catch {
           console.error('Image compression failed');
           return;

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -102,7 +102,7 @@ export default function ImageUploadCapture({
     let imageFile: File = file;
 
     if (file.size > 5e6) {
-      if (option?.compress) {
+      if (true) {
         try {
           const blob = await compressImage(file);
 
@@ -112,6 +112,9 @@ export default function ImageUploadCapture({
           }
 
           imageFile = new File([blob], file.name, { type: blob.type });
+          console.log(
+            `Image compressed from ${(file.size / 1e6).toFixed(2)} MB to ${(imageFile.size / 1e6).toFixed(2)} MB`,
+          );
         } catch {
           console.error('Image compression failed');
           return;


### PR DESCRIPTION
**Description**

Compress camera-captured images exceeding 5MB before upload.

Jira link: https://lite-farm.atlassian.net/browse/LF-5248

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

1. Apply a temporary commit (8a302c2e4618c8779c4154e9e4a455f75625c1c6) that enables the compression for all images and logs the compression result to the console:
    ```
     git cherry-pick 8a302c --no-commit
     ```
    Then select or drag and drop an image over 5MB. The console should show the before/after size in MB.
2. To test on mobile, lower the threshold to 2MB to make it easier to trigger:
     In `packages/webapp/src/components/ImageUploadCapture/index.tsx`, replace `5e6` with `2097152` (2MB), then run `vite preview --host` and take a photo with the camera.

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
