### PR TITLE
LF-5328: Show expense allocations in transaction list

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1104,6 +1104,7 @@
       "REVENUE_TYPES": "Search revenue type"
     },
     "TRANSACTION": {
+      "AMOUNT_UNATTRIBUTED": "Amount unattributed",
       "ANIMALS": "Animals",
       "CROPS": "Crops",
       "DAILY_TOTAL": "DAILY TOTAL",

--- a/packages/webapp/src/components/Finances/Transaction/ExpandedContent/GeneralTransactionTable.jsx
+++ b/packages/webapp/src/components/Finances/Transaction/ExpandedContent/GeneralTransactionTable.jsx
@@ -19,20 +19,19 @@ import { TableKind } from '../../../Table/types';
 import { transactionTypeEnum } from '../../../../containers/Finances/useTransactions';
 
 const formatData = (t, data) => {
-  const formattedData = {
-    [transactionTypeEnum.revenue]: {
+  if (data.transactionType === transactionTypeEnum.revenue) {
+    return {
       titleLabel: t('FINANCES.REVENUE'),
       amountLabel: t('common:AMOUNT'),
       tableData: data.items,
-    },
-    [transactionTypeEnum.expense]: {
-      titleLabel: t('FINANCES.EXPENSES'),
-      amountLabel: t('FINANCES.COST'),
-      tableData: [{ title: data.note, amount: data.amount }],
-    },
-  };
+    };
+  }
 
-  return formattedData[data.transactionType];
+  return {
+    titleLabel: t('FINANCES.EXPENSES'),
+    amountLabel: t('FINANCES.COST'),
+    tableData: data.items,
+  };
 };
 
 const getColumns = (mobileView, currencySymbol, titleLabel, amountLabel) => [
@@ -48,7 +47,10 @@ const getColumns = (mobileView, currencySymbol, titleLabel, amountLabel) => [
     id: 'amount',
     label: amountLabel,
     align: 'right',
-    format: (d) => currencySymbol + Math.abs(d.amount).toFixed(2),
+    format: (d) => {
+      const sign = d.amount < 0 ? '-' : '';
+      return sign + currencySymbol + Math.abs(d.amount).toFixed(2);
+    },
     columnProps: {
       style: { width: '150px', paddingRight: `${mobileView ? 9 : 75}px` },
     },

--- a/packages/webapp/src/containers/Finances/useTransactions.js
+++ b/packages/webapp/src/containers/Finances/useTransactions.js
@@ -28,7 +28,13 @@ import { userFarmsByFarmSelector } from '../userFarmSlice';
 import { useGetAnimalsQuery, useGetAnimalBatchesQuery } from '../../store/api/apiSlice';
 import { LABOUR_ITEMS_GROUPING_OPTIONS } from './constants';
 import { allExpenseTypeSelector, expenseSelector, salesSelector } from './selectors';
-import { isAnimalSale, isCropSale, mapSalesToRevenueItems, mapTasksToLabourItems } from './util';
+import {
+  isAnimalSale,
+  isCropSale,
+  mapSalesToRevenueItems,
+  mapTasksToLabourItems,
+  generateExpenseItems,
+} from './util';
 
 export const transactionTypeEnum = {
   expense: 'EXPENSE',
@@ -104,7 +110,15 @@ const getRevenueTypeLabel = (revenueType) => {
     : i18n.t(`revenue:${revenueType?.revenue_translation_key}.REVENUE_NAME`);
 };
 
-const buildExpenseTransactions = ({ expenses, expenseTypes, dateFilter, expenseTypeFilter }) => {
+const buildExpenseTransactions = ({
+  expenses,
+  expenseTypes,
+  dateFilter,
+  expenseTypeFilter,
+  cropVarieties,
+  animals,
+  animalBatches,
+}) => {
   return expenses
     .filter(
       (expense) =>
@@ -118,13 +132,14 @@ const buildExpenseTransactions = ({ expenses, expenseTypes, dateFilter, expenseT
         (expenseType) => expenseType?.expense_type_id === expense.expense_type_id,
       );
       return {
-        icon: expenseType?.farm_id ? 'OTHER' : (expenseType?.expense_translation_key ?? 'OTHER'),
+        icon: expenseType?.farm_id ? 'OTHER' : expenseType?.expense_translation_key ?? 'OTHER',
         date: expense.expense_date,
         transactionType: transactionTypeEnum.expense,
         typeLabel: getExpenseTypeLabel(expenseType),
         amount: -roundToTwoDecimal(expense.value),
         note: expense.note,
         relatedId: expense.farm_expense_id,
+        items: generateExpenseItems(expense, cropVarieties, animals, animalBatches),
       };
     });
 };
@@ -168,7 +183,7 @@ const buildRevenueTransactions = ({
       (revenueType) => revenueType?.revenue_type_id == item.sale.revenue_type_id,
     );
     return {
-      icon: revenueType?.farm_id ? 'CUSTOM' : (revenueType?.revenue_translation_key ?? 'CUSTOM'),
+      icon: revenueType?.farm_id ? 'CUSTOM' : revenueType?.revenue_translation_key ?? 'CUSTOM',
       date: item.sale.sale_date,
       transactionType: getRevenueTransactionType(revenueType),
       typeLabel: getRevenueTypeLabel(revenueType),
@@ -203,7 +218,15 @@ export const buildTransactions = ({
       dateFilter,
       expenseTypeFilter,
     }),
-    ...buildExpenseTransactions({ expenses, expenseTypes, dateFilter, expenseTypeFilter }),
+    ...buildExpenseTransactions({
+      expenses,
+      expenseTypes,
+      dateFilter,
+      expenseTypeFilter,
+      cropVarieties,
+      animals,
+      animalBatches,
+    }),
     ...buildRevenueTransactions({
       sales,
       revenueTypes,

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -157,6 +157,30 @@ export const mapTasksToLabourItems = (tasks, taskTypes, users) => {
   return labourItemGroups;
 };
 
+export const generateExpenseItems = (expense, cropVarieties, animals, animalBatches) => {
+  const { farm_expense_animal, farm_expense_crop_variety } = expense;
+
+  if (farm_expense_animal?.length > 0) {
+    return farm_expense_animal.map((animalExpense) => {
+      return {
+        title: getAnimalBatchLabel(animalExpense, animals, animalBatches),
+        amount: animalExpense.allocated_value,
+      };
+    });
+  }
+
+  if (farm_expense_crop_variety?.length > 0) {
+    return farm_expense_crop_variety.map(({ crop_variety_id, allocated_value }) => {
+      const cropVariety = cropVarieties.find(
+        (cropVariety) => cropVariety.crop_variety_id === crop_variety_id,
+      );
+      return { title: formatCropVarietyLabel(cropVariety), amount: allocated_value };
+    });
+  }
+
+  return [{ title: expense.note, amount: -roundToTwoDecimal(expense.value) }];
+};
+
 export const mapSalesToRevenueItems = (
   sales,
   revenueTypes,

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -160,25 +160,40 @@ export const mapTasksToLabourItems = (tasks, taskTypes, users) => {
 export const generateExpenseItems = (expense, cropVarieties, animals, animalBatches) => {
   const { farm_expense_animal, farm_expense_crop_variety } = expense;
 
-  if (farm_expense_animal?.length > 0) {
-    return farm_expense_animal.map((animalExpense) => {
-      return {
-        title: getAnimalBatchLabel(animalExpense, animals, animalBatches),
-        amount: -animalExpense.allocated_value,
-      };
-    });
+  if (!farm_expense_animal?.length && !farm_expense_crop_variety?.length) {
+    return [{ title: expense.note, amount: -expense.value }];
   }
 
-  if (farm_expense_crop_variety?.length > 0) {
-    return farm_expense_crop_variety.map(({ crop_variety_id, allocated_value }) => {
+  const items = [];
+  let sum = 0;
+
+  if (farm_expense_animal?.length > 0) {
+    farm_expense_animal.forEach((animalExpense) => {
+      items.push({
+        title: getAnimalBatchLabel(animalExpense, animals, animalBatches),
+        amount: -animalExpense.allocated_value,
+      });
+      sum += animalExpense.allocated_value;
+    });
+  } else {
+    farm_expense_crop_variety.forEach(({ crop_variety_id, allocated_value }) => {
       const cropVariety = cropVarieties.find(
         (cropVariety) => cropVariety.crop_variety_id === crop_variety_id,
       );
-      return { title: formatCropVarietyLabel(cropVariety), amount: -allocated_value };
+      items.push({ title: formatCropVarietyLabel(cropVariety), amount: -allocated_value });
+      sum += allocated_value;
     });
   }
 
-  return [{ title: expense.note, amount: -roundToTwoDecimal(expense.value) }];
+  const unAllocatedAmount = expense.value - sum;
+  if (unAllocatedAmount) {
+    items.push({
+      title: i18n.t('FINANCES.TRANSACTION.AMOUNT_UNATTRIBUTED'),
+      amount: -unAllocatedAmount,
+    });
+  }
+
+  return items;
 };
 
 export const mapSalesToRevenueItems = (

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -30,15 +30,15 @@ import {
   SALE_VALUE,
   VALUE,
 } from '../../components/Forms/RevenueForm/constants';
-import { chooseIdentification } from '../Animals/utils';
 import i18n from '../../locales/i18n';
 import { getMass, getMassUnit, roundToTwoDecimal } from '../../util';
 import { isSameDay } from '../../util/date-migrate-TS';
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
 import { LABOUR_ITEMS_GROUPING_OPTIONS } from './constants';
 import { transactionTypeEnum } from './useTransactions';
-import { parseInventoryId } from '../../util/animal';
+import { getAnimalBatchLabel, parseInventoryId } from '../../util/animal';
 import { AnimalOrBatchKeys } from '../Animals/types';
+import { formatCropVarietyLabel } from '../../util/crop';
 
 // Polyfill for tests and older browsers
 const groupBy = typeof Object.groupBy === 'function' ? Object.groupBy : lodashGroupBy;
@@ -180,14 +180,9 @@ export const mapSalesToRevenueItems = (
             const cropVariety = cropVarieties.find(
               (cropVariety) => cropVariety.crop_variety_id === cvs.crop_variety_id,
             );
-            const cropVarietyName = cropVariety?.crop_variety_name;
-            const cropTranslationKey = cropVariety?.crop.crop_translation_key;
-            const title = cropVarietyName
-              ? `${cropVarietyName}, ${i18n.t(`crop:${cropTranslationKey}`)}`
-              : i18n.t(`crop:${cropTranslationKey}`);
             return {
               key: cvs.crop_variety_id,
-              title,
+              title: formatCropVarietyLabel(cropVariety),
               subtitle: `${convertedQuantity} ${quantityUnit}`,
               quantity: convertedQuantity,
               quantityUnit,
@@ -205,18 +200,11 @@ export const mapSalesToRevenueItems = (
         financeItemsProps: animalSale
           .map((row) => {
             const convertedQuantity = roundToTwoDecimal(getMass(row.quantity).toString());
-            const matched =
-              row.animal_id != null
-                ? animals.find((a) => a.id === row.animal_id)
-                : animalBatches.find((b) => b.id === row.animal_batch_id);
-            const title = matched
-              ? chooseIdentification(matched)
-              : (row.animal_id ?? row.animal_batch_id);
             const key =
               row.animal_id != null ? `animal_${row.animal_id}` : `batch_${row.animal_batch_id}`;
             return {
               key,
-              title,
+              title: getAnimalBatchLabel(row, animals, animalBatches),
               subtitle: `${convertedQuantity} ${quantityUnit}`,
               quantity: convertedQuantity,
               quantityUnit,

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -221,7 +221,10 @@ export const mapSalesToRevenueItems = (
             );
             return {
               key: cvs.crop_variety_id,
-              title: formatCropVarietyLabel(cropVariety),
+              title: formatCropVarietyLabel({
+                crop_variety_name: cropVariety?.crop_variety_name,
+                crop_translation_key: cropVariety?.crop.crop_translation_key,
+              }),
               subtitle: `${convertedQuantity} ${quantityUnit}`,
               quantity: convertedQuantity,
               quantityUnit,

--- a/packages/webapp/src/containers/Finances/util.js
+++ b/packages/webapp/src/containers/Finances/util.js
@@ -164,7 +164,7 @@ export const generateExpenseItems = (expense, cropVarieties, animals, animalBatc
     return farm_expense_animal.map((animalExpense) => {
       return {
         title: getAnimalBatchLabel(animalExpense, animals, animalBatches),
-        amount: animalExpense.allocated_value,
+        amount: -animalExpense.allocated_value,
       };
     });
   }
@@ -174,7 +174,7 @@ export const generateExpenseItems = (expense, cropVarieties, animals, animalBatc
       const cropVariety = cropVarieties.find(
         (cropVariety) => cropVariety.crop_variety_id === crop_variety_id,
       );
-      return { title: formatCropVarietyLabel(cropVariety), amount: allocated_value };
+      return { title: formatCropVarietyLabel(cropVariety), amount: -allocated_value };
     });
   }
 

--- a/packages/webapp/src/tests/buildTransactions.test.jsx
+++ b/packages/webapp/src/tests/buildTransactions.test.jsx
@@ -244,6 +244,7 @@ const allResults = [
     amount: -20,
     note: 'Expense 2',
     relatedId: 'c239a46a-69e6-11ee-8e6f-0242ac180006',
+    items: [{ amount: -20, title: 'Expense 2' }],
   },
   {
     icon: 'LABOUR',
@@ -280,6 +281,7 @@ const allResults = [
     amount: -100,
     note: 'Expense 3',
     relatedId: '39bc4644-6e8a-11ee-a583-0242ac180005',
+    items: [{ amount: -100, title: 'Expense 3' }],
   },
   {
     icon: 'CROP_SALE',
@@ -338,6 +340,7 @@ const allResults = [
     amount: -10,
     note: 'Expense 1',
     relatedId: 'aff01e2e-69e6-11ee-9b0c-0242ac180006',
+    items: [{ amount: -10, title: 'Expense 1' }],
   },
   {
     icon: 'CROP_SALE',

--- a/packages/webapp/src/util/animal.ts
+++ b/packages/webapp/src/util/animal.ts
@@ -22,6 +22,7 @@ import type {
   AnimalBatch,
 } from '../store/api/types';
 import { ANIMAL_ID_PREFIX, AnimalOrBatchKeys } from '../containers/Animals/types';
+import { chooseIdentification } from '../containers/Animals/utils';
 
 /**
  * Generates a unique ID based on the given type or breed entity.
@@ -77,4 +78,21 @@ export const generateInventoryId = (
 export const parseInventoryId = (inventoryId: string): { kind: AnimalOrBatchKeys; id: number } => {
   const [kind, id] = inventoryId.split('_');
   return { kind: kind as AnimalOrBatchKeys, id: Number(id) };
+};
+
+export const getAnimalBatchLabel = (
+  {
+    animal_id,
+    animal_batch_id,
+  }: {
+    animal_id: number | null;
+    animal_batch_id: number | null;
+  },
+  animals: Animal[],
+  animalBatches: AnimalBatch[],
+) => {
+  const matched = animal_id
+    ? animals.find((a) => a.id === animal_id)
+    : animalBatches.find((b) => b.id === animal_batch_id);
+  return matched ? chooseIdentification(matched) : animal_id ?? animal_batch_id;
 };


### PR DESCRIPTION
**Description**

- Update `buildExpenseTransactions` to format allocations.
- Update the transaction table amount column format to display expenses as `-${currency}${amount}`.
- Extract `getAnimalBatchLabel` function into a utility function.
- Replace logic in `mapSalesToRevenueItems` with utility functions.

Jira link: https://lite-farm.atlassian.net/browse/LF-5328

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
