### PR TITLE
LF-5377: Include certifications in DFC output

### DIFF
--- a/packages/api/src/controllers/dataFoodConsortiumController.ts
+++ b/packages/api/src/controllers/dataFoodConsortiumController.ts
@@ -48,7 +48,10 @@ const dataFoodConsortiumController = {
           .findById(id)
           .withGraphFetched({
             market_product_categories: true,
-          });
+            certifications: { certificationSystemType: true, certifier: true },
+          })
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          .modifyGraph('certifications', (builder: any) => builder.whereNotDeleted());
 
         const marketProductCategoryMap = await MarketProductCategoryModel.getLookupMap();
         const dfcFormattedListingData = await formatFarmDataToDfcStandard(
@@ -94,7 +97,10 @@ const dataFoodConsortiumController = {
           )
           .withGraphFetched({
             market_product_categories: true,
-          });
+            certifications: { certificationSystemType: true, certifier: true },
+          })
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          .modifyGraph('certifications', (builder: any) => builder.whereNotDeleted());
 
         let data = {};
 

--- a/packages/api/src/controllers/dataFoodConsortiumController.ts
+++ b/packages/api/src/controllers/dataFoodConsortiumController.ts
@@ -51,7 +51,16 @@ const dataFoodConsortiumController = {
             certifications: { certificationSystemType: true, certifier: true },
           })
           /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-          .modifyGraph('certifications', (builder: any) => builder.whereNotDeleted());
+          .modifyGraph('certifications', (builder: any) =>
+            builder
+              .whereNotDeleted()
+              // Exclude certifications from their expiry date (UTC) onward, guaranteeing an
+              // expired cert is never shown regardless of the farm's timezone
+              /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+              .where((qb: any) =>
+                qb.whereNull('valid_until').orWhereRaw('valid_until > CURRENT_DATE'),
+              ),
+          );
 
         const marketProductCategoryMap = await MarketProductCategoryModel.getLookupMap();
         const dfcFormattedListingData = await formatFarmDataToDfcStandard(
@@ -100,7 +109,16 @@ const dataFoodConsortiumController = {
             certifications: { certificationSystemType: true, certifier: true },
           })
           /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-          .modifyGraph('certifications', (builder: any) => builder.whereNotDeleted());
+          .modifyGraph('certifications', (builder: any) =>
+            builder
+              .whereNotDeleted()
+              // Exclude certifications from their expiry date (UTC) onward, guaranteeing an
+              // expired cert is never shown regardless of the farm's timezone
+              /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+              .where((qb: any) =>
+                qb.whereNull('valid_until').orWhereRaw('valid_until > CURRENT_DATE'),
+              ),
+          );
 
         let data = {};
 

--- a/packages/api/src/models/certificationModel.js
+++ b/packages/api/src/models/certificationModel.js
@@ -20,6 +20,19 @@ import farmModel from './farmModel.js';
 import certificationSystemTypeModel from './certificationSystemTypeModel.js';
 import certifierModel from './certifierModel.js';
 
