### PR TITLE
LF-5352 Map takes over a minute to load for farms with multiple Ensemble systems

### DIFF
--- a/packages/api/src/util/ensemble.js
+++ b/packages/api/src/util/ensemble.js
@@ -77,22 +77,34 @@ const getEnsembleSensors = async (farm_id) => {
 
   const farm = await FarmModel.query().findById(farm_id);
   const farmCenterCoordinates = farm.grid_points;
+
+  // Each profiles request is slow (several seconds), so fetch all systems concurrently
+  // and tolerate individual failures rather than failing the whole fetch
+  const profileResults = await Promise.allSettled(
+    orgSystems.map(async (system) => {
+      const { results: systemProfiles = [] } =
+        (await getOrganisationProfiles(farmEnsembleAddon.org_pk, system.pk)) ?? {};
+
+      return systemProfiles
+        .filter((profile) => profile.water_profile?.sensors?.length)
+        .map((profile) =>
+          mapProfileToSensorArray(
+            enrichProfileWithDefaultPosition(profile, farmCenterCoordinates),
+            system.name,
+          ),
+        );
+    }),
+  );
+
   const sensorArrays = [];
-  for (const system of orgSystems) {
-    const { results: systemProfiles = [] } =
-      (await getOrganisationProfiles(farmEnsembleAddon.org_pk, system.pk)) ?? {};
-
-    const mappedProfiles = systemProfiles
-      .filter((profile) => profile.water_profile?.sensors?.length)
-      .map((profile) =>
-        mapProfileToSensorArray(
-          enrichProfileWithDefaultPosition(profile, farmCenterCoordinates),
-          system.name,
-        ),
+  for (const [index, result] of profileResults.entries()) {
+    if (result.status === 'fulfilled') {
+      sensorArrays.push(...result.value);
+    } else {
+      console.error(
+        `Failed to fetch Ensemble profiles for system ${orgSystems[index].pk}:`,
+        result.reason,
       );
-
-    if (mappedProfiles?.length) {
-      sensorArrays.push(...mappedProfiles);
     }
   }
 


### PR DESCRIPTION
**Description**

The Ensemble endpoint that returns the system profiles, which we use to group sensors and place them on the map:

```
https://api.esci.io/organizations/{{org_pk}}/systems/{{system_id}}/profiles/
```

is exceedingly slow this year. In Postman I'm seeing about 4 seconds per system, which is almost certainly the cause of the longer wait times associated with fetching Ensemble sensors this year. I've emailed Ensemble to see if this is something we can adjust (details are in Jira; we really need so little of what that endpoint returns), but in the meantime, and probably for this release, we need to make do with what is available now.

The adjust in this PR is simply to address a testing state (we hope) situation whereby all 12 systems associated with this year's research project have been grouped under a single `organisation_id`. This isn't correct, but while we wait for Ensemble + Farming Smarter to reorganise those systems into separate organisations, this change makes that org_id usable for testing purposes in the meantime.

Jira link: https://lite-farm.atlassian.net/browse/LF-5352

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

I used Postman to query the organisation uuid (the pk is 351) and added that to my testing farm in local. In Postman I also checked the individual response times of the endpoints in the `getSensors()` flow to establish which Ensemble API call was responsible for the delay. If you want to test the above endpoint in Postman, you can first use this query

```
https://api.esci.io/organizations/{{org_pk}}/systems/
```

to get the list of the 12 system_ids.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
