### PR TITLE
LF-5249 Disable the expandable chevron for offline-added notes in Farm Notes feature

### DIFF
--- a/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
+++ b/packages/webapp/src/components/FarmNotes/FarmNoteItem/styles.module.scss
@@ -121,7 +121,7 @@
       color: var(--Colors-Neutral-Neutral-400);
     }
 
-    .chevronInline {
+    .chevronDown {
       color: var(--Colors-Neutral-Neutral-100);
       background: var(--Colors-Neutral-Neutral-50);
     }


### PR DESCRIPTION
_Ticket renamed from **[Nice to have] Implement expandable preview screen for offline-added notes in Farm Notes feature**. Explanation below._

**Description**

This one was fun! One reason I requested the expandable pending view on the bug bash table was that the chevron looked clickable (I had also written about the chevron "maybe it should be removed"?)

What I had missed is that
1) the Figma shows a disabled state for that chevron in the pending view! And then ALSO
2) that disabled state was already added to the code in commit 05d0f7143cee0c4c43b0eaa905bf88c51284735e -- but the chevron class had been renamed in 46eb2da46437f1b13bd0d2174ebfcac0ea5761a5 so it never applied!

I think with the correctly disabled chevron there is no issue with the non-expandable preview. In any case the note image can't be shown (which I think of as the main benefit of expanding), and Loïc already said he didn't think it had to be expandable, as this keeps parallelism with tasks.

Jira link: https://lite-farm.atlassian.net/browse/LF-5249

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
