### PR TITLE
LF-5297 Incorrect labels displayed when creating and viewing crops and crop varieties

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -517,6 +517,7 @@
   },
   "CROP": {
     "ADD_CROP": "Add a crop",
+    "ADD_CROP_VARIETY": "Add a crop variety",
     "ADD_IMAGE": "Add Custom Image",
     "ANNUAL": "Annual",
     "ANNUAL_OR_PERENNIAL": "Is the crop an annual or perennial?",

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -621,7 +621,8 @@
       "UNABLE_TO_RETIRE": "You can only retire crops that have no active or future crop plans. You'll need to complete or abandon those plans to retire this crop",
       "UNABLE_TO_RETIRE_TITLE": "Unable to retire"
     },
-    "SUPPLIER": "Supplier"
+    "SUPPLIER": "Supplier",
+    "TITLE": "{{crop_name}} varieties"
   },
   "DATE_RANGE": {
     "INVALID_RANGE_MESSAGE": "End date must be after start date to return results"

--- a/packages/webapp/src/components/AddCropVariety/ComplianceInfo/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/ComplianceInfo/index.jsx
@@ -19,6 +19,7 @@ export default function ComplianceInfo({
   useHookFormPersist,
   match,
   crop,
+  isNewCrop,
 }) {
   const { t } = useTranslation(['translation', 'common', 'crop']);
   const CERTIFIED_ORGANIC = 'organic';
@@ -64,7 +65,7 @@ export default function ComplianceInfo({
       <MultiStepPageTitle
         onGoBack={onGoBack}
         onCancel={historyCancel}
-        title={t('CROP.ADD_CROP')}
+        title={isNewCrop ? t('CROP.ADD_CROP') : t('CROP.ADD_CROP_VARIETY')}
         value={progress}
         style={{
           marginBottom: '23px',

--- a/packages/webapp/src/components/AddCropVariety/index.jsx
+++ b/packages/webapp/src/components/AddCropVariety/index.jsx
@@ -24,6 +24,7 @@ export default function PureAddCropVariety({
   imageUploader,
   handleGoBack,
   farmCropVarieties,
+  isNewCrop,
 }) {
   const { t } = useTranslation(['translation', 'common', 'crop']);
   const COMMON_NAME = 'crop_variety_name';
@@ -122,7 +123,7 @@ export default function PureAddCropVariety({
         style={{ marginBottom: '24px' }}
         onGoBack={handleGoBack}
         onCancel={historyCancel}
-        title={t('CROP.ADD_CROP')}
+        title={isNewCrop ? t('CROP.ADD_CROP') : t('CROP.ADD_CROP_VARIETY')}
         value={progress}
       />
 

--- a/packages/webapp/src/components/Crop/CropHeader.jsx
+++ b/packages/webapp/src/components/Crop/CropHeader.jsx
@@ -38,7 +38,7 @@ function CropHeader({ variety, onBackClick }) {
         <div className={styles.headerTitleContainer} onClick={onBackClick}>
           <Back style={{ verticalAlign: 'text-bottom' }} />
           <Title className={clsx(styles.headerTitle, styles.textOverFlowBehaviour)}>
-            {t(`crop:${crop_translation_key}`)}
+            {crop_variety_name || t(`crop:${crop_translation_key}`)}
           </Title>
         </div>
         <div className={styles.headerAttributesContainer}>

--- a/packages/webapp/src/components/Crop/CropHeader.jsx
+++ b/packages/webapp/src/components/Crop/CropHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Label, Text, Title } from '../Typography';
 import { ReactComponent as Back } from '../../assets/images/managementPlans/back.svg';
 import { useTranslation } from 'react-i18next';

--- a/packages/webapp/src/components/CropTile/index.jsx
+++ b/packages/webapp/src/components/CropTile/index.jsx
@@ -101,6 +101,7 @@ PureCropTile.propTypes = {
     active: PropTypes.number,
     planned: PropTypes.number,
     completed: PropTypes.number,
+    noPlans: PropTypes.number,
   }),
   needsPlan: PropTypes.bool,
   title: PropTypes.string,

--- a/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
+++ b/packages/webapp/src/containers/AddCropVariety/AddCropVariety.jsx
@@ -66,6 +66,7 @@ function AddCropVarietyForm() {
         }
         handleGoBack={() => history.back()}
         farmCropVarieties={farmCropVarieties}
+        isNewCrop={isNewCrop}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/AddCropVariety/ComplianceInfo.jsx
+++ b/packages/webapp/src/containers/AddCropVariety/ComplianceInfo.jsx
@@ -48,6 +48,7 @@ function ComplianceInfoForm() {
         onGoBack={onGoBack}
         match={match}
         crop={crop}
+        isNewCrop={isNewCrop}
       />
     </HookFormPersistProvider>
   );

--- a/packages/webapp/src/containers/CropCatalogue/index.jsx
+++ b/packages/webapp/src/containers/CropCatalogue/index.jsx
@@ -15,10 +15,8 @@ import { useHistory } from 'react-router-dom';
 import { getCropsAndManagementPlans } from '../saga';
 import CropCatalogueFilterPage from '../Filter/CropCatalogue';
 import {
-  cropCatalogueFilterDateSelector,
   cropCatalogueFilterSelector,
   isFilterCurrentlyActiveSelector,
-  setCropCatalogueFilterDate,
   resetCropCatalogueFilter,
 } from '../filterSlice';
 import { isAdminSelector } from '../userFarmSlice';
@@ -69,9 +67,6 @@ export default function CropCatalogue() {
   const onFilterOpen = () => {
     setIsFilterOpen(true);
   };
-
-  const date = useSelector(cropCatalogueFilterDateSelector);
-  const setDate = (date) => dispatch(setCropCatalogueFilterDate(date));
 
   const cropCatalogueFilter = useSelector(cropCatalogueFilterSelector);
   const isFilterCurrentlyActive = useSelector(isFilterCurrentlyActiveSelector('cropCatalogue'));
@@ -130,8 +125,6 @@ export default function CropCatalogue() {
             <CropStatusInfoBox
               status={{ active, abandoned, completed, planned, noPlans }}
               style={{ marginBottom: '16px' }}
-              date={date}
-              setDate={setDate}
             />
             <PureCropTileContainer gap={gap} padding={padding}>
               {filteredCropsWithoutManagementPlan.map((cropVariety) => {

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -95,7 +95,7 @@ export default function CropVarieties() {
   return (
     <Layout>
       <PageTitle
-        title={`${t(`crop:${crop.crop_translation_key}`)} ${t('CROP_VARIETIES.CROP_VARIETIES')}`}
+        title={t(`crop:${crop.crop_translation_key}`)}
         style={{ paddingBottom: '20px' }}
         onGoBack={onGoBack}
       />

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -87,7 +87,7 @@ export default function CropVarieties() {
   return (
     <Layout>
       <PageTitle
-        title={t(`crop:${crop.crop_translation_key}`)}
+        title={t('CROP_VARIETIES.TITLE', { crop_name: t(`crop:${crop.crop_translation_key}`) })}
         style={{ paddingBottom: '20px' }}
         onGoBack={onGoBack}
       />

--- a/packages/webapp/src/containers/CropVarieties/index.jsx
+++ b/packages/webapp/src/containers/CropVarieties/index.jsx
@@ -12,12 +12,7 @@ import PureCropTileContainer from '../../components/CropTile/CropTileContainer';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import { getCropVarieties } from '../saga';
-import {
-  cropCatalogueFilterDateSelector,
-  cropVarietyFilterSelector,
-  isFilterCurrentlyActiveSelector,
-  setCropCatalogueFilterDate,
-} from '../filterSlice';
+import { cropVarietyFilterSelector, isFilterCurrentlyActiveSelector } from '../filterSlice';
 import { isAdminSelector } from '../userFarmSlice';
 import { resetAndUnLockFormData } from '../hooks/useHookFormPersist/hookFormPersistSlice';
 import CropVarietyFilterPage from '../Filter/CropVariety';
@@ -78,9 +73,6 @@ export default function CropVarieties() {
     setIsFilterOpen(true);
   };
 
-  const date = useSelector(cropCatalogueFilterDateSelector);
-  const setDate = (date) => dispatch(setCropCatalogueFilterDate(date));
-
   const onGoBack = () => history.push('/crop_catalogue');
 
   const goToVarietyManagement = (varietyId) => {
@@ -121,8 +113,6 @@ export default function CropVarieties() {
         />
       )}
 
-      {/* <CropStatusInfoBox style={{ marginBottom: '16px' }} date={date} setDate={setDate} /> */}
-
       <div ref={containerRef}>
         {sum + filteredCropsWithoutManagementPlan.length ? (
           <>
@@ -130,8 +120,6 @@ export default function CropVarieties() {
             <CropStatusInfoBox
               status={{ active, abandoned, completed, planned, noPlans }}
               style={{ marginBottom: '16px' }}
-              date={date}
-              setDate={setDate}
             />
             <PureCropTileContainer gap={gap} padding={padding}>
               {filteredCropsWithoutManagementPlan.map((cropVariety) => {

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -81,8 +81,8 @@ const AddSensorsForm = React.lazy(() => import('../containers/AddSensors'));
 
 const CropCatalogue = React.lazy(() => import('../containers/CropCatalogue'));
 const CropVarieties = React.lazy(() => import('../containers/CropVarieties'));
-const AddCrop = React.lazy(() => import('../containers/AddCropVariety/AddCropVariety'));
-const EditCrop = React.lazy(() => import('../containers/EditCropVariety'));
+const AddCropVariety = React.lazy(() => import('../containers/AddCropVariety/AddCropVariety'));
+const EditCropVariety = React.lazy(() => import('../containers/EditCropVariety'));
 const ComplianceInfo = React.lazy(() => import('../containers/AddCropVariety/ComplianceInfo'));
 const AddNewCrop = React.lazy(() => import('../containers/AddNewCrop'));
 const PlantingLocation = React.lazy(
@@ -298,7 +298,11 @@ const Routes = ({ isCompactSideMenu }) => {
                     <Route path="/user/:user_id" exact children={<EditUser />} />
                     <Route path="/consent" exact children={<ConsentForm />} />
                     <Route path="/crop/new" exact children={<AddNewCrop />} />
-                    <Route path="/crop/:crop_id/add_crop_variety" exact children={<AddCrop />} />
+                    <Route
+                      path="/crop/:crop_id/add_crop_variety"
+                      exact
+                      children={<AddCropVariety />}
+                    />
                     <Route
                       path="/crop/:crop_id/add_crop_variety/compliance"
                       exact
@@ -313,7 +317,7 @@ const Routes = ({ isCompactSideMenu }) => {
                     <Route
                       path="/crop/:variety_id/edit_crop_variety"
                       exact
-                      children={<EditCrop />}
+                      children={<EditCropVariety />}
                     />
                     <Route
                       path="/crop/:variety_id/add_management_plan/planted_already"
@@ -790,7 +794,7 @@ const Routes = ({ isCompactSideMenu }) => {
                     <Route
                       path="/crop/:variety_id/edit_crop_variety"
                       exact
-                      children={<EditCrop />}
+                      children={<EditCropVariety />}
                     />
                     <Route path="/documents" exact children={<Documents />} />
                     <Route path="/documents/add_document" exact children={<AddDocument />} />
@@ -826,7 +830,11 @@ const Routes = ({ isCompactSideMenu }) => {
                     <Route path="/sensor_array/:id" exact>
                       <SensorReadings type={'sensor_array'} />
                     </Route>
-                    <Route path="/crop/:crop_id/add_crop_variety" exact children={<AddCrop />} />
+                    <Route
+                      path="/crop/:crop_id/add_crop_variety"
+                      exact
+                      children={<AddCropVariety />}
+                    />
                     <Route
                       path="/crop/:crop_id/add_crop_variety/compliance"
                       exact


### PR DESCRIPTION
**Description**

Adjusts the following:

- Form header updated from 'Add a crop' to 'Add a crop variety' when accessing that form page directly from "Add a new variety" link. The header remains 'Add crop' when this page appears as the second page in the 'Add crop' flow and the (already existing) `isNewCrop` value is passed to disambiguate these two cases.

<img width="400" alt="Add a crop variety header" src="https://github.com/user-attachments/assets/df86f483-9eaf-440d-91bf-1c71dab4d29e" />

- Header that incorrectly read `<crop name> variety` is corrected to `{{ crop_name }} varieties`. This was actually an error in the ENGLISH STRING (the key is correctly pluralized 'VARIETIES' but 'variety' was used). This error was propagated to all languages and had the following effects:
  - extremely confusing UX: you click on a crop tile, and are taken to the list of all varieties for that crop, but the header suggests you have somehow landed on a single variety!
  - without context, the Punjabi + Malayalam translators picked a word that means "diversity" (a synonym for 'variety') rather than the word that means varieties of the crop. I used AI to query the right term for those and I will fix manually on CrowdIn, since I don't think PA and ML are actively translated anymore (ditto German)

- The so-called `<CropHeader>` that is only shown at the top of pages referring to crop varieties now shows the Crop Variety name in the header since it was _never shown_. It appears to have been lost, via Product decision, in the redesign [implemented here](https://github.com/LiteFarmOrg/LiteFarm/pull/2577). But this makes no sense. The photo is the crop _variety_ and so is the page content. So I am now showing the Crop Variety in that header with Crop as fallback (since Crop Varieties can be empty strings). I consider this a more minor issue than the two above.
- A few dev cleanups: component imports in the routes file adjusted to match the component names (incorrectly named as Add/Edit Crop for containers that are actually Add/Edit Crop Variety) and cleaning up some longstanding console warnings on the Crop Catalogue page (will indicate in-line)

Jira link: https://lite-farm.atlassian.net/browse/LF-5297

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [x] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
