### PR TITLE
LF-5366 Survey draft persists when creating a new farm via switch farm

### DIFF
--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -101,7 +101,7 @@ import {
   userFarmsByFarmSelector,
 } from './userFarmSlice';
 import { logUserInfoSuccess, userLogReducerSelector } from './userLogSlice';
-import { resetFarmState } from '../store/actionTypes';
+import { resetFarmStateReducer } from '../store/actionTypes';
 import { api, invalidateTags } from '../store/api/apiSlice';
 import { locationApi } from '../store/api/locationApi';
 import { FarmLibraryTags, FarmTags } from '../store/api/apiTags';
@@ -556,7 +556,7 @@ export function* fetchAllSaga() {
 }
 
 export function* clearOldFarmStateSaga() {
-  yield put(resetFarmState());
+  yield put(resetFarmStateReducer());
   yield put(resetTasks());
   yield put(resetDateRange());
   releaseFarmScopedQuerySubscriptions();

--- a/packages/webapp/src/containers/saga.js
+++ b/packages/webapp/src/containers/saga.js
@@ -101,6 +101,7 @@ import {
   userFarmsByFarmSelector,
 } from './userFarmSlice';
 import { logUserInfoSuccess, userLogReducerSelector } from './userLogSlice';
+import { resetFarmState } from '../store/actionTypes';
 import { api, invalidateTags } from '../store/api/apiSlice';
 import { locationApi } from '../store/api/locationApi';
 import { FarmLibraryTags, FarmTags } from '../store/api/apiTags';
@@ -555,6 +556,7 @@ export function* fetchAllSaga() {
 }
 
 export function* clearOldFarmStateSaga() {
+  yield put(resetFarmState());
   yield put(resetTasks());
   yield put(resetDateRange());
   releaseFarmScopedQuerySubscriptions();

--- a/packages/webapp/src/store/actionTypes.js
+++ b/packages/webapp/src/store/actionTypes.js
@@ -19,7 +19,5 @@ export const ActionTypes = {
   RESET_FARM_STATE: 'farmStateReducer/reset',
 };
 
-// Dispatched by clearOldFarmStateSaga on every in-session farm entry (switch, add, invite
-// accept). rootReducer drops the farmStateReducer branch on this action so combineReducers
-// re-initialises it.
-export const resetFarmState = createAction(ActionTypes.RESET_FARM_STATE);
+// Dispatched by clearOldFarmStateSaga (switch, add, and invite)
+export const resetFarmStateReducer = createAction(ActionTypes.RESET_FARM_STATE);

--- a/packages/webapp/src/store/actionTypes.js
+++ b/packages/webapp/src/store/actionTypes.js
@@ -13,6 +13,13 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
+import { createAction } from '@reduxjs/toolkit';
+
 export const ActionTypes = {
-  SWITCH_FARMS: 'chooseFarmFlowReducer/startSwitchFarmModal',
+  RESET_FARM_STATE: 'farmStateReducer/reset',
 };
+
+// Dispatched by clearOldFarmStateSaga on every in-session farm entry (switch, add, invite
+// accept). rootReducer drops the farmStateReducer branch on this action so combineReducers
+// re-initialises it.
+export const resetFarmState = createAction(ActionTypes.RESET_FARM_STATE);

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -232,9 +232,7 @@ const appReducer = combineReducers({
 
 const rootReducer = (state, action) => {
   if (state && action.type === ActionTypes.RESET_FARM_STATE) {
-    // Reset farmStateReducer (notifications, survey drafts) by dropping the branch so
-    // combineReducers re-initialises it. These slices are farm-scoped but their selectors do
-    // not filter by farm_id, so they must be cleared on every farm change.
+    // Drop the farmStateReducer branch so combineReducers re-initialises it
     const { farmStateReducer, ...otherReducers } = state;
     state = otherReducers;
   }

--- a/packages/webapp/src/store/reducer.js
+++ b/packages/webapp/src/store/reducer.js
@@ -231,8 +231,10 @@ const appReducer = combineReducers({
 });
 
 const rootReducer = (state, action) => {
-  if (state && action.type === ActionTypes.SWITCH_FARMS) {
-    // selectively only reset farmStateReducer state when switching farms
+  if (state && action.type === ActionTypes.RESET_FARM_STATE) {
+    // Reset farmStateReducer (notifications, survey drafts) by dropping the branch so
+    // combineReducers re-initialises it. These slices are farm-scoped but their selectors do
+    // not filter by farm_id, so they must be cleared on every farm change.
     const { farmStateReducer, ...otherReducers } = state;
     state = otherReducers;
   }


### PR DESCRIPTION
**Description**

### Background

The more I dig around in our Redux the more interesting it is 😂 

It turns out that we had YET ANOTHER "clear data on farm switch" mechanism that I had completely missed, because it had only been applied to notifications (the list, not the alerts/new notification dot), and _only when the farm switch modal was shown_. (Note that the farm switch modal is not shown when you Add Farm, which is the cause of the bug in both the two linked Jira tickets).

The mechanism was a bit fascinating. There was a dedicated logical branch in the rootReducer:

```js
// reducer.js
const rootReducer = (state, action) => {
  if (state && action.type === ActionTypes.SWITCH_FARMS) {
    // selectively only reset farmStateReducer state when switching farms
    const { farmStateReducer, ...otherReducers } = state;
    state = otherReducers;
  }
 ```
 
And that action type constant `SWITCH_FARMS` was the only entry in this `actionTypes.js` file (that I had also missed)!
 
 ```js
 export const ActionTypes = {
  SWITCH_FARMS: 'chooseFarmFlowReducer/startSwitchFarmModal',
};
```

That type held by the constant is the type dispatched by (as it says) `startSwitchFarmModal` in `chooseFarmFlowSlice.js`. What's super interesting about this was:
- it's just piggy-backing! Even though it's called "SWITCH_FARM" and it's used to drop the farmStateReducer state, what the action ACTUALLY does is simply set the "show modal" state to true for the given farm:

```js
// chooseFarmFlowSlice.js
startSwitchFarmModal: (state, { payload: farm_id }) => {
  updateFarmState(state, { farm_id, showSwitchFarmModal: true });
},
```
  - that means if, for any reason we refactored the UI to stop showing this modal and removed the action, we would incidentally have also lost the Redux state reset
- as mentioned above, the modal isn't shown on every case of moving from an old farm to a new farm. Add Farm in particular will never call `startSwitchFarmModal`

### Chosen Solution

To address these issues, this PR:
- adds a dedicated action specifically for what we want to do in (resetting the FarmStateReducer) in place of the piggy-back on showing the farm switch modal
- calls this in `clearOldFarmState()` since that is now reliably shared between _all_ the pathways that involve from moving from one farm to another without logging out (switch, Add Farm, and accept invite)

### Implications for future refactor
An implication of this not pursued further in _this_ PR, is that we actually could have -- and probably should have -- thrown all the `tempStateReducer` Redux state that we wanted dropped on farm switch here into `farmStateReducer`. I'm thinking in particular the filter state and the date ranges (finances, profitability).

What both `tempStateReducer` and `farmStateReducer` share is that they aren't keyed to `farm_id` via `loginSelector` the way that the entries in `entitiesReducer` are. It's not within scope here, but it should be safe and effective to rearrange them a little bit so that all the ones that should be dropped on switch live only in `farmStateReducer`. If we follow that convention moving forward, we will have three predictable ways to drop Redux state on farm switch (=`loginSelector`, `invalidatesTags`, and `resetFarmStateReducer`) and we should be clear of this category of bugs moving forward 🤞

Jira link: 
https://lite-farm.atlassian.net/browse/LF-5366 (surveyDraftSlice) and 
https://lite-farm.atlassian.net/browse/LF-5368 (notificationSlice)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
