### PR TITLE
LF-5370 Completed survey can be retaken by using the browser Back button

### DIFF
--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -90,7 +90,8 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
         }).unwrap();
         prefetchLatestResponse({ surveyKey: surveyId });
         dispatch(clearSurvey({ surveyId }));
-        history.push(`/insights/survey/${surveyId}/results`);
+        // Replace instead of push so the browser back button returns to Insights
+        history.replace(`/insights/survey/${surveyId}/results`);
       } catch {
         // Display the default "An error occurred and we could not save the results." message.
         options.showSaveError();

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -90,7 +90,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
         }).unwrap();
         prefetchLatestResponse({ surveyKey: surveyId });
         dispatch(clearSurvey({ surveyId }));
-        // Replace instead of push so the browser back button returns to Insights
+        // Replace instead of push so the submitted survey is not left in the history stack
         history.replace(`/insights/survey/${surveyId}/results`);
       } catch {
         // Display the default "An error occurred and we could not save the results." message.


### PR DESCRIPTION
**Description**

As Loïc indicated, this is not a particularly important bug, but the fix is minimal as well. 

Jira link: https://lite-farm.atlassian.net/browse/LF-5370

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested on Cathi Gao and FAO TAPE. If desired, can also be tested on a modified testing FAO TAPE by pointing `surveyConfig.ts` to this version uploaded to the local DO bucket:

```ts
//surveyConfig.ts -- SURVEY_INFO.tape
versionsByCountry: { default: 'fao_local_no_required', AU: 'au' },
```

`fao_local_no_required.json` is identical to the prod-served `fao.json`, except that it has no required questions, making submission MUCH easier.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
