### PR TITLE
LF-5429: Hide khmer language option and exclude its translations from the webapp bundle

### DIFF
--- a/packages/webapp/.storybook/preview.jsx
+++ b/packages/webapp/.storybook/preview.jsx
@@ -95,7 +95,7 @@ export const globalTypes = {
         { value: 'hi', title: 'Hindi' },
         { value: 'pa', title: 'Punjabi' },
         { value: 'ml', title: 'Malayalam' },
-        { value: 'km', title: 'Khmer' },
+        // { value: 'km', title: 'Khmer' }, TODO: LF-5430 Re-add Khmer
       ],
       showName: true,
     },

--- a/packages/webapp/src/components/FullYearCalendar/index.jsx
+++ b/packages/webapp/src/components/FullYearCalendar/index.jsx
@@ -7,7 +7,13 @@ import { Semibold } from '../Typography';
 import YearSelectorModal from '../Modals/YearSelectorModal';
 import { getNewDate } from '../Form/InputDuration/utils';
 import { languageCodes } from '../../hooks/useLanguageOptions';
-const languageJsonFiles = import.meta.glob('../../locales/*/rcYearCalendar.json', { eager: true });
+
+// TODO: LF-5430 Revert to re-add Khmer
+// Exclude km
+const languageJsonFiles = import.meta.glob(
+  '../../locales/{en,es,de,fr,pt,hi,pa,ml}/rcYearCalendar.json',
+  { eager: true },
+);
 
 languageCodes.forEach((language) => {
   const translationJson = languageJsonFiles[`../../locales/${language}/rcYearCalendar.json`];

--- a/packages/webapp/src/containers/Consent/index.jsx
+++ b/packages/webapp/src/containers/Consent/index.jsx
@@ -22,8 +22,8 @@ import PunjabiOwnerConsent from './locales/pa/Owner.Consent.md';
 import PunjabiWorkerConsent from './locales/pa/Worker.Consent.md';
 import MalayalamOwnerConsent from './locales/ml/Owner.Consent.md';
 import MalayalamWorkerConsent from './locales/ml/Worker.Consent.md';
-import KhmerOwnerConsent from './locales/km/Owner.Consent.md';
-import KhmerWorkerConsent from './locales/km/Worker.Consent.md';
+// import KhmerOwnerConsent from './locales/km/Owner.Consent.md'; TODO: LF-5430 Re-add Khmer
+// import KhmerWorkerConsent from './locales/km/Worker.Consent.md'; TODO: LF-5430 Re-add Khmer
 import { getLanguageFromLocalStorage } from '../../util/getLanguageFromLocalStorage';
 import { CONSENT_VERSION } from '../../util/constants';
 
@@ -36,7 +36,7 @@ const languageConsent = {
   hi: { worker: <HindiWorkerConsent />, owner: <HindiOwnerConsent /> },
   pa: { worker: <PunjabiWorkerConsent />, owner: <PunjabiOwnerConsent /> },
   ml: { worker: <MalayalamWorkerConsent />, owner: <MalayalamOwnerConsent /> },
-  km: { worker: <KhmerWorkerConsent />, owner: <KhmerOwnerConsent /> },
+  // km: { worker: <KhmerWorkerConsent />, owner: <KhmerOwnerConsent /> }, TODO: LF-5430 Re-add Khmer
 };
 
 const getLanguageConsent = (language) => languageConsent[language] || languageConsent.en;

--- a/packages/webapp/src/hooks/useLanguageOptions.ts
+++ b/packages/webapp/src/hooks/useLanguageOptions.ts
@@ -22,7 +22,7 @@ const supportedLanguages = [
   ['hi', 'हिंदी'],
   ['ml', 'മലയാളം'],
   ['pa', 'ਪੰਜਾਬੀ'],
-  ['km', 'ខ្មែរ'],
+  // ['km', 'ខ្មែរ'], TODO: LF-5430 Re-add Khmer
 ];
 
 const useLanguageOptions = () => {

--- a/packages/webapp/src/locales/i18n.js
+++ b/packages/webapp/src/locales/i18n.js
@@ -8,6 +8,10 @@ import { APP_VERSION } from '../util/constants';
 
 // Backend Fallback: https://www.i18next.com/how-to/backend-fallback
 
+// TODO: LF-5430 Revert to re-add Khmer
+// Explicit language list to exclude km
+const offlineLocales = import.meta.glob('../../public/locales/{en,es,de,fr,pt,hi,pa,ml}/*.json');
+
 i18n
   .use(ChainedBackend)
   .use(initReactI18next)
@@ -16,8 +20,9 @@ i18n
     defaultNS: 'translation',
     nsSeparator: ':',
     fallbackLng: 'en',
-    supportedLngs: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml', 'km'], // i18n allow list
-    locales: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml', 'km'],
+    // TODO: LF-5430 Re-add Khmer
+    supportedLngs: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml'], // i18n allow list
+    locales: ['en', 'pt', 'es', 'fr', 'de', 'hi', 'pa', 'ml'],
     debug: false,
     detection: {
       order: ['localStorage', 'navigator', 'querystring'],
@@ -32,10 +37,10 @@ i18n
       backends: [
         HttpBackend,
         resourcesToBackend((lng, ns) => {
-          if (lng === i18n.language) {
-            return import(`../../public/locales/${lng}/${ns}.json`);
-          } else if (lng === 'en') {
-            return import(`../../public/locales/${lng}/${ns}.json`);
+          const isAvailable = lng === i18n.language || lng === 'en';
+          const loadOfflineLocale = offlineLocales[`../../public/locales/${lng}/${ns}.json`];
+          if (isAvailable && loadOfflineLocale) {
+            return loadOfflineLocale();
           }
           throw new Error(`Language ${lng} not available offline`);
         }),

--- a/packages/webapp/src/util/rruleTranslation/index.js
+++ b/packages/webapp/src/util/rruleTranslation/index.js
@@ -14,7 +14,11 @@
  */
 import { languageCodes as supportedLanguages } from '../../hooks/useLanguageOptions';
 // Import all translation files directly not dynamically
-const languageJsonFiles = import.meta.glob('../../locales/*/rrule.json', { eager: true });
+// TODO: LF-5430 Revert to re-add Khmer
+// Exclude km
+const languageJsonFiles = import.meta.glob('../../locales/{en,es,de,fr,pt,hi,pa,ml}/rrule.json', {
+  eager: true,
+});
 
 const getLanguage = (language) => {
   const { getText, dayNames, monthNames } = language;


### PR DESCRIPTION
**Description**

- Remove Khmer from the language selector
- Remove Khmer consent imports
- Exclude km from the compiled locale glob chunks 

Jira link: https://lite-farm.atlassian.net/browse/LF-5429
Ticket to re-add Khmer: https://lite-farm.atlassian.net/browse/LF-5430

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

1. Compared `dist/assets` size
   - -38 files (19 namespaces x2 - a `.js` file and its `.js.map sourcemap`)
   - -0.52MB
```
python3 - <<'PY'
import os
files = [os.path.join(r, f) for r, _, fs in os.walk('dist/assets') for f in fs]
total_bytes = sum(os.path.getsize(f) for f in files)
print(f'file count: {len(files)}')
print(f'total bytes: {total_bytes:,}')
print(f'total MB: {total_bytes/1024/1024:.4f}')
PY
```

Before:
file count: 1432
total bytes: 42,439,166
total MB: 40.4731

After:
file count: 1394
total bytes: 41,895,850
total MB: 39.9550

2. Ran `pnpm build` in this branch and integration, and compared the number of translation files in `dist/assets`.
```
for ns in animal certifications common crop crop_group crop_nutrients expense fertilizer filter gender harvest_uses market_directory_info message profitability revenue role soil task translation; do
  count=$(ls dist/assets/${ns}-*.js 2>/dev/null | wc -l | tr -d ' ')
  echo "$ns: $count"
done
```

<details>
<summary>Before</summary>

```
animal: 9
certifications: 9
common: 9
crop: 9
crop_group: 9
crop_nutrients: 9
expense: 9
fertilizer: 9
filter: 9
gender: 9
harvest_uses: 9
market_directory_info: 7
message: 9
profitability: 6
revenue: 9
role: 9
soil: 9
task: 9
translation: 9
```
</details>

<details>
<summary>After</summary>

```
animal: 8
certifications: 8
common: 8
crop: 8
crop_group: 8
crop_nutrients: 8
expense: 8
fertilizer: 8
filter: 8
gender: 8
harvest_uses: 8
market_directory_info: 6
message: 8
profitability: 5
revenue: 8
role: 8
soil: 8
task: 8
translation: 8
```
</details>


**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
