### PR TITLE
LF-5428 Add GrownBy to Market Directory Tables

### DIFF
--- a/packages/api/db/migration/20260731000000_add_grownby_market_directory_partner.js
+++ b/packages/api/db/migration/20260731000000_add_grownby_market_directory_partner.js
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+const GROWNBY_COUNTRIES = ['United States', 'Canada'];
+
+/**
+ * Registers GrownBy (https://grownby.com) as a market-directory partner,
+ * alongside OFN. Mirrors 20251126175424_add_market_directory_partner.js.
+ *
+ * GrownBy operates in the United States and Canada, so it is linked to both
+ * countries; farms in either will see the GrownBy tile.
+ *
+ *
+ * MANUAL STEP REQUIRED PER ENVIRONMENT. This migration does not insert the
+ * `market_directory_partner_auth` row. The values for this record differ per
+ * environment, so insert the row by hand against each database. The OFN
+ * auth row is maintained the same way.
+ *
+ * Until the auth row exists the tile renders and the Share toggle saves, but
+ * nothing else happens: notifyMarketDirectoryPartners.ts finds no row and sends
+ * no webhook, and checkMarketPartnerAuth.ts rejects GrownBy's own requests with
+ * 404 `client_id not recognized`.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  let grownby = await knex('market_directory_partner').where({ key: 'GROWNBY' }).first();
+
+  if (!grownby) {
+    [grownby] = await knex('market_directory_partner').insert({ key: 'GROWNBY' }).returning('*');
+  }
+
+  for (const countryName of GROWNBY_COUNTRIES) {
+    const country = await knex('countries').where({ country_name: countryName }).first();
+    if (!country) {
+      continue;
+    }
+
+    const countryRelation = await knex('market_directory_partner_country')
+      .where({ market_directory_partner_id: grownby.id, country_id: country.id })
+      .first();
+
+    if (!countryRelation) {
+      await knex('market_directory_partner_country').insert({
+        market_directory_partner_id: grownby.id,
+        country_id: country.id,
+      });
+    }
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  try {
+    // Cleanup GROWNBY and its country relations if not in use elsewhere.
+    // Foreign key constraint errors are expected and ignored.
+    const grownby = await knex('market_directory_partner').where({ key: 'GROWNBY' }).first();
+    if (!grownby) {
+      return;
+    }
+
+    for (const countryName of GROWNBY_COUNTRIES) {
+      const country = await knex('countries').where({ country_name: countryName }).first();
+      if (!country) {
+        continue;
+      }
+
+      await knex('market_directory_partner_country')
+        .where({ market_directory_partner_id: grownby.id, country_id: country.id })
+        .del();
+    }
+
+    await knex('market_directory_partner').where({ id: grownby.id }).del();
+  } catch (e) {
+    // foreign_key_violation = 23503
+    if (e.code === '23503') {
+      console.log('Could not delete GROWNBY - in use by other records');
+      return;
+    }
+    throw e;
+  }
+};

--- a/packages/api/tests/marketDirectoryPartner.test.ts
+++ b/packages/api/tests/marketDirectoryPartner.test.ts
@@ -56,13 +56,24 @@ const getReqWithFilter = async (farmId: Farm['farm_id'], userId: User['user_id']
   return getRequest({ farm_id: farmId, user_id: userId }, '?filter=country');
 };
 
+// Migrations seed their own rows into market_directory_partner, so assert
+// only against the partners that this file creates.
+const createdPartnerIds = new Set<number>();
+
+const createPartner = async (): Promise<Partner> => {
+  const [partner] = await mocks.market_directory_partnerFactory();
+  createdPartnerIds.add(partner.id);
+  return partner;
+};
+
 const expectSuccessResponse = (
   res: Omit<Response, 'body'> & { body: Partner[] },
   expectedPartners: Partner[],
 ) => {
   expect(res.status).toBe(200);
-  expect(res.body.length).toBe(expectedPartners.length);
-  expect(res.body.map(({ id }) => id).sort()).toEqual(expectedPartners.map(({ id }) => id).sort());
+  const ids = res.body.map(({ id }) => id).filter((id) => createdPartnerIds.has(id));
+  expect(ids.length).toBe(expectedPartners.length);
+  expect(ids.sort()).toEqual(expectedPartners.map(({ id }) => id).sort());
 };
 
 describe('GET Market Directory Partner Tests', () => {
@@ -98,8 +109,8 @@ describe('GET Market Directory Partner Tests', () => {
       ),
     );
     [farmWithoutCountryId] = await mocks.farmFactory();
-    [[partner1], [partner2], [_partnerWithoutCountryRecord]] = await Promise.all(
-      new Array(3).fill('').map(() => mocks.market_directory_partnerFactory()),
+    [partner1, partner2, _partnerWithoutCountryRecord] = await Promise.all(
+      new Array(3).fill('').map(createPartner),
     );
 
     // Associate partner1 with canada and us
@@ -151,8 +162,8 @@ describe('GET Market Directory Partner Tests', () => {
     let globalPartner2: Partner;
 
     beforeAll(async () => {
-      [[globalPartner1], [globalPartner2]] = await Promise.all(
-        new Array(2).fill('').map(() => mocks.market_directory_partnerFactory()),
+      [globalPartner1, globalPartner2] = await Promise.all(
+        new Array(2).fill('').map(createPartner),
       );
 
       // Associate global partners with all countries


### PR DESCRIPTION
_Drafted as this is not intended for production yet._ I'm opening the PR in draft just to have a record of what has to be done when we're ready to integrate.

**Description**

With the frontend already merged (#4290), adding GrownBy to the `market_directory_partner` and `market_directory_partner_country` returns it to the specified farms (here, US and Canadian) and shows the partner tile.

This migration can be run locally to test, and it should be safe to run on beta where all the values are already supplied.

Note, as as written in the migration comments, the `market_directory_partner_auth` has to be added before the integration (webhook + keycloak) will work; it is not included in the migration becuase the values differ per environment.

**Test file change**

The test fix addresses an error I don't know if I've ever seen on GitHub actions; it's one of those issues that is only present if another test hasn't already dropped the table and so the migrated data still stands. You can see it by running (only) `marketDirectoryPartner.test.ts` after a fresh migration of the test db, without this fix. You can see it on integration too if you do that, with OFN Canada being the trigger.

The fix makes sure the partners are only compared against the records that are added by the test, so it doesn't matter if the migrated records are still present or not.

Jira link: https://lite-farm.atlassian.net/browse/LF-5428

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Ran the migration to generate the tile locally, although the webhook / integration is really only testable on beta.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
