### PR TITLE
LF-5417 Add the dashboard ticket exchange endpoint

### DIFF
--- a/packages/api/db/migration/20260806000000_add_dashboard_ticket_use.js
+++ b/packages/api/db/migration/20260806000000_add_dashboard_ticket_use.js
@@ -20,7 +20,7 @@
 export const up = async function (knex) {
   await knex.schema.createTable('dashboard_ticket_use', (table) => {
     table.text('jti').primary();
-    table.timestamp('used_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('used_at').notNullable().defaultTo(knex.fn.now());
   });
 };
 

--- a/packages/api/db/migration/20260806000000_add_dashboard_ticket_use.js
+++ b/packages/api/db/migration/20260806000000_add_dashboard_ticket_use.js
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.createTable('dashboard_ticket_use', (table) => {
+    table.text('jti').primary();
+    table.timestamp('used_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  await knex.schema.dropTable('dashboard_ticket_use');
+};

--- a/packages/api/src/controllers/loginController.js
+++ b/packages/api/src/controllers/loginController.js
@@ -309,8 +309,6 @@ const loginController = {
           return res.sendStatus(401);
         }
 
-        // The insert is what claims the ticket. A second, concurrent exchange of the same ticket
-        // conflicts on the primary key, is ignored, and returns no row.
         const claimed = await knex.transaction(async (trx) => {
           await trx('dashboard_ticket_use')
             .whereRaw("used_at < now() - interval '5 minutes'")
@@ -322,6 +320,7 @@ const loginController = {
             .ignore()
             .returning('jti');
 
+          // False when this ticket has already been exchanged
           return inserted.length > 0;
         });
 
@@ -343,8 +342,6 @@ const loginController = {
           .andWhere('userFarm.status', 'Active')
           .andWhere('farm.deleted', false);
 
-        // The Dashboard writes this farm_id into its session as the active farm without checking
-        // it appears in farms, so membership is confirmed here.
         if (farm_id && !farms.some((farm) => farm.farm_id === farm_id)) {
           return res.sendStatus(401);
         }

--- a/packages/api/src/controllers/loginController.js
+++ b/packages/api/src/controllers/loginController.js
@@ -309,7 +309,7 @@ const loginController = {
           return res.sendStatus(401);
         }
 
-        const claimed = await knex.transaction(async (trx) => {
+        const claimSucceeded = await knex.transaction(async (trx) => {
           await trx('dashboard_ticket_use')
             .whereRaw("used_at < now() - interval '5 minutes'")
             .del();
@@ -324,7 +324,7 @@ const loginController = {
           return inserted.length > 0;
         });
 
-        if (!claimed) {
+        if (!claimSucceeded) {
           return res.sendStatus(401);
         }
 

--- a/packages/api/src/controllers/loginController.js
+++ b/packages/api/src/controllers/loginController.js
@@ -25,6 +25,8 @@ import UserLogModel from '../models/userLogModel.js';
 import EmailModel from '../models/emailTokenModel.js';
 import { createToken } from '../util/jwt.js';
 import { randomUUID } from 'crypto';
+import jwt from 'jsonwebtoken';
+import knex from '../util/knex.js';
 
 const loginController = {
   authenticateUser() {
@@ -277,6 +279,83 @@ const loginController = {
         });
 
         return res.status(200).send({ ticket, return_to });
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({ error });
+      }
+    };
+  },
+
+  dashboardExchange() {
+    return async (req, res) => {
+      try {
+        const { ticket } = req.body;
+
+        if (!ticket) {
+          return res.status(400).send({ message: 'ticket is required.' });
+        }
+
+        let payload;
+        try {
+          payload = jwt.verify(ticket, process.env.JWT_DASHBOARD_SECRET, {
+            algorithms: ['HS256'],
+          });
+        } catch (_verificationError) {
+          return res.sendStatus(401);
+        }
+
+        const { jti, user_id, farm_id } = payload;
+        if (!jti || !user_id) {
+          return res.sendStatus(401);
+        }
+
+        // The insert is what claims the ticket. A second, concurrent exchange of the same ticket
+        // conflicts on the primary key, is ignored, and returns no row.
+        const claimed = await knex.transaction(async (trx) => {
+          await trx('dashboard_ticket_use')
+            .whereRaw("used_at < now() - interval '5 minutes'")
+            .del();
+
+          const inserted = await trx('dashboard_ticket_use')
+            .insert({ jti })
+            .onConflict('jti')
+            .ignore()
+            .returning('jti');
+
+          return inserted.length > 0;
+        });
+
+        if (!claimed) {
+          return res.sendStatus(401);
+        }
+
+        const user = await UserModel.query()
+          .select('user_id', 'email', 'first_name')
+          .findById(user_id);
+        if (!user) {
+          return res.sendStatus(401);
+        }
+
+        const farms = await UserFarmModel.query()
+          .select('userFarm.farm_id', 'farm.farm_name', 'userFarm.role_id')
+          .join('farm', 'userFarm.farm_id', 'farm.farm_id')
+          .where('userFarm.user_id', user_id)
+          .andWhere('userFarm.status', 'Active')
+          .andWhere('farm.deleted', false);
+
+        // The Dashboard writes this farm_id into its session as the active farm without checking
+        // it appears in farms, so membership is confirmed here.
+        if (farm_id && !farms.some((farm) => farm.farm_id === farm_id)) {
+          return res.sendStatus(401);
+        }
+
+        return res.status(200).send({
+          user_id: user.user_id,
+          email: user.email,
+          first_name: user.first_name,
+          farm_id: farm_id ?? null,
+          farms,
+        });
       } catch (error) {
         console.error(error);
         return res.status(500).json({ error });

--- a/packages/api/src/routes/loginRoute.js
+++ b/packages/api/src/routes/loginRoute.js
@@ -10,5 +10,8 @@ router.get('/user/:email', loginController.getUserNameByUserEmail());
 // This router is mounted before the global checkJwt in server.ts,
 // so the middleware is attached here to make the endpoint require a login token
 router.post('/dashboard/ticket', checkJwt, loginController.dashboardIssueTicket());
+// The Analytics Dashboard's server calls this route and holds no LiteFarm token; the ticket in the
+// body is the whole credential
+router.post('/dashboard/exchange', loginController.dashboardExchange());
 
 export default router;

--- a/packages/api/src/routes/loginRoute.js
+++ b/packages/api/src/routes/loginRoute.js
@@ -10,8 +10,6 @@ router.get('/user/:email', loginController.getUserNameByUserEmail());
 // This router is mounted before the global checkJwt in server.ts,
 // so the middleware is attached here to make the endpoint require a login token
 router.post('/dashboard/ticket', checkJwt, loginController.dashboardIssueTicket());
-// The Analytics Dashboard's server calls this route and holds no LiteFarm token; the ticket in the
-// body is the whole credential
 router.post('/dashboard/exchange', loginController.dashboardExchange());
 
 export default router;

--- a/packages/api/tests/dashboardExchange.test.ts
+++ b/packages/api/tests/dashboardExchange.test.ts
@@ -1,0 +1,284 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import chai from 'chai';
+
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+import { Response } from 'superagent';
+import server from '../src/server.js';
+import knex from '../src/util/knex.js';
+import { tableCleanup } from './testEnvironment.js';
+import mocks from './mock.factories.js';
+import { createToken } from '../src/util/jwt.js';
+import { Farm, User, UserFarm } from '../src/models/types.js';
+
+jest.mock('jsdom');
+jest.mock('../src/jobs/station_sync/mapping.js');
+jest.mock('../src/templates/sendEmailTemplate.js', () => ({
+  sendEmail: jest.fn(),
+  emails: { INVITATION: { path: 'invitation_to_farm_email' } },
+}));
+
+interface ExchangeResponseBody {
+  user_id?: User['user_id'];
+  email?: User['email'];
+  first_name?: User['first_name'];
+  farm_id?: Farm['farm_id'] | null;
+  farms?: {
+    farm_id: Farm['farm_id'];
+    farm_name: Farm['farm_name'];
+    role_id: UserFarm['role_id'];
+  }[];
+  message?: string;
+  ticket?: string;
+  id_token?: string;
+  token?: string;
+  access_token?: string;
+}
+
+type ExchangeResponse = Omit<Response, 'body'> & { body: ExchangeResponseBody };
+
+function postRequest(body: Record<string, unknown>): Promise<ExchangeResponse> {
+  return chai
+    .request(server)
+    .post('/login/dashboard/exchange')
+    .set('content-type', 'application/json')
+    .send(body) as unknown as Promise<ExchangeResponse>;
+}
+
+function mintTicket({
+  user_id,
+  farm_id = null,
+}: {
+  user_id: User['user_id'];
+  farm_id?: Farm['farm_id'] | null;
+}) {
+  return createToken('dashboard', { user_id, farm_id, jti: randomUUID() });
+}
+
+describe('POST /login/dashboard/exchange', () => {
+  let user: User;
+  let activeFarm: Farm;
+  let secondActiveFarm: Farm;
+  let invitedFarm: Farm;
+  let deletedFarm: Farm;
+
+  beforeAll(async () => {
+    [user] = await mocks.usersFactory();
+
+    [activeFarm] = await mocks.farmFactory();
+    [secondActiveFarm] = await mocks.farmFactory();
+    [invitedFarm] = await mocks.farmFactory();
+    [deletedFarm] = await mocks.farmFactory();
+
+    for (const farm of [activeFarm, secondActiveFarm, deletedFarm]) {
+      await mocks.userFarmFactory({
+        promisedUser: Promise.resolve([user]),
+        promisedFarm: Promise.resolve([farm]),
+      });
+    }
+    await mocks.userFarmFactory(
+      {
+        promisedUser: Promise.resolve([user]),
+        promisedFarm: Promise.resolve([invitedFarm]),
+      },
+      mocks.fakeUserFarm({ status: 'Invited' }),
+    );
+
+    await knex('farm').update({ deleted: true }).where({ farm_id: deletedFarm.farm_id });
+  });
+
+  afterAll(async () => {
+    await tableCleanup(knex);
+    await knex.destroy();
+  });
+
+  describe('Successful exchange', () => {
+    test('returns the user and the live farm list for a ticket naming no farm', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: user.user_id }) });
+
+      expect(res.status).toBe(200);
+      expect(res.body.user_id).toBe(user.user_id);
+      expect(res.body.email).toBe(user.email);
+      expect(res.body.first_name).toBe(user.first_name);
+      expect(res.body.farm_id).toBe(null);
+      expect(res.body.farms).toEqual(
+        expect.arrayContaining([
+          {
+            farm_id: activeFarm.farm_id,
+            farm_name: activeFarm.farm_name,
+            role_id: expect.any(Number),
+          },
+          {
+            farm_id: secondActiveFarm.farm_id,
+            farm_name: secondActiveFarm.farm_name,
+            role_id: expect.any(Number),
+          },
+        ]),
+      );
+      expect(res.body.farms).toHaveLength(2);
+    });
+
+    test('returns the farm the ticket names when the membership is Active', async () => {
+      const res = await postRequest({
+        ticket: await mintTicket({ user_id: user.user_id, farm_id: activeFarm.farm_id }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.farm_id).toBe(activeFarm.farm_id);
+    });
+
+    test('returns no token of any kind', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: user.user_id }) });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ticket).toBeUndefined();
+      expect(res.body.id_token).toBeUndefined();
+      expect(res.body.token).toBeUndefined();
+      expect(res.body.access_token).toBeUndefined();
+    });
+
+    test('is reachable with no Authorization header', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: user.user_id }) });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Single use', () => {
+    test('returns 401 when the same ticket is exchanged a second time', async () => {
+      const ticket = await mintTicket({ user_id: user.user_id });
+
+      const first = await postRequest({ ticket });
+      const second = await postRequest({ ticket });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(401);
+    });
+
+    test('lets exactly one of two concurrent exchanges succeed', async () => {
+      const ticket = await mintTicket({ user_id: user.user_id });
+
+      const [first, second] = await Promise.all([postRequest({ ticket }), postRequest({ ticket })]);
+
+      expect([first.status, second.status].sort()).toEqual([200, 401]);
+    });
+  });
+
+  describe('Rejected tickets', () => {
+    test('returns 401 for a ticket signed with JWT_SECRET', async () => {
+      const ticket = await createToken('access', {
+        user_id: user.user_id,
+        farm_id: null,
+        jti: randomUUID(),
+      });
+
+      const res = await postRequest({ ticket });
+
+      expect(res.status).toBe(401);
+    });
+
+    test('returns 401 for an expired ticket', async () => {
+      const ticket = jwt.sign(
+        { user_id: user.user_id, farm_id: null, jti: randomUUID() },
+        process.env.JWT_DASHBOARD_SECRET as string,
+        { algorithm: 'HS256', expiresIn: '-1s' },
+      );
+
+      const res = await postRequest({ ticket });
+
+      expect(res.status).toBe(401);
+    });
+
+    test('returns 400 when the body has no ticket', async () => {
+      const res = await postRequest({});
+
+      expect(res.status).toBe(400);
+    });
+
+    test('returns 401 for a validly signed ticket with no jti', async () => {
+      const ticket = await createToken('dashboard', { user_id: user.user_id, farm_id: null });
+
+      const res = await postRequest({ ticket });
+
+      expect(res.status).toBe(401);
+    });
+
+    test('returns 401 for a ticket naming a user that does not exist', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: randomUUID() }) });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Live membership', () => {
+    let revokedUser: User;
+    let revokedFarm: Farm;
+    let keptFarm: Farm;
+
+    beforeAll(async () => {
+      [revokedUser] = await mocks.usersFactory();
+      [revokedFarm] = await mocks.farmFactory();
+      [keptFarm] = await mocks.farmFactory();
+
+      for (const farm of [revokedFarm, keptFarm]) {
+        await mocks.userFarmFactory({
+          promisedUser: Promise.resolve([revokedUser]),
+          promisedFarm: Promise.resolve([farm]),
+        });
+      }
+
+      await knex('userFarm')
+        .update({ status: 'Inactive' })
+        .where({ user_id: revokedUser.user_id, farm_id: revokedFarm.farm_id });
+    });
+
+    test('returns 401 when the ticket names a farm the user is no longer Active on', async () => {
+      const res = await postRequest({
+        ticket: await mintTicket({
+          user_id: revokedUser.user_id,
+          farm_id: revokedFarm.farm_id,
+        }),
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    test('omits a no-longer-Active farm from farms when the ticket names no farm', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: revokedUser.user_id }) });
+
+      expect(res.status).toBe(200);
+      expect(res.body.farms?.map(({ farm_id }) => farm_id)).toEqual([keptFarm.farm_id]);
+    });
+
+    test('omits a farm the user is only Invited to', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: user.user_id }) });
+
+      expect(res.status).toBe(200);
+      expect(res.body.farms?.map(({ farm_id }) => farm_id)).not.toContain(invitedFarm.farm_id);
+    });
+
+    test('omits a soft-deleted farm the user is an Active member of', async () => {
+      const res = await postRequest({ ticket: await mintTicket({ user_id: user.user_id }) });
+
+      expect(res.status).toBe(200);
+      expect(res.body.farms?.map(({ farm_id }) => farm_id)).not.toContain(deletedFarm.farm_id);
+    });
+  });
+});


