### PR TITLE
LF-5343 Fix Browser Back Navigation Issue Causing UI Glitches on Add Revenue Page

### DIFF
--- a/packages/webapp/src/components/Forms/RevenueForm/index.jsx
+++ b/packages/webapp/src/components/Forms/RevenueForm/index.jsx
@@ -44,6 +44,7 @@ const RevenueForm = ({
   currency,
   sale,
   persistedFormData,
+  useHookFormPersist = () => ({}),
   view,
   handleGoBack,
   onClick,
@@ -82,7 +83,11 @@ const RevenueForm = ({
     watch,
     control,
     setValue,
+    getValues,
   } = reactHookFormFunctions;
+
+  // Mirrors PureAddExpense; on unmount, rewinds the multi-step flow's pages out of history
+  useHookFormPersist(getValues);
 
   const selectedTypeOption = watch(REVENUE_TYPE_OPTION);
   const selectedRevenueType = revenueTypes?.find(


### PR DESCRIPTION
**Description**

This bug has been on App for a long time... maybe three years!

`useHookFormPersist()` was not called in `<RevenueForm>` (previously known as `<GeneralRevenue>`) so the cleanup activity of that hook (including the resetting of the history stack) was not executed when the component unmounted. Therefore it was possible to browser back right into the middle of the form flow, which is what that cleanup normally prohibits.

The hook call was originally in the component (commit https://github.com/LiteFarmOrg/LiteFarm/commit/214fe259b) and then removed later during the original 2023 finances refactor (https://github.com/LiteFarmOrg/LiteFarm/commit/ff3f3019d); I have just restored it to the original state, which is also the state that parallels Expense.

Jira link: https://lite-farm.atlassian.net/browse/LF-5343

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

I have been testing as shown in the Jira video: navigate to Add Revenue (Type List) > Add Sale (form) and then navigate either to e.g. /animals (which doesn't touch hook form persist) or /crops (which will reset it). Then browser back, which lands you on the form.

On integration the behaviour is different in those two cases (you only get the crash if you go to /crops), but in on this branch the behaviour should be identical (routing to Finances/, not to the form) and consistent with Add Expense.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
