### PR TITLE
LF-5253 Fix incorrect farm note read indicator flicker after clearing

### DIFF
--- a/packages/webapp/src/containers/FarmNotes/index.tsx
+++ b/packages/webapp/src/containers/FarmNotes/index.tsx
@@ -68,6 +68,7 @@ export default function FarmNotes() {
   const readUpTo = farmNotesRead?.read_up_to;
   const latestOtherUserNote = farmNotes?.find((note) => note.user_id !== userFarm?.user_id);
   const hasUnread =
+    farmNotesRead !== undefined &&
     !!latestOtherUserNote &&
     (!readUpTo || new Date(latestOtherUserNote.updated_at) > new Date(readUpTo));
 


### PR DESCRIPTION
**Description**

My description in the bug bash table was needlessly complicated -- I thought this had something to do with stale cache on farm switch (which I now understand does not happen) -- but in fact, it's just a tiny race condition between the completion of the farm_notes and farm_notes_read endpoints.

If the farm notes manage to complete first, `hasUnread` will resolve as follows:

```ts
const hasUnread =
  !!latestOtherUserNote && // <-- true if switching to such a farm
  (!readUpTo || // <-- resolves to true, because readUpTo is not defined yet
  new Date(latestOtherUserNote.updated_at) > new Date(readUpTo)); // <-- doesn't matter; won't reach
```

Result is a flicker of `hasUnread` being true before it's re-evaluated. Interesting, I can pretty much never replicate this on local; I wonder if the network throttling in dev tools applies some sort of consistent delay, but never re-orders the queries?

On beta, however (no throttling) it's extremely common (but very brief!) It happens on each one of the following farm switches, but I often miss at least one when I play back the video 🙂

https://github.com/user-attachments/assets/8230cca0-17bb-4c20-a313-f9918f7f3822

You really have to focus to see it, so it's not a very important bug. But the fix is also easy, so...!

Jira link: https://lite-farm.atlassian.net/browse/LF-5253

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

As mentioned above, I can't really reproduce the flicker locally, so I did not test.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
