### PR TITLE
LF-5443 Signing in while a second tab sits on the sign on screen locks the user on the welcome screen with no way back

### DIFF
--- a/packages/api/src/routes/userFarmRoute.js
+++ b/packages/api/src/routes/userFarmRoute.js
@@ -25,8 +25,7 @@ import checkInvitationTokenContent from '../middleware/acl/checkInviteTokenConte
 import checkUserFarmStatus from '../middleware/acl/checkUserFarmStatus.js';
 
 // Get all userFarms for a specified user
-// no permission limits
-router.get('/user/:user_id', userFarmController.getUserFarmByUserID());
+router.get('/user/:user_id', isSelf, userFarmController.getUserFarmByUserID());
 
 // Get info on all users (userFarm) at a farm
 router.get(

--- a/packages/api/tests/userFarm.test.js
+++ b/packages/api/tests/userFarm.test.js
@@ -40,8 +40,13 @@ import userModel from '../src/models/userModel.js';
 describe('User Farm Tests', () => {
   // let middleware;
 
-  function getUserFarmsOfUserRequest({ user_id }, callback) {
-    chai.request(server).get(`/user_farm/user/${user_id}`).end(callback);
+  // The mocked checkJwt above reads the authenticated user from the user_id header, so that header
+  // is what stands in for the caller's token
+  function getUserFarmsOfUserRequest({ user_id, requesting_user_id = user_id }) {
+    return chai
+      .request(server)
+      .get(`/user_farm/user/${user_id}`)
+      .set('user_id', requesting_user_id);
   }
 
   // note: the object that is sent should be adjusted to not include consent_version
@@ -217,11 +222,22 @@ describe('User Farm Tests', () => {
     await createUserFarmForUser({}, user);
     await createUserFarmForUser({}, user);
 
-    getUserFarmsOfUserRequest({ user_id: user.user_id }, async (_err, res) => {
-      expect(_err).toEqual(null);
-      expect(res.status).toBe(200);
-      expect(res.body.length).toBe(3);
+    const res = await getUserFarmsOfUserRequest({ user_id: user.user_id });
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(3);
+  });
+
+  test('Get all user farms of another user is forbidden', async () => {
+    const { user } = await setupUserFarm({});
+    const { user: otherUser } = await setupUserFarm({});
+
+    const res = await getUserFarmsOfUserRequest({
+      user_id: user.user_id,
+      requesting_user_id: otherUser.user_id,
     });
+
+    expect(res.status).toBe(403);
   });
 
   test('Update consent status for user farm', async () => {

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -124,6 +124,7 @@
     "@storybook/react-vite": "^8.2.8",
     "@storybook/test": "^8.2.8",
     "@storybook/test-runner": "^0.19.1",
+    "@testing-library/react": "^16.3.2",
     "@types/d3": "^7.4.0",
     "@types/google.maps": "^3.58.1",
     "@types/history": "4",

--- a/packages/webapp/pnpm-lock.yaml
+++ b/packages/webapp/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@storybook/test-runner':
         specifier: ^0.19.1
         version: 0.19.1(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(storybook@8.6.14(prettier@3.6.2))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/d3':
         specifier: ^7.4.0
         version: 7.4.3
@@ -2389,6 +2392,21 @@ packages:
   '@testing-library/jest-dom@6.5.0':
     resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@testing-library/user-event@14.5.2':
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
@@ -9848,6 +9866,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:

--- a/packages/webapp/src/containers/ChooseFarm/saga.js
+++ b/packages/webapp/src/containers/ChooseFarm/saga.js
@@ -40,6 +40,11 @@ export function* getUserFarmsSaga() {
   const { userFarmUrl } = apiConfig;
   try {
     const { user_id } = yield select(loginSelector);
+    if (!user_id) {
+      // Without an identity the request cannot succeed, and the catch below dispatches
+      // onLoadingUserFarmsFail, which sets loaded: true.
+      return;
+    }
     const header = getHeader(user_id);
     yield put(onLoadingUserFarmsStart());
     const result = yield call(axios.get, userFarmUrl + '/user/' + user_id, header);

--- a/packages/webapp/src/containers/hooks/useDashboardHandoff.ts
+++ b/packages/webapp/src/containers/hooks/useDashboardHandoff.ts
@@ -14,7 +14,6 @@
  */
 
 import { useEffect, useState } from 'react';
-import { isAuthenticated } from '../../util/jwt';
 import { getDashboardReturnTo } from '../dashboardReturnTo';
 import { handOffToDashboardIfRequested } from '../dashboardTicketHandoff';
 
@@ -25,11 +24,11 @@ import { handOffToDashboardIfRequested } from '../dashboardTicketHandoff';
  * Returns true until the ticket request finishes, so the caller can render a Spinner instead of a
  * route. The first value is computed during the first render, so no route renders before the
  * redirect.
+ *
+ * @param isSignedIn whether the browser holds a session the app can use.
  */
-export default function useDashboardHandoff(): boolean {
-  const [isHandingOff, setIsHandingOff] = useState(
-    () => !!getDashboardReturnTo() && isAuthenticated(),
-  );
+export default function useDashboardHandoff(isSignedIn: boolean): boolean {
+  const [isHandingOff, setIsHandingOff] = useState(() => !!getDashboardReturnTo() && isSignedIn);
 
   useEffect(() => {
     if (!isHandingOff) {

--- a/packages/webapp/src/hooks/useAuthenticatedSession.ts
+++ b/packages/webapp/src/hooks/useAuthenticatedSession.ts
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { loginSelector } from '../containers/userFarmSlice';
+import { isAuthenticated, logout } from '../util/jwt';
+
+/**
+ * Reports whether the browser holds a session the app can render, and clears one it cannot.
+ *
+ * A session needs two values that are written to browser storage separately: `id_token` in
+ * `localStorage`, and `user_id` in the persisted Redux store. They can disagree. `localStorage` is
+ * shared between tabs and each tab writes the whole of `persist:root` on any state change, so a
+ * tab holding no identity overwrites a signed-in tab's `user_id` and leaves the token behind.
+ *
+ * A token with no identity is not recoverable in the app: every farm selector filters on `user_id`
+ * and returns empty, onboarding reads that as "no farms" and sends the user to the
+ * create-your-first-farm screen, and no request returns 401, so nothing signs the user out.
+ *
+ * This is the single place the app decides whether a stored session is usable.
+ */
+export default function useAuthenticatedSession(): boolean {
+  const { user_id } = useSelector(loginSelector);
+  const hasIdentity = !!user_id;
+
+  useEffect(() => {
+    if (isAuthenticated() && !hasIdentity) {
+      logout();
+    }
+  }, []);
+
+  return isAuthenticated() && hasIdentity;
+}

--- a/packages/webapp/src/hooks/useAuthenticatedSession.ts
+++ b/packages/webapp/src/hooks/useAuthenticatedSession.ts
@@ -13,34 +13,24 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { loginSelector } from '../containers/userFarmSlice';
-import { isAuthenticated, logout } from '../util/jwt';
+import { userFarmReducerSelector } from '../containers/userFarmSlice';
+import type { RootState } from '../store/store';
+import { isAuthenticated } from '../util/jwt';
 
 /**
- * Reports whether the browser holds a session the app can render, and clears one it cannot.
+ * Reports whether the browser holds a session the app can render.
  *
  * A session needs two values that are written to browser storage separately: `id_token` in
  * `localStorage`, and `user_id` in the persisted Redux store. They can disagree. `localStorage` is
  * shared between tabs and each tab writes the whole of `persist:root` on any state change, so a
  * tab holding no identity overwrites a signed-in tab's `user_id` and leaves the token behind.
  *
- * A token with no identity is not recoverable in the app: every farm selector filters on `user_id`
- * and returns empty, onboarding reads that as "no farms" and sends the user to the
- * create-your-first-farm screen, and no request returns 401, so nothing signs the user out.
- *
- * This is the single place the app decides whether a stored session is usable.
+ * A token on its own admits nothing: every farm selector filters on `user_id` and returns empty,
+ * so the app has no farm to render.
  */
 export default function useAuthenticatedSession(): boolean {
-  const { user_id } = useSelector(loginSelector);
-  const hasIdentity = !!user_id;
+  const hasIdentity = useSelector((state: RootState) => !!userFarmReducerSelector(state).user_id);
 
-  useEffect(() => {
-    if (isAuthenticated() && !hasIdentity) {
-      logout();
-    }
-  }, []);
-
-  return isAuthenticated() && hasIdentity;
+  return hasIdentity && isAuthenticated();
 }

--- a/packages/webapp/src/routes/index.jsx
+++ b/packages/webapp/src/routes/index.jsx
@@ -22,7 +22,7 @@ import Spinner from '../components/Spinner';
 import OnboardingFlow from './Onboarding';
 import CustomSignUp from '../containers/CustomSignUp';
 import { useSelector } from 'react-redux';
-import { isAuthenticated } from '../util/jwt';
+import useAuthenticatedSession from '../hooks/useAuthenticatedSession';
 
 // action
 import { userFarmSelector } from '../containers/userFarmSlice';
@@ -208,7 +208,8 @@ const UnknownRecord = React.lazy(
 const Routes = ({ isCompactSideMenu }) => {
   useScrollToTop();
   useReduxSnackbar();
-  const isHandingOffToDashboard = useDashboardHandoff();
+  const isSignedIn = useAuthenticatedSession();
+  const isHandingOffToDashboard = useDashboardHandoff(isSignedIn);
   const userFarm = useSelector(
     userFarmSelector,
     (pre, next) =>
@@ -238,7 +239,7 @@ const Routes = ({ isCompactSideMenu }) => {
         <Route
           path="*"
           render={() => {
-            if (isAuthenticated()) {
+            if (isSignedIn) {
               role_id = Number(role_id);
               // TODO check every step
               if (isInvitationFlow) {
@@ -1061,7 +1062,7 @@ const Routes = ({ isCompactSideMenu }) => {
                   </Switch>
                 );
               }
-            } else if (!isAuthenticated()) {
+            } else {
               return (
                 <Switch>
                   <Route path={'/render_survey'} exact children={<RenderSurvey />} />

--- a/packages/webapp/src/tests/chooseFarmSaga.test.ts
+++ b/packages/webapp/src/tests/chooseFarmSaga.test.ts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { put, select } from 'redux-saga/effects';
+import { describe, expect, test } from 'vitest';
+import { getUserFarmsSaga } from '../containers/ChooseFarm/saga';
+import { loginSelector, onLoadingUserFarmsStart } from '../containers/userFarmSlice';
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('getUserFarmsSaga', () => {
+  test('makes no request and dispatches nothing without an identity', () => {
+    const saga = getUserFarmsSaga();
+
+    expect(saga.next().value).toEqual(select(loginSelector));
+
+    const afterSelect = saga.next({ user_id: undefined });
+
+    expect(afterSelect.done).toBe(true);
+    expect(afterSelect.value).toBe(undefined);
+  });
+
+  test('proceeds to the request when an identity is present', () => {
+    const saga = getUserFarmsSaga();
+
+    expect(saga.next().value).toEqual(select(loginSelector));
+    expect(saga.next({ user_id: USER_ID }).value).toEqual(put(onLoadingUserFarmsStart()));
+  });
+});

--- a/packages/webapp/src/tests/useAuthenticatedSession.test.tsx
+++ b/packages/webapp/src/tests/useAuthenticatedSession.test.tsx
@@ -68,11 +68,13 @@ describe('useAuthenticatedSession', () => {
     expect(localStorage.getItem('id_token')).toBe('a-token');
   });
 
-  test('a token with no identity is not a usable session, and the token is cleared', () => {
+  // `localStorage` is shared between tabs, so removing the token here would reach a tab that is
+  // signed in and using it.
+  test('a token with no identity is not a usable session, and the token is left in place', () => {
     const { result } = renderSession({ token: 'a-token' });
 
     expect(result.current).toBe(false);
-    expect(localStorage.getItem('id_token')).toBe(null);
+    expect(localStorage.getItem('id_token')).toBe('a-token');
   });
 
   test('an identity with no token is not a usable session', () => {

--- a/packages/webapp/src/tests/useAuthenticatedSession.test.tsx
+++ b/packages/webapp/src/tests/useAuthenticatedSession.test.tsx
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+// store/reducer pulls in slices that import store/store, and store/store imports store/reducer.
+// Evaluating store/store first keeps that cycle from handing configureStore an undefined reducer.
+import '../store/store';
+import rootReducer from '../store/reducer';
+import { loginSuccess } from '../containers/userFarmSlice';
+import useAuthenticatedSession from '../hooks/useAuthenticatedSession';
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+
+const buildStore = ({ userId }: { userId?: string }) => {
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ immutableCheck: false, serializableCheck: false }),
+  });
+
+  if (userId) {
+    store.dispatch(loginSuccess({ user_id: userId }));
+  }
+
+  return store;
+};
+
+const renderSession = ({ token, userId }: { token?: string; userId?: string }) => {
+  if (token) {
+    localStorage.setItem('id_token', token);
+  }
+
+  const store = buildStore({ userId });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return renderHook(() => useAuthenticatedSession(), { wrapper });
+};
+
+describe('useAuthenticatedSession', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(cleanup);
+
+  test('a token with an identity is a usable session', () => {
+    const { result } = renderSession({ token: 'a-token', userId: USER_ID });
+
+    expect(result.current).toBe(true);
+    expect(localStorage.getItem('id_token')).toBe('a-token');
+  });
+
+  test('a token with no identity is not a usable session, and the token is cleared', () => {
+    const { result } = renderSession({ token: 'a-token' });
+
+    expect(result.current).toBe(false);
+    expect(localStorage.getItem('id_token')).toBe(null);
+  });
+
+  test('an identity with no token is not a usable session', () => {
+    const { result } = renderSession({ userId: USER_ID });
+
+    expect(result.current).toBe(false);
+  });
+
+  test('a signed-out browser is left alone', () => {
+    const { result } = renderSession({});
+
+    expect(result.current).toBe(false);
+    expect(localStorage.getItem('id_token')).toBe(null);
+  });
+});

--- a/packages/webapp/vitest.config.ts
+++ b/packages/webapp/vitest.config.ts
@@ -5,7 +5,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      include: ['src/tests/**/*.test.js?(x)'],
+      include: ['src/tests/**/*.test.{js,jsx,ts,tsx}'],
       environment: 'happy-dom',
     },
   }),


### PR DESCRIPTION
**Description**

As mentioned in tech daily today, I've been landing on this particular `/welcome` screen, prompted by having an `id_token` but no Redux store / `persist:root`, a lot while testing the dashboard SSO login.

I'm not completely convinced that two tabs are _always_ involved, but I haven't figured out another mechanism and it's not an outrageous assumption (I might easily have a LiteFarm tab side-by-side with the instance called up by the dashboard redirect). Certainly two tabs is the easiest and most reliable reproduction, as described in the Jira ticket and reproduced in "testing" below.

In any case, the code solution on this branch (requiring both an `id_token` and Redux `user_id` to qualify for `isAuthenticated`), definitely addresses the state we saw today on Beta, regardless of how that state was produced.

### Tracing the bug
Our original `isAuthenticated` read only the `id_token` value from local storage:

```js
// util/jwt.js
export const isAuthenticated = () => !!localStorage.getItem('id_token'); // <-- never reads Redux
```

Routes renders its signed-in branch on that alone. No `farm_id` is set, so it renders `OnboardingFlow` and routes as follows:

```jsx
// routes/Onboarding.jsx
const hasUserFarms = useSelector(userFarmLengthSelector); // 0 — userFarmsByUserSelector returns [] with no user_id, so "no identity" counts as "no farms"
const { loaded: farmsLoaded } = useSelector(userFarmStatusSelector); // false — set true once a userFarm fetch finishes, succeed or fail
// ...
if ((!farm_id || !step_one) && !hasUserFarms) {
  const target = farmsLoaded ? '/welcome' : '/farm_selection';
  return <Redirect to={target} />;
}
```

`farmsLoaded` is false, so the first redirect is to `/farm_selection` — the correct target, because `ChooseFarm` normally fetches the farm list and fills the store.

```jsx
// containers/ChooseFarm/index.jsx
useEffect(() => {
  dispatch(getUserFarms()); // <-- runs on on mount
  dispatch(getSpotlightFlags());
}, []);
```

`getUserFarmsSaga` selects the absent `user_id` and requests `GET /user_farm/user/undefined`. That request satisfies `checkJwt` but can't (of course) locate any userFarms, so the controller answers with `200 []`. `getUserFarmsSuccess([])` sets `loaded: true`, which `ChooseFarm` reads as an answer about farms:

```jsx
// containers/ChooseFarm/index.jsx
const farms = useSelector(userFarmsByUserSelector); // [] for the same reason as above
const { loaded } = useSelector(userFarmStatusSelector); // now true
useEffect(() => {
  loaded && farms.length === 0 && history.push('/welcome');
}, [farms, loaded]);
```

### Fix 1 — require both `id_token` and `user_id` to be present for authenticated routes

This is a new hook combining both the `id_token` and Redux:

```ts
// hooks/useAuthenticatedSession.ts
export default function useAuthenticatedSession(): boolean {
  const hasIdentity = useSelector((state: RootState) => !!userFarmReducerSelector(state).user_id);

  return hasIdentity && isAuthenticated();
}
```

now used in place of the old `isAuthenticated` that controls route rendering:

```jsx
// routes/index.jsx — Routes
const isSignedIn = useAuthenticatedSession();
const isHandingOffToDashboard = useDashboardHandoff(isSignedIn);
// ...
if (isSignedIn) {
  // ... OnboardingFlow, and every signed-in Switch
} else {
  // ... CustomSignUp at '/', and a Redirect to '/' for anything else
}
```

(As a side note there is one other use of `isAuthenticated` in app that was untouched -- `useIsFarmSelected`. That one didn't need any adjust because it already combines the `id_token` with selecting from a Redux slice.)


### Fix 2a — preventing `GET /user_farm/user/undefined`

The adjust in the saga just exits `getUserFarmsSaga` if there is no `user_id` to form the request with

```js
// containers/ChooseFarm/saga.js — getUserFarmsSaga
const { user_id } = yield select(loginSelector);
if (!user_id) {
  return; // <-- early return before adjusting the loading state or calling the API
}
const header = getHeader(user_id);
yield put(onLoadingUserFarmsStart());
const result = yield call(axios.get, userFarmUrl + '/user/' + user_id, header);
```

### Fix 2b — the route now errors on `GET /user_farm/user/undefined`

Previously this would have returned `200 []`; now it would return 403 (if it were called!)

```js
// packages/api/src/routes/userFarmRoute.js
- router.get('/user/:user_id', userFarmController.getUserFarmByUserID());
+ router.get('/user/:user_id', isSelf, userFarmController.getUserFarmByUserID());
```

This change in isolation does trigger `logout()` via `handle403Saga` and therefore works on its own, but the failed request will also set `loaded: true` which would push the user to `/welcome` briefly before logout; therefore pairing with the saga change (never sending the malformed request at all) is preferable.

Jira link: https://lite-farm.atlassian.net/browse/LF-5443

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

As described in Jira, the two-tab method is the quickest and most reliable to differentiate this branch and integration:

Tab 1: open LiteFarm, stop at the sign-on screen, do not sign in.
Tab 2, same window: open LiteFarm and sign in normally. Do not choose a farm (note: this is also where the dashboard redirect would naturally leave you)
Tab 1: type any valid email and press Continue.
Tab 1 redirects itself to Welcome


**Checklist:**

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
