### PR TITLE
LF-5326 Newly created farm initially displays map data from previous farm until page refresh

### DIFF
--- a/packages/webapp/src/containers/AddFarm/saga.js
+++ b/packages/webapp/src/containers/AddFarm/saga.js
@@ -24,12 +24,10 @@ import {
   setLoadingStart,
   userFarmSelector,
 } from '../userFarmSlice';
-import { axios, getHeader, selectFarm } from '../saga';
+import { axios, clearOldFarmStateSaga, getHeader, selectFarmSaga } from '../saga';
 import { createAction } from '@reduxjs/toolkit';
 import i18n from '../../locales/i18n';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
-import { invalidateTags } from '../../store/api/apiSlice';
-import { FarmLibraryTags, FarmTags } from '../../store/api/apiTags';
 
 const patchRoleUrl = (farm_id, user_id) => `${userFarmUrl}/role/farm/${farm_id}/user/${user_id}`;
 const patchFarmUrl = (farm_id) => `${farmUrl}/owner_operated/${farm_id}`;
@@ -60,9 +58,6 @@ export function* postFarmSaga({ payload: { showFarmNameCharacterLimitExceededErr
     };
     yield call(axios.patch, patchStepUrl(farm_id, user_id), step, getHeader(user_id, farm_id));
 
-    // Clear old farm RTK Query data
-    yield put(invalidateTags([...FarmTags, ...FarmLibraryTags]));
-
     const user = getUserResult?.data;
     yield put(
       postFarmSuccess({
@@ -73,7 +68,8 @@ export function* postFarmSaga({ payload: { showFarmNameCharacterLimitExceededErr
         country_code: addFarmData.country,
       }),
     );
-    yield put(selectFarm({ farm_id }));
+    yield call(selectFarmSaga, { payload: { farm_id } });
+    yield call(clearOldFarmStateSaga);
     history.push('/role_selection');
   } catch (e) {
     yield put(setLoadingEnd());

--- a/packages/webapp/src/containers/taskSlice.js
+++ b/packages/webapp/src/containers/taskSlice.js
@@ -245,17 +245,20 @@ export const taskEntitiesSelector = createSelector(
         taskEntities[task_id].managementPlans =
           taskEntities[task_id].managementPlans?.map(getManagementPlanByPlantingManagementPlan) ||
           [];
+        // Drop location_ids with no cached location so tasksSelector never reads farm_id off undefined.
         taskEntities[task_id].locations =
-          taskEntities[task_id].locations?.map((location_id) => locationEntities[location_id]) ||
-          [];
+          taskEntities[task_id].locations
+            ?.map((location_id) => locationEntities[location_id])
+            .filter(Boolean) || [];
         const taskType = taskTypeEntities[taskEntities[task_id].task_type_id];
         taskEntities[task_id].taskType = taskType;
         const { task_translation_key, farm_id } = taskType;
         const subtask = subTaskEntities[task_id];
         !farm_id && (taskEntities[task_id][getSubtaskName(task_translation_key)] = subtask);
         if (!farm_id && ['PLANT_TASK', 'TRANSPLANT_TASK'].includes(task_translation_key)) {
+          // Keep the location only when its record is cached, so an unloaded location yields [] not [undefined].
           taskEntities[task_id].locations = subtask.planting_management_plan.location_id
-            ? [locationEntities[subtask.planting_management_plan.location_id]]
+            ? [locationEntities[subtask.planting_management_plan.location_id]].filter(Boolean)
             : [];
           taskEntities[task_id].managementPlans = [
             getManagementPlanByPlantingManagementPlan(subtask),

--- a/packages/webapp/src/store/api/locationApi.ts
+++ b/packages/webapp/src/store/api/locationApi.ts
@@ -24,6 +24,10 @@ export const locationApi = api.injectEndpoints({
       queryFn: async (_arg, { getState }, _extraOptions, baseQuery) => {
         const state = getState() as RootState;
         const farm_id = state.entitiesReducer.userFarmReducer.farm_id;
+        if (!farm_id) {
+          // Skip the request rather than calling /location/farm/undefined, which the backend rejects with a 403.
+          return { error: { status: 'CUSTOM_ERROR', error: 'No farm selected' } };
+        }
         const result = await baseQuery({
           url: `${getLocationsByFarmIdUrl(farm_id)}`,
           method: 'GET',


### PR DESCRIPTION
**Description**

The actual fix for both bugs is the [first commit](https://github.com/LiteFarmOrg/LiteFarm/pull/4199/changes/2ddd858bd43f038ac723782a97ff3b0dfea5f319); the changes in the second and third commits are defensive to prevent those two not-nice patterns (taskSlice crash by calling `undefined.farm_id` and hitting the backend with `location/farm/undefined`) from arising in different contexts.

As mentioned in the [Slack thread](https://litefarm.slack.com/archives/C05B9KJLJ82/p1781291743045359), the first bug (old farm's locations persist after creating a new farm) is due to the locations API being called with `/location/farm/undefined` and returning a 403. Because the response is an error, the old farm data persists in RTK Query rather than being overwritten as it would be by a `200 []`.

Although it's true that the locations query is subscribed at the time -- in fact, all of the queries called in saga with the `.initiate()` pattern appear to be never unsubscribed and this might be worth a follow-up PR -- I do want to note that it's not _because_ the queries are subscribed that they re-fetch on `invalidatesTags`. ALL invalidated queries refetch, it's just that the old data is additionally purged before refetch if the query is not subscribed at the time (see 6.i. in the [RTK query docs here](https://redux-toolkit.js.org/rtk-query/internal/buildMiddleware/invalidationByTags#core-sequence))

Edit: sorry let me correct that. The timing of the fetch is actually different and I was reading the docs wrong -- at the point of `invalidatesTags`, the unsubscribed queries are _just_ dumped., not dumped and refetched This will lead to refetch, but not at the time of invalidatesTags. Will become relevant in the follow-up PR I will open.

This PR makes the following changes to Add Farm:
- call selectFarmSaga first, so farm_id is populated before the data is refetched via tag invalidation, preventing the 'missing farm_id in headers' and undefined location path
- use the full `clearOldFarmStateSaga()` in place of the bare `invalidateTags`
  - this now matters specifically for the taskSlice (and is the reason that the task slice started crashing): specifically in that slice we are now combining non RTK-Query (task) and RTK Query (location) data, and just the second was being purged
  - clearOldFarmState additionally dumps tasks. This was not necessary before (in the non-Query Redux, multiple farms' data can happily coexist since it's filtered by login selector), but it's probably the better pattern as its more consistent with the switch farm flow anyway

Jira link: https://lite-farm.atlassian.net/browse/LF-5326 & https://lite-farm.atlassian.net/browse/LF-5325

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
