### PR TITLE
LF-5375 Handle pagination on the irrigation prescription list endpoint

### DIFF
--- a/packages/api/src/controllers/timeNotificationController.js
+++ b/packages/api/src/controllers/timeNotificationController.js
@@ -135,7 +135,10 @@ const timeNotificationController = {
       );
 
       for (const locationId in prescriptionsByLocation) {
-        const latestPrescription = prescriptionsByLocation[locationId].at(-1);
+        // Select the latest prescription explicitly rather than relying on the order Ensemble returns.
+        const latestPrescription = prescriptionsByLocation[locationId].reduce((latest, current) =>
+          current.id > latest.id ? current : latest,
+        );
         const { id: irrigation_prescription_id, recommended_start_date } = latestPrescription;
 
         const previousNotification = await NotificationModel.query()

--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -138,13 +138,18 @@ export const getIrrigationPrescriptions = async (
   // Get and check data
   const irrigationPrescriptionListResponse = await ensembleAPICall(axiosObject, onError);
 
+  // Ensemble will paginate this endpoint, returning prescriptions under 'results'
+  // Accept both the paginated envelope and the original bare array
+  const responseBody = irrigationPrescriptionListResponse.data;
+  const prescriptions = Array.isArray(responseBody) ? responseBody : responseBody?.results ?? [];
+
   // Add url names (org and system) to each prescription
   const organisation = await getValidEnsembleOrg(externalOrganizationIds.org_uuid);
   const systemUrlNames = Object.fromEntries(
     (organisation?.systems ?? []).map((system) => [system.pk, system.url_name]),
   );
 
-  irrigationPrescriptionListResponse.data = irrigationPrescriptionListResponse.data.map(
+  irrigationPrescriptionListResponse.data = prescriptions.map(
     (prescription: ExternalIrrigationPrescription) => ({
       ...prescription,
       organisation_url_name: organisation?.url_name,

--- a/packages/api/src/util/ensembleService.ts
+++ b/packages/api/src/util/ensembleService.ts
@@ -138,10 +138,8 @@ export const getIrrigationPrescriptions = async (
   // Get and check data
   const irrigationPrescriptionListResponse = await ensembleAPICall(axiosObject, onError);
 
-  // Ensemble will paginate this endpoint, returning prescriptions under 'results'
-  // Accept both the paginated envelope and the original bare array
-  const responseBody = irrigationPrescriptionListResponse.data;
-  const prescriptions = Array.isArray(responseBody) ? responseBody : responseBody?.results ?? [];
+  // Ensemble paginates this endpoint, returning prescriptions under 'results'
+  const { results: prescriptions = [] } = irrigationPrescriptionListResponse.data ?? {};
 
   // Add url names (org and system) to each prescription
   const organisation = await getValidEnsembleOrg(externalOrganizationIds.org_uuid);

--- a/packages/api/tests/irrigation_prescription.test.ts
+++ b/packages/api/tests/irrigation_prescription.test.ts
@@ -215,6 +215,62 @@ describe('Get Irrigation Prescription Tests', () => {
     });
   });
 
+  describe('Paginated prescription list response', () => {
+    test('Unwraps prescriptions returned under a paginated `results` envelope', async () => {
+      const { farm, field, user } = await setupFarmEnvironment(1);
+      await connectFarmToEnsemble(farm, ESciAddonPartner);
+
+      const externalIrrigationPrescriptions = await Promise.all(
+        [1, 2].map(async (id) =>
+          mocks.buildExternalIrrigationPrescription({
+            id,
+            providedFarm: farm,
+            providedLocation: field,
+          }),
+        ),
+      );
+
+      const irrigationPrescriptions = await Promise.all(
+        externalIrrigationPrescriptions.map(async (externalIrrigationPrescription) =>
+          mocks.buildIrrigationPrescription({
+            providedExternalIrrigationPrescription: externalIrrigationPrescription,
+            providedPartner: ESciAddonPartner,
+            linkToTask: false,
+          }),
+        ),
+      );
+
+      const today = new Date();
+      const startDate = today.toISOString().split('T')[0];
+      const endDate = addDaysToDate(today, 1).toISOString().split('T')[0];
+
+      // GET prescription list — paginated envelope
+      mockedAxios.mockResolvedValueOnce({
+        data: {
+          count: externalIrrigationPrescriptions.length,
+          next: null,
+          previous: null,
+          results: externalIrrigationPrescriptions,
+        },
+      });
+
+      // GET Ensemble Organisation (org content not part of tests)
+      mockedAxios.mockResolvedValueOnce({
+        data: [],
+      });
+
+      const res = await getIrrigationPrescription({
+        farm_id: farm.farm_id,
+        user_id: user.user_id,
+        startTime: startDate,
+        endTime: endDate,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(removeUndefined(irrigationPrescriptions));
+    });
+  });
+
   describe('All users should be able to GET irrigation prescription details', () => {
     [1, 2, 3, 5].forEach((role) => {
       test(`User with role ${role} should request IP details`, async () => {

--- a/packages/api/tests/irrigation_prescription.test.ts
+++ b/packages/api/tests/irrigation_prescription.test.ts
@@ -158,9 +158,14 @@ describe('Get Irrigation Prescription Tests', () => {
         const startDate = today.toISOString().split('T')[0];
         const endDate = addDaysToDate(today, 1).toISOString().split('T')[0];
 
-        // GET prescription list
+        // GET prescription list — paginated envelope
         mockedAxios.mockResolvedValueOnce({
-          data: externalIrrigationPrescriptions,
+          data: {
+            count: externalIrrigationPrescriptions.length,
+            next: null,
+            previous: null,
+            results: externalIrrigationPrescriptions,
+          },
         });
 
         // GET Ensemble Organisation (org content not part of tests)
@@ -193,9 +198,14 @@ describe('Get Irrigation Prescription Tests', () => {
         expect(irrigationPrescriptionsWithTasks.length).toBe(2);
         expect(irrigationPrescriptionsWithTasks[0].task_id).toBeTruthy();
 
-        // GET prescription list
+        // GET prescription list — paginated envelope
         mockedAxios.mockResolvedValueOnce({
-          data: irrigationPrescriptionsWithTasks,
+          data: {
+            count: irrigationPrescriptionsWithTasks.length,
+            next: null,
+            previous: null,
+            results: irrigationPrescriptionsWithTasks,
+          },
         });
 
         // GET Ensemble Organisation (org content not part of tests)
@@ -212,62 +222,6 @@ describe('Get Irrigation Prescription Tests', () => {
 
         expect(res2.body).toMatchObject(removeUndefined(irrigationPrescriptionsWithTasks));
       });
-    });
-  });
-
-  describe('Paginated prescription list response', () => {
-    test('Unwraps prescriptions returned under a paginated `results` envelope', async () => {
-      const { farm, field, user } = await setupFarmEnvironment(1);
-      await connectFarmToEnsemble(farm, ESciAddonPartner);
-
-      const externalIrrigationPrescriptions = await Promise.all(
-        [1, 2].map(async (id) =>
-          mocks.buildExternalIrrigationPrescription({
-            id,
-            providedFarm: farm,
-            providedLocation: field,
-          }),
-        ),
-      );
-
-      const irrigationPrescriptions = await Promise.all(
-        externalIrrigationPrescriptions.map(async (externalIrrigationPrescription) =>
-          mocks.buildIrrigationPrescription({
-            providedExternalIrrigationPrescription: externalIrrigationPrescription,
-            providedPartner: ESciAddonPartner,
-            linkToTask: false,
-          }),
-        ),
-      );
-
-      const today = new Date();
-      const startDate = today.toISOString().split('T')[0];
-      const endDate = addDaysToDate(today, 1).toISOString().split('T')[0];
-
-      // GET prescription list — paginated envelope
-      mockedAxios.mockResolvedValueOnce({
-        data: {
-          count: externalIrrigationPrescriptions.length,
-          next: null,
-          previous: null,
-          results: externalIrrigationPrescriptions,
-        },
-      });
-
-      // GET Ensemble Organisation (org content not part of tests)
-      mockedAxios.mockResolvedValueOnce({
-        data: [],
-      });
-
-      const res = await getIrrigationPrescription({
-        farm_id: farm.farm_id,
-        user_id: user.user_id,
-        startTime: startDate,
-        endTime: endDate,
-      });
-
-      expect(res.status).toBe(200);
-      expect(res.body).toMatchObject(removeUndefined(irrigationPrescriptions));
     });
   });
 

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -616,6 +616,36 @@ describe('Time Based Notification Tests', () => {
         );
       });
 
+      test('Selects the latest prescription per location when responses are in descending order', async () => {
+        await mockedAxios.mockResolvedValue({
+          status: 201,
+          data: [
+            {
+              id: 402,
+              recommended_start_date: '2025-05-08',
+              location_id: field.location_id,
+            },
+            {
+              id: 401,
+              recommended_start_date: '2025-05-07',
+              location_id: field.location_id,
+            },
+          ],
+        });
+
+        const res = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
+
+        expect(res.status).toBe(201);
+
+        const rows = await knex('notification')
+          .where('farm_id', farm.farm_id)
+          .whereRaw("(context->'irrigation_prescription_id') IN (?, ?)", [401, 402]);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].context.irrigation_prescription_id).toBe(402);
+        expect(rows[0].ref.url).toBe('/irrigation_prescription/402');
+      });
+
       test('Repeat notifications are not sent for the same irrigation prescription', async () => {
         await mockedAxios.mockResolvedValue({
           status: 201,

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -564,10 +564,7 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('One notification record should be created for the latest irrigation prescription on each location', async () => {
-        // Organisation lookup (2nd Ensemble call) and any retry resolve to an empty array.
-        mockedAxios.mockResolvedValue({ data: [] });
-        // Prescription list (1st Ensemble call) — paginated envelope.
-        await mockedAxios.mockResolvedValueOnce({
+        const listResponse = {
           status: 201,
           data: {
             count: 4,
@@ -596,7 +593,15 @@ describe('Time Based Notification Tests', () => {
               },
             ],
           },
-        });
+        };
+
+        // Prescription requests return the paginated envelope; the organisation
+        // lookup (and anything else) returns an empty array.
+        mockedAxios.mockImplementation((config) =>
+          config.url?.includes('/prescriptions')
+            ? Promise.resolve(listResponse)
+            : Promise.resolve({ data: [] }),
+        );
 
         const res = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
 
@@ -625,10 +630,8 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('Selects the latest prescription per location when responses are in descending order', async () => {
-        // Organisation lookup (2nd Ensemble call) and any retry resolve to an empty array.
-        mockedAxios.mockResolvedValue({ data: [] });
-        // Prescription list (1st Ensemble call) — paginated envelope, descending order.
-        await mockedAxios.mockResolvedValueOnce({
+        // Prescription list in descending order.
+        const listResponse = {
           status: 201,
           data: {
             count: 2,
@@ -647,7 +650,15 @@ describe('Time Based Notification Tests', () => {
               },
             ],
           },
-        });
+        };
+
+        // Prescription requests return the paginated envelope; the organisation
+        // lookup (and anything else) returns an empty array.
+        mockedAxios.mockImplementation((config) =>
+          config.url?.includes('/prescriptions')
+            ? Promise.resolve(listResponse)
+            : Promise.resolve({ data: [] }),
+        );
 
         const res = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
 
@@ -684,13 +695,13 @@ describe('Time Based Notification Tests', () => {
           },
         };
 
-        // Each controller call fetches the list then the organisation; the organisation
-        // lookup (and any retry) resolves to an empty array.
-        mockedAxios
-          .mockResolvedValue({ data: [] })
-          .mockResolvedValueOnce(listResponse)
-          .mockResolvedValueOnce({ data: [] })
-          .mockResolvedValueOnce(listResponse);
+        // Prescription requests return the paginated envelope; the organisation
+        // lookup (and anything else) returns an empty array
+        mockedAxios.mockImplementation((config) =>
+          config.url?.includes('/prescriptions')
+            ? Promise.resolve(listResponse)
+            : Promise.resolve({ data: [] }),
+        );
 
         const res1 = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
 
@@ -711,10 +722,7 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('Notifications should not be sent for irrigation prescriptions associated with deleted locations', async () => {
-        // Organisation lookup (2nd Ensemble call) and any retry resolve to an empty array.
-        mockedAxios.mockResolvedValue({ data: [] });
-        // Prescription list (1st Ensemble call) — paginated envelope.
-        await mockedAxios.mockResolvedValueOnce({
+        const listResponse = {
           status: 201,
           data: {
             count: 4,
@@ -743,7 +751,15 @@ describe('Time Based Notification Tests', () => {
               },
             ],
           },
-        });
+        };
+
+        // Prescription requests return the paginated envelope; the organisation
+        // lookup (and anything else) returns an empty array.
+        mockedAxios.mockImplementation((config) =>
+          config.url?.includes('/prescriptions')
+            ? Promise.resolve(listResponse)
+            : Promise.resolve({ data: [] }),
+        );
 
         // Delete the first location
         await knex('location').where({ location_id: field.location_id }).update({ deleted: true });

--- a/packages/api/tests/timeNotification.test.js
+++ b/packages/api/tests/timeNotification.test.js
@@ -564,30 +564,38 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('One notification record should be created for the latest irrigation prescription on each location', async () => {
-        await mockedAxios.mockResolvedValue({
+        // Organisation lookup (2nd Ensemble call) and any retry resolve to an empty array.
+        mockedAxios.mockResolvedValue({ data: [] });
+        // Prescription list (1st Ensemble call) — paginated envelope.
+        await mockedAxios.mockResolvedValueOnce({
           status: 201,
-          data: [
-            {
-              id: 122,
-              recommended_start_date: '2025-05-07',
-              location_id: field.location_id,
-            },
-            {
-              id: 123,
-              recommended_start_date: '2025-05-07',
-              location_id: secondField.location_id,
-            },
-            {
-              id: 124,
-              recommended_start_date: '2025-05-08',
-              location_id: field.location_id,
-            },
-            {
-              id: 125,
-              recommended_start_date: '2025-05-08',
-              location_id: secondField.location_id,
-            },
-          ],
+          data: {
+            count: 4,
+            next: null,
+            previous: null,
+            results: [
+              {
+                id: 122,
+                recommended_start_date: '2025-05-07',
+                location_id: field.location_id,
+              },
+              {
+                id: 123,
+                recommended_start_date: '2025-05-07',
+                location_id: secondField.location_id,
+              },
+              {
+                id: 124,
+                recommended_start_date: '2025-05-08',
+                location_id: field.location_id,
+              },
+              {
+                id: 125,
+                recommended_start_date: '2025-05-08',
+                location_id: secondField.location_id,
+              },
+            ],
+          },
         });
 
         const res = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
@@ -617,20 +625,28 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('Selects the latest prescription per location when responses are in descending order', async () => {
-        await mockedAxios.mockResolvedValue({
+        // Organisation lookup (2nd Ensemble call) and any retry resolve to an empty array.
+        mockedAxios.mockResolvedValue({ data: [] });
+        // Prescription list (1st Ensemble call) — paginated envelope, descending order.
+        await mockedAxios.mockResolvedValueOnce({
           status: 201,
-          data: [
-            {
-              id: 402,
-              recommended_start_date: '2025-05-08',
-              location_id: field.location_id,
-            },
-            {
-              id: 401,
-              recommended_start_date: '2025-05-07',
-              location_id: field.location_id,
-            },
-          ],
+          data: {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+              {
+                id: 402,
+                recommended_start_date: '2025-05-08',
+                location_id: field.location_id,
+              },
+              {
+                id: 401,
+                recommended_start_date: '2025-05-07',
+                location_id: field.location_id,
+              },
+            ],
+          },
         });
 
         const res = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
@@ -647,21 +663,35 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('Repeat notifications are not sent for the same irrigation prescription', async () => {
-        await mockedAxios.mockResolvedValue({
+        const listResponse = {
           status: 201,
-          data: [
-            {
-              id: 223,
-              recommended_start_date: '2025-05-07',
-              location_id: field.location_id,
-            },
-            {
-              id: 224,
-              recommended_start_date: '2025-05-08',
-              location_id: field.location_id,
-            },
-          ],
-        });
+          data: {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+              {
+                id: 223,
+                recommended_start_date: '2025-05-07',
+                location_id: field.location_id,
+              },
+              {
+                id: 224,
+                recommended_start_date: '2025-05-08',
+                location_id: field.location_id,
+              },
+            ],
+          },
+        };
+
+        // Each controller call fetches the list then the organisation; the organisation
+        // lookup (and any retry) resolves to an empty array.
+        mockedAxios
+          .mockResolvedValue({ data: [] })
+          .mockResolvedValueOnce(listResponse)
+          .mockResolvedValueOnce({ data: [] })
+          .mockResolvedValueOnce(listResponse);
+
         const res1 = await postDailyNewIrrigationPrescriptions({ farm_id: farm.farm_id });
 
         // 201 is controller response for notifications sent
@@ -681,30 +711,38 @@ describe('Time Based Notification Tests', () => {
       });
 
       test('Notifications should not be sent for irrigation prescriptions associated with deleted locations', async () => {
-        await mockedAxios.mockResolvedValue({
+        // Organisation lookup (2nd Ensemble call) and any retry resolve to an empty array.
+        mockedAxios.mockResolvedValue({ data: [] });
+        // Prescription list (1st Ensemble call) — paginated envelope.
+        await mockedAxios.mockResolvedValueOnce({
           status: 201,
-          data: [
-            {
-              id: 301,
-              recommended_start_date: '2025-05-07',
-              location_id: field.location_id,
-            },
-            {
-              id: 302,
-              recommended_start_date: '2025-05-07',
-              location_id: secondField.location_id,
-            },
-            {
-              id: 303,
-              recommended_start_date: '2025-05-08',
-              location_id: field.location_id,
-            },
-            {
-              id: 304,
-              recommended_start_date: '2025-05-08',
-              location_id: secondField.location_id,
-            },
-          ],
+          data: {
+            count: 4,
+            next: null,
+            previous: null,
+            results: [
+              {
+                id: 301,
+                recommended_start_date: '2025-05-07',
+                location_id: field.location_id,
+              },
+              {
+                id: 302,
+                recommended_start_date: '2025-05-07',
+                location_id: secondField.location_id,
+              },
+              {
+                id: 303,
+                recommended_start_date: '2025-05-08',
+                location_id: field.location_id,
+              },
+              {
+                id: 304,
+                recommended_start_date: '2025-05-08',
+                location_id: secondField.location_id,
+              },
+            ],
+          },
         });
 
         // Delete the first location


### PR DESCRIPTION
**Description**

In repairing other issues with the Irrigation Prescriptions, Ensemble requested that they start paginating this endpoint:

```
organizations/{{org_pk}}/prescriptions
```

Apparently it was becoming too slow for orgs with multiple prescriptions. As we are only interested in the latest prescriptions anyway, pagination would make sense from our end too. Since we are releasing Monday morning, and since the IPs weren't quite working on prod anyway (with the exception of exactly one system), I thought the IPs breaking until then was an acceptable trade off and gave Ensemble the okay to go ahead.

Like with the profiles endpoint adjust added here: https://github.com/LiteFarmOrg/LiteFarm/pull/4194/changes/789d7af31242882da4a30281257102afb030d9e9 , we need to update our code to accept this. And like with the profiles endpoint change, the move to pagination breaks the original endpoint until updated.

Ensemble was quick to update to the new endpoint, so we can expect to see [Sentry errors like this](https://litefarm.sentry.io/issues/7592733752/events/81809275fb7d442599067f84b8221a70/) on prod until the adjustment goes live on our end as well.

In this PR there is a related but independent change -- the notifications controller relied on a `.at(-1)` to pull out the latest prescription per location, which in retrospect seems like a very dangerous way to grab the latest prescription :) With the pagination change, prescriptions are now returned in descending instead of ascending order, so that has been updated to a method that is less brittle and can handle either order.

Jira link: https://lite-farm.atlassian.net/browse/LF-5375

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

This is the frontend view that uses the notification list endpoint: you can see the tab disappear on intgration and restored on this branch for the newest (Farming Smarter) org ID (the singular working system)

<img width="1065" height="472" alt="Screenshot 2026-07-03 at 3 46 00 PM" src="https://github.com/user-attachments/assets/1a4c705b-7b16-4a09-a775-3ba18afca9f0" />

_I haven't actually gotten notifications working for that farm yet; not sure why_. But I saw notifications generated on one of the other testing farms I set up last year, so I think the flow is functional; will continue to investigate the missing notifications on the new org. -- oh, it was a missing `utc_offset`. Not related.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
