### PR TITLE
LF-5250 Fix Note Collapsing Whitespace Issue in Farm Notes

### DIFF
--- a/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
@@ -141,6 +141,7 @@
   color: var(--Colors-Neutral-Neutral-900);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: pre-line;
 
   // 2-line clamp
   display: -webkit-box;
@@ -216,6 +217,7 @@
   font-weight: 400;
   line-height: 24px;
   color: var(--Colors-Neutral-Neutral-900);
+  white-space: pre-line;
 }
 
 /* ── Author actions ────────────────────────────── */


### PR DESCRIPTION
**Description**

This adds `white-space: pre-line `to the note preview and text.

`pre-line` acts like the default, other than it [preserves line breaks](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/white-space#values).

Jira link: https://lite-farm.atlassian.net/browse/LF-5250

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
