### PR TITLE
LF-5400 Certifications: show all certifiers regardless of country and expand the certifier list

### DIFF
--- a/packages/api/db/migration/20260729000000_expand_certifier_list.js
+++ b/packages/api/db/migration/20260729000000_expand_certifier_list.js
@@ -19,6 +19,11 @@ const PGS_KEY = 'PGS';
 const OLD_FVOPA_NAME = 'Fraser Valley Organic Producers';
 const NEW_FVOPA_NAME = 'Fraser Valley Organic Producers Association';
 
+// TAPE's `certifiers` row exists only on beta and production.
+const TAPE_CERTIFIER_NAME = 'Tool for Agroecology Performance Evaluation';
+
+const MIGRATION_NAME = 'expand_certifier_list';
+
 // `certifier_acronym` is null where the certifier has no acronym in genuine public
 // use, and where an acronym would exactly duplicate `certifier_name` — the
 // certification card renders `${acronym} — ${name}`, which would read "SGS — SGS".
@@ -73,8 +78,6 @@ const insertedNames = [...thirdPartyOrganicCertifiers, ...pgsGroups].map(
 );
 
 /**
- * Resolves system type ids by translation key rather than assuming literal ids, which
- * is how the webapp identifies them too (see `CertificationForm.tsx`).
  * @param { import("knex").Knex } knex
  */
 const getSystemTypeIds = async function (knex) {
@@ -93,6 +96,67 @@ const getSystemTypeIds = async function (knex) {
 };
 
 /**
+ * Removes TAPE, keeping its name as free text on the certifications that referenced it. Its rows
+ * are logged because `certifier_id` differs between beta and production and `down` needs the
+ * original.
+ * @param { import("knex").Knex } knex
+ */
+const removeTapeCertifier = async function (knex) {
+  const tape = await knex('certifiers').where({ certifier_name: TAPE_CERTIFIER_NAME }).first();
+
+  if (!tape) {
+    return;
+  }
+
+  await knex('certification')
+    .where({ certifier_id: tape.certifier_id })
+    .update({ certifier_id: null, other_certifier: TAPE_CERTIFIER_NAME });
+
+  const tapeCountries = await knex('certifier_country').where({ certifier_id: tape.certifier_id });
+
+  await knex('certifier_country').where({ certifier_id: tape.certifier_id }).delete();
+  await knex('certifiers').where({ certifier_id: tape.certifier_id }).delete();
+
+  await knex('migration_deletion_logs').insert([
+    ...tapeCountries.map((row) => ({
+      migration_name: MIGRATION_NAME,
+      table_name: 'certifier_country',
+      data: row,
+    })),
+    { migration_name: MIGRATION_NAME, table_name: 'certifiers', data: tape },
+  ]);
+};
+
+/**
+ * Restores whatever `removeTapeCertifier` logged and repoints the certifications back.
+ * @param { import("knex").Knex } knex
+ */
+const restoreTapeCertifier = async function (knex) {
+  const loggedRows = await knex('migration_deletion_logs')
+    .where({ migration_name: MIGRATION_NAME })
+    .orderBy('id', 'desc');
+
+  for (const { table_name, data } of loggedRows) {
+    try {
+      await knex(table_name).insert(data);
+    } catch (err) {
+      console.error(`Failed to restore row in ${table_name}:`, err);
+      throw err;
+    }
+  }
+
+  await knex('migration_deletion_logs').where({ migration_name: MIGRATION_NAME }).delete();
+
+  const tape = await knex('certifiers').where({ certifier_name: TAPE_CERTIFIER_NAME }).first();
+
+  if (tape) {
+    await knex('certification')
+      .where({ other_certifier: TAPE_CERTIFIER_NAME })
+      .update({ certifier_id: tape.certifier_id, other_certifier: null });
+  }
+};
+
+/**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
@@ -105,10 +169,11 @@ export const up = async function (knex) {
     .where({ certifier_name: OLD_FVOPA_NAME })
     .update({ certifier_name: NEW_FVOPA_NAME });
 
-  // `20210621152008_certifier_list_update.js` inserted certifier_id 19 explicitly, and
-  // Postgres does not advance a serial's sequence when the value is supplied, so the
-  // sequence trails the table's max id and the next insert would collide on the primary
-  // key. Realigning is a no-op where the sequence is already correct.
+  await removeTapeCertifier(knex);
+
+  // `20210621152008_certifier_list_update.js` inserted certifier_id 19 explicitly, which leaves
+  // the sequence at 18 on any database built from migrations alone. Beta and production were
+  // realigned by hand, where this is a no-op.
   await knex.raw(
     `SELECT setval(pg_get_serial_sequence('certifiers', 'certifier_id'),
                    (SELECT max(certifier_id) FROM certifiers))`,
@@ -116,8 +181,6 @@ export const up = async function (knex) {
 
   const idByKey = await getSystemTypeIds(knex);
 
-  // `survey_id` is left at its null default: none of these certifiers has a
-  // certifier-specific export survey, so the export falls back to the generic form.
   await knex.batchInsert('certifiers', [
     ...thirdPartyOrganicCertifiers.map((certifier) => ({
       ...certifier,
@@ -136,6 +199,8 @@ export const down = async function (knex) {
   await knex('certifiers')
     .where({ certifier_name: NEW_FVOPA_NAME })
     .update({ certifier_name: OLD_FVOPA_NAME });
+
+  await restoreTapeCertifier(knex);
 
   await knex.schema.alterTable('certifiers', (table) => {
     table.string('certifier_acronym').notNullable().alter();

--- a/packages/api/db/migration/20260729000000_expand_certifier_list.js
+++ b/packages/api/db/migration/20260729000000_expand_certifier_list.js
@@ -1,0 +1,143 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+const THIRD_PARTY_ORGANIC_KEY = 'THIRD_PARTY_ORGANIC';
+const PGS_KEY = 'PGS';
+
+const OLD_FVOPA_NAME = 'Fraser Valley Organic Producers';
+const NEW_FVOPA_NAME = 'Fraser Valley Organic Producers Association';
+
+// `certifier_acronym` is null where the certifier has no acronym in genuine public
+// use, and where an acronym would exactly duplicate `certifier_name` — the
+// certification card renders `${acronym} — ${name}`, which would read "SGS — SGS".
+const thirdPartyOrganicCertifiers = [
+  { certifier_name: 'CCOF Certification Services', certifier_acronym: 'CCOF' },
+  { certifier_name: 'Oregon Tilth', certifier_acronym: 'OTCO' },
+  { certifier_name: 'Quality Assurance International', certifier_acronym: 'QAI' },
+  { certifier_name: 'OCIA International', certifier_acronym: 'OCIA' },
+  { certifier_name: 'SCS Global Services', certifier_acronym: 'SCS' },
+  { certifier_name: 'Midwest Organic Services Association', certifier_acronym: 'MOSA' },
+  { certifier_name: 'OEFFA Certification', certifier_acronym: 'OEFFA' },
+  { certifier_name: 'Baystate Organic Certifiers', certifier_acronym: null },
+  { certifier_name: 'MOFGA Certification Services', certifier_acronym: 'MOFGA' },
+  { certifier_name: 'Global Organic Alliance', certifier_acronym: 'GOA' },
+  { certifier_name: 'Pro-Cert Organic Systems', certifier_acronym: null },
+  { certifier_name: 'Ecocert Canada', certifier_acronym: null },
+  { certifier_name: 'Ecocert', certifier_acronym: null },
+  { certifier_name: 'Control Union', certifier_acronym: 'CU' },
+  { certifier_name: 'Kiwa BCS Öko-Garantie', certifier_acronym: 'BCS' },
+  { certifier_name: 'SGS', certifier_acronym: null },
+  { certifier_name: 'Bureau Veritas', certifier_acronym: 'BV' },
+  { certifier_name: 'Soil Association Certification', certifier_acronym: 'SA Cert' },
+  { certifier_name: 'ABCERT', certifier_acronym: null },
+  {
+    certifier_name: 'Istituto per la Certificazione Etica ed Ambientale',
+    certifier_acronym: 'ICEA',
+  },
+  { certifier_name: 'OneCert', certifier_acronym: null },
+  { certifier_name: 'INDOCERT', certifier_acronym: null },
+  { certifier_name: 'Ecocert India', certifier_acronym: null },
+  { certifier_name: 'ACO Certification', certifier_acronym: 'ACO' },
+  { certifier_name: 'AUS-QUAL', certifier_acronym: null },
+  { certifier_name: 'Organic Food Chain', certifier_acronym: 'OFC' },
+  { certifier_name: 'Demeter', certifier_acronym: null },
+];
+
+// `PGS Organic India Council` (an NGO standards body) and `PGS-India` (the government
+// programme run through the National Centre of Organic Farming) are two distinct
+// systems, both called PGS.
+const pgsGroups = [
+  { certifier_name: 'Certified Naturally Grown', certifier_acronym: 'CNG' },
+  { certifier_name: 'Nature & Progrès', certifier_acronym: 'N&P' },
+  { certifier_name: 'PGS Organic India Council', certifier_acronym: 'PGSOC' },
+  { certifier_name: 'PGS-India', certifier_acronym: null },
+  { certifier_name: 'Bryanston Market PGS', certifier_acronym: null },
+  { certifier_name: 'PGS South Africa', certifier_acronym: 'PGS SA' },
+  { certifier_name: 'Organic Farm New Zealand', certifier_acronym: 'OFNZ' },
+];
+
+const insertedNames = [...thirdPartyOrganicCertifiers, ...pgsGroups].map(
+  ({ certifier_name }) => certifier_name,
+);
+
+/**
+ * Resolves system type ids by translation key rather than assuming literal ids, which
+ * is how the webapp identifies them too (see `CertificationForm.tsx`).
+ * @param { import("knex").Knex } knex
+ */
+const getSystemTypeIds = async function (knex) {
+  const systemTypes = await knex('certification_system_type').select('id', 'translation_key');
+  const idByKey = Object.fromEntries(
+    systemTypes.map(({ id, translation_key }) => [translation_key, id]),
+  );
+
+  for (const key of [THIRD_PARTY_ORGANIC_KEY, PGS_KEY]) {
+    if (!idByKey[key]) {
+      throw new Error(`certification_system_type is missing the ${key} row`);
+    }
+  }
+
+  return idByKey;
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.alterTable('certifiers', (table) => {
+    table.string('certifier_acronym').nullable().alter();
+  });
+
+  await knex('certifiers')
+    .where({ certifier_name: OLD_FVOPA_NAME })
+    .update({ certifier_name: NEW_FVOPA_NAME });
+
+  // `20210621152008_certifier_list_update.js` inserted certifier_id 19 explicitly, and
+  // Postgres does not advance a serial's sequence when the value is supplied, so the
+  // sequence trails the table's max id and the next insert would collide on the primary
+  // key. Realigning is a no-op where the sequence is already correct.
+  await knex.raw(
+    `SELECT setval(pg_get_serial_sequence('certifiers', 'certifier_id'),
+                   (SELECT max(certifier_id) FROM certifiers))`,
+  );
+
+  const idByKey = await getSystemTypeIds(knex);
+
+  // `survey_id` is left at its null default: none of these certifiers has a
+  // certifier-specific export survey, so the export falls back to the generic form.
+  await knex.batchInsert('certifiers', [
+    ...thirdPartyOrganicCertifiers.map((certifier) => ({
+      ...certifier,
+      system_type_id: idByKey[THIRD_PARTY_ORGANIC_KEY],
+    })),
+    ...pgsGroups.map((certifier) => ({
+      ...certifier,
+      system_type_id: idByKey[PGS_KEY],
+    })),
+  ]);
+};
+
+export const down = async function (knex) {
+  await knex('certifiers').whereIn('certifier_name', insertedNames).delete();
+
+  await knex('certifiers')
+    .where({ certifier_name: NEW_FVOPA_NAME })
+    .update({ certifier_name: OLD_FVOPA_NAME });
+
+  await knex.schema.alterTable('certifiers', (table) => {
+    table.string('certifier_acronym').notNullable().alter();
+  });
+};

--- a/packages/api/src/controllers/certificationsController.ts
+++ b/packages/api/src/controllers/certificationsController.ts
@@ -66,30 +66,17 @@ const certificationsController = {
   },
 
   getSupportedCertifiers() {
-    return async (req: LiteFarmRequest, res: Response) => {
+    return async (_req: LiteFarmRequest, res: Response) => {
       try {
-        const { farm_id } = req.headers;
-
-        // Joining through certifier_country to farm restricts the list to certifiers
-        // operating in the requesting farm's country.
-        const certifiers = await CertifierModel.query()
-          .select(
-            'certifiers.certifier_id',
-            'certifiers.system_type_id',
-            'certifiers.certifier_name',
-            'certifiers.certifier_acronym',
-            'certifiers.survey_id',
-            'certifier_country.country_id',
-            'certifier_country.certifier_country_id',
-          )
-          .join(
-            'certifier_country',
-            'certifiers.certifier_id',
-            '=',
-            'certifier_country.certifier_id',
-          )
-          .join('farm', 'farm.country_id', '=', 'certifier_country.country_id')
-          .where('farm.farm_id', farm_id!);
+        // Every farm sees the same certifier list, so this returns one row per
+        // certifier and does not read the farm's country.
+        const certifiers = await CertifierModel.query().select(
+          'certifier_id',
+          'system_type_id',
+          'certifier_name',
+          'certifier_acronym',
+          'survey_id',
+        );
 
         return res.status(200).json(certifiers);
       } catch (error: unknown) {

--- a/packages/api/src/models/certifierModel.js
+++ b/packages/api/src/models/certifierModel.js
@@ -32,7 +32,7 @@ class Certifier extends Model {
         certifier_id: { type: 'integer' },
         system_type_id: { type: 'integer' },
         certifier_name: { type: 'string' },
-        certifier_acronym: { type: 'string' },
+        certifier_acronym: { type: ['string', 'null'] },
         survey_id: { type: 'string' },
       },
       additionalProperties: false,

--- a/packages/api/tests/certifications.test.ts
+++ b/packages/api/tests/certifications.test.ts
@@ -69,6 +69,7 @@ interface Certifier {
   certifier_id: number;
   system_type_id: number;
   certifier_name: string;
+  certifier_acronym: string | null;
 }
 
 interface SystemType {
@@ -404,6 +405,18 @@ describe('Certifications CRUD tests', () => {
         'survey_id',
         'system_type_id',
       ]);
+    });
+
+    test('Returns certifiers that have no acronym', async () => {
+      const userFarmIds = await createUserFarmInCountry(countryWithCertifiersId);
+
+      const res = await getSupportedCertifiersRequest(userFarmIds);
+
+      expect(res.status).toBe(200);
+      const withoutAcronym = res.body.filter(
+        (certifier: Certifier) => certifier.certifier_acronym === null,
+      );
+      expect(withoutAcronym.length).toBeGreaterThan(0);
     });
 
     test('Workers cannot list supported certifiers', async () => {

--- a/packages/api/tests/certifications.test.ts
+++ b/packages/api/tests/certifications.test.ts
@@ -189,8 +189,8 @@ describe('Certifications CRUD tests', () => {
       .orderBy('certifier_id')
       .first();
 
-    // certifier_country covers only a handful of countries, so the supported_certifiers
-    // response depends on which country the farm is in
+    // Two contrasting countries, one covered by certifier_country and one not, so the
+    // supported_certifiers tests can show the response is the same either way.
     const certifierCountry = await knex('certifier_country')
       .where({ certifier_id: thirdPartyCertifier.certifier_id })
       .first();
@@ -367,27 +367,43 @@ describe('Certifications CRUD tests', () => {
       return { user_id: user.user_id, farm_id: farm.farm_id };
     }
 
-    test("Returns the certifiers for the farm's country", async () => {
+    const sortedIds = (certifiers: Certifier[]) =>
+      certifiers.map(({ certifier_id }) => certifier_id).sort((a, b) => a - b);
+
+    test("Returns every certifier, regardless of the farm's country", async () => {
+      const inCoveredCountry = await createUserFarmInCountry(countryWithCertifiersId);
+      const inUncoveredCountry = await createUserFarmInCountry(countryWithoutCertifiersId);
+
+      const coveredRes = await getSupportedCertifiersRequest(inCoveredCountry);
+      const uncoveredRes = await getSupportedCertifiersRequest(inUncoveredCountry);
+
+      expect(coveredRes.status).toBe(200);
+      expect(uncoveredRes.status).toBe(200);
+
+      const allCertifiers = await knex('certifiers').select('certifier_id');
+      expect(sortedIds(coveredRes.body)).toEqual(sortedIds(allCertifiers));
+      expect(sortedIds(uncoveredRes.body)).toEqual(sortedIds(coveredRes.body));
+    });
+
+    test('Returns one row per certifier, with no country columns', async () => {
       const userFarmIds = await createUserFarmInCountry(countryWithCertifiersId);
 
       const res = await getSupportedCertifiersRequest(userFarmIds);
 
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
-      const returned = res.body.find(
+      const returned = res.body.filter(
         (certifier: Certifier) => certifier.certifier_id === thirdPartyCertifier.certifier_id,
       );
-      expect(returned.system_type_id).toBe(thirdPartySystemTypeId);
-      expect(returned.certifier_name).toBe(thirdPartyCertifier.certifier_name);
-    });
-
-    test('Returns an empty list for a farm whose country has no certifiers', async () => {
-      const userFarmIds = await createUserFarmInCountry(countryWithoutCertifiersId);
-
-      const res = await getSupportedCertifiersRequest(userFarmIds);
-
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual([]);
+      expect(returned).toHaveLength(1);
+      expect(returned[0].system_type_id).toBe(thirdPartySystemTypeId);
+      expect(returned[0].certifier_name).toBe(thirdPartyCertifier.certifier_name);
+      expect(Object.keys(returned[0]).sort()).toEqual([
+        'certifier_acronym',
+        'certifier_id',
+        'certifier_name',
+        'survey_id',
+        'system_type_id',
+      ]);
     });
 
     test('Workers cannot list supported certifiers', async () => {

--- a/packages/webapp/src/components/Certifications/CertificationForm.tsx
+++ b/packages/webapp/src/components/Certifications/CertificationForm.tsx
@@ -170,6 +170,7 @@ export default function CertificationForm({
       value: certifier.certifier_id,
       label: certifier.certifier_name,
     }))
+    .sort((a, b) => a.label.localeCompare(b.label))
     .concat([{ value: 0, label: t('common:OTHER') }]);
 
   // Once a system type is picked, if "Other" is the only certifier available, select it

--- a/packages/webapp/src/containers/Certifications/utils.ts
+++ b/packages/webapp/src/containers/Certifications/utils.ts
@@ -132,7 +132,8 @@ const formatCertifierLabel = (
   let certifierName;
   if (certification.certifier_id) {
     const certifier = certifiersMap[certification.certifier_id];
-    certifierName = certifier?.certifier_acronym;
+    // Certifiers with no acronym in public use store null, so fall back to the name.
+    certifierName = certifier?.certifier_acronym || certifier?.certifier_name;
   } else {
     certifierName = certification.other_certifier;
   }
@@ -161,7 +162,7 @@ export const toCertificationItems = (
       systemTypeTranslationKey: systemType?.translation_key ?? '',
       requestedSystemType: certification.requested_system_type ?? undefined,
       certifierName: certifier?.certifier_name ?? certification.other_certifier ?? '',
-      certifierAcronym: certifier?.certifier_acronym,
+      certifierAcronym: certifier?.certifier_acronym ?? undefined,
       certificateNumber: certification.certificate_number,
       certificateMemberId: certification.certificate_member_id,
       isActive: certification.is_active,

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -468,7 +468,7 @@ export interface SupportedCertifier {
   certifier_id: number;
   system_type_id: number;
   certifier_name: string;
-  certifier_acronym: string;
+  certifier_acronym: string | null;
   survey_id: string | null;
 }
 

--- a/packages/webapp/src/store/api/types/index.ts
+++ b/packages/webapp/src/store/api/types/index.ts
@@ -463,14 +463,12 @@ export interface Certification {
   valid_until: string | null;
 }
 
-// Reference data from the certifiers table, filtered to the farm's country.
+// Reference data from the certifiers table. Every farm receives the same list.
 export interface SupportedCertifier {
   certifier_id: number;
   system_type_id: number;
   certifier_name: string;
   certifier_acronym: string;
-  certifier_country_id: number;
-  country_id: number;
   survey_id: string | null;
 }
 


### PR DESCRIPTION
**Description**

- Removes the country filter from `getSupportedCertifiers()`; returns all certifiers to every farm
- Migration:
  - Adds 34 certifiers
  - Relaxes the acronym constraint, since not every new certifier has one
  - TAPE and its `certifier_country` record gets deleted (or rather, archived in `migration_deletion_logs`)
  - 15 (10 prod, 5 beta) certifications pointing at TAPE are adjusted, writing TAPE into the `other_certifier` (see image in testing section below
  
The TAPE records after migration are still editable and still appear as a certification, just populated as "Other" instead of as a certifying body in the dropdown

Jira link: https://lite-farm.atlassian.net/browse/LF-5400

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

To test the TAPE migration (what existing TAPE-as-certifier records would look like after running this migration), I used this SQL to add TAPE to my local:

```sql
SELECT setval(
  pg_get_serial_sequence('certifiers', 'certifier_id'),
  (SELECT max(certifier_id) FROM certifiers)
);

INSERT INTO certifiers (certifier_name, certifier_acronym, system_type_id)
VALUES ('Tool for Agroecology Performance Evaluation', 'TAPE', 1)
RETURNING certifier_id;

INSERT INTO certifier_country (certifier_id, country_id)
SELECT certifier_id, 11
FROM certifiers
WHERE certifier_name = 'Tool for Agroecology Performance Evaluation';
```

and then set it up the way it would look after the original migration of certification data (TAPE as the certifying body, status pursuing). Then ran migration to check result:

<img width="1089" height="348" alt="Screenshot 2026-07-30 at 2 12 17 PM" src="https://github.com/user-attachments/assets/f0eed14a-1018-48d6-be00-9caba24808e1" />


**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
