### PR TITLE
LF-5420 Redirect loop flickering between Choose Farm and Welcome after switching accounts in a second tab

### DIFF
--- a/packages/webapp/.storybook/state.js
+++ b/packages/webapp/.storybook/state.js
@@ -1263,12 +1263,6 @@ export default {
   },
   entitiesReducer: {
     userFarmReducer: {
-      farmIdUserIdTuple: [
-        {
-          farm_id: '31881f94-83c6-11ec-9fa9-0242ac130004',
-          user_id: '2cc91b7a-83c6-11ec-9fa9-0242ac130004',
-        },
-      ],
       byFarmIdUserId: {
         '31881f94-83c6-11ec-9fa9-0242ac130004': {
           '2cc91b7a-83c6-11ec-9fa9-0242ac130004': {

--- a/packages/webapp/src/containers/userFarmSlice.ts
+++ b/packages/webapp/src/containers/userFarmSlice.ts
@@ -23,7 +23,6 @@ interface UserFarm {
 type SagaError = Error & Partial<AxiosError>;
 
 interface UserFarmState {
-  farmIdUserIdTuple: Array<{ farm_id: string; user_id: string }>;
   byFarmIdUserId: {
     [farmId: string]: {
       [userId: string]: UserFarm;
@@ -61,7 +60,6 @@ export function onLoadingSuccess(state: UserFarmState) {
 const adminRoles = [1, 2, 5];
 
 export const initialState: UserFarmState = {
-  farmIdUserIdTuple: [],
   byFarmIdUserId: {},
   loading: false,
   error: undefined,
@@ -75,9 +73,6 @@ const addUserFarm = (state: UserFarmState, action: PayloadAction<UserFarm>) => {
   state.loading = false;
   state.error = null;
   const { farm_id, user_id } = userFarm;
-  if (!(state.byFarmIdUserId[farm_id] && state.byFarmIdUserId[farm_id][user_id])) {
-    state.farmIdUserIdTuple.push({ farm_id, user_id });
-  }
   state.byFarmIdUserId[farm_id] = state.byFarmIdUserId[farm_id] || {};
   state.byFarmIdUserId[farm_id][user_id] = userFarm;
   delete state.byFarmIdUserId[farm_id][user_id].role;
@@ -86,13 +81,7 @@ const addUserFarm = (state: UserFarmState, action: PayloadAction<UserFarm>) => {
 const removeUserFarm = (state: UserFarmState, action: PayloadAction<UserFarm>) => {
   const { payload: userFarm } = action;
   const { farm_id, user_id } = userFarm;
-  if (state.byFarmIdUserId[farm_id]?.[user_id]) {
-    delete state.byFarmIdUserId[farm_id]?.[user_id];
-    state.farmIdUserIdTuple = state.farmIdUserIdTuple.filter(
-      (farmIdUserIdTuple) =>
-        farmIdUserIdTuple.farm_id !== farm_id && farmIdUserIdTuple.user_id !== user_id,
-    );
-  }
+  delete state.byFarmIdUserId[farm_id]?.[user_id];
 };
 
 const userFarmSlice = createSlice({
@@ -119,9 +108,6 @@ const userFarmSlice = createSlice({
       state.loaded = true;
       userFarms.forEach((userFarm: UserFarm) => {
         const { farm_id, user_id } = userFarm;
-        if (!(state.byFarmIdUserId[farm_id] && state.byFarmIdUserId[farm_id][user_id])) {
-          state.farmIdUserIdTuple.push({ farm_id, user_id });
-        }
         const prevUserFarms = state.byFarmIdUserId[farm_id] || {};
         state.byFarmIdUserId[farm_id] = prevUserFarms;
         state.byFarmIdUserId[farm_id][user_id] = prevUserFarms[user_id] || {};

--- a/packages/webapp/src/containers/userFarmSlice.ts
+++ b/packages/webapp/src/containers/userFarmSlice.ts
@@ -272,11 +272,12 @@ export const userFarmStatusSelector = createSelector(
     loaded,
   }),
 );
+// Derive from userFarmsByUserSelector so that this selector
+// (Welcome, Onboarding Routes) cannot disagree with
+// ChooseFarm's farms.length === 0
 export const userFarmLengthSelector = createSelector(
-  userFarmReducerSelector,
-  ({ farmIdUserIdTuple }) => {
-    return farmIdUserIdTuple.length;
-  },
+  userFarmsByUserSelector,
+  (userFarms) => userFarms.length,
 );
 export const userFarmEntitiesSelector = createSelector(
   userFarmReducerSelector,


### PR DESCRIPTION
**Description**

Signing out of one account and into another with a second tab open can put onboarding into a redirect loop: the app flickers between **Choose farm** (`/farm_selection`) and **Welcome** (`/welcome`), and the console reports `Maximum update depth exceeded`. Refreshing does not clear it.

The cause is two redirects that point at each other. Both screens ask whether the signed-in user has farms, but through different selectors:

```jsx
// containers/WelcomeScreen/index.jsx
const hasUserFarm = useSelector(userFarmLengthSelector);
// ...
useEffect(() => {
  loaded && hasUserFarm && history.push('/farm_selection');
}, [loaded, hasUserFarm]);
```

```jsx
// containers/ChooseFarm/index.jsx
const farms = useSelector(userFarmsByUserSelector);
// ...
useEffect(() => {
  loaded && farms.length === 0 && history.push('/welcome');
}, [farms, loaded]);
```

In the original code, the first selector is not `user_id` filtered, while the second is. In the erroring case, we saw the store (both `farmIdUserIdTuple` and `byFarmIdUserId`) held rows with a `user_id` that didn't match userFarm's `user_id`. That means that `userFarmsByUserSelector` (`user_id` filtered) would return no farms (pushing to `/welcome`), where the truthy  `hasUserFarm` would then push back to Choose Farm.

(Note: I was worried about the flicking on `loaded`, but it was actually *loading* that was flickering, not `loaded`, so that part was totally fine! I'll add today's video to the Jira ticket.)

### Solution in this PR

The fix is simply to point `userFarmLengthSelector` to the `user_id` filtered `userFarmsByUserSelector`, so that this disagreement is not possible

In the second commit, `farmIdUserIdTuple` is deleted; even though it is generated and updated in several places, its only consumer was `userFarmLengthSelector` so it became unneeded. AI also adds that

> it was the `allIds` half of a normalization pair: `byFarmIdUserId` holds the records themselves, keyed for lookup, and `farmIdUserIdTuple` held a flat list of those keys so callers could iterate the records in a known order without walking a nested object

(I.e. it is a normal Redux pattern to generate this structure, but this particular one didn't have any other reader beyond the length selector)

Jira link: https://lite-farm.atlassian.net/browse/LF-5420

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

This snippet can be used to manually create the problematic state, via localStorage. Note that in my own testing on localhost with two tabs open, I never once created the state organically. But interestingly, the adjust below (which predates today's reproduction/investigation) is actually exactly what we saw in the Redux dev tools today!

Snippet (paste into console):

```js
const root = JSON.parse(localStorage['persist:root']);
const entities = JSON.parse(root.entitiesReducer);
const uf = entities.userFarmReducer;

uf.user_id = 'GHOST-USER'; // a user owning none of the stored farms (like the SSO user in today's case)
delete uf.farm_id; // also as we saw in the video today; farm_id is not yet fetched and keeps failing to fetch in this loop
uf.loaded = true;

root.entitiesReducer = JSON.stringify(entities);
localStorage['persist:root'] = JSON.stringify(root);
location.assign('/farm_selection');
```

This should loop/flicker on integration but not on this branch.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files