+export const CERTIFICATION_TYPES = [
+  'ORGANIC',
+  'BIODYNAMIC',
+  'REGENERATIVE',
+  'CERTIFIED_HUMANE',
+  'FAIR_TRADE',
+  'GRASSFED/PASTURE',
+  'SUSTAINABILITY',
+  'ANIMAL_WELFARE',
+  'NON-GMO',
+  'CARBON/CLIMATE',
+];
+
 class Certification extends BaseModel {
   static get tableName() {
     return 'certification';
@@ -41,7 +54,7 @@ class Certification extends BaseModel {
         requested_system_type: { type: ['string', 'null'] },
         other_certifier: { type: ['string', 'null'] },
         is_active: { type: 'boolean' },
-        certification_type: { type: ['string', 'null'] },
+        certification_type: { type: ['string', 'null'], enum: [...CERTIFICATION_TYPES, null] },
         certificate_number: { type: ['string', 'null'] },
         certificate_member_id: { type: ['string', 'null'] },
         issue_date: { type: ['string', 'null'] },

--- a/packages/api/src/models/certificationModel.js
+++ b/packages/api/src/models/certificationModel.js
@@ -17,6 +17,8 @@ import Model from './baseFormatModel.js';
 import BaseModel from './baseModel.js';
 import userFarmModel from './userFarmModel.js';
 import farmModel from './farmModel.js';
+import certificationSystemTypeModel from './certificationSystemTypeModel.js';
+import certifierModel from './certifierModel.js';
 
 class Certification extends BaseModel {
   static get tableName() {
@@ -67,6 +69,22 @@ class Certification extends BaseModel {
         join: {
           from: 'certification.farm_id',
           to: 'farm.farm_id',
+        },
+      },
+      certificationSystemType: {
+        modelClass: certificationSystemTypeModel,
+        relation: Model.BelongsToOneRelation,
+        join: {
+          from: 'certification.system_type_id',
+          to: 'certification_system_type.id',
+        },
+      },
+      certifier: {
+        modelClass: certifierModel,
+        relation: Model.BelongsToOneRelation,
+        join: {
+          from: 'certification.certifier_id',
+          to: 'certifiers.certifier_id',
         },
       },
     };

--- a/packages/api/src/models/certifierModel.js
+++ b/packages/api/src/models/certifierModel.js
@@ -33,7 +33,6 @@ class Certifier extends Model {
         system_type_id: { type: 'integer' },
         certifier_name: { type: 'string' },
         certifier_acronym: { type: 'string' },
-        supported: { type: 'boolean' },
         survey_id: { type: 'string' },
       },
       additionalProperties: false,

--- a/packages/api/src/models/marketDirectoryInfoModel.js
+++ b/packages/api/src/models/marketDirectoryInfoModel.js
@@ -18,6 +18,7 @@ import { checkAndTrimString } from '../util/util.js';
 import Model from './baseFormatModel.js';
 import MarketDirectoryInfoMarketProductCategoryModel from './marketDirectoryInfoMarketProductCategoryModel.js';
 import MarketDirectoryPartnerPermissions from './marketDirectoryPartnerPermissions.js';
+import certificationModel from './certificationModel.js';
 
 class MarketDirectoryInfo extends baseModel {
   static get tableName() {
@@ -119,6 +120,14 @@ class MarketDirectoryInfo extends baseModel {
         join: {
           from: 'market_directory_info.id',
           to: 'market_directory_partner_permissions.market_directory_info_id',
+        },
+      },
+      certifications: {
+        relation: Model.HasManyRelation,
+        modelClass: certificationModel,
+        join: {
+          from: 'market_directory_info.farm_id',
+          to: 'certification.farm_id',
         },
       },
     };

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -632,6 +632,37 @@ export interface DocumentWithFiles extends Document {
   files?: File[];
 }
 
+// TODO LF-5379: field names use the $formatJson shim names — update when shim is removed
+export type CertificationSystemType = {
+  certification_id: number;
+  certification_type: string;
+  certification_translation_key: string;
+};
+
+export type Certifier = {
+  certifier_id: number;
+  certification_id?: CertificationSystemType['certification_id'];
+  certifier_name: string;
+  certifier_acronym: string | null;
+  survey_id?: string;
+};
+
+export type Certification = {
+  survey_id: string;
+  certification_id: number | null;
+  certifier_id: number | null;
+  certificate_member_id: string | null;
+  farm_id: string;
+  certificationSystemType?: CertificationSystemType | null;
+  certifier?: Certifier | null;
+  is_active: boolean;
+  certification_type?: string | null;
+  certification_identifier?: string | null;
+  start_date?: string | null;
+  expiry_date?: string | null;
+  document_file_url?: string | null;
+};
+
 export type MarketDirectoryInfo = {
   id: string;
   farm_id: Farm['farm_id'];
@@ -662,32 +693,9 @@ export type MarketDirectoryInfoMarketProductCategory = {
   market_product_category_id: MarketProductCategory['id'];
 };
 
-// TODO LF-5379: field names use the $formatJson shim names — update when shim is removed
-export type MarketDirectoryCertificationSystemType = {
-  certification_id: number;
-  certification_type: string;
-  certification_translation_key: string;
-};
-
-export type MarketDirectoryCertifier = {
-  certifier_id: number;
-  certifier_name: string;
-  certifier_acronym: string | null;
-};
-
-export type MarketDirectoryCertification = {
-  survey_id: string;
-  certification_id: number | null;
-  certifier_id: number | null;
-  certificate_member_id: string | null;
-  farm_id: string;
-  certificationSystemType?: MarketDirectoryCertificationSystemType | null;
-  certifier?: MarketDirectoryCertifier | null;
-};
-
 export interface MarketDirectoryInfoWithRelations extends MarketDirectoryInfo {
   market_product_categories?: MarketDirectoryInfoMarketProductCategory[] | null;
-  certifications?: MarketDirectoryCertification[] | null;
+  certifications?: Certification[] | null;
 }
 export interface MarketDirectoryPartner {
   id: number;

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -662,8 +662,32 @@ export type MarketDirectoryInfoMarketProductCategory = {
   market_product_category_id: MarketProductCategory['id'];
 };
 
+// TODO LF-5379: field names use the $formatJson shim names — update when shim is removed
+export type MarketDirectoryCertificationSystemType = {
+  certification_id: number;
+  certification_type: string;
+  certification_translation_key: string;
+};
+
+export type MarketDirectoryCertifier = {
+  certifier_id: number;
+  certifier_name: string;
+  certifier_acronym: string | null;
+};
+
+export type MarketDirectoryCertification = {
+  survey_id: string;
+  certification_id: number | null;
+  certifier_id: number | null;
+  certificate_member_id: string | null;
+  farm_id: string;
+  certificationSystemType?: MarketDirectoryCertificationSystemType | null;
+  certifier?: MarketDirectoryCertifier | null;
+};
+
 export interface MarketDirectoryInfoWithRelations extends MarketDirectoryInfo {
   market_product_categories?: MarketDirectoryInfoMarketProductCategory[] | null;
+  certifications?: MarketDirectoryCertification[] | null;
 }
 export interface MarketDirectoryPartner {
   id: number;

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -653,6 +653,7 @@ export type Certification = {
   certificate_member_id: string | null;
   farm_id: string;
   is_active: boolean;
+  other_certifier?: string | null;
   certification_type?: string | null;
   certificate_number?: string | null;
   issue_date?: string | null;

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -632,24 +632,23 @@ export interface DocumentWithFiles extends Document {
   files?: File[];
 }
 
-// TODO LF-5379: field names use the $formatJson shim names — update when shim is removed
 export type CertificationSystemType = {
-  certification_id: number;
-  certification_type: string;
-  certification_translation_key: string;
+  id: number;
+  name: string;
+  translation_key: string;
 };
 
 export type Certifier = {
   certifier_id: number;
-  certification_id?: CertificationSystemType['certification_id'];
+  system_type_id?: CertificationSystemType['id'];
   certifier_name: string;
   certifier_acronym: string | null;
   survey_id?: string;
 };
 
 export type Certification = {
-  survey_id: string;
-  certification_id: number | null;
+  id: string;
+  system_type_id: number | null;
   certifier_id: number | null;
   certificate_member_id: string | null;
   farm_id: string;
@@ -657,10 +656,10 @@ export type Certification = {
   certifier?: Certifier | null;
   is_active: boolean;
   certification_type?: string | null;
-  certification_identifier?: string | null;
-  start_date?: string | null;
-  expiry_date?: string | null;
-  document_file_url?: string | null;
+  certificate_number?: string | null;
+  issue_date?: string | null;
+  valid_until?: string | null;
+  certificate_document_url?: string | null;
 };
 
 export type MarketDirectoryInfo = {

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -652,14 +652,14 @@ export type Certification = {
   certifier_id: number | null;
   certificate_member_id: string | null;
   farm_id: string;
-  certificationSystemType?: CertificationSystemType | null;
-  certifier?: Certifier | null;
   is_active: boolean;
   certification_type?: string | null;
   certificate_number?: string | null;
   issue_date?: string | null;
   valid_until?: string | null;
   certificate_document_url?: string | null;
+  certificationSystemType?: CertificationSystemType | null;
+  certifier?: Certifier | null;
 };
 
 export type MarketDirectoryInfo = {

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -168,7 +168,7 @@ export const formatFarmDataToDfcStandard = async (
       (cert) =>
         new Certification({
           connector,
-          semanticId: `${enterpriseUrl}#certification-${cert.survey_id}`,
+          semanticId: `${enterpriseUrl}#certification-${cert.id}`,
           name: cert.certification_type!,
           description: undefined,
           certificationReferences: cert.certifier?.certifier_name

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -32,6 +32,7 @@ import type {
   MarketDirectoryInfoWithRelations,
   MarketProductCategory,
 } from '../../models/types.js';
+import { CERTIFICATION_TYPES } from '../../models/certificationModel.js';
 import { liteFarmToDFCTaxonomy, getNestedValue } from './litefarmToDFCTaxonomy.js';
 
 let sharedProductTypesConnector: Connector;
@@ -42,8 +43,10 @@ export const createEnterpriseUrl = (market_directory_info_id: string): string =>
   return `${apiUrl()}/dfc/enterprises/${market_directory_info_id}`;
 };
 
+type CertificationType = (typeof CERTIFICATION_TYPES)[number];
+
 // certification_type enum values → official display names for DFC partners
-const CERTIFICATION_TYPE_NAMES: Record<string, string> = {
+const CERTIFICATION_TYPE_NAMES: Record<CertificationType, string> = {
   ORGANIC: 'Organic',
   BIODYNAMIC: 'Biodynamic',
   REGENERATIVE: 'Regenerative',
@@ -184,7 +187,9 @@ export const formatFarmDataToDfcStandard = async (
           connector,
           semanticId: `${enterpriseUrl}#certification-${cert.id}`,
           // Fall back to the raw enum value if a new type is missing from the map
-          name: CERTIFICATION_TYPE_NAMES[cert.certification_type!] ?? cert.certification_type!,
+          name:
+            CERTIFICATION_TYPE_NAMES[cert.certification_type as CertificationType] ??
+            cert.certification_type!,
           description: undefined,
           certificationReferences: cert.certifier?.certifier_name
             ? [cert.certifier.certifier_name]

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -176,11 +176,7 @@ export const formatFarmDataToDfcStandard = async (
   });
 
   const certificationInstances = (certifications ?? [])
-    .filter((cert) => {
-      // TODO: confirm which certifications should be included in DFC output —
-      // e.g., should certifications without a certificationSystemType or certifier be excluded?
-      return cert.is_active && cert.certification_type;
-    })
+    .filter((cert) => cert.is_active && cert.certification_type)
     .map(
       (cert) =>
         new Certification({

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -193,7 +193,7 @@ export const formatFarmDataToDfcStandard = async (
           description: undefined,
           certificationReferences: cert.certifier?.certifier_name
             ? [cert.certifier.certifier_name]
-            : [],
+            : [cert.other_certifier!],
           operatorIds: cert.certificate_member_id ? [cert.certificate_member_id] : [],
           certificationScores: [],
         }),

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -42,6 +42,20 @@ export const createEnterpriseUrl = (market_directory_info_id: string): string =>
   return `${apiUrl()}/dfc/enterprises/${market_directory_info_id}`;
 };
 
+// certification_type enum values → official display names for DFC partners
+const CERTIFICATION_TYPE_NAMES: Record<string, string> = {
+  ORGANIC: 'Organic',
+  BIODYNAMIC: 'Biodynamic',
+  REGENERATIVE: 'Regenerative',
+  CERTIFIED_HUMANE: 'Certified Humane',
+  FAIR_TRADE: 'Fair Trade',
+  'GRASSFED/PASTURE': 'Grassfed/Pasture',
+  SUSTAINABILITY: 'Sustainability',
+  ANIMAL_WELFARE: 'Animal Welfare',
+  'NON-GMO': 'Non-GMO',
+  'CARBON/CLIMATE': 'Carbon/Climate',
+};
+
 // Build and populate a lookup map: LiteFarm key → actual DFC product type object
 const buildProductTypeMappings = (connector: Connector) => {
   const liteFarmKeyToDfcType = new Map<string, ISKOSConcept>();
@@ -169,7 +183,8 @@ export const formatFarmDataToDfcStandard = async (
         new Certification({
           connector,
           semanticId: `${enterpriseUrl}#certification-${cert.id}`,
-          name: cert.certification_type!,
+          // Fall back to the raw enum value if a new type is missing from the map
+          name: CERTIFICATION_TYPE_NAMES[cert.certification_type!] ?? cert.certification_type!,
           description: undefined,
           certificationReferences: cert.certifier?.certifier_name
             ? [cert.certifier.certifier_name]

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import {
   Connector,
   Organization,
+  Certification,
   SKOSConcept,
   SocialMedia,
   Address,
@@ -97,6 +98,7 @@ export const formatFarmDataToDfcStandard = async (
     facebook,
     x,
     market_product_categories,
+    certifications,
   } = marketDirectoryInfo;
 
   const parsedAddress = await parseGoogleGeocodedAddress(addressString);
@@ -155,6 +157,24 @@ export const formatFarmDataToDfcStandard = async (
     localizations: [address],
     suppliedProducts: products,
   });
+
+  // TODO: confirm which certifications should be included in DFC output —
+  // e.g., should certifications without a certificationSystemType or certifier be excluded?
+  const certificationInstances = (certifications ?? []).map(
+    (cert) =>
+      new Certification({
+        connector,
+        semanticId: `${enterpriseUrl}#certification-${cert.survey_id}`,
+        name: cert.certificationSystemType?.certification_type ?? undefined,
+        description: undefined,
+        certificationReferences: cert.certifier
+          ? [cert.certifier.certifier_acronym ?? cert.certifier.certifier_name]
+          : [],
+        operatorIds: cert.certificate_member_id ? [cert.certificate_member_id] : [],
+        certificationScores: [],
+      }),
+  );
+  certificationInstances.forEach((c) => farm.addCertification(c));
 
   let phoneNumber;
   if (phone_number) {
@@ -221,6 +241,7 @@ export const formatFarmDataToDfcStandard = async (
     ...(phoneNumber ? [phoneNumber] : []),
     ...socialMediaInstances,
     ...products,
+    ...certificationInstances,
   ]);
 
   return JSON.parse(exportFormattedData);

--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -158,23 +158,27 @@ export const formatFarmDataToDfcStandard = async (
     suppliedProducts: products,
   });
 
-  // TODO: confirm which certifications should be included in DFC output —
-  // e.g., should certifications without a certificationSystemType or certifier be excluded?
-  const certificationInstances = (certifications ?? []).map(
-    (cert) =>
-      new Certification({
-        connector,
-        semanticId: `${enterpriseUrl}#certification-${cert.survey_id}`,
-        name: cert.certificationSystemType?.certification_type ?? undefined,
-        description: undefined,
-        certificationReferences: cert.certifier
-          ? [cert.certifier.certifier_acronym ?? cert.certifier.certifier_name]
-          : [],
-        operatorIds: cert.certificate_member_id ? [cert.certificate_member_id] : [],
-        certificationScores: [],
-      }),
-  );
-  certificationInstances.forEach((c) => farm.addCertification(c));
+  const certificationInstances = (certifications ?? [])
+    .filter((cert) => {
+      // TODO: confirm which certifications should be included in DFC output —
+      // e.g., should certifications without a certificationSystemType or certifier be excluded?
+      return cert.is_active && cert.certification_type;
+    })
+    .map(
+      (cert) =>
+        new Certification({
+          connector,
+          semanticId: `${enterpriseUrl}#certification-${cert.survey_id}`,
+          name: cert.certification_type!,
+          description: undefined,
+          certificationReferences: cert.certifier?.certifier_name
+            ? [cert.certifier.certifier_name]
+            : [],
+          operatorIds: cert.certificate_member_id ? [cert.certificate_member_id] : [],
+          certificationScores: [],
+        }),
+    );
+  certificationInstances.forEach((cert) => farm.addCertification(cert));
 
   let phoneNumber;
   if (phone_number) {

--- a/packages/api/tests/dataFoodConsortium.test.ts
+++ b/packages/api/tests/dataFoodConsortium.test.ts
@@ -52,6 +52,7 @@ const mockedParseAddress = parseGoogleGeocodedAddress as jest.MockedFunction<
 import mocks from './mock.factories.js';
 import { createUserFarmIds } from './utils/testDataSetup.js';
 import {
+  DfcEntity,
   expectedBaseDfcStructure,
   getOrganizationCount,
   mockCompleteMarketDirectoryInfo,
@@ -79,8 +80,11 @@ describe('Data Food Consortium Tests', () => {
 
   let marketDirectoryPartner: MarketDirectoryPartner;
 
-  async function createMarketDirectoryInfoForTest(partner?: MarketDirectoryPartner) {
-    const userFarmIds = await createUserFarmIds(1);
+  async function createMarketDirectoryInfoForTest(
+    partner?: MarketDirectoryPartner,
+    existingUserFarmIds?: Awaited<ReturnType<typeof createUserFarmIds>>,
+  ) {
+    const userFarmIds = existingUserFarmIds ?? (await createUserFarmIds(1));
     const [marketDirectoryInfo] = await mocks.market_directory_infoFactory({
       promisedUserFarm: Promise.resolve([userFarmIds]),
       marketDirectoryInfo: mockCompleteMarketDirectoryInfo,
@@ -273,6 +277,82 @@ describe('Data Food Consortium Tests', () => {
 
       expect(res.status).toBe(200);
       expect(getOrganizationCount(res)).toBe(1);
+    });
+  });
+
+  describe('Certifications in DFC output', () => {
+    test('Should include active certifications in the DFC output', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const marketDirectoryInfo = await createMarketDirectoryInfoForTest(undefined, userFarmIds);
+
+      const certifier1 = await knex('certifiers').where({ system_type_id: 2 }).first();
+      const certifier2 = await knex('certifiers').where({ system_type_id: 1 }).first();
+
+      const [certification1] = await mocks.certificationFactory(
+        { promisedUserFarm: Promise.resolve([userFarmIds]) },
+        mocks.fakeCertification(userFarmIds.farm_id, {
+          certifier_id: certifier1.certifier_id,
+          certification_type: 'BIODYNAMIC',
+          certificate_member_id: 'Ecocert',
+        }),
+      );
+
+      const [_certification2] = await mocks.certificationFactory(
+        { promisedUserFarm: Promise.resolve([userFarmIds]) },
+        mocks.fakeCertification(userFarmIds.farm_id, {
+          certification_type: 'ORGANIC',
+          certifier_id: certifier2.certifier_id,
+        }),
+      );
+
+      const res = await getDfcEnterpriseRequest(marketDirectoryInfo.id);
+
+      expect(res.status).toBe(200);
+
+      const certifications = res.body['@graph'].filter(
+        (entity: DfcEntity) => entity['@type'] === 'dfc-b:Certfication',
+      );
+      expect(certifications.length).toBe(2);
+
+      const certNode = certifications.find(
+        (entity: DfcEntity) =>
+          entity['@id'] ===
+          `https://api.beta.litefarm.org/dfc/enterprises/${marketDirectoryInfo.id}#certification-${certification1.id}`,
+      );
+      expect(certNode).toMatchObject({
+        '@id': expect.stringContaining(`#certification-${certification1.id}`),
+        'dfc-b:name': 'Biodynamic',
+        'dfc-b:certiferReference': certifier1.certifier_name,
+        'dfc-b:operatorId': 'Ecocert',
+      });
+
+      const orgNode = res.body['@graph'].find(
+        (entity: DfcEntity) => entity['@type'] === 'dfc-b:Organization',
+      );
+      expect(orgNode).toHaveProperty('dfc-b:isCertifiedBy');
+    });
+
+    test('Should not include soft-deleted certifications in the DFC output', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const marketDirectoryInfo = await createMarketDirectoryInfoForTest(undefined, userFarmIds);
+
+      await mocks.certificationFactory(
+        { promisedUserFarm: Promise.resolve([userFarmIds]) },
+        mocks.fakeCertification(userFarmIds.farm_id, {
+          is_active: true,
+          certification_type: 'ORGANIC',
+          deleted: true,
+        }),
+      );
+
+      const res = await getDfcEnterpriseRequest(marketDirectoryInfo.id);
+
+      expect(res.status).toBe(200);
+
+      const certNode = res.body['@graph'].find(
+        (entity: DfcEntity) => entity['@type'] === 'dfc-b:Certfication',
+      );
+      expect(certNode).toBeUndefined();
     });
   });
 

--- a/packages/api/tests/dataFoodConsortium.test.ts
+++ b/packages/api/tests/dataFoodConsortium.test.ts
@@ -339,7 +339,6 @@ describe('Data Food Consortium Tests', () => {
       await mocks.certificationFactory(
         { promisedUserFarm: Promise.resolve([userFarmIds]) },
         mocks.fakeCertification(userFarmIds.farm_id, {
-          is_active: true,
           certification_type: 'ORGANIC',
           deleted: true,
         }),
@@ -353,6 +352,60 @@ describe('Data Food Consortium Tests', () => {
         (entity: DfcEntity) => entity['@type'] === 'dfc-b:Certfication',
       );
       expect(certNode).toBeUndefined();
+    });
+
+    test('Should not include inactive certifications in the DFC output', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const marketDirectoryInfo = await createMarketDirectoryInfoForTest(undefined, userFarmIds);
+
+      await mocks.certificationFactory(
+        { promisedUserFarm: Promise.resolve([userFarmIds]) },
+        mocks.fakeCertification(userFarmIds.farm_id, {
+          is_active: false,
+          certification_type: 'ORGANIC',
+        }),
+      );
+
+      const res = await getDfcEnterpriseRequest(marketDirectoryInfo.id);
+
+      expect(res.status).toBe(200);
+
+      const certNode = res.body['@graph'].find(
+        (entity: DfcEntity) => entity['@type'] === 'dfc-b:Certfication',
+      );
+      expect(certNode).toBeUndefined();
+    });
+
+    test('Should only include certifications that expire after today', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const marketDirectoryInfo = await createMarketDirectoryInfoForTest(undefined, userFarmIds);
+
+      const createCertificationWithValidUntil = async (validUntil: unknown) => {
+        const [certification] = await mocks.certificationFactory(
+          { promisedUserFarm: Promise.resolve([userFarmIds]) },
+          mocks.fakeCertification(userFarmIds.farm_id, {
+            certification_type: 'ORGANIC',
+            valid_until: validUntil,
+          }),
+        );
+        return certification;
+      };
+
+      await createCertificationWithValidUntil('2020-01-01'); // expired
+      await createCertificationWithValidUntil(knex.raw('CURRENT_DATE')); // expires today — excluded
+      const validCertification = await createCertificationWithValidUntil(
+        knex.raw('CURRENT_DATE + 1'),
+      );
+
+      const res = await getDfcEnterpriseRequest(marketDirectoryInfo.id);
+
+      expect(res.status).toBe(200);
+
+      const certNodes = res.body['@graph'].filter(
+        (entity: DfcEntity) => entity['@type'] === 'dfc-b:Certfication',
+      );
+      expect(certNodes).toHaveLength(1);
+      expect(certNodes[0]['@id']).toContain(`#certification-${validCertification.id}`);
     });
   });
 

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2100,14 +2100,20 @@ async function supportTicketFactory(
     .returning('*');
 }
 
-function fakeCertification(farm_id, defaultData = {}) {
-  const certificationIDS = [1, 2];
+/**
+ * @template {object} T
+ * @param {string} [farm_id]
+ * @param {T} [defaultData]
+ * @returns {{ certifier_id: number, system_type_id: number, created_at: Date, updated_at: Date, farm_id: string } & T}
+ */
+function fakeCertification(farm_id, defaultData = /** @type {T} */ ({})) {
+  const systemTypeIds = [1, 2];
   const certifierIDS = [1, 2, 3, 4, 5, 6, 7, 10, 13, 15, 16, 17, 18];
   const past = faker.date.past();
   const now = new Date();
   return {
     certifier_id: faker.helpers.arrayElement(certifierIDS),
-    system_type_id: faker.helpers.arrayElement(certificationIDS),
+    system_type_id: faker.helpers.arrayElement(systemTypeIds),
     created_at: past,
     updated_at: faker.date.between(past, now),
     farm_id,

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2117,6 +2117,7 @@ function fakeCertification(farm_id, defaultData = /** @type {T} */ ({})) {
     created_at: past,
     updated_at: faker.date.between(past, now),
     farm_id,
+    is_active: true,
     ...defaultData,
   };
 }

--- a/packages/api/tests/service-tests/dfcAdapter.test.ts
+++ b/packages/api/tests/service-tests/dfcAdapter.test.ts
@@ -18,6 +18,7 @@ import { formatFarmDataToDfcStandard } from '../../src/services/datafoodconsorti
 import {
   DfcEntity,
   expectedBaseDfcStructure,
+  mockCertification,
   mockCompleteMarketDirectoryInfo,
   mockMarketProductCategoryMap,
   mockParsedAddress,
@@ -305,5 +306,95 @@ describe('dfcAdapter', () => {
     expect(addressEntity).toMatchObject({
       'dfc-b:hasCountry': 'Unknown Country',
     });
+  });
+
+  test('should include a certification node when certifications are present', async () => {
+    const fakeId = faker.datatype.uuid();
+    const fakeData = {
+      ...fakeMarketDirectoryInfoWithRelations({
+        info: mockCompleteMarketDirectoryInfo,
+        marketProductCategories: [marketProductCategory],
+        fakeId,
+      }),
+      id: fakeId,
+      farm_id: faker.datatype.uuid(),
+      certifications: [mockCertification],
+    };
+    const result = await formatFarmDataToDfcStandard(fakeData, marketProductCategoryMap);
+    const graph: DfcEntity[] = result['@graph'];
+
+    const certNode = graph.find((e) => e['@type'] === 'dfc-b:Certfication');
+    expect(certNode).toBeDefined();
+    expect(certNode).toMatchObject({
+      '@id': `https://api.beta.litefarm.org/dfc/enterprises/${fakeId}#certification-mock-cert-uuid-001`,
+      'dfc-b:name': 'Organic',
+      'dfc-b:certiferReference': 'SA',
+      'dfc-b:operatorId': 'UK-ORG-05-1234',
+    });
+
+    const orgNode = graph.find((e) => e['@type'] === 'dfc-b:Organization');
+    expect(orgNode).toHaveProperty('dfc-b:isCertifiedBy');
+  });
+
+  test('should not include a certification node when certifications is empty', async () => {
+    const fakeId = faker.datatype.uuid();
+    const fakeData = {
+      ...fakeMarketDirectoryInfoWithRelations({
+        info: mockCompleteMarketDirectoryInfo,
+        marketProductCategories: [marketProductCategory],
+        fakeId,
+      }),
+      id: fakeId,
+      farm_id: faker.datatype.uuid(),
+      certifications: [],
+    };
+    const result = await formatFarmDataToDfcStandard(fakeData, marketProductCategoryMap);
+    const graph: DfcEntity[] = result['@graph'];
+
+    const certNode = graph.find((e) => e['@type'] === 'dfc-b:Certfication');
+    expect(certNode).toBeUndefined();
+
+    const orgNode = graph.find((e) => e['@type'] === 'dfc-b:Organization');
+    expect(orgNode).not.toHaveProperty('dfc-b:isCertifiedBy');
+  });
+
+  test('should include multiple certification nodes when multiple certifications are present', async () => {
+    const secondCertification = {
+      ...mockCertification,
+      survey_id: 'mock-cert-uuid-002',
+      certificate_member_id: 'FR-BIO-01-9999',
+      certificationSystemType: {
+        certification_id: 2,
+        certification_type: 'Biodynamic',
+        certification_translation_key: 'BIODYNAMIC',
+      },
+      certifier: {
+        certifier_id: 2,
+        certifier_name: 'Demeter',
+        certifier_acronym: null,
+      },
+    };
+
+    const fakeId = faker.datatype.uuid();
+    const fakeData = {
+      ...fakeMarketDirectoryInfoWithRelations({
+        info: mockCompleteMarketDirectoryInfo,
+        marketProductCategories: [marketProductCategory],
+        fakeId,
+      }),
+      id: fakeId,
+      farm_id: faker.datatype.uuid(),
+      certifications: [mockCertification, secondCertification],
+    };
+    const result = await formatFarmDataToDfcStandard(fakeData, marketProductCategoryMap);
+    const graph: DfcEntity[] = result['@graph'];
+
+    const certNodes = graph.filter((e) => e['@type'] === 'dfc-b:Certfication');
+    expect(certNodes).toHaveLength(2);
+
+    const orgNode = graph.find((e) => e['@type'] === 'dfc-b:Organization');
+    const isCertifiedBy = orgNode?.['dfc-b:isCertifiedBy'];
+    expect(Array.isArray(isCertifiedBy)).toBe(true);
+    expect(isCertifiedBy).toHaveLength(2);
   });
 });

--- a/packages/api/tests/service-tests/dfcAdapter.test.ts
+++ b/packages/api/tests/service-tests/dfcAdapter.test.ts
@@ -328,7 +328,7 @@ describe('dfcAdapter', () => {
     expect(certNode).toMatchObject({
       '@id': `https://api.beta.litefarm.org/dfc/enterprises/${fakeId}#certification-mock-cert-uuid-001`,
       'dfc-b:name': 'Organic',
-      'dfc-b:certiferReference': 'SA',
+      'dfc-b:certiferReference': 'Soil Association',
       'dfc-b:operatorId': 'UK-ORG-05-1234',
     });
 

--- a/packages/api/tests/service-tests/dfcAdapter.test.ts
+++ b/packages/api/tests/service-tests/dfcAdapter.test.ts
@@ -365,8 +365,8 @@ describe('dfcAdapter', () => {
       certificate_member_id: 'FR-BIO-01-9999',
       certificationSystemType: {
         id: 2,
-        name: 'Biodynamic',
-        translation_key: 'BIODYNAMIC',
+        name: 'Participatory Guarantee System',
+        translation_key: 'PGS',
       },
       certifier: {
         certifier_id: 2,

--- a/packages/api/tests/service-tests/dfcAdapter.test.ts
+++ b/packages/api/tests/service-tests/dfcAdapter.test.ts
@@ -361,12 +361,12 @@ describe('dfcAdapter', () => {
   test('should include multiple certification nodes when multiple certifications are present', async () => {
     const secondCertification = {
       ...mockCertification,
-      survey_id: 'mock-cert-uuid-002',
+      id: 'mock-cert-uuid-002',
       certificate_member_id: 'FR-BIO-01-9999',
       certificationSystemType: {
-        certification_id: 2,
-        certification_type: 'Biodynamic',
-        certification_translation_key: 'BIODYNAMIC',
+        id: 2,
+        name: 'Biodynamic',
+        translation_key: 'BIODYNAMIC',
       },
       certifier: {
         certifier_id: 2,

--- a/packages/api/tests/utils/dfcUtils.ts
+++ b/packages/api/tests/utils/dfcUtils.ts
@@ -85,7 +85,7 @@ export const mockCertification: Certification = {
     system_type_id: 1,
     certifier_id: 1,
     certificate_member_id: 'UK-ORG-05-1234',
-    certification_type: 'Organic',
+    certification_type: 'ORGANIC',
     is_active: true,
   }),
   certificationSystemType: {

--- a/packages/api/tests/utils/dfcUtils.ts
+++ b/packages/api/tests/utils/dfcUtils.ts
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { MarketDirectoryCertification, MarketProductCategory } from '../../src/models/types.js';
+import { Certification, MarketProductCategory } from '../../src/models/types.js';
 
 export interface DfcEntity {
   '@type': string;
@@ -78,7 +78,7 @@ export const mockMarketProductCategoryMap = (): Map<number, MarketProductCategor
   return map;
 };
 
-export const mockCertification: MarketDirectoryCertification = {
+export const mockCertification: Certification = {
   survey_id: 'mock-cert-uuid-001',
   certification_id: 1,
   certifier_id: 1,
@@ -86,14 +86,16 @@ export const mockCertification: MarketDirectoryCertification = {
   farm_id: 'mock-farm-id',
   certificationSystemType: {
     certification_id: 1,
-    certification_type: 'Organic',
-    certification_translation_key: 'ORGANIC',
+    certification_type: 'Third-party Organic',
+    certification_translation_key: 'THIRD_PARTY_ORGANIC',
   },
   certifier: {
     certifier_id: 1,
     certifier_name: 'Soil Association',
     certifier_acronym: 'SA',
   },
+  certification_type: 'Organic',
+  is_active: true,
 };
 
 export const getOrganizationCount = (res: { body: { '@graph': DfcEntity[] } }) => {

--- a/packages/api/tests/utils/dfcUtils.ts
+++ b/packages/api/tests/utils/dfcUtils.ts
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { MarketProductCategory } from '../../src/models/types.js';
+import { MarketDirectoryCertification, MarketProductCategory } from '../../src/models/types.js';
 
 export interface DfcEntity {
   '@type': string;
@@ -76,6 +76,24 @@ export const mockMarketProductCategoryMap = (): Map<number, MarketProductCategor
   const enums = [{ id: 1, key: 'BAKERY' }];
   const map = new Map(enums.map((e) => [e.id, e]));
   return map;
+};
+
+export const mockCertification: MarketDirectoryCertification = {
+  survey_id: 'mock-cert-uuid-001',
+  certification_id: 1,
+  certifier_id: 1,
+  certificate_member_id: 'UK-ORG-05-1234',
+  farm_id: 'mock-farm-id',
+  certificationSystemType: {
+    certification_id: 1,
+    certification_type: 'Organic',
+    certification_translation_key: 'ORGANIC',
+  },
+  certifier: {
+    certifier_id: 1,
+    certifier_name: 'Soil Association',
+    certifier_acronym: 'SA',
+  },
 };
 
 export const getOrganizationCount = (res: { body: { '@graph': DfcEntity[] } }) => {

--- a/packages/api/tests/utils/dfcUtils.ts
+++ b/packages/api/tests/utils/dfcUtils.ts
@@ -14,6 +14,7 @@
  */
 
 import { Certification, MarketProductCategory } from '../../src/models/types.js';
+import mocks from '../mock.factories.js';
 
 export interface DfcEntity {
   '@type': string;
@@ -79,23 +80,24 @@ export const mockMarketProductCategoryMap = (): Map<number, MarketProductCategor
 };
 
 export const mockCertification: Certification = {
-  id: 'mock-cert-uuid-001',
-  system_type_id: 1,
-  certifier_id: 1,
-  certificate_member_id: 'UK-ORG-05-1234',
-  farm_id: 'mock-farm-id',
+  ...mocks.fakeCertification('mock-farm-id', {
+    id: 'mock-cert-uuid-001',
+    system_type_id: 1,
+    certifier_id: 1,
+    certificate_member_id: 'UK-ORG-05-1234',
+    certification_type: 'Organic',
+    is_active: true,
+  }),
   certificationSystemType: {
     id: 1,
-    name: 'Third-party Organic',
-    translation_key: 'THIRD_PARTY_ORGANIC',
+    name: 'Organic',
+    translation_key: 'ORGANIC',
   },
   certifier: {
     certifier_id: 1,
     certifier_name: 'Soil Association',
     certifier_acronym: 'SA',
   },
-  certification_type: 'Organic',
-  is_active: true,
 };
 
 export const getOrganizationCount = (res: { body: { '@graph': DfcEntity[] } }) => {

--- a/packages/api/tests/utils/dfcUtils.ts
+++ b/packages/api/tests/utils/dfcUtils.ts
@@ -79,15 +79,15 @@ export const mockMarketProductCategoryMap = (): Map<number, MarketProductCategor
 };
 
 export const mockCertification: Certification = {
-  survey_id: 'mock-cert-uuid-001',
-  certification_id: 1,
+  id: 'mock-cert-uuid-001',
+  system_type_id: 1,
   certifier_id: 1,
   certificate_member_id: 'UK-ORG-05-1234',
   farm_id: 'mock-farm-id',
   certificationSystemType: {
-    certification_id: 1,
-    certification_type: 'Third-party Organic',
-    certification_translation_key: 'THIRD_PARTY_ORGANIC',
+    id: 1,
+    name: 'Third-party Organic',
+    translation_key: 'THIRD_PARTY_ORGANIC',
   },
   certifier: {
     certifier_id: 1,


### PR DESCRIPTION
**Description**

Adds farm certifications to the DFC JSON-LD output so market directory partners can see a farm's credentials in both GET `/dfc/enterprises/:id` and GET `/dfc/enterprises`.

Certifications now appear as `dfc-b:Certfication` nodes referenced from the organization's `dfc-b:isCertifiedBy`:

```
{
  "@id": ".../dfc/enterprises/<id>#certification-<certification id>",
  "@type": "dfc-b:Certfication",
  "dfc-b:name": "Organic",
  "dfc-b:certiferReference": "Islands Organic Producers Association",
  "dfc-b:operatorId": "MEMBER-123"
}
```

Changes
- Models: `certification` → `certificationSystemType`/`certifier` relations; `market_directory_info` → `certifications` relation; `CERTIFICATION_TYPES` exported from the `certification` model and enforced as a jsonSchema enum (invalid values now fail with 400 instead of a DB check-constraint error); removed the stale `supported` property from the certifier jsonSchema
- Controller: both DFC endpoints fetch certifications via `withGraphFetched`, excluding soft-deleted and expired rows (valid_until > CURRENT_DATE, in SQL — certificates disappear from the listing starting on their expiry date)
   - The expiry cutoff is the UTC start of the expiry date, chosen deliberately: since no timezone is ahead of UTC+14, an expired certificate is never shown in any farm's local time (the trade-off is disappearing up to a day early for farms behind UTC).
- Adapter: serializes certifications that are active and have a `certification_type`; the enum value is mapped to an official display name for partners (`ORGANIC` → `Organic`), with a raw-key fallback if a future enum value is missing from the map

Notes:
- A bug was caught by the new integration tests: the adapter originally read `cert.survey_id` (a shim-only field name), producing `#certification-undefined` semantic IDs. The shim only applies at JSON serialization, not on model instances — fixed to `cert.id`, and the types were aligned to DB column names to prevent recurrence.


Jira link: https://lite-farm.atlassian.net/browse/LF-5377

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
