### PR TITLE
LF-5284 Finance: Newly created transaction not visible under "Year To Date" filter until filter is changed

### DIFF
--- a/packages/webapp/src/components/DateRangeSelector/useDateRange.ts
+++ b/packages/webapp/src/components/DateRangeSelector/useDateRange.ts
@@ -20,7 +20,9 @@ import { MONDAY, SUNDAY } from '../../util/dateRange';
 
 /**
  * Returns startDate and endDate in state (local or Redux).
- * If they are not defined initially, set them using the DateRange utility class.
+ * For any semantic option (e.g. YEAR_TO_DATE), the dates are recomputed on mount
+ * from the current date so they do not go stale when the underlying state is
+ * persisted (e.g. via Redux Persist) across days. CUSTOM ranges are left as-is.
  */
 
 interface useDateRangeProps {
@@ -40,9 +42,9 @@ export default function useDateRange({
   const option = dateRange.option || defaultOption;
 
   useEffect(() => {
-    if ((!dateRange.startDate || !dateRange.endDate) && option !== DateRangeOptions.CUSTOM) {
+    if (option !== DateRangeOptions.CUSTOM) {
       const { startDate, endDate } = dateRangeUtil.getDates(option);
-      updateDateRange({ option: option, startDate, endDate });
+      updateDateRange({ option, startDate, endDate });
     }
   }, []);
 


### PR DESCRIPTION
**Description**

The initial calculation of dates that runs on first mount / first render of `useDateRange` was being skipped if `startDate` and `endDate` were provided, which means the date ranges could become indefinitely stale (i.e. would not be re-computed without logout or switching the date dropdown option).

For finances (unlike sensor readings) these values are persisted in Redux, meaning this initial mount `useEffect` action was never re-running.

Since relative dates ("Last week" etc.) need to be recomputed relative to the current date, this part of the conditional was removed. Therefore the dates will be calculated a bit more often with this code change, but this is definitely preferable to them going stale!

Jira link: https://lite-farm.atlassian.net/browse/LF-5284

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I didn't really test, honestly. To test organically you would need to have not switched your date range selector over a date boundary, which I had not done. Maybe there is another way to mimic this situation but I was not that clever about it 😅

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
