### PR TITLE
LF-5433 Bound the dynamic-chunks service worker cache

### DIFF
--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -51,7 +51,7 @@ async function validatePrecacheIntegrity() {
 
 // Assets omitted from precache, but cached on first fetch for fast subsequent loads
 registerRoute(
-  ({ url }) => /\/assets\/(survey-vendor)-[^/]+\.(js|css)$/.test(url.pathname),
+  ({ url }) => /\/assets\/(survey-vendor)-[^/]+\.(js)$/.test(url.pathname),
   new CacheFirst({
     cacheName: 'dynamic-chunks',
     plugins: [new ExpirationPlugin({ maxEntries: 2, purgeOnQuotaError: true })],

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -58,6 +58,22 @@ registerRoute(
   }),
 );
 
+async function purgeStaleDynamicChunks() {
+  try {
+    const cache = await caches.open('dynamic-chunks');
+    const keys = await cache.keys();
+    // Keep only the last key in insertion order
+    const stale = keys.slice(0, -1);
+    await Promise.all(stale.map((request) => cache.delete(request)));
+  } catch {
+    return;
+  }
+}
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(purgeStaleDynamicChunks());
+});
+
 // Farm note images served through the Cloudflare Worker proxy (beta/prod) or minio (dev)
 registerRoute(
   ({ url, request }) =>

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -49,21 +49,34 @@ async function validatePrecacheIntegrity() {
   }
 }
 
-// Assets omitted from precache, but cached on first fetch for fast subsequent loads
+// Assets omitted from precache, but cached on first fetch for fast subsequent loads.
+// Each chunk name here must also be listed in `globIgnores` in vite.config.ts
+const DYNAMIC_CHUNK_PATTERN = /\/assets\/(survey-vendor)-[^/]+\.js$/;
+
 registerRoute(
-  ({ url }) => /\/assets\/(survey-vendor)-[^/]+\.(js)$/.test(url.pathname),
+  ({ url }) => DYNAMIC_CHUNK_PATTERN.test(url.pathname),
   new CacheFirst({
     cacheName: 'dynamic-chunks',
+    // Two versions per chunk name matched by DYNAMIC_CHUNK_PATTERN
     plugins: [new ExpirationPlugin({ maxEntries: 2 })],
   }),
 );
 
