### PR TITLE
LF-5344 400 Error After Using Browser Back Navigation During Farm Map Area Creation

### DIFF
--- a/packages/webapp/src/components/LocationDetailLayout/PureLocationFormWrapper.jsx
+++ b/packages/webapp/src/components/LocationDetailLayout/PureLocationFormWrapper.jsx
@@ -13,6 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { useEffect } from 'react';
 import { PersistedFormWrapper } from './PersistedFormWrapper';
 import { getFormDataWithoutNulls } from '../../containers/hooks/useHookFormPersist/utils';
 import { PureLocationDetailLayout } from './PureLocationDetailLayout';
@@ -81,6 +82,21 @@ export default function PureLocationFormWrapper({
   isAdmin = false,
   locationType,
 }) {
+  const geometryKey = { area: 'grid_points', line: 'line_points', point: 'point' }[
+    getFigureType(locationType)
+  ];
+  const hasGeometry = !!persistedFormData?.[geometryKey];
+
+  useEffect(() => {
+    if (!hasGeometry) {
+      history.replace({ pathname: '/map' });
+    }
+  }, [hasGeometry, history]);
+
+  if (!hasGeometry) {
+    return null;
+  }
+
   const onSubmit = (data) => {
     // area units lift value up to top level
     if (getFigureType(locationType) === 'area') {

--- a/packages/webapp/src/containers/LocationDetails/PostLocationDetailForm.tsx
+++ b/packages/webapp/src/containers/LocationDetails/PostLocationDetailForm.tsx
@@ -13,10 +13,11 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { useEffect } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { loginSelector, measurementSelector } from '../userFarmSlice';
-import { formatLocationTypeToLocationForDB } from './utils';
+import { formatLocationTypeToLocationForDB, getFigureType } from './utils';
 import { InternalMapLocation, InternalMapLocationType } from '../../store/api/types';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
 import useHookFormPersist from '../hooks/useHookFormPersist';
@@ -36,6 +37,17 @@ function PostLocationDetailForm({ locationType }: { locationType: InternalMapLoc
   const { farm_id } = useSelector(loginSelector);
 
   const [addLocationByType] = useAddLocationByTypeMutation();
+
+  const geometryKey = { area: 'grid_points', line: 'line_points', point: 'point' }[
+    getFigureType(locationType)
+  ];
+  // The drawn shape's geometry only lives in the form-persist slice;
+  // if missing leave rather than submit a figure the backend will reject
+  useEffect(() => {
+    if (!persistedFormData?.[geometryKey]) {
+      history.replace({ pathname: '/map' });
+    }
+  }, [persistedFormData, geometryKey, history]);
 
   const submitForm = async (data: { formData: any }) => {
     const { formData } = data;

--- a/packages/webapp/src/containers/LocationDetails/PostLocationDetailForm.tsx
+++ b/packages/webapp/src/containers/LocationDetails/PostLocationDetailForm.tsx
@@ -13,11 +13,10 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { loginSelector, measurementSelector } from '../userFarmSlice';
-import { formatLocationTypeToLocationForDB, getFigureType } from './utils';
+import { formatLocationTypeToLocationForDB } from './utils';
 import { InternalMapLocation, InternalMapLocationType } from '../../store/api/types';
 import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
 import useHookFormPersist from '../hooks/useHookFormPersist';
@@ -37,17 +36,6 @@ function PostLocationDetailForm({ locationType }: { locationType: InternalMapLoc
   const { farm_id } = useSelector(loginSelector);
 
   const [addLocationByType] = useAddLocationByTypeMutation();
-
-  const geometryKey = { area: 'grid_points', line: 'line_points', point: 'point' }[
-    getFigureType(locationType)
-  ];
-  // The drawn shape's geometry only lives in the form-persist slice;
-  // if missing leave rather than submit a figure the backend will reject
-  useEffect(() => {
-    if (!persistedFormData?.[geometryKey]) {
-      history.replace({ pathname: '/map' });
-    }
-  }, [persistedFormData, geometryKey, history]);
 
   const submitForm = async (data: { formData: any }) => {
     const { formData } = data;


### PR DESCRIPTION
**Description**

Although superficially similar to the bug fixed in #4207, this flow is a bit simpler, because it's only concerned with the form data part of the hookFormPersistSlice, and not with the history stack. In fixing the bug I've decided to leave it this way -- I haven't added the hook call that will clear the history stack (whether it's a multi-step form is a bit debatable) so you can browser back right into the form still. Only if the figure data is missing will the solution in this PR route you back to `/map`.

The advantage is a very minimal change to this flow, the tradeoff being that where you land is different based on whether you navigate to /tasks or /crops, which reset that hookFormPersistSlice, or to somewhere else (/animals, /inventory) that doesn't.

Loïc's position is that it's better to allow users to resume the form from where they left of. The app's general pattern is absolutely the opposite (can't re-enter forms). I guess this change is leaving this flow agnostic -- you can continue your form if the data is still there; otherwise restart. Maybe not ideal, but a way to keep the scope and change minimal for release.

Jira link: https://lite-farm.atlassian.net/browse/LF-5344

(Also now fixes https://lite-farm.atlassian.net/browse/LF-5348 as well)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Followed the flow in the Jira video:

Draw location > Confirm > Route to elsewhere in app (see above for the differing behaviour based on destination) > Browser back.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
