### PR TITLE
LF-5380: Add certifications section to market directory

### DIFF
--- a/packages/webapp/src/components/Certifications/CertificationsEmptyState.tsx
+++ b/packages/webapp/src/components/Certifications/CertificationsEmptyState.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
 import { ReactComponent as AwardIcon } from '../../assets/images/nav/certifications.svg';
 import { ReactComponent as PlusCircleIcon } from '../../assets/images/plus-circle.svg';
 import Button from '../Form/Button';
@@ -21,15 +22,17 @@ import styles from './index.module.scss';
 
 interface CertificationsEmptyStateProps {
   onAddCertification: () => void;
+  className?: string;
 }
 
 export default function CertificationsEmptyState({
   onAddCertification,
+  className,
 }: CertificationsEmptyStateProps) {
   const { t } = useTranslation(['translation', 'common']);
 
   return (
-    <div className={styles.emptyState}>
+    <div className={clsx(styles.emptyState, className)}>
       <AwardIcon className={styles.emptyIcon} aria-hidden />
       <p className={styles.emptyHeading}>{t('CERTIFICATION.EMPTY_STATE.HEADING')}</p>
       <p className={styles.emptyBody}>{t('CERTIFICATION.EMPTY_STATE.BODY')}</p>

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Certifications/index.tsx
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Certifications/index.tsx
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import clsx from 'clsx';
+import { useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toCertificationItems } from '../../../../Certifications/utils';
+import CertificationsEmptyState from '../../../../../components/Certifications/CertificationsEmptyState';
+import CertificationCard, {
+  getCertificationStatus,
+} from '../../../../../components/Certifications/CertificationCard';
+import {
+  Certification,
+  SupportedCertificationSystemType,
+  SupportedCertifier,
+} from '../../../../../store/api/types';
+import certificationStyles from '../../../../../components/Certifications/index.module.scss';
+import styles from './styles.module.scss';
+
+interface MarketDirectoryCertificationsProps {
+  certifications: Certification[];
+  systemTypes: SupportedCertificationSystemType[];
+  certifiers: SupportedCertifier[];
+}
+export default function MarketDirectoryCertifications({
+  certifications,
+  systemTypes,
+  certifiers,
+}: MarketDirectoryCertificationsProps) {
+  const { t } = useTranslation('common');
+  const history = useHistory();
+
+  const certificationItems = toCertificationItems(certifications, systemTypes, certifiers, t);
+
+  // Only certifications that are actually publishable (active and not expired) belong on this read-only summary
+  const publishableCertifications = certificationItems.filter(
+    (cert) =>
+      !['expired', 'pursuing'].includes(getCertificationStatus(cert.isActive, cert.expiryDate)),
+  );
+
+  return publishableCertifications.length === 0 ? (
+    <CertificationsEmptyState
+      className={styles.emptyState}
+      onAddCertification={() => history.push('/certifications/add_certification')}
+    />
+  ) : (
+    <div className={clsx(certificationStyles.listCards, certificationStyles.active, styles.list)}>
+      {publishableCertifications.map((cert) => (
+        <CertificationCard
+          key={cert.id}
+          {...cert}
+          onEdit={() => history.push(`/certifications/${cert.id}/edit_certification`)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Certifications/styles.module.scss
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Certifications/styles.module.scss
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+@use '@assets/mixin' as *;
+
+.emptyState {
+  box-shadow: none;
+}
+
+.list {
+  padding: 32px 8px 16px 8px;
+}

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Certifications/styles.module.scss
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/Certifications/styles.module.scss
@@ -13,8 +13,6 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-@use '@assets/mixin' as *;
-
 .emptyState {
   box-shadow: none;
 }

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/index.tsx
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/index.tsx
@@ -15,6 +15,7 @@
 
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import clsx from 'clsx';
@@ -29,24 +30,35 @@ import { ReactComponent as CheckComplete } from '../../../../assets/images/check
 import { ReactComponent as CheckIncomplete } from '../../../../assets/images/check-incomplete.svg';
 import MarketDirectoryInfoForm from './InfoForm';
 import MarketDirectoryConsent from './Consent';
+import MarketDirectoryCertifications from './Certifications';
+import { loginSelector } from '../../../userFarmSlice';
 import { useGetMarketDirectoryInfoQuery } from '../../../../store/api/marketDirectoryInfoApi';
 import { useGetMarketProductCategoriesQuery } from '../../../../store/api/marketProductCategoryApi';
+import { useGetCertificationsQuery } from '../../../../store/api/certificationsApi';
+import {
+  useGetSupportedCertifiersQuery,
+  useGetSupportedCertificationSystemTypesQuery,
+} from '../../../../store/api/certifiersApi';
 
 // When adding/removing forms, update farmCardsLength below to match the number of enum values
 enum FormCards {
   INFO,
+  CERTIFICATIONS,
 }
 
-const farmCardsLength = 1;
+const farmCardsLength = 2;
 
 const MarketDirectory = () => {
   const history = useHistory();
   const routerTabs = useFarmSettingsRouterTabs();
   const { t } = useTranslation();
+  const { farm_id } = useSelector(loginSelector);
 
   const { expandedIds, toggleExpanded, unExpand } = useExpandable({ isSingleExpandable: true });
 
-  const [completionStatus, setCompletionStatus] = useState<Partial<Record<FormCards, boolean>>>({});
+  const [completionStatus, setCompletionStatus] = useState<Partial<Record<FormCards, boolean>>>({
+    [FormCards.CERTIFICATIONS]: true,
+  });
 
   const updateCompletionStatus = (formKey: FormCards, isComplete: boolean) => {
     setCompletionStatus((prev) => ({
@@ -68,11 +80,22 @@ const MarketDirectory = () => {
   const { data: marketProductCategories = [], isLoading: isMarketProductCategoriesLoading } =
     useGetMarketProductCategoriesQuery();
 
+  const { data: certifications = [], isLoading: isCertificationsLoading } =
+    useGetCertificationsQuery();
+  const { data: certifiers = [], isLoading: isCertifiersLoading } = useGetSupportedCertifiersQuery(
+    farm_id!,
+  );
+  const { data: systemTypes = [], isLoading: isSystemTypesLoading } =
+    useGetSupportedCertificationSystemTypesQuery(farm_id!);
+
   const isMarketDirectoryDataLoading = [
     isMarketDirectoryInfoLoading,
     isMarketProductCategoriesLoading,
     !marketProductCategories.length,
   ].some(Boolean);
+
+  const isCertificationDataLoading =
+    isCertificationsLoading || isCertifiersLoading || isSystemTypesLoading;
 
   useEffect(() => {
     if (!isMarketDirectoryInfoLoading) {
@@ -89,6 +112,17 @@ const MarketDirectory = () => {
           marketDirectoryInfo={marketDirectoryInfo}
           close={() => unExpand(FormCards.INFO)}
           marketProductCategories={marketProductCategories}
+        />
+      ),
+    },
+    {
+      key: FormCards.CERTIFICATIONS,
+      title: t('MENU.CERTIFICATIONS'),
+      content: !isCertificationDataLoading && (
+        <MarketDirectoryCertifications
+          certifications={certifications}
+          systemTypes={systemTypes}
+          certifiers={certifiers}
         />
       ),
     },

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/index.tsx
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/index.tsx
@@ -135,29 +135,31 @@ const MarketDirectory = () => {
       <div className={styles.container}>
         <DirectoryCallout t={t} />
 
-        {formCards.map(({ key, title, content }) => {
-          const isExpanded = expandedIds.includes(key);
+        <div className={styles.formCards}>
+          {formCards.map(({ key, title, content }) => {
+            const isExpanded = expandedIds.includes(key);
 
-          return (
-            <div key={key} className={clsx(styles.formCard, isExpanded && styles.expanded)}>
-              <ExpandableItem
-                itemKey={key}
-                isExpanded={isExpanded}
-                onClick={() => toggleExpanded(key)}
-                mainContent={
-                  <ExpandableHeader
-                    title={title}
-                    isExpanded={isExpanded}
-                    isComplete={completionStatus[key] || false}
-                  />
-                }
-                expandedContent={content}
-                leftCollapseIcon
-                iconClickOnly={false}
-              />
-            </div>
-          );
-        })}
+            return (
+              <div key={key} className={clsx(styles.formCard, isExpanded && styles.expanded)}>
+                <ExpandableItem
+                  itemKey={key}
+                  isExpanded={isExpanded}
+                  onClick={() => toggleExpanded(key)}
+                  mainContent={
+                    <ExpandableHeader
+                      title={title}
+                      isExpanded={isExpanded}
+                      isComplete={completionStatus[key] || false}
+                    />
+                  }
+                  expandedContent={content}
+                  leftCollapseIcon
+                  iconClickOnly={false}
+                />
+              </div>
+            );
+          })}
+        </div>
 
         {areAllFormsComplete !== undefined && (
           <MarketDirectoryConsent

--- a/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/styles.module.scss
+++ b/packages/webapp/src/containers/Profile/FarmSettings/MarketDirectory/styles.module.scss
@@ -45,6 +45,13 @@
   }
 }
 
+.formCards {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .formCard {
   width: 100%;
   padding: 16px;


### PR DESCRIPTION
**Description**

Adds a read-only "Certifications" card to the Market Directory profile page (`/farm_settings/market_directory`.

- **MarketDirectoryCertifications** (new component)
    - Filters certifications to only those that are actually publishable (active and not expired; Pursuing and Expired are excluded entirely).
    - Shows `CertificationsEmptyState` when there are none, or a list of `CertificationCard`s (edit icon only, no delete) when there are — clicking edit navigates to `/certifications/:id/edit_certification`, and the empty state's CTA navigates to `/certifications/add_certification`.
- **MarketDirectory/index.tsx**
    - Registers Certifications as a new `FormCards` entry alongside Info. It's always reported as "complete" — certifications are optional and never block the consent/publish flow.
    - Fetches the farm's certifications, system types and certifiers
- **CertificationsEmptyState**
   - Added an optional `className` prop.

Jira link: https://lite-farm.atlassian.net/browse/LF-5380

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
