### PR TITLE
LF-5326 (2) Newly Created Farm Initially Displays Map Data from Previous Farm Until Page Refresh

### DIFF
--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -421,7 +421,10 @@ export const getCropsAndManagementPlans = createAction('getCropsAndManagementPla
 
 export function* getCropsAndManagementPlansSaga() {
   try {
-    yield all([put(locationApi.endpoints.getLocations.initiate()), call(getCropsSaga)]);
+    yield all([
+      call(openFarmScopedQuery, locationApi.endpoints.getLocations.initiate()),
+      call(getCropsSaga),
+    ]);
     yield call(getCropVarietiesSaga);
     yield call(getManagementPlansSaga);
   } catch (e) {
@@ -477,11 +480,30 @@ export function* checkAppVersionSaga() {
   if (isStoreOutdated) logout();
 }
 
+// Subscription handles for farm-scoped RTK Query queries
+// Retained so clearOldFarmStateSaga can release them before invalidating tags;
+// with no remaining subscriber, invalidateTags removes each cached entry
+// (removeQueryResult) instead of refetching it.
+let farmScopedQuerySubscriptions = [];
+
+function* openFarmScopedQuery(initiateThunk) {
+  // Starting a query with `.initiate()` returns a handle for that query — an object of shape
+  //  ({ requestId, unsubscribe, refetch, ... })
+  // https://redux-toolkit.js.org/rtk-query/usage/usage-without-react-hooks#removing-a-subscription
+  const subscription = yield put(initiateThunk);
+  farmScopedQuerySubscriptions.push(subscription);
+}
+
+function releaseFarmScopedQuerySubscriptions() {
+  farmScopedQuerySubscriptions.forEach((subscription) => subscription?.unsubscribe?.());
+  farmScopedQuerySubscriptions = [];
+}
+
 export function* fetchAllSaga() {
   const { has_consent, user_id, farm_id } = yield select(userFarmSelector);
   if (!has_consent) return history.push('/consent');
 
-  yield put(api.endpoints.getSensors.initiate());
+  yield call(openFarmScopedQuery, api.endpoints.getSensors.initiate());
 
   const isAdmin = yield select(isAdminSelector);
   const adminTasks = [
@@ -500,7 +522,7 @@ export function* fetchAllSaga() {
     put(api.endpoints.getSoilAmendmentFertiliserTypes.initiate()),
     put(api.endpoints.getAnimalMovementPurposes.initiate()),
     //Todo: LF-4672 Remove once refactor to rtk is complete
-    put(locationApi.endpoints.getLocations.initiate()),
+    call(openFarmScopedQuery, locationApi.endpoints.getLocations.initiate()),
   ];
 
   yield all(isAdmin ? [...tasks, ...adminTasks] : tasks);
@@ -508,13 +530,14 @@ export function* fetchAllSaga() {
   yield put(fetchAllFinanceData());
 
   // Animals
+  // Open farm-scoped queries through openFarmScopedQuery so their subscriptions can be released on farm switch
   yield all([
-    put(api.endpoints.getAnimals.initiate()),
-    put(api.endpoints.getAnimalBatches.initiate()),
-    put(api.endpoints.getDefaultAnimalTypes.initiate()),
+    call(openFarmScopedQuery, api.endpoints.getAnimals.initiate()),
+    call(openFarmScopedQuery, api.endpoints.getAnimalBatches.initiate()),
+    call(openFarmScopedQuery, api.endpoints.getDefaultAnimalTypes.initiate()),
     put(api.endpoints.getDefaultAnimalBreeds.initiate()),
-    put(api.endpoints.getCustomAnimalTypes.initiate()),
-    put(api.endpoints.getCustomAnimalBreeds.initiate()),
+    call(openFarmScopedQuery, api.endpoints.getCustomAnimalTypes.initiate()),
+    call(openFarmScopedQuery, api.endpoints.getCustomAnimalBreeds.initiate()),
     put(api.endpoints.getAnimalSexes.initiate()),
     put(api.endpoints.getAnimalIdentifierTypes.initiate()),
     put(api.endpoints.getAnimalIdentifierColors.initiate()),
@@ -534,6 +557,11 @@ export function* fetchAllSaga() {
 export function* clearOldFarmStateSaga() {
   yield put(resetTasks());
   yield put(resetDateRange());
+  releaseFarmScopedQuerySubscriptions();
+  // RTK Query tracks subscriptions in two places: a live copy that `unsubscribe` updates right
+  // away, and the redux store, which catches up one microtask later. `invalidateTags` reads the
+  // store copy, so `delay(0)` lets it catch up first
+  yield delay(0);
   yield put(invalidateTags([...FarmTags, ...FarmLibraryTags]));
 
   // Reset finance loading state


### PR DESCRIPTION
**Description**

As noted on #4199, `api.endpoints.initiate()` in the sagas subscribes to each called query and never unsubscribes.

Because the queries stay subscribed, `invalidateTags` in `clearOldFarmStateSaga` refetches them instead of simply purging. Previously (prior to #4199 merge) this caused 400 errors on most of the invalidated RTK query endpoints (and 403 on locations due to the missing `farm_id` in the path). In that PR I re-ordered that `invalidateTags` call and the setting of the `farm_id` so the new `farm_id` is used to call the queries. Although that resolves the previous errors, I missed in testing (and the reason why is kind of interesting, will note below) that now the same path will produce a _different_ 403 failure because the fetch happens before there is a consented _userFarm_ record for that new farm, and `checkScope` middleware will 403 on that. This is possible via the ChooseFarm > Invited Farm, Choose Farm > Farm with role updated (=reset of `has_consent`), and Add Farm flows.

_In the PR, I am taking the more correct approach of making sure the queries are not refetched at all at the point of `invalidateTags`_

Since `api.endpoints.initiate()` returns a subscription handler (see [RTK Query Docs: Removing a subscription](https://redux-toolkit.js.org/rtk-query/usage/usage-without-react-hooks#removing-a-subscription)) this PR adds new helper functions to store those subscription handlers and unsubscribe each before `invalidatesTags` is called. This is only necessary so long as we have this mixed RTK Query-Saga infrastructure: queries called via the hooks unsubscribe themselves when their component is unmounted.

One slightly interesting note about the solution is that the array of subscription handlers is stored merely in module memory in the saga where they are called -- and this is sufficient because the subscriptions themselves are written to api.subscriptions from non-persisted RTK Query middleware; when you reload the page they are lost. (Note: the middleware bit comes from Claude inspecting the library code and I didn't look into it, but the behaviour is easily verifiable from inspecting api.subscriptions in the Redux dev tools before and after page reload). This is almost certainly whey I didn't observe the new 403 before -- any page reload (or hot module reload, like when working in the code) also purges the subscriptions, at which point there is no bug!

Jira link: https://lite-farm.atlassian.net/browse/LF-5326

Note for follow-up: There are also many many `.initiate()` calls from _within ApiSlice_ in the `onQueryStarted` of the animal mutations. I haven't looked into the subscription status or behaviour of those but it would be my next follow-up (e.g. does a mutation on animals then lead to a 403 and persisted old animal data on invited farm switch... there is another ticket for animals and invite that might relate to this)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Verified bug and fix by inspecting network tab and redux dev tools in concert on these flows (we have _way_ too many of these sagas, and these multiple paths are really starting to feel like a liability these last few months!):
- Add Farm (original bug);  which is `postFarmSaga`
- Choose Farm > Invited Farm; `patchUserFarmStatusWithIDTokenSaga`
- Choose Farm > Farm where consent has been revoked (easiest via database -or- change worker role in UI); `selectFarmAndFetchAllSaga`

Also verified no regression in the happy path which is `selectFarmAndFetchAllSaga` without revoked consent (= switching between two existing farms, both consented to).

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
