### PR TITLE
LF-5283: Show FAO TAPE on Beta

### DIFF
--- a/packages/webapp/src/containers/Insights/TapeSurvey/getSurveyVersion.ts
+++ b/packages/webapp/src/containers/Insights/TapeSurvey/getSurveyVersion.ts
@@ -24,7 +24,5 @@ const COUNTRY_VERSIONS = ['AU'];
  * 2. Add a country_code to `COUNTRY_VERSIONS`.
  */
 export const getSurveyVersion = (countryCode: string | undefined): string | undefined => {
-  return countryCode && COUNTRY_VERSIONS.includes(countryCode)
-    ? countryCode.toLowerCase()
-    : undefined;
+  return countryCode && COUNTRY_VERSIONS.includes(countryCode) ? countryCode.toLowerCase() : 'fao';
 };


### PR DESCRIPTION
**Description**

Update `getSurveyVersion` function to show FAO TAPE survey as default.

The file has been uploaded to the buckets for local/beta testing.

Jira link: https://lite-farm.atlassian.net/browse/LF-5283

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
