### PR TITLE
LF-5354: Redraw map locations when background refetch completes

### DIFF
--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -189,12 +189,11 @@ export default function Map({ isCompactSideMenu }) {
       fullscreenControl: false,
     };
   };
-  const { drawAssets, assetGeometriesRef, markerClusterRef, isLocationsLoading } =
-    useMapAssetRenderer({
-      isClickable: !drawingState.type,
-      drawingState: drawingState,
-      showingConfirmButtons: showingConfirmButtons,
-    });
+  const { drawAssets, assetGeometriesRef, markerClusterRef } = useMapAssetRenderer({
+    isClickable: !drawingState.type,
+    drawingState: drawingState,
+    showingConfirmButtons: showingConfirmButtons,
+  });
 
   // Cleanup listeners on map instance objects
   useEffect(() => {
@@ -424,7 +423,7 @@ export default function Map({ isCompactSideMenu }) {
 
   return (
     <>
-      {!isLocationsLoading && isLoaded && (
+      {isLoaded && (
         <>
           {!drawingState.type && !showSuccessHeader && <PureMapHeader farmName={farm_name} />}
           {showSuccessHeader && (
@@ -560,7 +559,7 @@ export default function Map({ isCompactSideMenu }) {
         </>
       )}
       <LoadingBackdrop
-        isOpen={isLocationsLoading}
+        isOpen={!isLoaded}
         isCompactSideMenu={isCompactSideMenu}
         dataName={t('MENU.MAP').toLocaleLowerCase()}
       />

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -17,6 +17,7 @@ import styles, { defaultColour } from './styles.module.scss';
 import { areaStyles, hoverIcons, icons, lineStyles } from './mapStyles';
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { cleanupGeometryListeners } from '../../util/google-maps/cleanupListeners';
 import { mapFilterSettingSelector } from './mapFilterSettingSlice';
 import { setPosition, setZoomLevel } from '../mapSlice';
 import {
@@ -64,6 +65,12 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
 
   const [assetGeometries, setAssetGeometries] = useState(initAssetGeometriesState());
   const assetGeometriesRef = useRef({});
+
+  const mapRef = useRef(null);
+  const mapsRef = useRef(null);
+  const mapClickListenerRef = useRef(null);
+  const initialDrawDoneRef = useRef(false);
+  const prevFetchingRef = useRef(false);
 
   // Keep ref (for cleanup) in sync with state
   useEffect(() => {
@@ -149,8 +156,8 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
         ? drawNoFillArea
         : drawArea
       : isLine(assetType)
-        ? drawLine
-        : drawPoint;
+      ? drawLine
+      : drawPoint;
   };
 
   const { maxZoomRef } = useMaxZoom();
@@ -231,18 +238,25 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
     }
   }, [drawingState.isActive, showingConfirmButtons, farmLocationMarker]);
 
-  const drawAssets = (map, maps, mapBounds) => {
+  const drawAssets = (map, maps, mapBounds, startingState = null) => {
+    mapRef.current = map;
+    mapsRef.current = maps;
+    initialDrawDoneRef.current = true;
+
     maps.event.addListenerOnce(map, 'idle', function () {
       // markerClusterRef?.current?.repaint();
     });
 
-    // Event listener for general map click
-    maps.event.addListener(map, 'click', function (mapsMouseEvent) {
+    // Replace old map click listener to avoid duplicates on re-draw
+    if (mapClickListenerRef.current) {
+      maps.event.removeListener(mapClickListenerRef.current);
+    }
+    mapClickListenerRef.current = maps.event.addListener(map, 'click', function (mapsMouseEvent) {
       handleSelection(mapsMouseEvent.latLng, assetGeometries, maps, false);
     });
 
     let hasLocation = false;
-    const newState = { ...assetGeometries };
+    const newState = startingState !== null ? { ...startingState } : { ...assetGeometries };
     const assets = { ...areaAssets, ...lineAssets, ...pointAssets };
     const assetsWithLocations = Object.keys(assets).filter(
       (type) =>
@@ -586,6 +600,36 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
       isAddonSensor: point.isAddonSensor,
     };
   };
+
+  const redrawAssets = () => {
+    if (!initialDrawDoneRef.current || !mapRef.current || !mapsRef.current) {
+      return;
+    }
+
+    // Remove all existing overlays from the map before re-drawing
+    Object.values(assetGeometriesRef.current).forEach((geometries) => {
+      const items = Array.isArray(geometries) ? geometries : [geometries];
+      items.forEach((geometry) => {
+        geometry.polygon?.setMap(null);
+        geometry.marker?.setMap(null);
+        geometry.polyline?.setMap(null);
+      });
+    });
+    cleanupGeometryListeners(assetGeometriesRef.current, mapsRef.current);
+    setPoints({});
+
+    const emptyState = initAssetGeometriesState();
+    const mapBounds = new mapsRef.current.LatLngBounds();
+    drawAssets(mapRef.current, mapsRef.current, mapBounds, emptyState);
+  };
+
+  useEffect(() => {
+    const wasFetching = prevFetchingRef.current;
+    prevFetchingRef.current = isLocationsFetching;
+    if (wasFetching && !isLocationsFetching) {
+      redrawAssets();
+    }
+  }, [isLocationsFetching]);
 
   return {
     drawAssets,


### PR DESCRIPTION
**Description**

I used Claude to investigate the regression and propose a fix.

* After the RTK Query locations migration (#4083), the map no longer redraws when background refetches complete
* `onGoogleApiLoaded` fires exactly once on mount — that's the only place `drawAssets` is called. Before #4083, locations came from stable Redux selectors, so data was always ready at mount. RTK Query introduced async fetching and background refetches, making the one-shot draw insufficient
* The initial implementation after #4083 handled this by gating GoogleMap on `!isLocationsFetching`, which unmounted/remounted it on every refetch, re-triggering `onGoogleApiLoaded`. #4213 later changed this gate to `!isLocationsLoading`, which inadvertently broke the redraw.
* Fix: Store map/maps `refs` inside `useMapAssetRenderer` on first draw, then watch  `isLocationsFetching` transitioning `true` → `false` in a `useEffect`. When a background refetch completes, remove all existing overlays and re-call `drawAssets` with the fresh data.
* Additionally, restore the pre-#4083 UX by removing the `isLocationsLoading` gate, so the map renders immediately and locations appear once the first fetch completes.

Jira link: https://lite-farm.atlassian.net/browse/LF-5354

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
