### PR TITLE
LF-5355: Delete Confirmation Panel Has No Margins and Overlaps Form Content

### DIFF
--- a/packages/webapp/src/components/Forms/RevenueForm/index.jsx
+++ b/packages/webapp/src/components/Forms/RevenueForm/index.jsx
@@ -98,8 +98,8 @@ const RevenueForm = ({
   const notesPlaceholder = isCropSale(selectedRevenueType)
     ? t('SALE.ADD_SALE.CROP_NOTES_PLACEHOLDER')
     : isAnimalSale(selectedRevenueType)
-      ? t('SALE.ADD_SALE.ANIMAL_NOTES_PLACEHOLDER')
-      : t('SALE.ADD_SALE.NOTES_PLACEHOLDER');
+    ? t('SALE.ADD_SALE.ANIMAL_NOTES_PLACEHOLDER')
+    : t('SALE.ADD_SALE.NOTES_PLACEHOLDER');
 
   useEffect(() => {
     if (revenueTypeOptions?.length && !selectedTypeOption) {
@@ -225,7 +225,7 @@ const RevenueForm = ({
             disabled={disabledInput}
           />
         )}
-        <div style={{ marginTop: 'auto' }}>
+        <div style={{ marginTop: 'auto', paddingTop: '24px' }}>
           {readonly && !isDeleting && (
             <IconLink
               style={{ color: 'var(--grey600)' }}

--- a/packages/webapp/src/components/Forms/RevenueForm/index.jsx
+++ b/packages/webapp/src/components/Forms/RevenueForm/index.jsx
@@ -225,7 +225,7 @@ const RevenueForm = ({
             disabled={disabledInput}
           />
         )}
-        <div style={{ marginTop: 'auto', paddingTop: '24px' }}>
+        <div style={{ marginTop: 'auto', paddingTop: '32px' }}>
           {readonly && !isDeleting && (
             <IconLink
               style={{ color: 'var(--grey600)' }}


### PR DESCRIPTION
**Description**

Add padding above delete confirmation box in `RevenueForm`.

saleItemContainer's `margin-bottom: 32px` was removed here:
https://github.com/LiteFarmOrg/LiteFarm/commit/781aa96d293ceabaa07d3fd408bab587116f4d5d#diff-b2a85abf334b7854398738548f363d83cb7b57f59ad8af521a6110ed23ae1ac3L113

Jira link: https://lite-farm.atlassian.net/browse/LF-5355

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
