### PR TITLE
LF-5376: Certification CRUD API

### DIFF
--- a/packages/api/src/controllers/certificationController.js
+++ b/packages/api/src/controllers/certificationController.js
@@ -32,6 +32,45 @@ const redisConf = {
   },
 };
 
+// TODO LF-5379: remove with legacy /organic_certifier_survey endpoints — maps old API field names to DB column names
+function mapLegacyCertificationBody(body) {
+  const mapped = { ...body };
+  if (mapped.survey_id !== undefined) {
+    mapped.id = mapped.survey_id;
+    delete mapped.survey_id;
+  }
+  if (mapped.certification_id !== undefined) {
+    mapped.system_type_id = mapped.certification_id;
+    delete mapped.certification_id;
+  }
+  if (mapped.requested_certification !== undefined) {
+    mapped.requested_system_type = mapped.requested_certification;
+    delete mapped.requested_certification;
+  }
+  if (mapped.requested_certifier !== undefined) {
+    mapped.other_certifier = mapped.requested_certifier;
+    delete mapped.requested_certifier;
+  }
+  return mapped;
+}
+
+// TODO LF-5379: remove with legacy /organic_certifier_survey endpoints — maps DB column names to old API field names
+function formatCertificationAsLegacy(certification) {
+  // toJSON() runs BaseModel.$formatJson, which hides audit fields as before
+  const json =
+    typeof certification.toJSON === 'function' ? certification.toJSON() : { ...certification };
+  json.survey_id = json.id;
+  json.certification_id = json.system_type_id;
+  json.requested_certification = json.requested_system_type;
+  json.requested_certifier = json.other_certifier;
+  json.interested = true;
+  delete json.id;
+  delete json.system_type_id;
+  delete json.requested_system_type;
+  delete json.other_certifier;
+  return json;
+}
+
 const certificationController = {
   getCertificationByFarmId() {
     return async (req, res) => {
@@ -45,7 +84,7 @@ const certificationController = {
         if (!result) {
           return res.status(200).json({ farm_id, interested: false });
         }
-        return res.status(200).send(result);
+        return res.status(200).send(formatCertificationAsLegacy(result));
       } catch (error) {
         //handle more exceptions
         console.error(error);
@@ -124,11 +163,12 @@ const certificationController = {
           return res.status(200).json({ farm_id, interested: false });
         }
 
+        const { id: _id, ...insertData } = mapLegacyCertificationBody(rest);
         const result = await CertificationModel.query()
           .context({ user_id })
-          .insert({ farm_id, ...rest })
+          .insert({ farm_id, ...insertData })
           .returning('*');
-        res.status(201).send(result);
+        res.status(201).send(formatCertificationAsLegacy(result));
       } catch (error) {
         res.status(400).json({
           error,
@@ -151,7 +191,8 @@ const certificationController = {
           return res.status(200).json({ farm_id, interested: false });
         }
 
-        const { survey_id: surveyId, id: _id, ...patchData } = rest;
+        const { survey_id: surveyId, id: _id, ...rawPatchData } = rest;
+        const patchData = mapLegacyCertificationBody(rawPatchData);
         let result;
         if (surveyId !== undefined) {
           result = await CertificationModel.query()
@@ -165,7 +206,7 @@ const certificationController = {
             .insert({ farm_id, ...patchData })
             .returning('*');
         }
-        return res.status(200).send(result);
+        return res.status(200).send(formatCertificationAsLegacy(result));
       } catch (error) {
         console.log(error);
         return res.status(400).json({

--- a/packages/api/src/controllers/certificationController.js
+++ b/packages/api/src/controllers/certificationController.js
@@ -219,7 +219,9 @@ const certificationController = {
   triggerExport() {
     return async (req, res) => {
       // TODO: getting email from request body is commented out for now
-      const { farm_id, from_date, to_date, submission_id } = req.body;
+      const { certifier_id, other_certifier, from_date, to_date, submission_id } = req.body;
+      // The legacy route requires body farm_id to match the header via hasFarmAccess, so the header works for both routes
+      const farm_id = req.headers.farm_id;
       const invalid = [farm_id, from_date, to_date].some((property) => !property);
       if (invalid) {
         return res.status(400).json({
@@ -228,6 +230,14 @@ const certificationController = {
       }
       const certificationRecord = await knex('certification')
         .where({ farm_id, deleted: false })
+        .modify((queryBuilder) => {
+          if (certifier_id) {
+            queryBuilder.where({ certifier_id });
+          }
+          if (other_certifier) {
+            queryBuilder.where({ other_certifier });
+          }
+        })
         .first();
 
       // Skip the whole flow in case this Farm is not pursuing any cert.

--- a/packages/api/src/controllers/certificationsController.ts
+++ b/packages/api/src/controllers/certificationsController.ts
@@ -15,13 +15,31 @@
 
 import { Response } from 'express';
 import { transaction, Model } from 'objection';
+import { v4 as uuidv4 } from 'uuid';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import CertificationModel from '../models/certificationModel.js';
 import {
   CertificationBody,
   CertificationParams,
 } from '../middleware/validation/checkCertification.js';
 import { handleObjectionError } from '../util/errorCodes.js';
+import {
+  s3,
+  imaginaryPost,
+  getPrivateS3BucketName,
+  getPrivateS3Url,
+  getRandomFileName,
+} from '../util/digitalOceanSpaces.js';
 import { HttpError, LiteFarmRequest } from '../types.js';
+
+interface UploadRequest extends LiteFarmRequest<unknown, { farm_id: string }> {
+  // eslint-disable-next-line no-undef
+  file?: Express.Multer.File;
+  // Flags set by the validateFileExtension middleware
+  isMinimized?: boolean;
+  isTextDocument?: boolean;
+  isNotMinimized?: boolean;
+}
 
 const MUTABLE_FIELDS = [
   'system_type_id',
@@ -142,6 +160,70 @@ const certificationsController = {
         return res.sendStatus(204);
       } catch (error: unknown) {
         return await handleObjectionError(error as Error, res, trx);
+      }
+    };
+  },
+
+  uploadCertificationDocument() {
+    return async (req: UploadRequest, res: Response) => {
+      const { farm_id } = req.params;
+      try {
+        const s3BucketName = getPrivateS3BucketName();
+        const fileName = `${farm_id}/certification/${getRandomFileName(req.file)}`;
+
+        const uploadOriginalDocument = () =>
+          s3.send(
+            new PutObjectCommand({
+              Body: req.file!.buffer,
+              Bucket: s3BucketName,
+              Key: fileName,
+              ACL: 'private',
+            }),
+          );
+
+        if (req.isMinimized) {
+          await uploadOriginalDocument();
+          return res.status(201).json({
+            url: `${getPrivateS3Url()}/${fileName}`,
+            thumbnail_url: `${getPrivateS3Url()}/${fileName}`,
+          });
+        } else if (req.isTextDocument) {
+          await uploadOriginalDocument();
+          return res.status(201).json({
+            url: `${getPrivateS3Url()}/${fileName}`,
+          });
+        } else if (req.isNotMinimized) {
+          const THUMBNAIL_FORMAT = 'webp';
+          const THUMBNAIL_WIDTH = '300';
+
+          const [thumbnail] = await Promise.all([
+            imaginaryPost(req.file!, {
+              width: THUMBNAIL_WIDTH,
+              type: THUMBNAIL_FORMAT,
+            }),
+            uploadOriginalDocument(),
+          ]);
+
+          const thumbnailName = `${farm_id}/thumbnail/${uuidv4()}.${THUMBNAIL_FORMAT}`;
+
+          await s3.send(
+            new PutObjectCommand({
+              Body: thumbnail.data,
+              Bucket: s3BucketName,
+              Key: thumbnailName,
+              ACL: 'private',
+            }),
+          );
+
+          return res.status(201).json({
+            url: `${getPrivateS3Url()}/${fileName}`,
+            thumbnail_url: `${getPrivateS3Url()}/${thumbnailName}`,
+          });
+        }
+        return res.sendStatus(400);
+      } catch (error: unknown) {
+        console.error(error);
+        return res.status(400).send('Fail to upload document');
       }
     };
   },

--- a/packages/api/src/controllers/certificationsController.ts
+++ b/packages/api/src/controllers/certificationsController.ts
@@ -87,11 +87,13 @@ const certificationsController = {
       try {
         const { farm_id } = req.headers;
         const { user_id } = req.auth!;
+        // BaseModel hooks overwrite the audit fields; id and deleted are the ones to guard here
+        const { id: _id, deleted: _deleted, ...data } = req.body as Record<string, unknown>;
 
         /* @ts-expect-error known issue with models */
         const certification = await CertificationModel.query(trx)
           .context({ user_id })
-          .insert({ ...req.body, farm_id })
+          .insert({ ...data, farm_id })
           .returning('*');
 
         await trx.commit();

--- a/packages/api/src/controllers/certificationsController.ts
+++ b/packages/api/src/controllers/certificationsController.ts
@@ -23,6 +23,7 @@ import {
   CertificationParams,
 } from '../middleware/validation/checkCertification.js';
 import { handleObjectionError } from '../util/errorCodes.js';
+import { notifyFarmMarketDirectoryPartners } from '../services/notifyMarketDirectoryPartners.js';
 import {
   s3,
   imaginaryPost,
@@ -94,7 +95,10 @@ const certificationsController = {
           .returning('*');
 
         await trx.commit();
-        return res.status(201).json(certification);
+        res.status(201).json(certification);
+        // Fire-and-forget after the response — partners see certifications in DFC output
+        notifyFarmMarketDirectoryPartners(farm_id!);
+        return;
       } catch (error: unknown) {
         return await handleObjectionError(error as Error, res, trx);
       }
@@ -129,7 +133,9 @@ const certificationsController = {
           .patchAndFetchById(id, fullData);
 
         await trx.commit();
-        return res.status(200).json(updated);
+        res.status(200).json(updated);
+        notifyFarmMarketDirectoryPartners(req.headers.farm_id!);
+        return;
       } catch (error: unknown) {
         return await handleObjectionError(error as Error, res, trx);
       }
@@ -157,7 +163,9 @@ const certificationsController = {
         await CertificationModel.query(trx).context({ user_id }).deleteById(id);
 
         await trx.commit();
-        return res.sendStatus(204);
+        res.sendStatus(204);
+        notifyFarmMarketDirectoryPartners(req.headers.farm_id!);
+        return;
       } catch (error: unknown) {
         return await handleObjectionError(error as Error, res, trx);
       }

--- a/packages/api/src/controllers/certificationsController.ts
+++ b/packages/api/src/controllers/certificationsController.ts
@@ -1,0 +1,150 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Response } from 'express';
+import { transaction, Model } from 'objection';
+import CertificationModel from '../models/certificationModel.js';
+import {
+  CertificationBody,
+  CertificationParams,
+} from '../middleware/validation/checkCertification.js';
+import { handleObjectionError } from '../util/errorCodes.js';
+import { HttpError, LiteFarmRequest } from '../types.js';
+
+const MUTABLE_FIELDS = [
+  'system_type_id',
+  'certifier_id',
+  'requested_system_type',
+  'other_certifier',
+  'is_active',
+  'certification_type',
+  'certificate_number',
+  'certificate_member_id',
+  'issue_date',
+  'valid_until',
+  'certificate_document_url',
+] as const;
+
+const certificationsController = {
+  getCertifications() {
+    return async (req: LiteFarmRequest, res: Response) => {
+      try {
+        const { farm_id } = req.headers;
+
+        /* @ts-expect-error known issue with models */
+        const certifications = await CertificationModel.query()
+          .whereNotDeleted()
+          .where({ farm_id })
+          .orderBy('created_at');
+
+        return res.status(200).json(certifications);
+      } catch (error: unknown) {
+        console.error(error);
+        const err = error as HttpError;
+        const status = err.status || err.code || 500;
+        return res.status(status).json({ error: err.message || err });
+      }
+    };
+  },
+
+  addCertification() {
+    return async (
+      req: LiteFarmRequest<unknown, unknown, unknown, CertificationBody>,
+      res: Response,
+    ) => {
+      const trx = await transaction.start(Model.knex());
+      try {
+        const { farm_id } = req.headers;
+        const { user_id } = req.auth!;
+
+        /* @ts-expect-error known issue with models */
+        const certification = await CertificationModel.query(trx)
+          .context({ user_id })
+          .insert({ ...req.body, farm_id })
+          .returning('*');
+
+        await trx.commit();
+        return res.status(201).json(certification);
+      } catch (error: unknown) {
+        return await handleObjectionError(error as Error, res, trx);
+      }
+    };
+  },
+
+  updateCertification() {
+    return async (
+      req: LiteFarmRequest<unknown, CertificationParams, unknown, CertificationBody>,
+      res: Response,
+    ) => {
+      const trx = await transaction.start(Model.knex());
+      try {
+        const { id } = req.params;
+        const { user_id } = req.auth!;
+
+        /* @ts-expect-error known issue with models */
+        const existing = await CertificationModel.query(trx).findById(id).whereNotDeleted();
+        if (!existing) {
+          await trx.rollback();
+          return res.status(404).json({ error: 'Certification not found' });
+        }
+
+        // PUT semantics: replace all mutable fields; absent fields are cleared
+        const fullData = Object.fromEntries(
+          MUTABLE_FIELDS.map((field) => [field, req.body[field] ?? null]),
+        );
+
+        /* @ts-expect-error known issue with models */
+        const updated = await CertificationModel.query(trx)
+          .context({ user_id })
+          .patchAndFetchById(id, fullData);
+
+        await trx.commit();
+        return res.status(200).json(updated);
+      } catch (error: unknown) {
+        return await handleObjectionError(error as Error, res, trx);
+      }
+    };
+  },
+
+  deleteCertification() {
+    return async (
+      req: LiteFarmRequest<unknown, CertificationParams, unknown, unknown>,
+      res: Response,
+    ) => {
+      const trx = await transaction.start(Model.knex());
+      try {
+        const { id } = req.params;
+        const { user_id } = req.auth!;
+
+        /* @ts-expect-error known issue with models */
+        const existing = await CertificationModel.query(trx).findById(id).whereNotDeleted();
+        if (!existing) {
+          await trx.rollback();
+          return res.status(404).json({ error: 'Certification not found' });
+        }
+
+        /* @ts-expect-error known issue with models */
+        await CertificationModel.query(trx).context({ user_id }).deleteById(id);
+
+        await trx.commit();
+        return res.sendStatus(204);
+      } catch (error: unknown) {
+        return await handleObjectionError(error as Error, res, trx);
+      }
+    };
+  },
+};
+
+export default certificationsController;

--- a/packages/api/src/middleware/validation/checkCertification.ts
+++ b/packages/api/src/middleware/validation/checkCertification.ts
@@ -39,16 +39,6 @@ export interface CertificationParams {
   id: string;
 }
 
-const SERVER_MANAGED_FIELDS = [
-  'id',
-  'farm_id',
-  'deleted',
-  'created_at',
-  'updated_at',
-  'created_by_user_id',
-  'updated_by_user_id',
-];
-
 export function checkCertification() {
   return async (
     req: LiteFarmRequest<unknown, CertificationParams, unknown, CertificationBody>,
@@ -56,11 +46,6 @@ export function checkCertification() {
     next: NextFunction,
   ) => {
     try {
-      const body = req.body as Record<string, unknown>;
-      for (const field of SERVER_MANAGED_FIELDS) {
-        delete body[field];
-      }
-
       const {
         system_type_id,
         certifier_id,

--- a/packages/api/src/middleware/validation/checkCertification.ts
+++ b/packages/api/src/middleware/validation/checkCertification.ts
@@ -17,9 +17,7 @@ import { NextFunction, Response } from 'express';
 import knex from '../../util/knex.js';
 import { HttpError, LiteFarmRequest } from '../../types.js';
 
-// Seeded certification_system_type ids
-export const THIRD_PARTY_SYSTEM_TYPE_ID = 1;
-export const PGS_SYSTEM_TYPE_ID = 2;
+export const PGS_TRANSLATION_KEY = 'PGS';
 
 export interface CertificationBody {
   system_type_id?: number | null;
@@ -58,7 +56,11 @@ export function checkCertification() {
         valid_until,
       } = req.body;
 
-      if (![THIRD_PARTY_SYSTEM_TYPE_ID, PGS_SYSTEM_TYPE_ID].includes(system_type_id as number)) {
+      const systemType =
+        system_type_id != null
+          ? await knex('certification_system_type').where({ id: system_type_id }).first()
+          : undefined;
+      if (!systemType) {
         return res.status(400).json({ error: 'A valid system_type_id is required' });
       }
       if (typeof is_active !== 'boolean') {
@@ -86,19 +88,8 @@ export function checkCertification() {
       }
 
       if (is_active) {
-        if (system_type_id === THIRD_PARTY_SYSTEM_TYPE_ID) {
-          if (!certificate_number) {
-            return res
-              .status(400)
-              .json({ error: 'certificate_number is required for an active certification' });
-          }
-          if (certificate_member_id) {
-            return res
-              .status(400)
-              .json({ error: 'certificate_member_id is not accepted for this system type' });
-          }
-        }
-        if (system_type_id === PGS_SYSTEM_TYPE_ID) {
+        const isPgs = systemType.translation_key === PGS_TRANSLATION_KEY;
+        if (isPgs) {
           if (!certificate_member_id) {
             return res
               .status(400)
@@ -108,6 +99,17 @@ export function checkCertification() {
             return res
               .status(400)
               .json({ error: 'certificate_number is not accepted for this system type' });
+          }
+        } else {
+          if (!certificate_number) {
+            return res
+              .status(400)
+              .json({ error: 'certificate_number is required for an active certification' });
+          }
+          if (certificate_member_id) {
+            return res
+              .status(400)
+              .json({ error: 'certificate_member_id is not accepted for this system type' });
           }
         }
         if (!issue_date || !valid_until) {

--- a/packages/api/src/middleware/validation/checkCertification.ts
+++ b/packages/api/src/middleware/validation/checkCertification.ts
@@ -1,0 +1,144 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { NextFunction, Response } from 'express';
+import knex from '../../util/knex.js';
+import { HttpError, LiteFarmRequest } from '../../types.js';
+
+// Seeded certification_system_type ids
+export const THIRD_PARTY_SYSTEM_TYPE_ID = 1;
+export const PGS_SYSTEM_TYPE_ID = 2;
+
+export interface CertificationBody {
+  system_type_id?: number | null;
+  certifier_id?: number | null;
+  requested_system_type?: string | null;
+  other_certifier?: string | null;
+  is_active?: boolean;
+  certification_type?: string | null;
+  certificate_number?: string | null;
+  certificate_member_id?: string | null;
+  issue_date?: string | null;
+  valid_until?: string | null;
+  certificate_document_url?: string | null;
+}
+
+export interface CertificationParams {
+  id: string;
+}
+
+const SERVER_MANAGED_FIELDS = [
+  'id',
+  'farm_id',
+  'deleted',
+  'created_at',
+  'updated_at',
+  'created_by_user_id',
+  'updated_by_user_id',
+];
+
+export function checkCertification() {
+  return async (
+    req: LiteFarmRequest<unknown, CertificationParams, unknown, CertificationBody>,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    try {
+      const body = req.body as Record<string, unknown>;
+      for (const field of SERVER_MANAGED_FIELDS) {
+        delete body[field];
+      }
+
+      const {
+        system_type_id,
+        certifier_id,
+        other_certifier,
+        is_active,
+        certification_type,
+        certificate_number,
+        certificate_member_id,
+        issue_date,
+        valid_until,
+      } = req.body;
+
+      if (![THIRD_PARTY_SYSTEM_TYPE_ID, PGS_SYSTEM_TYPE_ID].includes(system_type_id as number)) {
+        return res.status(400).json({ error: 'A valid system_type_id is required' });
+      }
+      if (typeof is_active !== 'boolean') {
+        return res.status(400).json({ error: 'is_active is required' });
+      }
+      if (!certification_type) {
+        return res.status(400).json({ error: 'certification_type is required' });
+      }
+
+      const hasCertifierId = certifier_id != null;
+      const hasOtherCertifier = !!other_certifier?.trim();
+      if (hasCertifierId === hasOtherCertifier) {
+        return res
+          .status(400)
+          .json({ error: 'Exactly one of certifier_id and other_certifier is required' });
+      }
+
+      if (hasCertifierId) {
+        const certifier = await knex('certifiers').where({ certifier_id }).first();
+        if (!certifier || certifier.system_type_id !== system_type_id) {
+          return res
+            .status(400)
+            .json({ error: 'certifier_id does not match the given system_type_id' });
+        }
+      }
+
+      if (is_active) {
+        if (system_type_id === THIRD_PARTY_SYSTEM_TYPE_ID) {
+          if (!certificate_number) {
+            return res
+              .status(400)
+              .json({ error: 'certificate_number is required for an active certification' });
+          }
+          if (certificate_member_id) {
+            return res
+              .status(400)
+              .json({ error: 'certificate_member_id is not accepted for this system type' });
+          }
+        }
+        if (system_type_id === PGS_SYSTEM_TYPE_ID) {
+          if (!certificate_member_id) {
+            return res
+              .status(400)
+              .json({ error: 'certificate_member_id is required for an active certification' });
+          }
+          if (certificate_number) {
+            return res
+              .status(400)
+              .json({ error: 'certificate_number is not accepted for this system type' });
+          }
+        }
+        if (!issue_date || !valid_until) {
+          return res
+            .status(400)
+            .json({ error: 'issue_date and valid_until are required for an active certification' });
+        }
+      }
+
+      next();
+    } catch (error: unknown) {
+      console.error(error);
+
+      const err = error as HttpError;
+      const status = err.status || err.code || 500;
+      return res.status(status).json({ error: err.message || err });
+    }
+  };
+}

--- a/packages/api/src/models/baseModel.js
+++ b/packages/api/src/models/baseModel.js
@@ -24,6 +24,7 @@ class BaseModel extends softDelete({ columnName: 'deleted' })(Model) {
       'effective_date',
       'germination_date',
       'harvest_date',
+      'issue_date',
       'plant_date',
       'seed_date',
       'start_date',

--- a/packages/api/src/models/certificationModel.js
+++ b/packages/api/src/models/certificationModel.js
@@ -57,8 +57,8 @@ class Certification extends BaseModel {
         certification_type: { type: ['string', 'null'], enum: [...CERTIFICATION_TYPES, null] },
         certificate_number: { type: ['string', 'null'] },
         certificate_member_id: { type: ['string', 'null'] },
-        issue_date: { type: ['string', 'null'] },
-        valid_until: { type: ['string', 'null'] },
+        issue_date: { type: ['string', 'null'], format: 'date' },
+        valid_until: { type: ['string', 'null'], format: 'date' },
         certificate_document_url: { type: ['string', 'null'] },
         ...super.baseProperties,
       },
@@ -101,6 +101,24 @@ class Certification extends BaseModel {
         },
       },
     };
+  }
+
+  $trimStringFields() {
+    for (const [key, value] of Object.entries(this)) {
+      if (typeof value === 'string') {
+        this[key] = value.trim();
+      }
+    }
+  }
+
+  async $beforeInsert(context) {
+    await super.$beforeInsert(context);
+    this.$trimStringFields();
+  }
+
+  async $beforeUpdate(opt, context) {
+    await super.$beforeUpdate(opt, context);
+    this.$trimStringFields();
   }
 }
 

--- a/packages/api/src/models/certificationModel.js
+++ b/packages/api/src/models/certificationModel.js
@@ -102,42 +102,6 @@ class Certification extends BaseModel {
       },
     };
   }
-
-  // TODO LF-5379: temporary shim — maps new DB column names back to old API field names for frontend compatibility
-  $formatJson(json) {
-    json = super.$formatJson(json);
-    json.survey_id = json.id;
-    json.certification_id = json.system_type_id;
-    json.requested_certification = json.requested_system_type;
-    json.requested_certifier = json.other_certifier;
-    json.interested = true;
-    delete json.id;
-    delete json.system_type_id;
-    delete json.requested_system_type;
-    return json;
-  }
-
-  // TODO LF-5379: temporary shim — maps old API field names back to new DB column names
-  $parseJson(json) {
-    json = super.$parseJson(json);
-    if (json.survey_id !== undefined) {
-      json.id = json.survey_id;
-      delete json.survey_id;
-    }
-    if (json.certification_id !== undefined) {
-      json.system_type_id = json.certification_id;
-      delete json.certification_id;
-    }
-    if (json.requested_certification !== undefined) {
-      json.requested_system_type = json.requested_certification;
-      delete json.requested_certification;
-    }
-    if (json.requested_certifier !== undefined) {
-      json.other_certifier = json.requested_certifier;
-      delete json.requested_certifier;
-    }
-    return json;
-  }
 }
 
 export default Certification;

--- a/packages/api/src/routes/certificationsRoute.ts
+++ b/packages/api/src/routes/certificationsRoute.ts
@@ -16,7 +16,9 @@
 import express from 'express';
 import checkScope from '../middleware/acl/checkScope.js';
 import hasFarmAccess from '../middleware/acl/hasFarmAccess.js';
+import multerDiskUpload from '../util/fileUpload.js';
 import { checkCertification } from '../middleware/validation/checkCertification.js';
+import validateFileExtension from '../middleware/validation/uploadDocument.js';
 import controller from '../controllers/certificationsController.js';
 import certificationController from '../controllers/certificationController.js';
 
@@ -50,6 +52,15 @@ router.post(
   '/request_export',
   checkScope(['add:certification']),
   certificationController.triggerExport(),
+);
+
+router.post(
+  '/upload/farm/:farm_id',
+  hasFarmAccess({ params: 'farm_id' }),
+  checkScope(['add:certification']),
+  multerDiskUpload,
+  validateFileExtension,
+  controller.uploadCertificationDocument(),
 );
 
 export default router;

--- a/packages/api/src/routes/certificationsRoute.ts
+++ b/packages/api/src/routes/certificationsRoute.ts
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import express from 'express';
+import checkScope from '../middleware/acl/checkScope.js';
+import hasFarmAccess from '../middleware/acl/hasFarmAccess.js';
+import { checkCertification } from '../middleware/validation/checkCertification.js';
+import controller from '../controllers/certificationsController.js';
+
+const router = express.Router();
+
+router.get('/', checkScope(['get:certification']), controller.getCertifications());
+
+router.post(
+  '/',
+  checkScope(['add:certification']),
+  checkCertification(),
+  controller.addCertification(),
+);
+
+router.put(
+  '/:id',
+  checkScope(['edit:certification']),
+  hasFarmAccess({ tableName: 'certification' }),
+  checkCertification(),
+  controller.updateCertification(),
+);
+
+router.delete(
+  '/:id',
+  checkScope(['delete:certification']),
+  hasFarmAccess({ tableName: 'certification' }),
+  controller.deleteCertification(),
+);
+
+export default router;

--- a/packages/api/src/routes/certificationsRoute.ts
+++ b/packages/api/src/routes/certificationsRoute.ts
@@ -18,6 +18,7 @@ import checkScope from '../middleware/acl/checkScope.js';
 import hasFarmAccess from '../middleware/acl/hasFarmAccess.js';
 import { checkCertification } from '../middleware/validation/checkCertification.js';
 import controller from '../controllers/certificationsController.js';
+import certificationController from '../controllers/certificationController.js';
 
 const router = express.Router();
 
@@ -43,6 +44,12 @@ router.delete(
   checkScope(['delete:certification']),
   hasFarmAccess({ tableName: 'certification' }),
   controller.deleteCertification(),
+);
+
+router.post(
+  '/request_export',
+  checkScope(['add:certification']),
+  certificationController.triggerExport(),
 );
 
 export default router;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -156,6 +156,7 @@ import userFarmDataRoute from './routes/userFarmDataRoute.js';
 import userFarmRoute from './routes/userFarmRoute.js';
 import rolesRoutes from './routes/rolesRoute.js';
 import certificationRoutes from './routes/certificationRoute.js';
+import certificationsRoutes from './routes/certificationsRoute.js';
 import passwordResetRoutes from './routes/passwordResetRoute.js';
 import showedSpotlightRoutes from './routes/showedSpotlightRoute.js';
 import releaseBadgeRoutes from './routes/releaseBadgeRoute.js';
@@ -345,6 +346,7 @@ app
   .use('/user_farm', userFarmRoute)
   .use('/roles', rolesRoutes)
   .use('/organic_certifier_survey', certificationRoutes)
+  .use('/certifications', certificationsRoutes)
   .use('/support_ticket', supportTicketRoute)
   .use('/export', exportRoute)
   .use('/showed_spotlight', showedSpotlightRoutes)

--- a/packages/api/src/services/notifyMarketDirectoryPartners.ts
+++ b/packages/api/src/services/notifyMarketDirectoryPartners.ts
@@ -15,11 +15,33 @@
 
 import MarketDirectoryPartnerAuth from '../models/marketDirectoryPartnerAuthModel.js';
 import MarketDirectoryPartnerPermissionsModel from '../models/marketDirectoryPartnerPermissions.js';
+import MarketDirectoryInfoModel from '../models/marketDirectoryInfoModel.js';
 import { notifyPartnerRefresh } from './datafoodconsortium/dfcWebhook.js';
 import type {
   MarketDirectoryPartnerAuth as MarketDirectoryPartnerAuthType,
+  MarketDirectoryInfo,
   MarketDirectoryPartnerPermissions,
 } from '../models/types.js';
+
+async function notifyPartnersByIds(partnerIds: number[]) {
+  if (partnerIds.length === 0) {
+    return;
+  }
+
+  const partnerAuths = (await MarketDirectoryPartnerAuth.query().whereIn(
+    'market_directory_partner_id',
+    partnerIds,
+  )) as unknown as MarketDirectoryPartnerAuthType[];
+
+  // Send webhooks to each partner with a webhook URL
+  for (const auth of partnerAuths) {
+    if (!auth.webhook_endpoint) {
+      continue;
+    }
+
+    await notifyPartnerRefresh(auth.webhook_endpoint);
+  }
+}
 
 /**
  * Non-blocking post-response side effects; do not send HTTP responses here
@@ -62,23 +84,41 @@ export async function notifyMarketDirectoryPartners(
       partnerIdsToNotify = currentPartnerIds;
     }
 
-    if (partnerIdsToNotify.length === 0) {
+    await notifyPartnersByIds(partnerIdsToNotify);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+/**
+ * Non-blocking post-response side effect; do not send HTTP responses here
+ *
+ * Notifies all partners currently permitted to see the farm's market directory
+ * listing. Skips silently when the farm is not listed in the market directory.
+ *
+ * @param farm_id - ID of the farm whose data changed
+ */
+export async function notifyFarmMarketDirectoryPartners(farm_id: string) {
+  try {
+    const marketDirectoryInfo: MarketDirectoryInfo | undefined = await MarketDirectoryInfoModel
+      // @ts-expect-error: TS doesn't see query() through softDelete HOC; safe at runtime
+      .query()
+      .where({ farm_id })
+      .whereNotDeleted()
+      .first();
+
+    if (!marketDirectoryInfo) {
       return;
     }
 
-    const partnerAuths = (await MarketDirectoryPartnerAuth.query().whereIn(
-      'market_directory_partner_id',
-      partnerIdsToNotify,
-    )) as unknown as MarketDirectoryPartnerAuthType[];
+    const permissions: MarketDirectoryPartnerPermissions[] =
+      await MarketDirectoryPartnerPermissionsModel
+        // @ts-expect-error: TS doesn't see query() through softDelete HOC; safe at runtime
+        .query()
+        .where({ market_directory_info_id: marketDirectoryInfo.id })
+        .whereNotDeleted();
 
-    // Send webhooks to each partner with a webhook URL
-    for (const auth of partnerAuths) {
-      if (!auth.webhook_endpoint) {
-        continue;
-      }
-
-      await notifyPartnerRefresh(auth.webhook_endpoint);
-    }
+    await notifyPartnersByIds(permissions.map((p) => p.market_directory_partner_id));
   } catch (error) {
     console.error(error);
   }

--- a/packages/api/src/services/notifyMarketDirectoryPartners.ts
+++ b/packages/api/src/services/notifyMarketDirectoryPartners.ts
@@ -96,14 +96,14 @@ export async function notifyMarketDirectoryPartners(
  * Notifies all partners currently permitted to see the farm's market directory
  * listing. Skips silently when the farm is not listed in the market directory.
  *
- * @param farm_id - ID of the farm whose data changed
+ * @param farmId - ID of the farm whose data changed
  */
-export async function notifyFarmMarketDirectoryPartners(farm_id: string) {
+export async function notifyFarmMarketDirectoryPartners(farmId: string) {
   try {
     const marketDirectoryInfo: MarketDirectoryInfo | undefined = await MarketDirectoryInfoModel
       // @ts-expect-error: TS doesn't see query() through softDelete HOC; safe at runtime
       .query()
-      .where({ farm_id })
+      .where({ farm_id: farmId })
       .whereNotDeleted()
       .first();
 

--- a/packages/api/tests/certifications.test.ts
+++ b/packages/api/tests/certifications.test.ts
@@ -161,7 +161,7 @@ describe('Certifications CRUD tests', () => {
     pgsSystemTypeId = pgsSystemType.id;
 
     const thirdPartySystemType = await knex('certification_system_type')
-      .whereNot({ translation_key: PGS_TRANSLATION_KEY })
+      .where({ translation_key: 'THIRD_PARTY_ORGANIC' })
       .orderBy('id')
       .first();
     thirdPartySystemTypeId = thirdPartySystemType.id;
@@ -182,7 +182,7 @@ describe('Certifications CRUD tests', () => {
   });
 
   describe('GET /certifications', () => {
-    test('Farm members with certification scope can list certifications with real column names', async () => {
+    test('Admin users can list certifications', async () => {
       const userFarmIds = await createUserFarmIds(1);
       const certification = await createCertification(userFarmIds);
 
@@ -200,10 +200,6 @@ describe('Certifications CRUD tests', () => {
         expect(returned.id).toBe(certification.id);
         expect(returned.system_type_id).toBe(thirdPartySystemTypeId);
         expect(returned.certificate_number).toBe('CAN-ORG-2024-01567');
-        // Legacy shim names must not appear
-        expect(returned.survey_id).toBeUndefined();
-        expect(returned.certification_id).toBeUndefined();
-        expect(returned.interested).toBeUndefined();
       }
     });
 
@@ -227,7 +223,7 @@ describe('Certifications CRUD tests', () => {
       expect(res.body).toEqual([]);
     });
 
-    test("Excludes other farms' certifications", async () => {
+    test("Should not get other farms' certifications", async () => {
       const userFarmIds = await createUserFarmIds(1);
       const otherUserFarmIds = await createUserFarmIds(1);
       await createCertification(otherUserFarmIds);
@@ -264,7 +260,7 @@ describe('Certifications CRUD tests', () => {
   });
 
   describe('POST /certifications', () => {
-    test('Owners, managers, and extension officers can add a certification', async () => {
+    test('Admin users can add a certification', async () => {
       const userFarmIds = await createUserFarmIds(1);
 
       for (const roleId of [1, 2, 5]) {
@@ -280,39 +276,10 @@ describe('Certifications CRUD tests', () => {
 
         expect(res.status).toBe(201);
         expect(res.body.system_type_id).toBe(thirdPartySystemTypeId);
-
         const persisted = await knex('certification').where({ id: res.body.id }).first();
         expect(persisted.farm_id).toBe(userFarmIds.farm_id);
         expect(persisted.certificate_number).toBe('CAN-ORG-2024-01567');
-        expect(persisted.created_by_user_id).toBe(user_id);
       }
-    });
-
-    test('Body farm_id is ignored in favor of the header', async () => {
-      const userFarmIds = await createUserFarmIds(1);
-      const otherUserFarmIds = await createUserFarmIds(1);
-
-      const res = await postRequest(
-        validCertificationBody({ farm_id: otherUserFarmIds.farm_id }),
-        userFarmIds,
-      );
-
-      expect(res.status).toBe(201);
-      const persisted = await knex('certification').where({ id: res.body.id }).first();
-      expect(persisted.farm_id).toBe(userFarmIds.farm_id);
-    });
-
-    test('String fields are trimmed before saving', async () => {
-      const userFarmIds = await createUserFarmIds(1);
-
-      const res = await postRequest(
-        validCertificationBody({ certificate_number: '  CAN-ORG-2024-01567  ' }),
-        userFarmIds,
-      );
-
-      expect(res.status).toBe(201);
-      const persisted = await knex('certification').where({ id: res.body.id }).first();
-      expect(persisted.certificate_number).toBe('CAN-ORG-2024-01567');
     });
 
     test('Workers cannot add a certification', async () => {
@@ -337,49 +304,21 @@ describe('Certifications CRUD tests', () => {
         userFarmIds = await createUserFarmIds(1);
       });
 
-      test('Rejects an unknown field', async () => {
-        const res = await postRequest(
-          validCertificationBody({ requested_certifier: 'legacy name' }),
-          userFarmIds,
-        );
-        expect(res.status).toBe(400);
-      });
-
-      test('Rejects an invalid certification_type', async () => {
-        const res = await postRequest(
-          validCertificationBody({ certification_type: 'NOT_A_TYPE' }),
-          userFarmIds,
-        );
-        expect(res.status).toBe(400);
-      });
-
-      test('Rejects a missing system_type_id', async () => {
-        const res = await postRequest(
-          validCertificationBody({ system_type_id: undefined }),
-          userFarmIds,
-        );
-        expect(res.status).toBe(400);
-      });
-
-      test('Rejects a missing is_active', async () => {
-        const res = await postRequest(
-          validCertificationBody({ is_active: undefined }),
-          userFarmIds,
-        );
-        expect(res.status).toBe(400);
-      });
-
-      test('Rejects a missing certification_type', async () => {
-        const res = await postRequest(
-          validCertificationBody({ certification_type: undefined }),
-          userFarmIds,
-        );
+      const mandatoryFields = [
+        'system_type_id',
+        'is_active',
+        'certification_type',
+        'issue_date',
+        'valid_until',
+      ];
+      test.each(mandatoryFields)('Rejects a missing %s', async (field) => {
+        const res = await postRequest(validCertificationBody({ [field]: undefined }), userFarmIds);
         expect(res.status).toBe(400);
       });
 
       test('Rejects a missing certifier', async () => {
         const res = await postRequest(
-          validCertificationBody({ certifier_id: undefined }),
+          validCertificationBody({ certifier_id: undefined, other_certifier: undefined }),
           userFarmIds,
         );
         expect(res.status).toBe(400);
@@ -442,14 +381,6 @@ describe('Certifications CRUD tests', () => {
             other_certifier: 'PGS Group',
             certificate_number: undefined,
           }),
-          userFarmIds,
-        );
-        expect(res.status).toBe(400);
-      });
-
-      test('Rejects missing dates for an active certification', async () => {
-        const res = await postRequest(
-          validCertificationBody({ issue_date: undefined, valid_until: undefined }),
           userFarmIds,
         );
         expect(res.status).toBe(400);

--- a/packages/api/tests/certifications.test.ts
+++ b/packages/api/tests/certifications.test.ts
@@ -22,10 +22,7 @@ import knex from '../src/util/knex.js';
 import { tableCleanup } from './testEnvironment.js';
 import mocks from './mock.factories.js';
 import { createUserFarmIds } from './utils/testDataSetup.js';
-import {
-  THIRD_PARTY_SYSTEM_TYPE_ID,
-  PGS_SYSTEM_TYPE_ID,
-} from '../src/middleware/validation/checkCertification.js';
+import { PGS_TRANSLATION_KEY } from '../src/middleware/validation/checkCertification.js';
 
 jest.mock('jsdom');
 jest.mock('bull');
@@ -125,10 +122,12 @@ async function uploadRequest(fileName: string, { user_id, farm_id }: UserFarmIds
 
 describe('Certifications CRUD tests', () => {
   let thirdPartyCertifier: Certifier;
+  let thirdPartySystemTypeId: number;
+  let pgsSystemTypeId: number;
 
   function validCertificationBody(overrides: object = {}) {
     return {
-      system_type_id: THIRD_PARTY_SYSTEM_TYPE_ID,
+      system_type_id: thirdPartySystemTypeId,
       certifier_id: thirdPartyCertifier.certifier_id,
       is_active: true,
       certification_type: 'ORGANIC',
@@ -143,7 +142,7 @@ describe('Certifications CRUD tests', () => {
     const [certification] = await mocks.certificationFactory(
       { promisedUserFarm: Promise.resolve([userFarmIds]) },
       mocks.fakeCertification(userFarmIds.farm_id, {
-        system_type_id: THIRD_PARTY_SYSTEM_TYPE_ID,
+        system_type_id: thirdPartySystemTypeId,
         certifier_id: thirdPartyCertifier.certifier_id,
         certification_type: 'ORGANIC',
         certificate_number: 'CAN-ORG-2024-01567',
@@ -156,8 +155,19 @@ describe('Certifications CRUD tests', () => {
   }
 
   beforeAll(async () => {
+    const pgsSystemType = await knex('certification_system_type')
+      .where({ translation_key: PGS_TRANSLATION_KEY })
+      .first();
+    pgsSystemTypeId = pgsSystemType.id;
+
+    const thirdPartySystemType = await knex('certification_system_type')
+      .whereNot({ translation_key: PGS_TRANSLATION_KEY })
+      .orderBy('id')
+      .first();
+    thirdPartySystemTypeId = thirdPartySystemType.id;
+
     thirdPartyCertifier = await knex('certifiers')
-      .where({ system_type_id: THIRD_PARTY_SYSTEM_TYPE_ID })
+      .where({ system_type_id: thirdPartySystemTypeId })
       .orderBy('certifier_id')
       .first();
   });
@@ -188,7 +198,7 @@ describe('Certifications CRUD tests', () => {
         expect(res.body).toHaveLength(1);
         const [returned] = res.body;
         expect(returned.id).toBe(certification.id);
-        expect(returned.system_type_id).toBe(THIRD_PARTY_SYSTEM_TYPE_ID);
+        expect(returned.system_type_id).toBe(thirdPartySystemTypeId);
         expect(returned.certificate_number).toBe('CAN-ORG-2024-01567');
         // Legacy shim names must not appear
         expect(returned.survey_id).toBeUndefined();
@@ -269,7 +279,7 @@ describe('Certifications CRUD tests', () => {
         });
 
         expect(res.status).toBe(201);
-        expect(res.body.system_type_id).toBe(THIRD_PARTY_SYSTEM_TYPE_ID);
+        expect(res.body.system_type_id).toBe(thirdPartySystemTypeId);
 
         const persisted = await knex('certification').where({ id: res.body.id }).first();
         expect(persisted.farm_id).toBe(userFarmIds.farm_id);
@@ -386,7 +396,7 @@ describe('Certifications CRUD tests', () => {
       test('Rejects a certifier_id that does not match system_type_id', async () => {
         const res = await postRequest(
           validCertificationBody({
-            system_type_id: PGS_SYSTEM_TYPE_ID,
+            system_type_id: pgsSystemTypeId,
             certificate_number: undefined,
             certificate_member_id: 'MEMBER-1',
           }),
@@ -414,7 +424,7 @@ describe('Certifications CRUD tests', () => {
       test('Rejects certificate_number for an active PGS certification', async () => {
         const res = await postRequest(
           validCertificationBody({
-            system_type_id: PGS_SYSTEM_TYPE_ID,
+            system_type_id: pgsSystemTypeId,
             certifier_id: undefined,
             other_certifier: 'PGS Group',
             certificate_member_id: 'MEMBER-1',
@@ -427,7 +437,7 @@ describe('Certifications CRUD tests', () => {
       test('Rejects a missing certificate_member_id for an active PGS certification', async () => {
         const res = await postRequest(
           validCertificationBody({
-            system_type_id: PGS_SYSTEM_TYPE_ID,
+            system_type_id: pgsSystemTypeId,
             certifier_id: undefined,
             other_certifier: 'PGS Group',
             certificate_number: undefined,
@@ -448,7 +458,7 @@ describe('Certifications CRUD tests', () => {
       test('Accepts an active PGS certification with other_certifier and member id', async () => {
         const res = await postRequest(
           validCertificationBody({
-            system_type_id: PGS_SYSTEM_TYPE_ID,
+            system_type_id: pgsSystemTypeId,
             certifier_id: undefined,
             other_certifier: 'PGS Group',
             certificate_number: undefined,

--- a/packages/api/tests/certifications.test.ts
+++ b/packages/api/tests/certifications.test.ts
@@ -1,0 +1,767 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+
+import server from '../src/server.js';
+import knex from '../src/util/knex.js';
+import { tableCleanup } from './testEnvironment.js';
+import mocks from './mock.factories.js';
+import { createUserFarmIds } from './utils/testDataSetup.js';
+import {
+  THIRD_PARTY_SYSTEM_TYPE_ID,
+  PGS_SYSTEM_TYPE_ID,
+} from '../src/middleware/validation/checkCertification.js';
+
+jest.mock('jsdom');
+jest.mock('bull');
+jest.mock('../src/middleware/acl/checkJwt.js', () =>
+  jest.fn((req, _res, next) => {
+    req.auth = {};
+    req.auth.user_id = req.get('user_id');
+    next();
+  }),
+);
+
+// Mock partner webhook-calling service
+jest.mock('../src/services/datafoodconsortium/dfcWebhook.js', () => ({
+  notifyPartnerRefresh: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { notifyPartnerRefresh } from '../src/services/datafoodconsortium/dfcWebhook.js';
+const mockedNotifyPartnerRefresh = notifyPartnerRefresh as jest.MockedFunction<
+  typeof notifyPartnerRefresh
+>;
+
+// Mock S3/imaginary so file upload tests work without live infrastructure
+jest.mock('../src/util/digitalOceanSpaces.js', () => ({
+  s3: { send: jest.fn().mockResolvedValue({}) },
+  getPrivateS3BucketName: jest.fn().mockReturnValue('test-bucket'),
+  getPrivateS3Url: jest.fn().mockReturnValue('http://localhost:9000/test-bucket'),
+  getRandomFileName: jest.fn().mockImplementation((file) => `random-uuid-${file.originalname}`),
+  imaginaryPost: jest.fn().mockResolvedValue({ data: Buffer.from('fake-image') }),
+}));
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  PutObjectCommand: jest.fn().mockImplementation((args) => args),
+}));
+
+interface UserFarmIds {
+  user_id: string;
+  farm_id: string;
+}
+
+interface Certifier {
+  certifier_id: number;
+  system_type_id: number;
+  certifier_name: string;
+}
+
+async function getRequest({ user_id, farm_id }: UserFarmIds) {
+  return chai
+    .request(server)
+    .get('/certifications')
+    .set('user_id', user_id)
+    .set('farm_id', farm_id);
+}
+
+async function postRequest(data: object, { user_id, farm_id }: UserFarmIds) {
+  return chai
+    .request(server)
+    .post('/certifications')
+    .set('user_id', user_id)
+    .set('farm_id', farm_id)
+    .send(data);
+}
+
+async function putRequest(id: number, data: object, { user_id, farm_id }: UserFarmIds) {
+  return chai
+    .request(server)
+    .put(`/certifications/${id}`)
+    .set('user_id', user_id)
+    .set('farm_id', farm_id)
+    .send(data);
+}
+
+async function deleteRequest(id: number, { user_id, farm_id }: UserFarmIds) {
+  return chai
+    .request(server)
+    .delete(`/certifications/${id}`)
+    .set('user_id', user_id)
+    .set('farm_id', farm_id);
+}
+
+async function exportRequest(data: object, { user_id, farm_id }: UserFarmIds) {
+  return chai
+    .request(server)
+    .post('/certifications/request_export')
+    .set('user_id', user_id)
+    .set('farm_id', farm_id)
+    .send(data);
+}
+
+async function uploadRequest(fileName: string, { user_id, farm_id }: UserFarmIds) {
+  return chai
+    .request(server)
+    .post(`/certifications/upload/farm/${farm_id}`)
+    .set('user_id', user_id)
+    .set('farm_id', farm_id)
+    .attach('_file_', Buffer.from('fake-file-content'), fileName);
+}
+
+describe('Certifications CRUD tests', () => {
+  let thirdPartyCertifier: Certifier;
+
+  function validCertificationBody(overrides: object = {}) {
+    return {
+      system_type_id: THIRD_PARTY_SYSTEM_TYPE_ID,
+      certifier_id: thirdPartyCertifier.certifier_id,
+      is_active: true,
+      certification_type: 'ORGANIC',
+      certificate_number: 'CAN-ORG-2024-01567',
+      issue_date: '2024-01-01',
+      valid_until: '2026-12-31',
+      ...overrides,
+    };
+  }
+
+  async function createCertification(userFarmIds: UserFarmIds, overrides: object = {}) {
+    const [certification] = await mocks.certificationFactory(
+      { promisedUserFarm: Promise.resolve([userFarmIds]) },
+      mocks.fakeCertification(userFarmIds.farm_id, {
+        system_type_id: THIRD_PARTY_SYSTEM_TYPE_ID,
+        certifier_id: thirdPartyCertifier.certifier_id,
+        certification_type: 'ORGANIC',
+        certificate_number: 'CAN-ORG-2024-01567',
+        issue_date: '2024-01-01',
+        valid_until: '2026-12-31',
+        ...overrides,
+      }),
+    );
+    return certification;
+  }
+
+  beforeAll(async () => {
+    thirdPartyCertifier = await knex('certifiers')
+      .where({ system_type_id: THIRD_PARTY_SYSTEM_TYPE_ID })
+      .orderBy('certifier_id')
+      .first();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await tableCleanup(knex);
+    await knex.destroy();
+  });
+
+  describe('GET /certifications', () => {
+    test('Farm members with certification scope can list certifications with real column names', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+
+      for (const roleId of [1, 2, 5]) {
+        const [{ user_id }] = await mocks.userFarmFactory({
+          promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+          roleId,
+        });
+
+        const res = await getRequest({ user_id, farm_id: userFarmIds.farm_id });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveLength(1);
+        const [returned] = res.body;
+        expect(returned.id).toBe(certification.id);
+        expect(returned.system_type_id).toBe(THIRD_PARTY_SYSTEM_TYPE_ID);
+        expect(returned.certificate_number).toBe('CAN-ORG-2024-01567');
+        // Legacy shim names must not appear
+        expect(returned.survey_id).toBeUndefined();
+        expect(returned.certification_id).toBeUndefined();
+        expect(returned.interested).toBeUndefined();
+      }
+    });
+
+    test('Returns an empty array when the farm has no certifications', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await getRequest(userFarmIds);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    test('Excludes soft-deleted certifications', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+      await knex('certification').where({ id: certification.id }).update({ deleted: true });
+
+      const res = await getRequest(userFarmIds);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    test("Excludes other farms' certifications", async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const otherUserFarmIds = await createUserFarmIds(1);
+      await createCertification(otherUserFarmIds);
+
+      const res = await getRequest(userFarmIds);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    test('Workers cannot list certifications', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const [{ user_id }] = await mocks.userFarmFactory({
+        promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+        roleId: 3,
+      });
+
+      const res = await getRequest({ user_id, farm_id: userFarmIds.farm_id });
+
+      expect(res.status).toBe(403);
+    });
+
+    test('Members of another farm cannot list certifications', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const otherUserFarmIds = await createUserFarmIds(1);
+
+      const res = await getRequest({
+        user_id: otherUserFarmIds.user_id,
+        farm_id: userFarmIds.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /certifications', () => {
+    test('Owners, managers, and extension officers can add a certification', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      for (const roleId of [1, 2, 5]) {
+        const [{ user_id }] = await mocks.userFarmFactory({
+          promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+          roleId,
+        });
+
+        const res = await postRequest(validCertificationBody(), {
+          user_id,
+          farm_id: userFarmIds.farm_id,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.system_type_id).toBe(THIRD_PARTY_SYSTEM_TYPE_ID);
+
+        const persisted = await knex('certification').where({ id: res.body.id }).first();
+        expect(persisted.farm_id).toBe(userFarmIds.farm_id);
+        expect(persisted.certificate_number).toBe('CAN-ORG-2024-01567');
+        expect(persisted.created_by_user_id).toBe(user_id);
+      }
+    });
+
+    test('Body farm_id is ignored in favor of the header', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const otherUserFarmIds = await createUserFarmIds(1);
+
+      const res = await postRequest(
+        validCertificationBody({ farm_id: otherUserFarmIds.farm_id }),
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(201);
+      const persisted = await knex('certification').where({ id: res.body.id }).first();
+      expect(persisted.farm_id).toBe(userFarmIds.farm_id);
+    });
+
+    test('String fields are trimmed before saving', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await postRequest(
+        validCertificationBody({ certificate_number: '  CAN-ORG-2024-01567  ' }),
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(201);
+      const persisted = await knex('certification').where({ id: res.body.id }).first();
+      expect(persisted.certificate_number).toBe('CAN-ORG-2024-01567');
+    });
+
+    test('Workers cannot add a certification', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const [{ user_id }] = await mocks.userFarmFactory({
+        promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+        roleId: 3,
+      });
+
+      const res = await postRequest(validCertificationBody(), {
+        user_id,
+        farm_id: userFarmIds.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    describe('Validation', () => {
+      let userFarmIds: UserFarmIds;
+
+      beforeEach(async () => {
+        userFarmIds = await createUserFarmIds(1);
+      });
+
+      test('Rejects an unknown field', async () => {
+        const res = await postRequest(
+          validCertificationBody({ requested_certifier: 'legacy name' }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects an invalid certification_type', async () => {
+        const res = await postRequest(
+          validCertificationBody({ certification_type: 'NOT_A_TYPE' }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a missing system_type_id', async () => {
+        const res = await postRequest(
+          validCertificationBody({ system_type_id: undefined }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a missing is_active', async () => {
+        const res = await postRequest(
+          validCertificationBody({ is_active: undefined }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a missing certification_type', async () => {
+        const res = await postRequest(
+          validCertificationBody({ certification_type: undefined }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a missing certifier', async () => {
+        const res = await postRequest(
+          validCertificationBody({ certifier_id: undefined }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects both certifier_id and other_certifier', async () => {
+        const res = await postRequest(
+          validCertificationBody({ other_certifier: 'Some Certifier' }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a certifier_id that does not match system_type_id', async () => {
+        const res = await postRequest(
+          validCertificationBody({
+            system_type_id: PGS_SYSTEM_TYPE_ID,
+            certificate_number: undefined,
+            certificate_member_id: 'MEMBER-1',
+          }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects certificate_member_id for an active third-party certification', async () => {
+        const res = await postRequest(
+          validCertificationBody({ certificate_member_id: 'MEMBER-1' }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a missing certificate_number for an active third-party certification', async () => {
+        const res = await postRequest(
+          validCertificationBody({ certificate_number: undefined }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects certificate_number for an active PGS certification', async () => {
+        const res = await postRequest(
+          validCertificationBody({
+            system_type_id: PGS_SYSTEM_TYPE_ID,
+            certifier_id: undefined,
+            other_certifier: 'PGS Group',
+            certificate_member_id: 'MEMBER-1',
+          }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects a missing certificate_member_id for an active PGS certification', async () => {
+        const res = await postRequest(
+          validCertificationBody({
+            system_type_id: PGS_SYSTEM_TYPE_ID,
+            certifier_id: undefined,
+            other_certifier: 'PGS Group',
+            certificate_number: undefined,
+          }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Rejects missing dates for an active certification', async () => {
+        const res = await postRequest(
+          validCertificationBody({ issue_date: undefined, valid_until: undefined }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(400);
+      });
+
+      test('Accepts an active PGS certification with other_certifier and member id', async () => {
+        const res = await postRequest(
+          validCertificationBody({
+            system_type_id: PGS_SYSTEM_TYPE_ID,
+            certifier_id: undefined,
+            other_certifier: 'PGS Group',
+            certificate_number: undefined,
+            certificate_member_id: 'MEMBER-1',
+          }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(201);
+      });
+
+      test('Accepts an inactive certification without number, member id, or dates', async () => {
+        const res = await postRequest(
+          validCertificationBody({
+            is_active: false,
+            certificate_number: undefined,
+            issue_date: undefined,
+            valid_until: undefined,
+          }),
+          userFarmIds,
+        );
+        expect(res.status).toBe(201);
+      });
+    });
+  });
+
+  describe('PUT /certifications/:id', () => {
+    test('Updates and replaces all mutable fields', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds, {
+        certificate_document_url: 'https://example.com/old-doc.pdf',
+      });
+
+      // Body omits certificate_document_url — full-replace semantics clear it
+      const res = await putRequest(
+        certification.id,
+        validCertificationBody({ certificate_number: 'NEW-NUMBER-99' }),
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.certificate_number).toBe('NEW-NUMBER-99');
+
+      const persisted = await knex('certification').where({ id: certification.id }).first();
+      expect(persisted.certificate_number).toBe('NEW-NUMBER-99');
+      expect(persisted.certificate_document_url).toBeNull();
+      expect(persisted.updated_by_user_id).toBe(userFarmIds.user_id);
+    });
+
+    test('Returns 404 for a soft-deleted certification', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+      await knex('certification').where({ id: certification.id }).update({ deleted: true });
+
+      const res = await putRequest(certification.id, validCertificationBody(), userFarmIds);
+
+      expect(res.status).toBe(404);
+    });
+
+    test('Returns 403 for a nonexistent id (hasFarmAccess middleware behavior)', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await putRequest(99999999, validCertificationBody(), userFarmIds);
+
+      expect(res.status).toBe(403);
+    });
+
+    test("Returns 403 when targeting another farm's certification", async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const otherUserFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(otherUserFarmIds);
+
+      const res = await putRequest(certification.id, validCertificationBody(), userFarmIds);
+
+      expect(res.status).toBe(403);
+    });
+
+    test('Rejects an invalid certification_type', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+
+      const res = await putRequest(
+        certification.id,
+        validCertificationBody({ certification_type: 'NOT_A_TYPE' }),
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('DELETE /certifications/:id', () => {
+    test('Soft-deletes a certification', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+
+      const res = await deleteRequest(certification.id, userFarmIds);
+
+      expect(res.status).toBe(204);
+      const persisted = await knex('certification').where({ id: certification.id }).first();
+      expect(persisted.deleted).toBe(true);
+    });
+
+    test('Returns 404 when deleting an already-deleted certification', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+
+      await deleteRequest(certification.id, userFarmIds);
+      const res = await deleteRequest(certification.id, userFarmIds);
+
+      expect(res.status).toBe(404);
+    });
+
+    test('Workers cannot delete a certification', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(userFarmIds);
+      const [{ user_id }] = await mocks.userFarmFactory({
+        promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+        roleId: 3,
+      });
+
+      const res = await deleteRequest(certification.id, {
+        user_id,
+        farm_id: userFarmIds.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    test("Returns 403 when deleting another farm's certification", async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const otherUserFarmIds = await createUserFarmIds(1);
+      const certification = await createCertification(otherUserFarmIds);
+
+      const res = await deleteRequest(certification.id, userFarmIds);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /certifications/request_export', () => {
+    test('Exports for the certification matching the given certifier', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      await createCertification(userFarmIds);
+
+      const res = await exportRequest(
+        {
+          certifier_id: thirdPartyCertifier.certifier_id,
+          from_date: '2026-01-01',
+          to_date: '2026-06-30',
+        },
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Processing');
+    });
+
+    test('Returns 400 when dates are missing', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      await createCertification(userFarmIds);
+
+      const res = await exportRequest(
+        { certifier_id: thirdPartyCertifier.certifier_id },
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Returns 400 when no certification matches the given certifier', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      await createCertification(userFarmIds, { certifier_id: null, other_certifier: 'Someone' });
+
+      const res = await exportRequest(
+        {
+          certifier_id: thirdPartyCertifier.certifier_id,
+          from_date: '2026-01-01',
+          to_date: '2026-06-30',
+        },
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Workers cannot request an export', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const [{ user_id }] = await mocks.userFarmFactory({
+        promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+        roleId: 3,
+      });
+
+      const res = await exportRequest(
+        {
+          certifier_id: thirdPartyCertifier.certifier_id,
+          from_date: '2026-01-01',
+          to_date: '2026-06-30',
+        },
+        { user_id, farm_id: userFarmIds.farm_id },
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /certifications/upload/farm/:farm_id', () => {
+    test('Uploads a PDF and returns urls', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await uploadRequest('certificate.pdf', userFarmIds);
+
+      expect(res.status).toBe(201);
+      expect(res.body.url).toContain(`${userFarmIds.farm_id}/certification/`);
+      expect(res.body.thumbnail_url).toBeDefined();
+    });
+
+    test('Uploads an image and returns urls', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await uploadRequest('certificate.png', userFarmIds);
+
+      expect(res.status).toBe(201);
+      expect(res.body.url).toContain(`${userFarmIds.farm_id}/certification/`);
+    });
+
+    test('Rejects an unsupported file type', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await uploadRequest('certificate.exe', userFarmIds);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('Workers cannot upload a document', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const [{ user_id }] = await mocks.userFarmFactory({
+        promisedFarm: Promise.resolve([{ farm_id: userFarmIds.farm_id }]),
+        roleId: 3,
+      });
+
+      const res = await uploadRequest('certificate.pdf', {
+        user_id,
+        farm_id: userFarmIds.farm_id,
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Partner webhook notifications', () => {
+    async function setupFarmWithPartner(userFarmIds: UserFarmIds) {
+      const [marketDirectoryInfo] = await mocks.market_directory_infoFactory({
+        promisedUserFarm: Promise.resolve([userFarmIds]),
+      });
+      const [partner] = await mocks.market_directory_partnerFactory();
+      const webhookUrl = `https://partner-${partner.id}.example.com/webhook`;
+      await mocks.market_directory_partner_authFactory(
+        { promisedPartner: Promise.resolve([partner]) },
+        mocks.fakeMarketDirectoryPartnerAuth({ webhook_endpoint: webhookUrl }),
+      );
+      await mocks.market_directory_partner_permissionsFactory({
+        promisedDirectoryInfo: Promise.resolve([marketDirectoryInfo]),
+        promisedPartner: Promise.resolve([partner]),
+      });
+      return webhookUrl;
+    }
+
+    const flushWebhooks = () => new Promise((resolve) => setTimeout(resolve, 100));
+
+    test('Notifies permitted partners after a successful write', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      const webhookUrl = await setupFarmWithPartner(userFarmIds);
+
+      const postRes = await postRequest(validCertificationBody(), userFarmIds);
+      expect(postRes.status).toBe(201);
+      await flushWebhooks();
+      expect(mockedNotifyPartnerRefresh).toHaveBeenCalledWith(webhookUrl);
+
+      jest.clearAllMocks();
+      const putRes = await putRequest(postRes.body.id, validCertificationBody(), userFarmIds);
+      expect(putRes.status).toBe(200);
+      await flushWebhooks();
+      expect(mockedNotifyPartnerRefresh).toHaveBeenCalledWith(webhookUrl);
+
+      jest.clearAllMocks();
+      const deleteRes = await deleteRequest(postRes.body.id, userFarmIds);
+      expect(deleteRes.status).toBe(204);
+      await flushWebhooks();
+      expect(mockedNotifyPartnerRefresh).toHaveBeenCalledWith(webhookUrl);
+    });
+
+    test('Does not notify when the farm is not in the market directory', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+
+      const res = await postRequest(validCertificationBody(), userFarmIds);
+
+      expect(res.status).toBe(201);
+      await flushWebhooks();
+      expect(mockedNotifyPartnerRefresh).not.toHaveBeenCalled();
+    });
+
+    test('Does not notify when the write fails', async () => {
+      const userFarmIds = await createUserFarmIds(1);
+      await setupFarmWithPartner(userFarmIds);
+
+      const res = await postRequest(
+        validCertificationBody({ certification_type: 'NOT_A_TYPE' }),
+        userFarmIds,
+      );
+
+      expect(res.status).toBe(400);
+      await flushWebhooks();
+      expect(mockedNotifyPartnerRefresh).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Description**

Adds per-record CRUD endpoints for the `certification` table to support the new multi-certification frontend.
The legacy single-cert `/organic_certifier_survey` routes are untouched and retain their exact HTTP contract. They will be removed in LF-5379 once the frontend migrates.

**Endpoints**
   - GET `/certifications`
   - POST `/certifications`
   - PUT `/certifications/:id`
   - DELETE `/certifications/:id`
   - POST `/certifications/request_export`
   - POST `/certifications/upload/farm/:farm_id`

All endpoints are scoped by the `farm_id` header. `:id` routes additionally verify record ownership via `hasFarmAccess({ tableName: 'certification' })`. Scopes remain unchanged.

**Changes**

- The `$formatJson` and `$parseJson` shims were removed from the model and replaced with explicit mapping helpers in the legacy controller. The new API uses actual database column names. (The legacy HTTP contract remains unchanged and is protected by the existing test suite.)
- Middleware (`checkCertification`)
- Model Hardening
   - Added `issue_date` to `BaseModel` date normalization.
- `request_export`
   - `request_export` reuses the legacy `triggerExport` implementation with one change:
   - `farm_id` now comes from the request header.
      - This is equivalent to the legacy route, which already enforced header/body equality via `hasFarmAccess`.
   - An optional body parameter can be provided. These determine which certification's certifier drives the export.
      - `certifier_id`
      - `other_certifier`
- Document Upload 
   - Files are stored in the private bucket. This may need revisiting if DFC documents become externally accessible.
- Partner Webhook Notifications
   - Successful `POST`, `PUT`, and `DELETE` requests trigger `notifyFarmMarketDirectoryPartners()`
- Legacy responses no longer expose `other_certifier` alongside `requested_certifier`.

Notes:

- PUT Semantics
`PUT` is implemented as a true replacement. The controller writes the complete mutable column set (omitted fields → `null`).
 
Jira link: https://lite-farm.atlassian.net/browse/LF-5376

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