### PR DESCRIPTION
**Description**

LiteFarm mints a 30-second ticket at `POST /login/dashboard/ticket`, added in the previous PR of this series. The browser carries that ticket to the Dashboard's `/auth/finish` endpoint, and the Dashboard's server trades it, server to server, for the identity behind it.

This adds the endpoint that performs the trade, `POST /login/dashboard/exchange`, and the `dashboard_ticket_use` table that makes a ticket good for exactly one trade.

### Request and response

POST to `/login/dashboard/exchange`, with no `Authorization` header:

```json
{ "ticket": "eyJhbGciOiJIUzI1NiIs…" }
```

Response:

```json
{
  "user_id": "0c1cf1b0-…",
  "email": "farmer@example.org",
  "first_name": "Ada",
  "farm_id": null,
  "farms": [{ "farm_id": "6f2a…", "farm_name": "Rooftop Acres", "role_id": 1 }]
}
```

`farms` is read live, and lists only farms with an `Active` membership and `deleted = false`. The Dashboard's own Postgres is a nightly copy, so it cannot see a farm created today or a membership revoked this morning. No token of any kind is in the response; the Dashboard never calls LiteFarm's API on a user's behalf.

400 means the body had no `ticket`. 401 covers every other rejection — expired, already exchanged, signed with a different secret, carrying no `jti`, or naming a user or membership that no longer holds.

### The insert is what makes the ticket single-use

The ticket's `jti` is the primary key of `dashboard_ticket_use`, and `onConflict('jti').ignore()` guarantees a single ticket can only be claimed once:

```js
// controllers/loginController.js — dashboardExchange
const inserted = await trx('dashboard_ticket_use')
  .insert({ jti })
  .onConflict('jti')
  .ignore()
  .returning('jti');

return inserted.length > 0; // <-- false when another request already claimed it
```

Alongside the insert, a prune deletes rows older than five minutes on every exchange, so the table holds a few minutes of sign-ins and needs no scheduled job, no index and no model.

Jira link: https://lite-farm.atlassian.net/browse/LF-5417

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Tested the ticket minting and exchange locally in Postman

POST to
```
http://localhost:5001/login/dashboard/ticket
```
With normal API auth and request body

```jsonc
{
    "return_to": "http://localhost:3000/auth/finish" // <-- can be anything; just match .env config
}
```

and script

```js
const response = pm.response.json();
pm.environment.set('ticket', response.ticket);
```

and then the exchange

POST to
```
http://localhost:5001/login/dashboard/exchange
```

```json
{
  "ticket": "{{ticket}}"
}
```

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
