### PR TITLE
LF-5358 (2) Send empty [] slots from legacy compatibility endpoint

### DIFF
--- a/packages/api/src/services/weatherService.ts
+++ b/packages/api/src/services/weatherService.ts
@@ -47,9 +47,15 @@ export interface WeatherForecast {
  *
  * The legacy WeatherBoard bundle (still live in cached service workers) renders
  * `city` directly as a React child, so it must stay a string and the legacy
- * top-level fields must be present. `slots` is included so the WeatherForecast
- * bundle released alongside the new API does not crash in `groupSlotsByLocalDay`.
- * The clean shape lives at `GET /weather/forecast`.
+ * top-level fields must be present.
+ *
+ * `slots` is intentionally an empty array. The WeatherForecast bundle released
+ * alongside the new API also requests this URL and iterates `slots`, computing
+ * dates with `city.timezoneOffsetSeconds` — which is undefined here because
+ * `city` is a string, producing `new Date(NaN)` and a RangeError. An empty list
+ * means it iterates nothing, skips the date math, and renders its empty state
+ * instead of crashing. It must stay an array: omitting it would throw on
+ * `slots.forEach`. The full forecast lives at `GET /weather/forecast`.
  */
 export interface LegacyWeatherCompat {
   city: string;
@@ -131,16 +137,7 @@ export const weatherService = {
         date: first.dt,
         wind: first.wind.speed,
         measurement: units,
-        slots: data.list.map((entry) => ({
-          dt: entry.dt,
-          tempC: entry.main.temp,
-          iconCode: entry.weather[0].icon,
-          pop: entry.pop ?? 0,
-          rainMm3h: entry.rain?.['3h'] ?? 0,
-          snowMm3h: entry.snow?.['3h'] ?? 0,
-          windMs: entry.wind.speed,
-          humidity: entry.main.humidity,
-        })),
+        slots: [],
       };
     } catch (error) {
       const axiosError = error as AxiosError;


### PR DESCRIPTION
**Description**

Missing timezone as not compatible with released frontend 6e6a1e6fc

Jira link:

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
