### PR TITLE
LF-5265 Old farm's note data persists after switching farms to a newly invited farm

### DIFF
--- a/packages/webapp/src/containers/ChooseFarm/saga.js
+++ b/packages/webapp/src/containers/ChooseFarm/saga.js
@@ -28,7 +28,7 @@ import {
   spotlightLoading,
 } from '../showedSpotlightSlice';
 import { createAction } from '@reduxjs/toolkit';
-import { axios, getHeader } from '../saga';
+import { axios, clearOldFarmStateSaga, getHeader } from '../saga';
 import history from '../../history';
 import { startInvitationFlowOnChooseFarmScreen } from './chooseFarmFlowSlice';
 
@@ -57,6 +57,7 @@ export function* patchUserFarmStatusWithIDTokenSaga({ payload: userFarm }) {
     const header = getHeader(user_id, farm_id);
     const result = yield call(axios.patch, patchUserFarmStatusWithIdTokenUrl(farm_id), {}, header);
     const { user: resUserFarm } = result.data;
+    yield call(clearOldFarmStateSaga);
     yield put(acceptInvitationSuccess(resUserFarm));
     yield put(startInvitationFlowOnChooseFarmScreen(resUserFarm.farm_id));
     history.push('/consent');

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -690,6 +690,7 @@ export function* selectFarmAndFetchAllSaga({ payload: farm }) {
   try {
     yield call(selectFarmSaga, { payload: farm });
     const userFarm = yield select(userFarmSelector);
+    yield call(clearOldFarmStateSaga);
     if (!userFarm.has_consent) {
       // has_consent is derived in the userFarmSelector from DB has_consent && consent_version === CONSENT_VERSION
       // Reachable when CONSENT_VERSION was bumped and the user hasn't re-accepted, or when an admin has changed the user's role (userFarmController.updateRole resets has_consent but leaves status='Active')
@@ -697,7 +698,6 @@ export function* selectFarmAndFetchAllSaga({ payload: farm }) {
       return history.push('/consent');
     }
     history.push({ pathname: '/' });
-    yield call(clearOldFarmStateSaga);
     yield call(fetchAllSaga);
   } catch (e) {
     console.error('failed to fetch farm info', e);

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -690,7 +690,12 @@ export function* selectFarmAndFetchAllSaga({ payload: farm }) {
   try {
     yield call(selectFarmSaga, { payload: farm });
     const userFarm = yield select(userFarmSelector);
-    if (!userFarm.has_consent) return history.push('/consent');
+    if (!userFarm.has_consent) {
+      // has_consent is derived in the userFarmSelector from DB has_consent && consent_version === CONSENT_VERSION
+      // Reachable when CONSENT_VERSION was bumped and the user hasn't re-accepted, or when an admin has changed the user's role (userFarmController.updateRole resets has_consent but leaves status='Active')
+      // Status 'Invited' farms do not use selectFarmAndFetchAllSaga, but instead use patchUserFarmStatusWithIdTokenUrl
+      return history.push('/consent');
+    }
     history.push({ pathname: '/' });
     yield call(clearOldFarmStateSaga);
     yield call(fetchAllSaga);


### PR DESCRIPTION
**Description**

This PR makes sure that `clearOldFarmStateSaga` (with the included `invalidatesTags`) is called in two flows where it was either missing entirely, or not called due to early return:

1. On switching to a new-to-you (userFarm status 'Invited') farm
2. On routing to consent on an existing userFarm due to need to re-consent (version bump, role change)

The code in the original Jira ticket / Slack thread is taken from pathway (2), but it so happens that the behaviour we were looking at was (1), which made debugging a bit needlessly hard!

It's pretty clear in `containers/ChooseFarm/index.jsx` though, I just failed to look at it 😝

```js
const onProceed = () => {
  const farm = userFarmEntities[selectedFarmId][user_id];
  if (farm.status === 'Active') {
    // ...
    dispatch(selectFarmAndFetchAll({ farm_id: selectedFarmId })); // <-- the saga we looked at
  } else {
    dispatch(patchUserFarmStatusWithIDToken(farm)); // <-- the invited case we were testing
  }
};
```

it didn't help that there are a lot of pathways to `/consent` and these flows are a bit convoluted...

Jira link: https://lite-farm.atlassian.net/browse/LF-5265

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

#### Testing Invited flow
- Manually set farms to Invited status via database (`status` 'Invited', `has_consent` and `step_three` FALSE, `step_three_end` NULL)

#### Testing consented flow within `selectFarmAndFetchAll()`
- Toggled a role between worker & admin using a different device

#### (Bonus) Testing Redux behaviour of `clearOldFarmStateSaga`
(Not really necessary, but was the most interesting finding from my debug!)
- Place debugger in farm switch saga(s). (Pausing via debugger is necessary within selectFarmAndFetchAll only; the consent screen actually pauses in the right place when looking at patchUserFarmStatusWithIDToken
- clear Redux state (pause and resume) and initiate farm switch. Step through with debugger if applicable
- result: you can see each piece of invalidated farm tag state being REMOVED from the api Redux tree! (Or, equivalently, you can see that at the end of tag invalidation + removeQueryResult, only library queries are left!)

<img width="1438" height="755" alt="Screenshot 2026-04-23 at 1 19 06 PM" src="https://github.com/user-attachments/assets/c5aa0174-05a2-4bcd-80f7-8af286628a5a" />

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
