### PR TITLE
LF-5365: Fix missing Jest type globals in API TypeScript config

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -4,7 +4,8 @@
     "allowJs": true,
     "noEmit": true,
     "skipLibCheck": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node", "jest"]
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION
**Description**

I've just noticed that in TS test files, `jest`, `expect`, `describe`, etc. are not recognized as types.

<img width="804" height="491" alt="Screenshot 2026-06-26 at 8 59 21 AM" src="https://github.com/user-attachments/assets/30c45591-4b04-4655-a235-f68cf1fde46c" />

This PR adds the [types field](https://www.typescriptlang.org/tsconfig/#types) to API `tsconfig.json` as suggested by the TS warning.

Jira link: https://lite-farm.atlassian.net/browse/LF-5365

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