+// Keep the newest entry per chunk name
 async function purgeStaleDynamicChunks() {
   try {
     const cache = await caches.open('dynamic-chunks');
     const keys = await cache.keys();
-    // Keep only the last key in insertion order
-    const stale = keys.slice(0, -1);
+    // cache.keys() returns in insertion order
+    const newest = new Map();
+    for (const request of keys) {
+      const chunkName = request.url.match(DYNAMIC_CHUNK_PATTERN)?.[1];
+      if (chunkName) {
+        newest.set(chunkName, request);
+      }
+    }
+    const keep = new Set(newest.values());
+    const stale = keys.filter((request) => !keep.has(request));
     await Promise.all(stale.map((request) => cache.delete(request)));
   } catch {
     return;

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -52,7 +52,10 @@ async function validatePrecacheIntegrity() {
 // Assets omitted from precache, but cached on first fetch for fast subsequent loads
 registerRoute(
   ({ url }) => /\/assets\/(survey-vendor)-[^/]+\.(js|css)$/.test(url.pathname),
-  new CacheFirst({ cacheName: 'dynamic-chunks' }),
+  new CacheFirst({
+    cacheName: 'dynamic-chunks',
+    plugins: [new ExpirationPlugin({ maxEntries: 2, purgeOnQuotaError: true })],
+  }),
 );
 
 // Farm note images served through the Cloudflare Worker proxy (beta/prod) or minio (dev)

--- a/packages/webapp/src/sw.js
+++ b/packages/webapp/src/sw.js
@@ -54,7 +54,7 @@ registerRoute(
   ({ url }) => /\/assets\/(survey-vendor)-[^/]+\.(js)$/.test(url.pathname),
   new CacheFirst({
     cacheName: 'dynamic-chunks',
-    plugins: [new ExpirationPlugin({ maxEntries: 2, purgeOnQuotaError: true })],
+    plugins: [new ExpirationPlugin({ maxEntries: 2 })],
   }),
 );
 


### PR DESCRIPTION
**Description**

This adds cleanup of old `survey-vendor-*.js` chunks to the `dynamic-chunks` runtime cache. Technically I should have added this when the cache was added, but it wasn't until farm notes that I learned about `ExpirationPlugin` 😬

The workbox precache is configured to clear out (delete) all unused entries each install, so that cache never holds chunks that aren't part of the current release's manifest. Our manually-configured runtime cache doesn't have that behaviour by default, so chunks can just accumulate.

Depending on if you've cleared your caches or not, you may be able to see this accumulation of `survey-vendor` chunks in your `dynamic-chunks` on beta or app. For instance, my cache on beta shows the chunk hashed on both the Vite 4 and Vite 5 formats:

<img width="696" height="135" alt="Screenshot 2026-08-24 at 10 31 25 AM" src="https://github.com/user-attachments/assets/b4770cc0-5d33-4255-8365-292d3dc4506e" />

If you really haven't cleared cache in a while, you may even see a third chunk from before the SurveyJS update for the Google Translation crash as well.

Each cache entry is about 1.4 MB on device (you can see this by searching the committed bundle-snapshot for `survey-vendor`) so ideally we don't want to keep all those stale copies forever.

This PR:
1. Adds `maxEntries: 2` to the `dynamic-chunks` cache. The second entry is permitted so that a cached frontend still in the process of update can call and use its old chunk
2. Adds a cleanup on activate, that prunes to only the latest chunk on each service worker _install_ (for our purposes, that means the cache for most prod users who have loaded surveys will stay at 2 until the _next_ release/install). Because maxEntries is only forward-looking (will apply to cache keys added since this addition of `ExpirationPlugin` to the route) we need this to clean up those old caches we've already accumulated. It will also tidy up those transition / compatibility chunks from (1) at each release event.

This usage of listening to the activation event is consistent with [workbox documentation](https://developer.chrome.com/docs/workbox/service-worker-lifecycle#activation_2). As it says there:

> A common task to perform in an updated service worker's activate event is to prune old caches... Old caches don't tidy themselves. We need to do that ourselves or risk exceeding [storage quotas](https://developer.mozilla.org/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria).

Jira link: https://lite-farm.atlassian.net/browse/LF-5433

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

(Not sure I would necessarily recommend this as it's a bit of work, although Claude can do all the worktree setup): The cache population and clear can be observed on `http://localhost:4173/` by setting up some worktrees, building in each, and running `vite preview` (always on the same port, so that each service worker kicks out the previous).

I had Claude set up these worktrees (and handle the pnpm install, build, `.env` copy-over etc.)

| Build | Worktree | Commit | Vite | `src/sw.js` contains |
| --- | --- | --- | --- | --- |
| A | `lf5433-vite4` | `ac776db7c` | 4.5.14 | no plugin, no purge, matcher `(js\|css)` |
| B | `lf5433-vite5-nofix` | `4c698d10c` | 5.4.21 | no plugin, no purge, matcher `(js\|css)` |
| C | `lf5433-fix` | `a26ab69e0` | 5.4.21 | plugin and purge, matcher `(js)` |

And then I switched between them sequentially with

```
cd ~/<path-to-your-claude-worktress>/.worktrees/lf5433-vite4/packages/webapp
pnpm exec vite preview --port 4173 --strictPort
```

loading the new service worker and the survey code each time to observe `dynamic-chunks`. Going from A to C directly is the most indicative of what our upcoming release would do on prod, but A > B > C should be indicative of beta, and shows the activation cleanup.

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
