### PR TITLE
LF-5345 Fix irrigation prescription date input styles

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -40,7 +40,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.5",
     "@mui/styles": "^5.13.2",
-    "@mui/x-date-pickers": "^8.0.0",
+    "@mui/x-date-pickers": "8.17.0",
     "@react-oauth/google": "^0.7.0",
     "@reactour/tour": "^3.1.6",
     "@reduxjs/toolkit": "^1.9.1",

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         specifier: ^5.13.2
         version: 5.18.0(@types/react@18.3.26)(react@18.3.1)
       '@mui/x-date-pickers':
-        specifier: ^8.0.0
+        specifier: 8.17.0
         version: 8.17.0(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(react@18.3.1))(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-oauth/google':
         specifier: ^0.7.0

--- a/packages/webapp/src/components/Inputs/DateTime/index.tsx
+++ b/packages/webapp/src/components/Inputs/DateTime/index.tsx
@@ -13,11 +13,10 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
 import moment from 'moment';
-import { InputAdornment } from '@mui/material';
 import { DatePicker as MuiXDatePicker } from '@mui/x-date-pickers';
 import { TimePicker as MuiXTimePicker } from '@mui/x-date-pickers/TimePicker';
+import type { FieldOwnerState } from '@mui/x-date-pickers/models';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
 import InputBaseLabel, { InputBaseLabelProps } from '../../Form/InputBase/InputBaseLabel';
@@ -31,30 +30,13 @@ interface DateTimePickerProps extends InputBaseLabelProps {
   className?: string;
 }
 
-const createSlotProps = (
-  Icon: React.ElementType,
-  handleOpen: React.Dispatch<React.SetStateAction<boolean>>,
-  disabled: boolean,
-) => ({
-  textField: {
-    fullWidth: true,
-    InputProps: {
-      classes: {
-        disabled: styles.inputDisabled,
-        focused: styles.inputFocusBorder,
-        root: styles.input,
-      },
-      startAdornment: (
-        <InputAdornment position="start">
-          <Icon
-            onClick={() => !disabled && handleOpen(true)}
-            className={clsx(styles.icon, disabled && styles.disabled)}
-          />
-        </InputAdornment>
-      ),
-    },
-  },
-});
+const pickerSlotProps = {
+  field: { openPickerButtonPosition: 'start' as const },
+  textField: { fullWidth: true, className: styles.field },
+  openPickerIcon: (ownerState: FieldOwnerState) => ({
+    className: clsx(styles.icon, ownerState.isFieldDisabled && styles.iconDisabled),
+  }),
+};
 
 export const DateInput = ({
   date,
@@ -63,8 +45,6 @@ export const DateInput = ({
   label,
   ...labelProps
 }: DateTimePickerProps) => {
-  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
-
   const { dateFormat } = getLocaleDateTimeFormats();
 
   return (
@@ -74,12 +54,8 @@ export const DateInput = ({
         format={dateFormat}
         defaultValue={moment(date)}
         disabled={disabled}
-        open={isDatePickerOpen}
-        onClose={() => setIsDatePickerOpen(false)}
-        slotProps={{
-          ...createSlotProps(Calendar, setIsDatePickerOpen, disabled),
-        }}
-        slots={{ openPickerIcon: () => null }}
+        slots={{ openPickerIcon: Calendar }}
+        slotProps={pickerSlotProps}
       />
     </div>
   );
@@ -92,8 +68,6 @@ export const TimeInput = ({
   label,
   ...labelProps
 }: DateTimePickerProps) => {
-  const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
-
   const { timeFormat, uses12HourFormat } = getLocaleDateTimeFormats();
 
   return (
@@ -103,11 +77,9 @@ export const TimeInput = ({
         defaultValue={moment(date)}
         format={timeFormat}
         disabled={disabled}
-        open={isTimePickerOpen}
-        onClose={() => setIsTimePickerOpen(false)}
         ampm={uses12HourFormat}
-        slotProps={createSlotProps(Clock, setIsTimePickerOpen, disabled)}
-        slots={{ openPickerIcon: () => null }}
+        slots={{ openPickerIcon: Clock }}
+        slotProps={pickerSlotProps}
       />
     </div>
   );

--- a/packages/webapp/src/components/Inputs/DateTime/styles.module.scss
+++ b/packages/webapp/src/components/Inputs/DateTime/styles.module.scss
@@ -13,43 +13,39 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-// styles taken from the <Input /> component
+// Styles for the MUI X DatePicker / TimePicker field, taken from the <Input /> component.
 
-.input {
-  height: 48px;
-  width: inherit;
-}
-
-.inputDisabled.inputDisabled {
-  background-color: var(--inputDisabled);
-
-  span {
-    color: var(--grey600);
+.field {
+  :global(.MuiPickersOutlinedInput-root) {
+    height: 48px;
   }
 
-  &.inputDisabled {
-    > fieldset {
-      border-color: var(--inputDefault);
-    }
-  }
-}
-
-.inputFocusBorder {
-  &.inputFocusBorder.inputFocusBorder.inputFocusBorder > fieldset {
+  // Focus border
+  :global(.MuiPickersOutlinedInput-root.Mui-focused .MuiPickersOutlinedInput-notchedOutline) {
     border-color: var(--inputActive);
     border-width: 1px;
   }
-}
 
-.icon {
-  path {
-    stroke: var(--fontColor);
+  // Disabled fill + border
+  :global(.MuiPickersOutlinedInput-root.Mui-disabled) {
+    background-color: var(--inputDisabled);
+  }
+  :global(.MuiPickersOutlinedInput-root.Mui-disabled .MuiPickersOutlinedInput-notchedOutline) {
+    border-color: var(--inputDefault);
+  }
+
+  // Disabled text, to match the disabled icon
+  :global(.MuiPickersOutlinedInput-root.Mui-disabled *) {
+    color: var(--grey600);
   }
 }
 
-.icon.disabled {
-  path {
-    stroke: var(--grey600);
-  }
-  cursor: default;
+// Trigger icon (calendar / clock). The class is applied directly to the SVG via the
+// openPickerIcon slot, so no MUI class targeting is needed.
+.icon path {
+  stroke: var(--fontColor);
+}
+
+.iconDisabled path {
+  stroke: var(--grey600);
 }


### PR DESCRIPTION
**Description**

Repairs the styles of the date input component ([Storybook](http://localhost:6006/?path=/docs/components-form-dateinput--docs)) used in the Irrigation Prescription view.

Current integration:
<img width="516" height="299" alt="Screenshot 2026-06-19 at 9 14 33 AM" src="https://github.com/user-attachments/assets/9af9d0c9-1793-4cd0-b938-62d96eb8a802" />


Original and on this branch:
<img width="516" height="299" alt="Screenshot 2026-06-19 at 9 13 35 AM" src="https://github.com/user-attachments/assets/333b0e98-a959-4cdc-90d6-5c120f46f1d7" />

The visual regression was due to a component version bump. The component was built on **8.0.0**, but since the lockfile regeneration in https://github.com/LiteFarmOrg/LiteFarm/pull/3984/changes/e6c5c28e725bd116edf4df737ce1a48962897f07 it has been **8.17.0**.

I don't think that minor version bump should have created a breaking change except the component was styled using a more v7-esque method of targetting the input field (`slotProps.textField.InputProps`) which was functional in 8.0.0 but not in 8.17.0. And there is also a newer styling method (will note inline) we cannot access because our Material remains on version 5.

Jira link: https://lite-farm.atlassian.net/browse/LF-5345

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
