### PR TITLE
LF-5292 Finance transactions in Actual Revenue are displayed in random/unexpected sorting order

### DIFF
--- a/packages/api/src/controllers/saleController.js
+++ b/packages/api/src/controllers/saleController.js
@@ -152,6 +152,10 @@ const SaleController = {
         const sales = await SaleModel.query()
           .whereNotDeleted()
           .where({ farm_id })
+          .orderBy([
+            { column: 'sale_date', order: 'desc' },
+            { column: 'sale_id', order: 'desc' },
+          ])
           .withGraphFetched('[crop_variety_sale, animal_sale]');
         if (!sales.length) {
           // Craig: I think this should return 200 otherwise we get an error in Finances front end, i changed it xD


### PR DESCRIPTION
**Description**

The Actual Revenue list is constructed (via `mapSalesToRevenueItems`) from a filter on `saleSelector`, which just returns the Redux data populated from the API return. Since the API return was unsorted, the Actual Revenue list was as well.

This sorts the API response by date (and secondarily, by `sale_id`) so that newer sales are returned at top. The result is a sorted list in Actual Revenue. Also, as a slight UX improvement, within a single given date in the transaction list, the sale that was created later will now be at the top. Nothing else on the frontend consumes the `salesSelector` and will be affected by this change.

Jira link: https://lite-farm.atlassian.net/browse/LF-5292

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
