### PR TITLE
LF-5361 Add the Kenya IDEMS Group (Niger Farms) survey to Insights

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1175,6 +1175,9 @@
       "SPECIES_COUNT_other": "{{count}} species",
       "TITLE": "Biodiversity"
     },
+    "CATHI_GAO": {
+      "TITLE": "Cathi-Gao Research Project"
+    },
     "CLICK_TO_CALCULATE": "Click to calculate",
     "CURRENT": "Current",
     "INFO": "Insights provides added data insights into what is happening on your farm. The more data you provide in the application, the more insights can be generated. See individual insights for further information.",

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -48,6 +48,11 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'fao', AU: 'au' },
   },
+  cathi_gao: {
+    image: tape_survey,
+    cdnDirectory: 'idems_surveys',
+    versionsByCountry: { NE: 'cathi_gao' }, // Niger only research project
+  },
 };
 
 /**

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyTitle.ts
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyTitle.ts
@@ -26,6 +26,7 @@ export const useSurveyTitle = (surveyId: string): string => {
 
   const titleBySurveyId: Record<string, string> = {
     tape: t('INSIGHTS.TAPE.TITLE'),
+    cathi_gao: t('INSIGHTS.CATHI_GAO.TITLE'),
   };
 
   return titleBySurveyId[surveyId] ?? t('INSIGHTS.SURVEY.TITLE');


### PR DESCRIPTION
**Description**

The payoff from #4229 🎉 This (and adding to CDN) is all that is needed now to add a new SurveyJS survey to app under the new configuration, if there is no custom results page / graph that has to be shown.

It's a bit confusing, but the research group IDEMS running this survey is Kenya-based. However, the research will be conducted in Niger. Only Niger farms will see the survey.

Cathi-Gao is the name of the project.

Jira link: https://lite-farm.atlassian.net/browse/LF-5361

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
