### PR TITLE
LF-5448: Take tape in other languages

### DIFF
--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -132,7 +132,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       <PageTitle title={surveyTitle} backUrl="/Insights" />
       <div className={clsx(styles.surveyContainer, isCompactSideMenu && styles.compactSideMenu)}>
         {/* wait for prepopulated data and survey JSON to load */}
-        {isLoading && !surveyJson && (
+        {isLoading && (
           <div className={styles.spinner}>
             <Spinner />
           </div>

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -48,7 +48,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   // @ts-expect-error - userFarmSelector is not typed with TypeScript yet
   const { farm_id, country_code } = useSelector(userFarmSelector);
 
-  const surveyVersion = getSurveyVersion(surveyId, country_code);
+  const { version: surveyVersion } = getSurveyVersion(surveyId, country_code) || {};
   const cdnDirectory = SURVEY_INFO[surveyId]?.cdnDirectory;
 
   const { prepopulatedData, isLoading: isPrepopulatedDataLoading } =

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -32,6 +32,7 @@ import {
   useAddSurveyResponseMutation,
 } from '../../../store/api/surveyApi';
 import { enqueueErrorSnackbar, snackbarSelector } from '../../Snackbar/snackbarSlice';
+import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 import styles from './styles.module.scss';
 import insightStyles from '../styles.module.scss';
 
@@ -48,7 +49,8 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   // @ts-expect-error - userFarmSelector is not typed with TypeScript yet
   const { farm_id, country_code } = useSelector(userFarmSelector);
 
-  const { version: surveyVersion } = getSurveyVersion(surveyId, country_code) || {};
+  const { version: surveyVersion, fallbackVersion: surveyFallbackVersion } =
+    getSurveyVersion(surveyId, country_code, getLanguageFromLocalStorage() || 'en') || {};
   const cdnDirectory = SURVEY_INFO[surveyId]?.cdnDirectory;
 
   const { prepopulatedData, isLoading: isPrepopulatedDataLoading } =
@@ -59,7 +61,11 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
     isLoading: isSurveyJsonLoading,
     isError: isSurveyJsonError,
   } = useGetSurveyJsonQuery(
-    { cdnDirectory: cdnDirectory ?? '', version: surveyVersion ?? '' },
+    {
+      cdnDirectory: cdnDirectory ?? '',
+      version: surveyVersion ?? '',
+      fallbackVersion: surveyFallbackVersion,
+    },
     { skip: !cdnDirectory || !surveyVersion },
   );
 

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -132,7 +132,12 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       <PageTitle title={surveyTitle} backUrl="/Insights" />
       <div className={clsx(styles.surveyContainer, isCompactSideMenu && styles.compactSideMenu)}>
         {/* wait for prepopulated data and survey JSON to load */}
-        {!isLoading && surveyJson ? (
+        {isLoading && !surveyJson && (
+          <div className={styles.spinner}>
+            <Spinner />
+          </div>
+        )}
+        {!isLoading && surveyJson && (
           <SurveyComponent
             surveyJson={surveyJson}
             onComplete={handleComplete}
@@ -140,10 +145,6 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
             initialData={initialData}
             initialPageNo={savedPageNo}
           />
-        ) : (
-          <div className={styles.spinner}>
-            <Spinner />
-          </div>
         )}
       </div>
     </div>

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -26,6 +26,7 @@ import { SURVEY_INFO, getSurveyVersion } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
 import PageTitle from '../../../components/PageTitle';
+import Spinner from '../../../components/Spinner';
 import {
   usePrefetch,
   useGetSurveyJsonQuery,
@@ -131,7 +132,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       <PageTitle title={surveyTitle} backUrl="/Insights" />
       <div className={clsx(styles.surveyContainer, isCompactSideMenu && styles.compactSideMenu)}>
         {/* wait for prepopulated data and survey JSON to load */}
-        {!isLoading && surveyJson && (
+        {!isLoading && surveyJson ? (
           <SurveyComponent
             surveyJson={surveyJson}
             onComplete={handleComplete}
@@ -139,6 +140,10 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
             initialData={initialData}
             initialPageNo={savedPageNo}
           />
+        ) : (
+          <div className={styles.spinner}>
+            <Spinner />
+          </div>
         )}
       </div>
     </div>

--- a/packages/webapp/src/containers/Insights/Survey/styles.module.scss
+++ b/packages/webapp/src/containers/Insights/Survey/styles.module.scss
@@ -44,3 +44,10 @@
     margin-left: calc(var(--global-side-menu-width) / 2);
   }
 }
+
+.spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -26,6 +26,7 @@ interface SurveyInfo {
   // Uppercase ISO-2 country code -> CDN version to load. The 'default' key is the global fallback;
   // a survey with no 'default' is available only in the countries it lists explicitly.
   versionsByCountry: Record<string, string>;
+  shouldTranslate?: (baseVersion: string) => boolean;
 }
 
 /**
@@ -36,10 +37,11 @@ interface SurveyInfo {
  *
  * Adding a survey:
  *  1. Add a SURVEY_INFO entry here: image, ResultsComponent (omit for the generic thank-you page),
- *     cdnDirectory, versionsByCountry.
+ *     cdnDirectory, versionsByCountry, and shouldTranslate if the survey has localized versions.
  *  2. Add the title in useSurveyTitle.ts by calling t() with the key INSIGHTS.<KEY>.TITLE.
  *  3. Add that title string to public/locales/en/translation.json (English only; Crowdin propagates).
- *  4. Upload the survey's <version>.json to its CDN directory.
+ *  4. Upload the survey's <version>.json to its CDN directory (plus <version>_<language>.json per
+ *     supported language, if shouldTranslate is set).
  */
 export const SURVEY_INFO: Record<string, SurveyInfo> = {
   tape: {
@@ -47,6 +49,7 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     ResultsComponent: TapeResults,
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'fao', AU: 'au' },
+    shouldTranslate: (baseVersion: string) => baseVersion === 'fao',
   },
   cathi_gao: {
     image: tape_survey,
@@ -59,12 +62,26 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
  * The CDN version of a survey for a given country, or undefined when the survey does not exist or is
  * not available in that country. A country-specific entry wins over the global 'default'.
  */
-export const getSurveyVersion = (surveyId: string, countryCode?: string): string | undefined => {
+export const getSurveyVersion = (
+  surveyId: string,
+  countryCode?: string,
+  language: string = 'en',
+): { version: string; fallbackVersion?: string } | undefined => {
   const info = SURVEY_INFO[surveyId];
   if (!info) {
     return undefined;
   }
-  return (countryCode && info.versionsByCountry[countryCode]) ?? info.versionsByCountry.default;
+  const baseVersion =
+    (countryCode && info.versionsByCountry[countryCode]) ?? info.versionsByCountry.default;
+
+  if (!baseVersion) {
+    return undefined;
+  }
+
+  const shouldTranslate = language === 'en' ? false : info.shouldTranslate?.(baseVersion) || false;
+  return shouldTranslate
+    ? { version: `${baseVersion}_${language}`, fallbackVersion: baseVersion }
+    : { version: baseVersion };
 };
 
 /**

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -21,12 +21,19 @@ import ThankYouResults from './ThankYouResults';
 interface SurveyInfo {
   image: string;
   ResultsComponent?: ComponentType<{ surveyId: string }>;
-  // CDN directory under DO_CDN_URL holding the survey's `<version>.json` definitions.
+  // CDN directory under DO_CDN_URL holding the survey's file(s), optionally nested under a per-language
+  // subfolder (see resolveVersion below).
   cdnDirectory: string;
   // Uppercase ISO-2 country code -> CDN version to load. The 'default' key is the global fallback;
   // a survey with no 'default' is available only in the countries it lists explicitly.
   versionsByCountry: Record<string, string>;
-  shouldTranslate?: (baseVersion: string) => boolean;
+  // Called only for the survey's 'default' version. Resolves the version to request for a language,
+  // plus a fallbackVersion for the untranslated default if that's missing. Omit if the default version
+  // has no per-language content (e.g. cathi_gao).
+  resolveVersion?: (
+    defaultVersion: string,
+    language: string,
+  ) => { version: string; fallbackVersion?: string };
 }
 
 /**
@@ -37,19 +44,28 @@ interface SurveyInfo {
  *
  * Adding a survey:
  *  1. Add a SURVEY_INFO entry here: image, ResultsComponent (omit for the generic thank-you page),
- *     cdnDirectory, versionsByCountry, and shouldTranslate if the survey has localized versions.
+ *     cdnDirectory, versionsByCountry, and resolveVersion if the default version has localized files.
  *  2. Add the title in useSurveyTitle.ts by calling t() with the key INSIGHTS.<KEY>.TITLE.
  *  3. Add that title string to public/locales/en/translation.json (English only; Crowdin propagates).
- *  4. Upload the survey's <version>.json to its CDN directory (plus <version>_<language>.json per
- *     supported language, if shouldTranslate is set).
+ *  4. Upload the survey's <version>.json to its CDN directory. A translatable default version goes
+ *     in a per-language subfolder (e.g. fao/step0_step1.json for English, fao_fr/step0_step1_fr.json
+ *     for French); a non-translatable, country-specific version (e.g. au) stays flat at the CDN
+ *     directory root, no subfolder.
  */
 export const SURVEY_INFO: Record<string, SurveyInfo> = {
   tape: {
     image: tape_survey,
     ResultsComponent: TapeResults,
     cdnDirectory: 'tape_surveys',
-    versionsByCountry: { default: 'fao', AU: 'au' },
-    shouldTranslate: (baseVersion: string) => baseVersion === 'fao',
+    versionsByCountry: { default: 'step0_step1', AU: 'au' },
+    resolveVersion: (defaultVersion: string, language: string) => {
+      return language === 'en'
+        ? { version: `fao/${defaultVersion}` }
+        : {
+            version: `fao_${language}/${defaultVersion}_${language}`,
+            fallbackVersion: `fao/${defaultVersion}`,
+          };
+    },
   },
   cathi_gao: {
     image: tape_survey,
@@ -71,17 +87,15 @@ export const getSurveyVersion = (
   if (!info) {
     return undefined;
   }
-  const baseVersion =
-    (countryCode && info.versionsByCountry[countryCode]) ?? info.versionsByCountry.default;
-
-  if (!baseVersion) {
+  const countryOverride = countryCode && info.versionsByCountry[countryCode];
+  if (countryOverride) {
+    return { version: countryOverride };
+  }
+  const defaultVersion = info.versionsByCountry.default;
+  if (!defaultVersion) {
     return undefined;
   }
-
-  const shouldTranslate = language === 'en' ? false : info.shouldTranslate?.(baseVersion) || false;
-  return shouldTranslate
-    ? { version: `${baseVersion}_${language}`, fallbackVersion: baseVersion }
-    : { version: baseVersion };
+  return info.resolveVersion?.(defaultVersion, language) ?? { version: defaultVersion };
 };
 
 /**

--- a/packages/webapp/src/containers/Insights/styles.module.scss
+++ b/packages/webapp/src/containers/Insights/styles.module.scss
@@ -18,7 +18,7 @@
 .insightContainer {
   width: 100%;
   max-width: 1024px;
-  min-height: 100vh;
+  min-height: calc(100vh - var(--global-navbar-height));
   height: auto;
   padding: 24px 24px 0 24px;
   display: flex;

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -46,8 +46,8 @@ export const surveyApi = api.injectEndpoints({
           fetch(`${DO_CDN_URL}/${cdnDirectory}/${filename}.json`);
         try {
           let response = await fetchVersion(version);
-          // DO Spaces returns 403, not 404, for a missing key when the bucket doesn't
-          // grant anonymous ListBucket — so a missing localized file surfaces as 403 here.
+          // DO Spaces returns 403 (not 404) for a file that doesn't exist, since the bucket
+          // won't confirm or deny what files exist to unauthenticated requests like this one.
           if (!response.ok && [403, 404].includes(response.status) && fallbackVersion) {
             response = await fetchVersion(fallbackVersion);
           }

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -42,14 +42,14 @@ export const surveyApi = api.injectEndpoints({
       { cdnDirectory: string; version: string; fallbackVersion?: string }
     >({
       queryFn: async ({ cdnDirectory, version, fallbackVersion }) => {
-        const fetchVersion = (filename: string) =>
+        const fetchSurvey = (filename: string) =>
           fetch(`${DO_CDN_URL}/${cdnDirectory}/${filename}.json`);
         try {
-          let response = await fetchVersion(version);
+          let response = await fetchSurvey(version);
           // DO Spaces returns 403 (not 404) for a file that doesn't exist, since the bucket
           // won't confirm or deny what files exist to unauthenticated requests like this one.
           if (!response.ok && [403, 404].includes(response.status) && fallbackVersion) {
-            response = await fetchVersion(fallbackVersion);
+            response = await fetchSurvey(fallbackVersion);
           }
           if (!response.ok) {
             return {

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -37,10 +37,20 @@ export const surveyApi = api.injectEndpoints({
   endpoints: (build) => ({
     // Fetches the SurveyJS JSON definition from DO CDN.
     // Uses queryFn (not query) because this bypasses the LiteFarm API base URL and auth headers.
-    getSurveyJson: build.query<Record<string, any>, { cdnDirectory: string; version: string }>({
-      queryFn: async ({ cdnDirectory, version }) => {
+    getSurveyJson: build.query<
+      Record<string, any>,
+      { cdnDirectory: string; version: string; fallbackVersion?: string }
+    >({
+      queryFn: async ({ cdnDirectory, version, fallbackVersion }) => {
+        const fetchVersion = (filename: string) =>
+          fetch(`${DO_CDN_URL}/${cdnDirectory}/${filename}.json`);
         try {
-          const response = await fetch(`${DO_CDN_URL}/${cdnDirectory}/${version}.json`);
+          let response = await fetchVersion(version);
+          // DO Spaces returns 403, not 404, for a missing key when the bucket doesn't
+          // grant anonymous ListBucket — so a missing localized file surfaces as 403 here.
+          if (!response.ok && [403, 404].includes(response.status) && fallbackVersion) {
+            response = await fetchVersion(fallbackVersion);
+          }
           if (!response.ok) {
             return {
               error: { status: response.status, data: `Failed to fetch survey JSON` },


### PR DESCRIPTION
**Description**

Adds localized-language support for the TAPE survey's base version, with a fallback to the default English file when no translation exists for the user's preferred language.

**The new flow:**
1. When the farm's country code is `AU`, the behaviour is unchanged.
2. When user's preferred language isn't English, fetch `fao_{language}.json`.
3. If the file isn't returned, fetch the English version: `fao.json`.

Adding a new language later needs no code changes — just upload `fao_<lang>.json` to the DO bucket.

**Changes:**
- Update `getSurveyVersion` to return `version` and `fallbackVersion`.
- Update `surveyApi` to fetch the English version if the file for the user's preferred language isn't returned.
- Add a Spinner to the component.
- Fix the `min-height` of `insightContainer` (which was `100vh`, ignoring the navbar). This was needed to centre the spinner, and also prevents insight pages (e.g. /insights) from becoming unnecessarily scrollable.

Jira link: https://lite-farm.atlassian.net/browse/LF-5448

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Added `fao_es.json` (the English version with the title translated to Spanish) to the DigitalOcean bucket, tested the behaviour with the language preferences `es` and `fr`, and observed the Network tab. For supported languages, the API call happens once and succeeds. For unsupported languages, the first call (`fao_{language}.json`) fails, followed by a second call for `fao.json`.

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
