### PR TITLE
LF-5354 (VERSION #2) Farm map does not update after area creation or retirement until page reload

### DIFF
--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -189,12 +189,11 @@ export default function Map({ isCompactSideMenu }) {
       fullscreenControl: false,
     };
   };
-  const { drawAssets, assetGeometriesRef, markerClusterRef, isLocationsLoading } =
-    useMapAssetRenderer({
-      isClickable: !drawingState.type,
-      drawingState: drawingState,
-      showingConfirmButtons: showingConfirmButtons,
-    });
+  const { drawAssets, assetGeometriesRef, markerClusterRef } = useMapAssetRenderer({
+    isClickable: !drawingState.type,
+    drawingState: drawingState,
+    showingConfirmButtons: showingConfirmButtons,
+  });
 
   // Cleanup listeners on map instance objects
   useEffect(() => {
@@ -424,7 +423,7 @@ export default function Map({ isCompactSideMenu }) {
 
   return (
     <>
-      {!isLocationsLoading && isLoaded && (
+      {isLoaded && (
         <>
           {!drawingState.type && !showSuccessHeader && <PureMapHeader farmName={farm_name} />}
           {showSuccessHeader && (
@@ -560,7 +559,7 @@ export default function Map({ isCompactSideMenu }) {
         </>
       )}
       <LoadingBackdrop
-        isOpen={isLocationsLoading}
+        isOpen={!isLoaded}
         isCompactSideMenu={isCompactSideMenu}
         dataName={t('MENU.MAP').toLocaleLowerCase()}
       />

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -580,7 +580,8 @@ export default function Map({ isCompactSideMenu }) {
         </>
       )}
       <LoadingBackdrop
-        isOpen={!isLoaded || isLoadingExternalLocations}
+        isOpen={!isLoaded || (!isFetchingInternalLocations && isLoadingExternalLocations)}
+        showDelay={400}
         isCompactSideMenu={isCompactSideMenu}
         dataName={t('MENU.MAP').toLocaleLowerCase()}
       />

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -80,6 +80,7 @@ export default function Map({ isCompactSideMenu }) {
   const dispatch = useDispatch();
   const system = useSelector(measurementSelector);
   const overlayData = useSelector(hookFormPersistSelector);
+  const [gMap, setGMap] = useState(null);
   const [gMaps, setGMaps] = useState(null);
 
   const isRedrawing = useSelector(hookFormPersistIsRedrawingSelector);
@@ -189,11 +190,12 @@ export default function Map({ isCompactSideMenu }) {
       fullscreenControl: false,
     };
   };
-  const { drawAssets, assetGeometriesRef, markerClusterRef } = useMapAssetRenderer({
-    isClickable: !drawingState.type,
-    drawingState: drawingState,
-    showingConfirmButtons: showingConfirmButtons,
-  });
+  const { drawAssets, assetGeometriesRef, markerClusterRef, isFetchingInternalLocations } =
+    useMapAssetRenderer({
+      isClickable: !drawingState.type,
+      drawingState: drawingState,
+      showingConfirmButtons: showingConfirmButtons,
+    });
 
   // Cleanup listeners on map instance objects
   useEffect(() => {
@@ -210,6 +212,29 @@ export default function Map({ isCompactSideMenu }) {
       }
     };
   }, [gMaps]);
+
+  // Draw locations on map
+  const hasDrawnRef = useRef(false);
+  useEffect(() => {
+    if (!gMap || !gMaps || isFetchingInternalLocations || hasDrawnRef.current) {
+      return;
+    }
+    hasDrawnRef.current = true;
+    const mapBounds = new gMaps.LatLngBounds();
+    drawAssets(gMap, gMaps, mapBounds);
+
+    if (history.location.state?.isStepBack) {
+      reconstructOverlay();
+    }
+
+    if (history.location.state?.cameraInfo) {
+      const { zoom, location } = history.location.state.cameraInfo;
+      if (zoom && location) {
+        gMap.setZoom(zoom);
+        gMap.setCenter(location);
+      }
+    }
+  }, [gMap, gMaps, isFetchingInternalLocations]);
 
   const { getMaxZoom } = useMaxZoom();
   const handleGoogleMapApi = async ({ map, maps }) => {
@@ -295,22 +320,7 @@ export default function Map({ isCompactSideMenu }) {
     rootCompassControlDiv.render(<CustomCompass style={{ marginRight: '12px' }} />);
     map.controls[maps.ControlPosition.RIGHT_BOTTOM].push(compassControlDiv);
 
-    // Drawing locations on map
-    let mapBounds = new maps.LatLngBounds();
-
-    drawAssets(map, maps, mapBounds);
-
-    if (history.location.state?.isStepBack) {
-      reconstructOverlay();
-    }
-
-    if (history.location.state?.cameraInfo) {
-      const { zoom, location } = history.location.state.cameraInfo;
-      if (zoom && location) {
-        map.setZoom(zoom);
-        map.setCenter(location);
-      }
-    }
+    setGMap(map);
     setGMaps(maps);
   };
 

--- a/packages/webapp/src/containers/Map/index.jsx
+++ b/packages/webapp/src/containers/Map/index.jsx
@@ -190,12 +190,17 @@ export default function Map({ isCompactSideMenu }) {
       fullscreenControl: false,
     };
   };
-  const { drawAssets, assetGeometriesRef, markerClusterRef, isFetchingInternalLocations } =
-    useMapAssetRenderer({
-      isClickable: !drawingState.type,
-      drawingState: drawingState,
-      showingConfirmButtons: showingConfirmButtons,
-    });
+  const {
+    drawAssets,
+    assetGeometriesRef,
+    markerClusterRef,
+    isFetchingInternalLocations,
+    isLoadingExternalLocations,
+  } = useMapAssetRenderer({
+    isClickable: !drawingState.type,
+    drawingState: drawingState,
+    showingConfirmButtons: showingConfirmButtons,
+  });
 
   // Cleanup listeners on map instance objects
   useEffect(() => {
@@ -216,7 +221,13 @@ export default function Map({ isCompactSideMenu }) {
   // Draw locations on map
   const hasDrawnRef = useRef(false);
   useEffect(() => {
-    if (!gMap || !gMaps || isFetchingInternalLocations || hasDrawnRef.current) {
+    if (
+      !gMap ||
+      !gMaps ||
+      isFetchingInternalLocations ||
+      isLoadingExternalLocations ||
+      hasDrawnRef.current
+    ) {
       return;
     }
     hasDrawnRef.current = true;
@@ -234,7 +245,7 @@ export default function Map({ isCompactSideMenu }) {
         gMap.setCenter(location);
       }
     }
-  }, [gMap, gMaps, isFetchingInternalLocations]);
+  }, [gMap, gMaps, isFetchingInternalLocations, isLoadingExternalLocations]);
 
   const { getMaxZoom } = useMaxZoom();
   const handleGoogleMapApi = async ({ map, maps }) => {
@@ -569,7 +580,7 @@ export default function Map({ isCompactSideMenu }) {
         </>
       )}
       <LoadingBackdrop
-        isOpen={!isLoaded}
+        isOpen={!isLoaded || isLoadingExternalLocations}
         isCompactSideMenu={isCompactSideMenu}
         dataName={t('MENU.MAP').toLocaleLowerCase()}
       />

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -597,6 +597,7 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
     isLocationsLoading,
     isLocationsFetching,
     isFetchingInternalLocations,
+    isLoadingExternalLocations,
   };
 };
 

--- a/packages/webapp/src/containers/Map/useMapAssetRenderer.js
+++ b/packages/webapp/src/containers/Map/useMapAssetRenderer.js
@@ -596,6 +596,7 @@ const useMapAssetRenderer = ({ isClickable, showingConfirmButtons, drawingState 
     markerClusterRef,
     isLocationsLoading,
     isLocationsFetching,
+    isFetchingInternalLocations,
   };
 };
 


### PR DESCRIPTION
**Description**

The main part of this solution was an implementation Claude Opus 4.8 came up with based on the original version in #4217.

The core of the change I'm satisfied with and I don't think it's too much to ship: it just moves the call to `drawAssets()`, and the following related code into a useEffect that is gated on `isLoadingExternalLocations` and a ref to make sure drawing happens only once. This part actually makes pretty intuitive sense.

The part that was a little harder was the modal behaviour 😂

My aim was to keep the restored UX from the second commit 5316d5b5f4cc01f3d56267186825d4e3237344ec of #4217, where the map renders without delay again. That commit had been cherry-picked onto this branch and worked great for non-sensor farms. The problem was entirely for farms with sensors, in that
- the drawing of the assets DOES have to be gated on the sensors being loaded, because unlike in the redraw solution, they will _not_ pop in later
- this would be an extremely poor UX without a loading screen. Actually even for the pop-in case, I think a loading screen becomes necessary when the sensor endpoint is taking 10-20 seconds as it does now

The problem was that since every single farm calls `getSensors()` (even if only to confirm that they have none), a modal that was gated on only `isLoadingExternalLocations` was flashing for every farm again, basically negating the UX of the commit I had cherry-picked!

The ultimate solution is a bit weird, but I actually think it is functional. The loading modal **only shows if the sensors request finishes after the locations request by more than 400 ms**. In other words, the modal is gated like this:

```ts
isOpen={!isLoaded || (!isFetchingInternalLocations && isLoadingExternalLocations)}
```

and it already had a feature built in `showDelay` such that the modal is only shown if the open condition is true for a given period of time. I think the tables and joins involved in the locations controller are probably inherently slower than the simple farm_addon check needed to return the empty response of a farm without sensors. Actually even with the delay set to 200ms, I never again saw the loading modal for a non-sensor farm again! But just as an extra precaution and to cover more network conditions, I bumped it to 400ms.

I hope I'm not missing anything, but in my testing, that seemed to achieve the best of both words -- the immediately loading map UX of `isOpen={!isLoaded}` for sensor-free farms WHILE still showing the modal when needed (sensor partner farms). And so no need to switch back to modal on every fetch 🤞

Jira link: https://lite-farm.atlassian.net/browse/LF-5354

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Just a lot of testing on switching to farms with and without sensors!

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
