### PR TITLE
LF-5251 Fix Farm Notes loading screen not showing on first load for slow networks

### DIFF
--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -27,6 +27,7 @@ import type { FarmNote } from '../../store/api/types';
 import { ReactComponent as MessageTextSquareIcon } from '../../assets/images/message-text-square-02.svg';
 import FarmNoteFormContainer from './FarmNoteForm';
 import FarmNoteList from '../../components/FarmNotes/FarmNoteList/';
+import Spinner from '../../components/Spinner';
 import FarmNotesFloatingButton from '../../components/FarmNotes/FarmNotesFloatingButton/';
 import DeleteFarmNoteModal from '../../components/Modals/DeleteFarmNoteModal';
 import Drawer, { DesktopDrawerVariants } from '../../components/Drawer';
@@ -47,7 +48,7 @@ export default function FarmNotes() {
   const userDisplayNameMap = useSelector(userDisplayNameMapSelector);
   const isOffline = useIsOffline();
 
-  const { data: farmNotes } = useGetFarmNotesQuery();
+  const { data: farmNotes, isLoading: isLoadingNotes } = useGetFarmNotesQuery();
   const [deleteFarmNote, { isLoading }] = useDeleteFarmNoteMutation();
 
   const { data: farmNotesRead } = useGetFarmNotesReadQuery();
@@ -138,6 +139,10 @@ export default function FarmNotes() {
             note={isEditState ? formState.note : undefined}
             onClose={() => setFormState(null)}
           />
+        ) : isLoadingNotes ? (
+          <div className={styles.spinnerWrapper}>
+            <Spinner />
+          </div>
         ) : (
           <FarmNoteList
             notes={farmNotes || []}

--- a/packages/webapp/src/containers/FarmNotes/styles.module.scss
+++ b/packages/webapp/src/containers/FarmNotes/styles.module.scss
@@ -25,6 +25,11 @@
   max-width: 100%;
 }
 
+.spinnerWrapper {
+  height: 100%;
+  display: flex;
+}
+
 .listTitle {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**Description**

Adds the default loading spinner to Farm Notes.

Jira link: https://lite-farm.atlassian.net/browse/LF-5251

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
