### PR TITLE
LF-5388(1): Address remaining certification TODOs

### DIFF
--- a/packages/api/src/controllers/certificationsController.ts
+++ b/packages/api/src/controllers/certificationsController.ts
@@ -29,7 +29,7 @@ import {
   imaginaryPost,
   getPrivateS3BucketName,
   getPrivateS3Url,
-  getRandomFileName,
+  getFileNameWithOriginalName,
 } from '../util/digitalOceanSpaces.js';
 import { HttpError, LiteFarmRequest } from '../types.js';
 
@@ -179,7 +179,7 @@ const certificationsController = {
       const { farm_id } = req.params;
       try {
         const s3BucketName = getPrivateS3BucketName();
-        const fileName = `${farm_id}/certification/${getRandomFileName(req.file)}`;
+        const fileName = `${farm_id}/certification/${getFileNameWithOriginalName(req.file)}`;
 
         const uploadOriginalDocument = () =>
           s3.send(

--- a/packages/api/src/util/digitalOceanSpaces.js
+++ b/packages/api/src/util/digitalOceanSpaces.js
@@ -121,6 +121,15 @@ function getRandomFileName(file) {
   return `${uuidv4()}${path.extname(file.originalname)}`;
 }
 
+// Like getRandomFileName, but keeps the original filename recoverable from the storage
+// key itself (encodeURIComponent, not a strip-unsafe-chars sanitizer, so the name round-trips
+// exactly via decodeURIComponent). The uuid prefix still guarantees no collisions.
+function getFileNameWithOriginalName(file) {
+  const ext = path.extname(file.originalname);
+  const baseName = path.basename(file.originalname, ext);
+  return `${uuidv4()}-${encodeURIComponent(baseName)}${ext}`;
+}
+
 function getPrivateS3Url() {
   if (process.env.NODE_ENV === 'development') {
     return `${MINIO_ENDPOINT}/${getPrivateS3BucketName()}`;
@@ -155,6 +164,7 @@ export {
   imaginaryPost,
   imaginaryGet,
   getRandomFileName,
+  getFileNameWithOriginalName,
   getPublicS3Url,
   getPrivateS3Url,
   deleteImage,

--- a/packages/api/tests/certifications.test.ts
+++ b/packages/api/tests/certifications.test.ts
@@ -50,6 +50,9 @@ jest.mock('../src/util/digitalOceanSpaces.js', () => ({
   getPrivateS3BucketName: jest.fn().mockReturnValue('test-bucket'),
   getPrivateS3Url: jest.fn().mockReturnValue('http://localhost:9000/test-bucket'),
   getRandomFileName: jest.fn().mockImplementation((file) => `random-uuid-${file.originalname}`),
+  getFileNameWithOriginalName: jest
+    .fn()
+    .mockImplementation((file) => `random-uuid-${file.originalname}`),
   imaginaryPost: jest.fn().mockResolvedValue({ data: Buffer.from('fake-image') }),
 }));
 

--- a/packages/webapp/public/locales/en/message.json
+++ b/packages/webapp/public/locales/en/message.json
@@ -37,6 +37,11 @@
       "ADD": "Failed to add certification",
       "DELETE": "Failed to delete certification",
       "EDIT": "Failed to update certification"
+    },
+    "SUCCESS": {
+      "ADD": "Successfully saved certification",
+      "DELETE": "Successfully deleted certification",
+      "EDIT": "Successfully updated certification"
     }
   },
   "CROP_VARIETY": {

--- a/packages/webapp/src/components/Certifications/CertificationForm.tsx
+++ b/packages/webapp/src/components/Certifications/CertificationForm.tsx
@@ -22,7 +22,8 @@ import RadioGroup from '../Form/RadioGroup';
 import Switch from '../Form/Switch';
 import ReactSelect from '../Form/ReactSelect';
 import ImagePicker from '../ImagePicker';
-import useImagePickerUpload from '../ImagePicker/useImagePickerUpload';
+import useImagePickerUpload, { GetOnFileUpload } from '../ImagePicker/useImagePickerUpload';
+import useMediaWithAuthentication from '../../containers/hooks/useMediaWithAuthentication';
 import FormNavigationButtons from '../Form/FormNavigationButtons';
 import InputBaseLabel from '../Form/InputBase/InputBaseLabel';
 import { Error } from '../Typography';
@@ -101,6 +102,38 @@ const DateError = ({
     (issueDate && validUntil && issueDate < validUntil) || !issueDate || !validUntil;
 
   return <>{!areDatesProperlySet && <Error>{errorMessage}</Error>}</>;
+};
+
+const CertificateDocumentPicker = ({
+  label,
+  value,
+  onChange,
+  onRemove,
+  getOnFileUpload,
+}: {
+  label: string;
+  value: string | null;
+  onChange: (url: string | null) => void;
+  onRemove: () => void;
+  getOnFileUpload: GetOnFileUpload;
+}) => {
+  const { mediaUrl, isLoading } = useMediaWithAuthentication({ fileUrls: value ? [value] : [] });
+
+  // ImagePicker only reads defaultUrl once, at mount (useState(defaultUrl), no sync effect) —
+  // so it must not mount until the authenticated fetch for an existing document has resolved,
+  // otherwise it'd permanently capture an empty preview and never pick up mediaUrl once ready.
+  if (value && isLoading) {
+    return null;
+  }
+
+  return (
+    <ImagePicker
+      label={label}
+      defaultUrl={mediaUrl ?? ''}
+      onFileUpload={getOnFileUpload('certification', onChange)}
+      onRemoveImage={onRemove}
+    />
+  );
 };
 
 const certificationTypes = [
@@ -347,11 +380,12 @@ export default function CertificationForm({
               name={DOCUMENT_URL}
               control={control}
               render={({ field }) => (
-                <ImagePicker
+                <CertificateDocumentPicker
                   label={t('CERTIFICATION.CERTIFICATE_DOCUMENT')}
-                  defaultUrl={field.value ?? ''}
-                  onFileUpload={getOnFileUpload('certification', (url) => field.onChange(url))}
-                  onRemoveImage={() => field.onChange(null)}
+                  value={field.value}
+                  onChange={field.onChange}
+                  onRemove={() => field.onChange(null)}
+                  getOnFileUpload={getOnFileUpload}
                 />
               )}
             />

--- a/packages/webapp/src/components/Certifications/CertificationForm.tsx
+++ b/packages/webapp/src/components/Certifications/CertificationForm.tsx
@@ -73,6 +73,7 @@ type CertificationFormProps = {
   defaultValues?: Partial<CertificationFormValues>;
   onSubmit: (data: CertificationFormValues) => void;
   onBack: () => void;
+  isSaving: boolean;
 };
 
 const DEFAULT_VALUES: CertificationFormValues = {
@@ -121,6 +122,7 @@ export default function CertificationForm({
   defaultValues,
   onSubmit,
   onBack,
+  isSaving,
 }: CertificationFormProps) {
   const { t } = useTranslation(['translation', 'common']);
   const {
@@ -358,7 +360,7 @@ export default function CertificationForm({
       </div>
 
       <FormNavigationButtons
-        isDisabled={!isValid}
+        isDisabled={!isValid || isSaving}
         onCancel={onBack}
         onContinue={handleSubmit(onSubmit)}
         isFinalStep

--- a/packages/webapp/src/components/Certifications/index.tsx
+++ b/packages/webapp/src/components/Certifications/index.tsx
@@ -36,7 +36,8 @@ interface CertificationsProps {
   onAddCertification: () => void;
   onExport: () => void;
   onEditCertification: (id: string) => void;
-  onDeleteCertification: (id: string) => void;
+  onDeleteCertification: (id: string) => Promise<void>;
+  isSaving: boolean;
 }
 
 export default function Certifications({
@@ -48,15 +49,16 @@ export default function Certifications({
   onExport,
   onEditCertification,
   onDeleteCertification,
+  isSaving,
 }: CertificationsProps) {
   const { t } = useTranslation('translation');
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
-  function handleDeleteConfirm() {
-    if (deletingId !== null) {
-      onDeleteCertification(deletingId);
+  async function handleDeleteConfirm() {
+    if (deletingId) {
+      await onDeleteCertification(deletingId);
     }
     setDeletingId(null);
   }
@@ -108,6 +110,7 @@ export default function Certifications({
           subject={t('CERTIFICATION.THIS_CERTIFICATION')}
           onClose={() => setDeletingId(null)}
           onConfirm={handleDeleteConfirm}
+          isLoading={isSaving}
         />
       )}
     </div>

--- a/packages/webapp/src/containers/Certifications/CertificationForm/index.tsx
+++ b/packages/webapp/src/containers/Certifications/CertificationForm/index.tsx
@@ -20,7 +20,7 @@ import PureCertificationForm, {
   CertificationFormValues,
 } from '../../../components/Certifications/CertificationForm';
 import { loginSelector } from '../../userFarmSlice';
-import { enqueueErrorSnackbar } from '../../Snackbar/snackbarSlice';
+import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../../Snackbar/snackbarSlice';
 import {
   useGetCertificationsQuery,
   useAddCertificationMutation,
@@ -44,11 +44,11 @@ export default function CertificationForm() {
   const history = useHistory();
   const { certification_id } = useParams<{ certification_id?: string }>();
   const { farm_id } = useSelector(loginSelector);
-  const { data: certifications = [] } = useGetCertificationsQuery();
+  const { data: certifications = [], refetch: refetchCertifications } = useGetCertificationsQuery();
   const { data: certifiers = [] } = useGetSupportedCertifiersQuery(farm_id!);
   const { data: systemTypes = [] } = useGetSupportedCertificationSystemTypesQuery(farm_id!);
-  const [addCertification] = useAddCertificationMutation();
-  const [editCertification] = useEditCertificationMutation();
+  const [addCertification, { isLoading: isAdding }] = useAddCertificationMutation();
+  const [editCertification, { isLoading: isEditing }] = useEditCertificationMutation();
 
   const certification = certification_id
     ? certifications.find((c) => c.id === certification_id)
@@ -71,6 +71,12 @@ export default function CertificationForm() {
       } else {
         await addCertification(body).unwrap();
       }
+
+      const message = certification_id
+        ? t('message:CERTIFICATION.SUCCESS.EDIT')
+        : t('message:CERTIFICATION.SUCCESS.ADD');
+      dispatch(enqueueSuccessSnackbar(message));
+
       history.push('/certifications', { certificationSaved: true });
     } catch {
       const message = certification_id
@@ -88,6 +94,7 @@ export default function CertificationForm() {
         defaultValues={defaultValues}
         onSubmit={onSubmit}
         onBack={onBack}
+        isSaving={isAdding || isEditing}
       />
     </Layout>
   );

--- a/packages/webapp/src/containers/Certifications/index.tsx
+++ b/packages/webapp/src/containers/Certifications/index.tsx
@@ -18,6 +18,8 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PureCertifications from '../../components/Certifications';
+import Layout from '../../components/Layout';
+import Loading from '../../components/Form/ContextForm/Loading';
 import { loginSelector } from '../userFarmSlice';
 import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
 import {
@@ -29,7 +31,6 @@ import {
   useGetSupportedCertificationSystemTypesQuery,
 } from '../../store/api/certifiersApi';
 import { toCertificationItems } from './utils';
-import Layout from '../../components/Layout';
 
 interface CertificationsProps {
   isCompactSideMenu: boolean;
@@ -41,10 +42,16 @@ export default function Certifications({ isCompactSideMenu }: CertificationsProp
   const location = useLocation();
   const history = useHistory();
   const { farm_id } = useSelector(loginSelector);
-  const { data: rawCertifications = [] } = useGetCertificationsQuery();
-  const { data: certifiers = [] } = useGetSupportedCertifiersQuery(farm_id!);
-  const { data: systemTypes = [] } = useGetSupportedCertificationSystemTypesQuery(farm_id!);
+  const { data: rawCertifications = [], isLoading: isCertificationsLoading } =
+    useGetCertificationsQuery();
+  const { data: certifiers = [], isLoading: isCertifiersLoading } = useGetSupportedCertifiersQuery(
+    farm_id!,
+  );
+  const { data: systemTypes = [], isLoading: isSystemTypesLoading } =
+    useGetSupportedCertificationSystemTypesQuery(farm_id!);
   const [deleteCertification] = useDeleteCertificationMutation();
+
+  const isLoading = isCertificationsLoading || isCertifiersLoading || isSystemTypesLoading;
 
   // Captured once on mount so the banner stays visible for this page visit even after
   // the underlying history state is cleared below.
@@ -73,6 +80,15 @@ export default function Certifications({ isCompactSideMenu }: CertificationsProp
       dispatch(enqueueErrorSnackbar(t('message:CERTIFICATION.ERROR.DELETE')));
     }
   };
+
+  if (isLoading) {
+    return (
+      <Loading
+        dataName={t('MENU.CERTIFICATIONS').toLowerCase()}
+        isCompactSideMenu={isCompactSideMenu}
+      />
+    );
+  }
 
   return (
     <Layout footer={false}>

--- a/packages/webapp/src/containers/Certifications/index.tsx
+++ b/packages/webapp/src/containers/Certifications/index.tsx
@@ -21,7 +21,7 @@ import PureCertifications from '../../components/Certifications';
 import Layout from '../../components/Layout';
 import Loading from '../../components/Form/ContextForm/Loading';
 import { loginSelector } from '../userFarmSlice';
-import { enqueueErrorSnackbar } from '../Snackbar/snackbarSlice';
+import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from '../Snackbar/snackbarSlice';
 import {
   useGetCertificationsQuery,
   useDeleteCertificationMutation,
@@ -49,7 +49,7 @@ export default function Certifications({ isCompactSideMenu }: CertificationsProp
   );
   const { data: systemTypes = [], isLoading: isSystemTypesLoading } =
     useGetSupportedCertificationSystemTypesQuery(farm_id!);
-  const [deleteCertification] = useDeleteCertificationMutation();
+  const [deleteCertification, { isLoading: isDeleting }] = useDeleteCertificationMutation();
 
   const isLoading = isCertificationsLoading || isCertifiersLoading || isSystemTypesLoading;
 
@@ -76,7 +76,9 @@ export default function Certifications({ isCompactSideMenu }: CertificationsProp
   const onDeleteCertification = async (id: string) => {
     try {
       await deleteCertification(id).unwrap();
-    } catch {
+      dispatch(enqueueSuccessSnackbar(t('message:CERTIFICATION.SUCCESS.DELETE')));
+    } catch (e) {
+      console.error(e);
       dispatch(enqueueErrorSnackbar(t('message:CERTIFICATION.ERROR.DELETE')));
     }
   };
@@ -101,6 +103,7 @@ export default function Certifications({ isCompactSideMenu }: CertificationsProp
         onAddCertification={() => history.push('/certifications/add_certification')}
         onEditCertification={(id) => history.push(`/certifications/${id}/edit_certification`)}
         onDeleteCertification={onDeleteCertification}
+        isSaving={isDeleting}
       />
     </Layout>
   );

--- a/packages/webapp/src/containers/Certifications/utils.ts
+++ b/packages/webapp/src/containers/Certifications/utils.ts
@@ -122,14 +122,23 @@ const formatCertifierLabel = (
   return systemTypeName ? `${certifierName} - ${systemTypeName}` : certifierName ?? '';
 };
 
-// The backend only ever persists a randomized `${uuid}.${ext}` storage key (see
-// getRandomFileName in digitalOceanSpaces.js) — the user's original filename is never
-// stored. Show a generic label instead of the UUID until a backend field exists for it.
+// getFileNameWithOriginalName (digitalOceanSpaces.js) stores keys as `${uuid}-${name}.${ext}`,
+// so the original filename can be recovered from the URL. Certifications uploaded before that
+// change only have a bare `${uuid}.${ext}` key (see getRandomFileName) with no name to recover —
+// those fall back to a generic label instead.
+const UUID_NAME_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(.+)$/i;
+
 const toDocumentFileName = (documentUrl: string | null, t: TFunction): string | null => {
   if (!documentUrl) {
     return null;
   }
-  const extension = documentUrl.split('.').pop();
+  const fullFileName = documentUrl.split('/').pop() ?? '';
+  const match = fullFileName.match(UUID_NAME_PATTERN);
+  if (match) {
+    return decodeURIComponent(match[1]);
+  }
+
+  const extension = fullFileName.split('.').pop();
   return extension ? `${t('common:DOCUMENT')}.${extension}` : t('common:DOCUMENT');
 };
 


### PR DESCRIPTION
**Description**

- Display loading view when fetching certifications
- Handle `isLoading` while adding/editing/deleting certifications
- Add success snackbars for adding/editing/deleting certifications
- Preserve original file name
- Fix document preview for private bucket storage

Jira link: https://lite-farm.atlassian.net/browse/LF-5388

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
