### PR TITLE
LF-5351 "Sit back we are fetching your map data modal" is showing every two minutes

### DIFF
--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -189,7 +189,7 @@ export default function Map({ isCompactSideMenu }) {
       fullscreenControl: false,
     };
   };
-  const { drawAssets, assetGeometriesRef, markerClusterRef, isLocationsFetching } =
+  const { drawAssets, assetGeometriesRef, markerClusterRef, isLocationsLoading } =
     useMapAssetRenderer({
       isClickable: !drawingState.type,
       drawingState: drawingState,
@@ -424,7 +424,7 @@ export default function Map({ isCompactSideMenu }) {
 
   return (
     <>
-      {!isLocationsFetching && isLoaded && (
+      {!isLocationsLoading && isLoaded && (
         <>
           {!drawingState.type && !showSuccessHeader && <PureMapHeader farmName={farm_name} />}
           {showSuccessHeader && (
@@ -560,7 +560,7 @@ export default function Map({ isCompactSideMenu }) {
         </>
       )}
       <LoadingBackdrop
-        isOpen={isLocationsFetching}
+        isOpen={isLocationsLoading}
         isCompactSideMenu={isCompactSideMenu}
         dataName={t('MENU.MAP').toLocaleLowerCase()}
       />


### PR DESCRIPTION
**Description**

Title is a _bit_ imprecise. Technically it's showing every time you revisit the map after 60 seconds has elapsed, since that's our RTK `refetchOnMountOrArgChange`.

As I wrote in the Jira ticket, using `isFetching` might have been a workaround for the RTK Query calls re-fetching instead of purging on farm switch? But in any case a completely blocking modal is not the right use case for isFetching.

In practice, we only see this when fetching sensors, where unfortunately it produced an almost unusable UI since the a multi-second modal was re-shown every 60 seconds. Using isLoading guarantees it is only shown on first fetch, when no cached data is available.

Jira link: https://lite-farm.atlassian.net/browse/LF-5351

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
