### PR TITLE
LF-5383: Certification export email is not sent when using the khmer language

### DIFF
--- a/packages/api/src/jobs/certification/fileUtils.js
+++ b/packages/api/src/jobs/certification/fileUtils.js
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Makes a string safe to use as a single file name segment. Translated or
+ * user-provided strings can contain path separators (e.g. "/" in the Khmer
+ * translation of "Crop Production Aids") or characters that are invalid on
+ * some filesystems, which would otherwise break file creation or zip
+ * extraction.
+ */
+export const sanitizeFileName = (name) =>
+  name
+    .replace(/[/\\:*?"<>|]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();

--- a/packages/api/src/jobs/certification/record_a_generation.js
+++ b/packages/api/src/jobs/certification/record_a_generation.js
@@ -1,5 +1,6 @@
 import XlsxPopulate from 'xlsx-populate';
 import { i18n, t, tCrop } from '../locales/i18nt.js';
+import { sanitizeFileName } from './fileUtils.js';
 
 export default (data, exportId, from_date, to_date, farm_name, measurement) => {
   return XlsxPopulate.fromBlankAsync().then((workbook) => {
@@ -193,7 +194,9 @@ export default (data, exportId, from_date, to_date, farm_name, measurement) => {
         });
       });
     return workbook.toFileAsync(
-      `${process.env.EXPORT_WD}/temp/${exportId}/${t('RECORD_A.EXPORT_DOCUMENT_NAME')}.xlsx`,
+      `${process.env.EXPORT_WD}/temp/${exportId}/${sanitizeFileName(
+        t('RECORD_A.EXPORT_DOCUMENT_NAME'),
+      )}.xlsx`,
     );
   });
 };

--- a/packages/api/src/jobs/certification/record_d_generation.js
+++ b/packages/api/src/jobs/certification/record_d_generation.js
@@ -1,5 +1,6 @@
 import XlsxPopulate from 'xlsx-populate';
 import { i18n, t, tCrop } from '../locales/i18nt.js';
+import { sanitizeFileName } from './fileUtils.js';
 const boolToStringTransformation = (bool) =>
   bool ? i18n.t('Y') : bool !== null ? i18n.t('N') : i18n.t('N/A');
 const blankTransformation = () => '';
@@ -173,7 +174,9 @@ export default (data, exportId, from_date, to_date, farm_name) => {
       });
     });
     return workbook.toFileAsync(
-      `${process.env.EXPORT_WD}/temp/${exportId}/${t('RECORD_D.EXPORT_DOCUMENT_NAME')}.xlsx`,
+      `${process.env.EXPORT_WD}/temp/${exportId}/${sanitizeFileName(
+        t('RECORD_D.EXPORT_DOCUMENT_NAME'),
+      )}.xlsx`,
     );
   });
 };

--- a/packages/api/src/jobs/certification/record_i_generation.js
+++ b/packages/api/src/jobs/certification/record_i_generation.js
@@ -1,5 +1,6 @@
 import XlsxPopulate from 'xlsx-populate';
 import { i18n, t, tCrop } from '../locales/i18nt.js';
+import { sanitizeFileName } from './fileUtils.js';
 const dataToCellMapping = {
   name: 'A',
   supplier: 'B',
@@ -230,9 +231,9 @@ export default (data, exportId, from_date, to_date, farm_name, measurement, isIn
         });
     });
     return workbook.toFileAsync(
-      `${process.env.EXPORT_WD}/temp/${exportId}/${t(
-        'RECORD_I.EXPORT_DOCUMENT_NAME',
-      )} - ${title}.xlsx`,
+      `${process.env.EXPORT_WD}/temp/${exportId}/${sanitizeFileName(
+        `${t('RECORD_I.EXPORT_DOCUMENT_NAME')} - ${title}`,
+      )}.xlsx`,
     );
   });
 };

--- a/packages/api/src/jobs/certification/survey_record.js
+++ b/packages/api/src/jobs/certification/survey_record.js
@@ -1,5 +1,6 @@
 import XlsxPopulate from 'xlsx-populate';
 import rp from 'request-promise';
+import { sanitizeFileName } from './fileUtils.js';
 const surveyStackURL = 'https://app.surveystack.io/api/';
 
 export default async (emailQueue, submission, exportId, organicCertifierSurvey, certifier) => {
@@ -374,6 +375,8 @@ export default async (emailQueue, submission, exportId, organicCertifierSurvey, 
     }
 
     // Write to file.
-    return workbook.toFileAsync(`${process.env.EXPORT_WD}/temp/${exportId}/${surveyName}.xlsx`);
+    return workbook.toFileAsync(
+      `${process.env.EXPORT_WD}/temp/${exportId}/${sanitizeFileName(surveyName)}.xlsx`,
+    );
   });
 };


### PR DESCRIPTION
**Description**

Certification export fails with `ENOENT` when the farm language is Khmer. The Khmer translation of "Crop Production Aids" — `សម្ភារៈ/សារធាតុជួយការផលិតដំណាំ` — legitimately contains a `/`. Record I generation interpolates this translated string directly into the output file path, so the filesystem treats the `/` as a directory separator and tries to write into a subdirectory that doesn't exist. The export job dies and the email is never sent.

* New `fileUtils.js` — `sanitizeFileName()` replaces path separators and Windows-reserved characters `(/ \ : * ? " < > |)` with spaces and collapses whitespace. The Windows characters matter because users download the export zip and may extract it on Windows, where such file names fail or get mangled.
* `record_i_generation.js` — the failing case; the full `RECORD I - {title}` filename is now sanitized. The Khmer file becomes `កំណត់ត្រា អាយ - សម្ភារៈ សារធាតុជួយការផលិតដំណាំ.xlsx`.
* `survey_record` — same bug waiting to happen with surveyName, which comes from `SurveyStack` data and could contain anything.
* `record_a_generation.js` — defensive, so a future Crowdin sync can't reintroduce the crash via EXPORT_DOCUMENT_NAME.

Jira link: https://lite-farm.atlassian.net/browse/LF-5383

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)
         Tested manually.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
