### PR TITLE
LF-5340 Blank Page Shown After Uploading Valid Sensors and No Success Confirmation Displayed

### DIFF
--- a/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
+++ b/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
@@ -159,19 +159,14 @@ const useGroupedSensors = (): {
   sensorSummary: SensorSummary;
   groupedSensors: GroupedSensors[];
 } => {
-  const {
-    data: sensors,
-    isLoading: isLoadingSensors,
-    isFetching: isFetchingSensors,
-  } = useGetSensorsQuery();
+  const { data: sensors, isFetching: isFetchingSensors } = useGetSensorsQuery();
   const system = useSelector(measurementSelector);
   const { locations: farmAreas, isLoading: isLoadingFarmAreas } = useLocations({
     filterBy: FigureType.AREA,
   });
 
   const hasNoSensorData = !sensors?.sensors.length && !sensors?.sensor_arrays.length;
-  const isLoading =
-    isLoadingSensors || isLoadingFarmAreas || (isFetchingSensors && hasNoSensorData);
+  const isLoading = isLoadingFarmAreas || (isFetchingSensors && hasNoSensorData);
   const dataNotReady = !sensors || !farmAreas;
 
   const sensorsData =

--- a/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
+++ b/packages/webapp/src/containers/SensorList/useGroupedSensors.ts
@@ -105,14 +105,17 @@ const formatSensorToGroup = (
 };
 
 const getSummary = (sensors: Sensor[], sensor_arrays: SensorArray[]): SensorSummary => {
-  const summaryMap = sensors.reduce((acc, { name }) => {
-    if (!(name in acc)) {
-      acc[name] = 0;
-    }
-    acc[name] += 1;
+  const summaryMap = sensors.reduce(
+    (acc, { name }) => {
+      if (!(name in acc)) {
+        acc[name] = 0;
+      }
+      acc[name] += 1;
 
-    return acc;
-  }, {} as Record<Sensor['name'], number>);
+      return acc;
+    },
+    {} as Record<Sensor['name'], number>,
+  );
 
   return {
     [SensorType.SENSOR_ARRAY]: sensor_arrays.length,
@@ -156,13 +159,19 @@ const useGroupedSensors = (): {
   sensorSummary: SensorSummary;
   groupedSensors: GroupedSensors[];
 } => {
-  const { data: sensors, isLoading: isLoadingSensors } = useGetSensorsQuery();
+  const {
+    data: sensors,
+    isLoading: isLoadingSensors,
+    isFetching: isFetchingSensors,
+  } = useGetSensorsQuery();
   const system = useSelector(measurementSelector);
   const { locations: farmAreas, isLoading: isLoadingFarmAreas } = useLocations({
     filterBy: FigureType.AREA,
   });
 
-  const isLoading = isLoadingSensors || isLoadingFarmAreas;
+  const hasNoSensorData = !sensors?.sensors.length && !sensors?.sensor_arrays.length;
+  const isLoading =
+    isLoadingSensors || isLoadingFarmAreas || (isFetchingSensors && hasNoSensorData);
   const dataNotReady = !sensors || !farmAreas;
 
   const sensorsData =


### PR DESCRIPTION
**Description**

I'm actually not sure when this stopped working, because I swear I remember seeing the loading screen when it was first added 🙂 Probably the return from the API was different originally.

In a funnily parallel (but opposite) case to the change in #4213, here the isLoading gate is not appropriate to block on, because for any farm that was loaded _disconnected_ to Ensemble (i.e. a farm that is still to go through the Add Sensors flow), the getSensors() API request has already returned with

```json
{
    "sensors": [],
    "sensor_arrays": []
}
```

Since there _is_ data, isLoading won't be true, and we need to check on isFetching -- but not EVERY isFetching, just when the arrays are still empty!

Jira link: https://lite-farm.atlassian.net/browse/LF-5340

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
