### PR TITLE
LF-5318 (2) Address 'null' user.language_preference for newly invited users

### DIFF
--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -413,12 +413,10 @@ const userFarmController = {
     return async (req, res) => {
       let result;
       const { user_id, farm_id } = req.auth;
-      const { language_preference } = req.body;
+
+      // A new invitee has a uuid id and no password record yet
       if (!/^\d+$/.test(user_id)) {
-        const user = await UserModel.query()
-          .findById(user_id)
-          .patch({ language_preference })
-          .returning('*');
+        const user = await UserModel.query().findById(user_id);
         const passwordRow = await PasswordModel.query().findById(user_id);
         if (!passwordRow || user.status_id === 2) {
           return res.status(404).send('User does not exist');

--- a/packages/api/src/models/emailTokenModel.js
+++ b/packages/api/src/models/emailTokenModel.js
@@ -90,6 +90,7 @@ class emailTokenModel extends Model {
         token = await createToken('invite', {
           ...user,
           ...userFarm,
+          language_preference: user.language_preference,
           invitation_id: emailToken.invitation_id,
         });
       } else {
@@ -105,6 +106,7 @@ class emailTokenModel extends Model {
         token = await createToken('invite', {
           ...user,
           ...userFarm,
+          language_preference: user.language_preference,
           invitation_id: emailToken.invitation_id,
         });
       }
@@ -121,7 +123,7 @@ class emailTokenModel extends Model {
       user.email,
       {
         sender,
-        buttonLink: `/callback/?invite_token=${token}&language=${user.language_preference}`,
+        buttonLink: `/callback/?invite_token=${token}`,
       },
     );
   }

--- a/packages/webapp/src/containers/Callback/index.jsx
+++ b/packages/webapp/src/containers/Callback/index.jsx
@@ -17,7 +17,6 @@ function Callback() {
       dispatch(
         patchUserFarmStatus({
           invite_token: params.get('invite_token'),
-          language: params.get('language'),
         }),
       );
     } else {

--- a/packages/webapp/src/containers/Callback/saga.js
+++ b/packages/webapp/src/containers/Callback/saga.js
@@ -50,7 +50,7 @@ export function* validateResetTokenSaga({ payload: { reset_token } }) {
 export const patchUserFarmStatus = createAction('patchUserFarmStatusSaga');
 
 export function* patchUserFarmStatusSaga({ payload }) {
-  const { invite_token, language } = payload;
+  const { invite_token } = payload;
   try {
     const result = yield call(
       axios.patch,
@@ -76,13 +76,11 @@ export function* patchUserFarmStatusSaga({ payload }) {
     history.push('/consent');
   } catch (e) {
     if (e?.response?.status === 404) {
-      // and message === 'user does not exist
-      console.log(e);
+      // user does not exist yet; the invite token carries the sender's selected language
+      const language = decodeToken(invite_token)?.language_preference || 'en';
       localStorage.setItem('litefarm_lang', language);
-      const requestedLang = getLanguageFromLocalStorage();
-      const targetLang = i18n.options.supportedLngs?.includes(requestedLang) ? requestedLang : 'en';
-      if (i18n.language !== targetLang) {
-        i18n.changeLanguage(targetLang);
+      if (i18n.language !== language) {
+        i18n.changeLanguage(language);
       }
       history.push('/accept_invitation/sign_up', invite_token);
     } else if (e?.response?.status === 401) {


### PR DESCRIPTION
**Description**

Unfortunately I came to the wrong conclusion on #4186 this morning! The fact that there is no `'null'` `language_preference` records on beta or prod was because the ability to create them came from the LF-5318 change. After that change, 100% of invited new accounts will show that pattern, so it needs to be fixed before patch.

There were a lot of errors in this invite account creation flow, but the closest proximate cause was the failure of this line:

```js
// containers/Callback/index.jsx
patchUserFarmStatus({
  invite_token: params.get('invite_token'),
  language: params.get('language'), // <-- always returns null
 }),
 ```
It looks like that params.get() fails because of how the `&language` is escaped, but I don't know if that is a change that happened since this logic was first written, or if it has never worked.

When language can't be taken from the URL like this, the saga payload language is also null, and `litefarm_lang` gets set as `'null'` in `patchUserFarmStatusSaga()`:
 
```js
// containers/Callback/saga.js
const { invite_token, language } = payload;

// ...
localStorage.setItem('litefarm_lang', language); // <-- local storage value now string 'null'
i18n.changeLanguage(language) // <-- original code; overwrites value to 'en'
```

When i18n.changeLanguage was changed to be called conditionally, that changeLanguage was skipped and the local storage value was never overwritten, exposing this bug.

One side effect of this is that what looks like the intended language setting (= matching the language selected for the invite email, in the case of a new account) was never applied. After accepting an invite, no matter the language of the invite email, the LiteFarm UI is rendered in English.

_This PR will repair that, so now LiteFarm show the accept invitation UI in the same language as the accept invitation email._

### Summary of Changes
- removes the failing language param (no longer appends it, and no longer reads it)
- updates the `language_preference` already passed in the invite token to the one that matches the inviting language
- removes a misleading destructure and no no-op patch in `userFarmController.js` to make the actual behaviour of the flow more transparent

Jira link: https://lite-farm.atlassian.net/browse/LF-5318

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested SSO + password account creation via invites to trace language in this flow.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
