### PR TITLE
LF-5101 Add the new patches/ folder to copy before pnpm install

### DIFF
--- a/packages/webapp/prod.Dockerfile
+++ b/packages/webapp/prod.Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/app
 
 COPY ./webapp/package.json ./webapp/.npmrc ./webapp/pnpm-lock.yaml /usr/src/app/
 
+COPY ./webapp/patches/ /usr/src/app/patches/
+
 RUN npm install pnpm@10.6.5 -g && pnpm install
 
 COPY ./webapp/ /usr/src/app/


### PR DESCRIPTION
**Description**

Addressing this ENOENT [in beta deploy](https://github.com/LiteFarmOrg/LiteFarm/actions/runs/24863251741/job/72793484103):

```
err: #10 5.605  ENOENT  ENOENT: no such file or directory, open '/usr/src/app/patches/terra-draw@1.28.8.patch'
```

This will also apply to prod since both `docker-compose.beta.yml` and `docker-compose.prod.yml` refer to this same `prod.Dockerfile`.

Jira link: https://lite-farm.atlassian.net/browse/LF-5101

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Did not test; will merge to test in actual deploy

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
