### PR TITLE
LF-5437 Also send certificate number as operatorId in DFC payload

### DIFF
--- a/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
+++ b/packages/api/src/services/datafoodconsortium/dfcAdapter.ts
@@ -178,6 +178,9 @@ export const formatFarmDataToDfcStandard = async (
   const certificationInstances = (certifications ?? [])
     .filter((cert) => cert.is_active && cert.certification_type)
     .map((cert) => {
+      // Note: dfc-b:operatorId is the only identifier property dfc-b:Certfication defines
+      const identifier = cert.certificate_member_id || cert.certificate_number;
+
       const certification = new Certification({
         connector,
         semanticId: `${enterpriseUrl}#certification-${cert.id}`,
@@ -189,7 +192,7 @@ export const formatFarmDataToDfcStandard = async (
         certificationReferences: cert.certifier?.certifier_name
           ? [cert.certifier.certifier_name]
           : [cert.other_certifier!],
-        operatorIds: cert.certificate_member_id ? [cert.certificate_member_id] : [],
+        operatorIds: identifier ? [identifier] : [],
         certificationScores: [],
       });
 

--- a/packages/api/tests/service-tests/dfcAdapter.test.ts
+++ b/packages/api/tests/service-tests/dfcAdapter.test.ts
@@ -337,6 +337,33 @@ describe('dfcAdapter', () => {
     expect(orgNode).toHaveProperty('dfc-b:isCertifiedBy');
   });
 
+  test('should send the certificate number as the operator id when there is no member id', async () => {
+    const thirdPartyCertification = {
+      ...mockCertification,
+      certificate_member_id: null,
+      certificate_number: 'FR-BIO-01.250-0087918.2024.004',
+    };
+
+    const fakeId = faker.datatype.uuid();
+    const fakeData = {
+      ...fakeMarketDirectoryInfoWithRelations({
+        info: mockCompleteMarketDirectoryInfo,
+        marketProductCategories: [marketProductCategory],
+        fakeId,
+      }),
+      id: fakeId,
+      farm_id: faker.datatype.uuid(),
+      certifications: [thirdPartyCertification],
+    };
+    const result = await formatFarmDataToDfcStandard(fakeData, marketProductCategoryMap);
+    const graph: DfcEntity[] = result['@graph'];
+
+    const certNode = graph.find((e) => e['@type'] === 'dfc-b:Certfication');
+    expect(certNode).toMatchObject({
+      'dfc-b:operatorId': 'FR-BIO-01.250-0087918.2024.004',
+    });
+  });
+
   test('should not include a certification node when certifications is empty', async () => {
     const fakeId = faker.datatype.uuid();
     const fakeData = {


### PR DESCRIPTION
**Description**

Although the DFC field naming indicates something more like a license ID, the only identification we collect for third-party certification is certificate (document) number, so this is the only way to identify an operator.

Although it abuses the DFC ontology naming a little, I think that is the lesser of two evils, between that and not sending any identifier for third-party certifications. This new [OFN mockup UI](https://redirect.github.com/openfoodfoundation/openfoodnetwork/issues/14600) suggests an ID is expected in this case.

Jira link: https://lite-farm.atlassian.net/browse/LF-5437

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

This should be communicated to OFN :)

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Checked the DFC `/enterprises` payload locally.

**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
