### PR TITLE
LF-5248 (2) Adjust ImageUploadCapture image compression logic to handle more real world cases

### DIFF
--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -30,19 +30,14 @@ import getDeviceType from '../../util/getDeviceType';
 import { isImageFile } from '../../util/validation';
 import styles from './styles.module.scss';
 
+const COMPRESSION_THRESHOLD = 5e6; // 5MB
+const MAX_ACCEPTED_FILE_SIZE = 50e6; // 50MB for orignal file, matching high MP images from most phones
+
 const compressImage = async (file: File): Promise<Blob> => {
-  if (file.size <= 5e6) {
-    return file;
-  }
-
-  return compressImageWithQuality(file, 0.8); // best-effort compression
-};
-
-const compressImageWithQuality = async (file: File, quality: number): Promise<Blob> => {
   const Compressor = await import('compressorjs').then((compressor) => compressor.default);
   return new Promise((resolve, reject) => {
     new Compressor(file, {
-      quality,
+      quality: 0.8,
       maxWidth: 2560,
       maxHeight: 2560,
       checkOrientation: false,
@@ -92,25 +87,22 @@ export default function ImageUploadCapture({
       return;
     }
 
-    let imageFile: File = file;
-
-    if (file.size > 5e6) {
-      try {
-        const blob = await compressImage(file);
-
-        if (blob.size > 5e6) {
-          setShowFileSizeExceedsModal(true);
-          return;
-        }
-
-        imageFile = new File([blob], file.name, { type: blob.type });
-      } catch {
-        console.error('Image compression failed');
-        return;
-      }
-    } else {
+    if (file.size > MAX_ACCEPTED_FILE_SIZE) {
       setShowFileSizeExceedsModal(true);
       return;
+    }
+
+    let imageFile: File = file;
+
+    if (file.size > COMPRESSION_THRESHOLD) {
+      try {
+        const blob = await compressImage(file);
+        imageFile = new File([blob], file.name, { type: blob.type });
+      } catch {
+        // Compression fails for e.g. DNG (RAW) or HEIC on non-Safari browsers
+        dispatch(enqueueErrorSnackbar(t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
+        return;
+      }
     }
 
     const url = URL.createObjectURL(imageFile);
@@ -149,7 +141,7 @@ export default function ImageUploadCapture({
   return (
     <>
       {showFileSizeExceedsModal && (
-        <FileSizeExceedModal size={5} dismissModal={() => setShowFileSizeExceedsModal(false)} />
+        <FileSizeExceedModal size={50} dismissModal={() => setShowFileSizeExceedsModal(false)} />
       )}
 
       <div className={styles.section}>

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -86,7 +86,7 @@ export default function ImageUploadCapture({
     };
   }, [localUrl]);
 
-  const handleFile = async (file: File, option?: { compress?: boolean }) => {
+  const handleFile = async (file: File) => {
     if (!isImageFile(file)) {
       dispatch(enqueueErrorSnackbar(t('UPLOADER.UNSUPPORTED_FILE_TYPE')));
       return;
@@ -95,35 +95,34 @@ export default function ImageUploadCapture({
     let imageFile: File = file;
 
     if (file.size > 5e6) {
-      if (option?.compress) {
-        try {
-          const blob = await compressImage(file);
+      try {
+        const blob = await compressImage(file);
 
-          if (blob.size > 5e6) {
-            setShowFileSizeExceedsModal(true);
-            return;
-          }
-
-          imageFile = new File([blob], file.name, { type: blob.type });
-        } catch {
-          console.error('Image compression failed');
+        if (blob.size > 5e6) {
+          setShowFileSizeExceedsModal(true);
           return;
         }
-      } else {
-        setShowFileSizeExceedsModal(true);
+
+        imageFile = new File([blob], file.name, { type: blob.type });
+      } catch {
+        console.error('Image compression failed');
         return;
       }
+    } else {
+      setShowFileSizeExceedsModal(true);
+      return;
     }
+
     const url = URL.createObjectURL(imageFile);
     setLocalUrl(url);
     onSelectImage(imageFile);
   };
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>, option?: { compress?: boolean }) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files?.length) {
       return;
     }
-    handleFile(e.target.files[0], option);
+    handleFile(e.target.files[0]);
     e.target.value = '';
   };
 
@@ -210,7 +209,7 @@ export default function ImageUploadCapture({
                 <PureFilePickerWrapper
                   accept="image/*"
                   capture="environment"
-                  onChange={(e) => handleChange(e, { compress: true })}
+                  onChange={handleChange}
                   className={styles.photoBtnWrapper}
                 >
                   <div className={styles.photoBtn}>

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -43,8 +43,8 @@ const compressImageWithQuality = async (file: File, quality: number): Promise<Bl
   return new Promise((resolve, reject) => {
     new Compressor(file, {
       quality,
-      maxWidth: 1920,
-      maxHeight: 1920,
+      maxWidth: 2560,
+      maxHeight: 2560,
       checkOrientation: false,
       success: resolve,
       error: reject,

--- a/packages/webapp/src/components/ImageUploadCapture/index.tsx
+++ b/packages/webapp/src/components/ImageUploadCapture/index.tsx
@@ -35,17 +35,7 @@ const compressImage = async (file: File): Promise<Blob> => {
     return file;
   }
 
-  let quality = 0.8;
-  let compressedFile: Blob = file;
-
-  while (quality > 0) {
-    compressedFile = await compressImageWithQuality(file, quality);
-    if (compressedFile.size < 5e6) {
-      return compressedFile;
-    }
-    quality -= 0.2;
-  }
-  return compressedFile; // return the best effort compressed image even if it still exceeds max size
+  return compressImageWithQuality(file, 0.8); // best-effort compression
 };
 
 const compressImageWithQuality = async (file: File, quality: number): Promise<Blob> => {
@@ -53,6 +43,9 @@ const compressImageWithQuality = async (file: File, quality: number): Promise<Bl
   return new Promise((resolve, reject) => {
     new Compressor(file, {
       quality,
+      maxWidth: 1920,
+      maxHeight: 1920,
+      checkOrientation: false,
       success: resolve,
       error: reject,
     });


### PR DESCRIPTION
**Description**

This PR adjusts the compressorjs logic within `<ImageUploadCapture />` to account for the following real-world cases that were discovered through QA and further testing with files from various devices:

1. The compression loop was taking an unreasonable amount of time on a mid-range older Android device (see videos in Jira ticket description + discussion thread) with its default settings of 64MP / 25-30MB per image
2. 5MB was a very unrealistic target for an image produced from a typical device! Even on my phone which is set to an un-adjustable 12.5MP, it is possible to take photos (in the normal photo app) that are > 6MB and cannot subsequently be uploaded. On the devices I checked with adjustable resolution settings, JPEGs were ranging from 25MB to 40MB to 60MB+ (Samsung Galaxy S24 Ultra)
3. Some filetypes available from the normal image file picker were hitting the `Image compression failed` catch block. This was DNG (RAW) on Android, and HEIC on MacOS Chrome. Note that Safari can compress both, and Imaginary can always handle both (i.e. they are perfectly fine filetypes to send to backend)

To handle the above:
- the `compressorjs` logic was adjusted to mostly deal in filesize instead of compression (it does still do an 0.8 compression pass, but only one)
- `checkOrientation` was set to false due to [this warning from the readme](https://github.com/fengyuanchen/compressorjs#checkorientation) -- I never saw a memory crash, but it seemed safer to follow the guideline!
> If the size of the target image is too large (e.g., greater than 10 MB), you should disable this option to avoid an out-of-memory crash.
- all images are now compressed, including file picker uploaded ones, so that the 5MB limit can be increased to something that covers the default for more phones
  - I've tentatively set this to 50MB and would like to discuss; note that the 40MB image I tested with compressed down to less than 1MB but this took 7 seconds with throttling. Denis's test image took ~4 sec with throttling and compressed to 1.6MB. I have not seen compression output larger than 2MB with the currently committed settings
- Hitting the "Image compression failed block" now triggers the wrong filetype snackbar; I never saw compressorjs fail for any other reason in my testing

Jira link: https://lite-farm.atlassian.net/browse/LF-5248

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [x] Other (please explain)

There is a logging patchfile included in the Jira ticket that can be run on integration's code.

This patchfile can be applied to this branch to log the compression time and output size. What I realize now after watching Denis' video is that is that we should probably be doing more of is logging with CPU throttling, not just network throttling!
[UPDATED-diagnostic-logging-image-compression.patch](https://github.com/user-attachments/files/27186289/UPDATED-diagnostic-logging-image-compression.patch)

If interested, I can share a testing kit to Slack with some different files and sizes I used (HEIC, DNG, large JPEGs) to test the compression behaviour, but if you have your own from different devices, even better!

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
