### PR TITLE
LF-5294 Missing frontend validation for notes field causes 400 error and generic failure message

### DIFF
--- a/packages/api/db/migration/20260520200700_change_sale_note_to_text.js
+++ b/packages/api/db/migration/20260520200700_change_sale_note_to_text.js
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.alterTable('sale', (table) => {
+    table.text('note').alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  await knex.schema.alterTable('sale', (table) => {
+    table.string('note', 255).alter();
+  });
+};

--- a/packages/api/src/models/saleModel.js
+++ b/packages/api/src/models/saleModel.js
@@ -43,7 +43,7 @@ class Sale extends baseModel {
         farm_id: { type: 'string' },
         revenue_type_id: { type: 'integer' },
         value: { type: ['number', 'null'], format: 'float' },
-        note: { type: ['string', 'null'], maxLength: 10000 },
+        note: { type: ['string', 'null'], maxLength: 3000 },
         ...this.baseProperties,
       },
       additionalProperties: false,


### PR DESCRIPTION
**Description**

The notes field of the `sale` table was defined with `table.string(columnName, length)` which defaults to 255 when length is omitted. Unlike the model validation error in #4174, this one triggered a Postgres error because the model was more permissive than both the frontend and the DB.

Our more recent pattern is to use `table.text(columnName)` for these text area fields (e.g, in farmNotes, marketDirectoryInfo) which doesn't supply a DB-enforced character limit, and then to cap both frontend and model at `3000`. This harmonizes the sale notes field with that pattern.

Jira link: https://lite-farm.atlassian.net/browse/LF-5294

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
