### PR TITLE
LF-5423 Split stable third-party code into named chunks to cut per-release re-download

### DIFF
--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -83,6 +83,10 @@ export default defineConfig({
             return 'charts-vendor';
           }
 
+          if (id.includes('/node_modules/react-redux-form/')) {
+            return 'react-redux-form-vendor';
+          }
+
           if (
             id.includes('/node_modules/@mui/material/') ||
             id.includes('/node_modules/@mui/system/') ||
@@ -100,7 +104,6 @@ export default defineConfig({
             id.includes('/node_modules/redux-saga/') ||
             id.includes('/node_modules/reselect/') ||
             id.includes('/node_modules/immer/') ||
-            id.includes('/node_modules/react-redux-form/') ||
             id.includes('/node_modules/moment/')
           ) {
             return 'app-vendor';

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -70,6 +70,42 @@ export default defineConfig({
             return 'survey-vendor';
           }
 
+          if (
+            id.includes('/node_modules/recharts/') ||
+            id.includes('/node_modules/chart.js/') ||
+            id.includes('/node_modules/react-chartjs-2/') ||
+            id.includes('/node_modules/@kurkle/color/') ||
+            id.includes('/node_modules/react-smooth/') ||
+            id.includes('/node_modules/decimal.js-light/') ||
+            id.includes('/node_modules/victory-vendor/') ||
+            id.includes('/node_modules/d3-')
+          ) {
+            return 'charts-vendor';
+          }
+
+          if (
+            id.includes('/node_modules/@mui/material/') ||
+            id.includes('/node_modules/@mui/system/') ||
+            id.includes('/node_modules/@mui/base/') ||
+            id.includes('/node_modules/@mui/utils/') ||
+            id.includes('/node_modules/@mui/styles/') ||
+            id.includes('/node_modules/@mui/styled-engine/') ||
+            id.includes('/node_modules/@mui/private-theming/') ||
+            id.includes('/node_modules/@emotion/') ||
+            id.includes('/node_modules/react-select/') ||
+            id.includes('/node_modules/@reduxjs/toolkit/') ||
+            id.includes('/node_modules/react-redux/') ||
+            id.includes('/node_modules/redux/') ||
+            id.includes('/node_modules/redux-persist/') ||
+            id.includes('/node_modules/redux-saga/') ||
+            id.includes('/node_modules/reselect/') ||
+            id.includes('/node_modules/immer/') ||
+            id.includes('/node_modules/react-redux-form/') ||
+            id.includes('/node_modules/moment/')
+          ) {
+            return 'app-vendor';
+          }
+
           return undefined;
         },
       },

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -77,7 +77,6 @@ export default defineConfig({
             id.includes('/node_modules/@kurkle/color/') ||
             id.includes('/node_modules/react-smooth/') ||
             id.includes('/node_modules/decimal.js-light/') ||
-            id.includes('/node_modules/victory-vendor/') ||
             id.includes('/node_modules/d3-')
           ) {
             return 'charts-vendor';
@@ -104,7 +103,8 @@ export default defineConfig({
             id.includes('/node_modules/redux-saga/') ||
             id.includes('/node_modules/reselect/') ||
             id.includes('/node_modules/immer/') ||
-            id.includes('/node_modules/moment/')
+            id.includes('/node_modules/moment/') ||
+            id.includes('/node_modules/tiny-invariant/')
           ) {
             return 'app-vendor';
           }


### PR DESCRIPTION
**Description**

This PR pulls out more named library code, following the successful `framework-vendor` and `survey-vendor` model, from chunks where it was mixed with application code. Application code, unlike stable library code, is re-hashed and therefore re-resent on each release. The new named chunks are:

- `charts-vendor` covering mainly our three (!) charting library recharts and chart.js and d3 (😬)
- `app-vendor` covering core UI (e.g. MUI, emotion) and state (redux, immer) libraries
  - This chunk was initially separated into two named chunks (`ui-vendor` + `state-vendor`), but complicated circular dependencies between them necessitated this grouping
- `react-redux-form-vendor` -- a temporary chunk, until this library is deleted in a follow-up PR

Claude made a fuss when picking the libraries (but I think this is correct) that each named chunk should only contain either all eager-loaded (i.e. delaying first paint) or lazy-loaded (not loaded into memory until requested) chunks. In this case, `charts-vendor` is lazy-loaded and `app-vendor` is eager-loaded, so first-paint behaviour should be _mostly_ unchanged. There is a slight increase (121 kB minified, or 32 kB gz) of eager-loaded MUI code when MUI is gathered into `app-vendor` like this. The alternative of listing every lazy-loaded MUI component separately to make a `mui-vendor-lazy` chunk bloats vite.config.ts quite a bit though, and the list would soon drift.

And just to be super clear because I noticed Claude, at different times, also kept getting confused about this, the lazy/eager distinction here is only for CPU and browser memory purposes, and not network fetches. Everything is network fetched upfront in the workbox precache.

### This works to move library code out of our source files...

I ran `pnpm bundle-snapshot` before and after the chunk change, and then both ran `bundle-compare` and had Claude investigate the snapshots.

The change moves about ~388 KB of library code (~250 KB of it in our entry chunk) from hashed chunks containing source + library code, into stable chunks that won't re-hash on normal update:

| category | before (kB gz) | after (kB gz) | % of after precache |
| --- | --- | --- | --- |
| entry chunk | 448.6 | 258.5 | 9.1% |
| `app-vendor` (eager) | — | 195.4 | 6.9% |
| `charts-vendor` (lazy) | — | 173.7 | 6.1% |
| `react-redux-form-vendor` (eager) | — | 27.5 | 1.0% |
| `framework-vendor` | 45.8 | 45.8 | 1.6% |
| other app + lib JS | 1671.8 | 1460.5 | 51.3% |
| locale chunks | 461.6 | 461.6 | 16.2% |
| SVG | 61.0 | 61.0 | 2.1% |
| CSS | 89.4 | 89.4 | 3.1% |
| image + survey css + other | 75.4 | 75.4 | 2.6% |
| **precache total** | **2853.6** | **2848.7** | **100%** |


### ... but ultimately that won't matter much

As mentioned in tech daily Aug 20 and in the PR description here:
- https://github.com/LiteFarmOrg/LiteFarm/pull/4313

hash cascade means that nearly 60% of our precache is re-hashed and re-sent on even a tiny release like `3.13.0` to `3.13.1`. This library chunking helps, but you can see that the vast majority of the precache remains within hash-cascade susceptible JS chunks, and we still require re-downloading 56% of a first install on a _minimal_ release:

| category | rehashed / total kB gz | rehash (overturn) rate |
| --- | --- | --- |
| entry chunk | 258.5 / 258.5 | 100% |
| `app-vendor` | 0 / 195.4 | 0% |
| `charts-vendor` | 0 / 173.7 | 0% |
| `react-redux-form-vendor` | 0 / 27.5 | 0% |
| `framework-vendor` | 0 / 45.8 | 0% |
| other app + lib JS (lazy `index-*`) | 1344.6 / 1461.9 | 92.0% |
| locale chunks(*) | 0 / 461.6 | 0%(*)|
| SVG / CSS / image | 0 | 0% |
| **TOTAL** | **1603.1 / 2850.2** | **56.2%**(*)|

(*) If we change anything in `translation.json` in all languages -- which is probably a more typical case -- this would jump to **65%** overall

As discussed Aug 20 in tech daily, the re-hashing cascade is a known issue in Vite ([vitejs/vite#10636](https://redirect.github.com/vitejs/vite/issues/10636), [vitejs/vite#6773](https://redirect.github.com/vitejs/vite/issues/6773)) has _just_ been fixed in Vite [`v8.1.0`](https://github.com/vitejs/vite/releases/tag/v8.1.0). That's great!! 🎉  But Vite 8 is going to be _quite_ a ways off for us, so not too much more can be done to recover this release cost anytime soon 😞

This table does make me want to bump the priority of the locales/languages situation up once again -- but at the same time, since nginx is now fixed, the entire workbox precache is currently less than, e.g. the re-download on login triggered by having a large image or PDF uploaded into `Documents/`. I will probably still open the planned tickets on cache, some of which are easy wins, but images are probably worth more overall going forward.

Jira link: https://lite-farm.atlassian.net/browse/LF-5423

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Used bundle-snapshots as described above:

```
pnpm bundle-snapshot --label before-vendor-chunks
```

and

```
pnpm bundle-snapshots --label after-vendor-chunks
```

I also set Claude to work in a worktree to change some application code and re-build to get the re-hash percentage table above.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
