### PR TITLE
LF-5477 Streamline developer mobile testing over the local area network

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ To run [ESLint](https://eslint.org/) checks execute `pnpm lint`
 
 Since this is a mobile web application, webapp should be viewed in a mobile view in the browser.
 
-You can also test LiteFarm on your actual mobile device using the network adddress returned by `vite --host` when you start the webapp in development mode. To do this, also update `VITE_API_URL` in your `webapp/.env` file from localhost to that address (or your computer's network name) and the appropriate API port. Most of LiteFarm can be tested like this, but please note that Google SSO and some other functionality will not work over the local network.
+You can also test LiteFarm on your actual mobile device using the network address returned by `pnpm dev` when you start the webapp in development mode. As long as `VITE_API_URL` is left blank in `packages/webapp/.env`, the app will automatically route API calls to the same host on port 5001. Most of LiteFarm can be tested like this, but please note that Google SSO and some other functionality will not work over the local network.
 
 # ngrok
 

--- a/packages/webapp/.env.default
+++ b/packages/webapp/.env.default
@@ -14,8 +14,9 @@ VITE_GOOGLE_OAUTH_CLIENT_ID=?
 VITE_ENV=development
 NODE_ENV=development
 
-# To view LiteFarm on your mobile device over the local network, replace "localhost" below with the network address returned by pnpm run dev or with your computer's network name, e.g. http://192.168.1.142:5001 or http://my-laptop.local:5001
-VITE_API_URL=http://localhost:5001
+# (Optional) API server URL.
+# Leave blank to automatically route API requests to the current host on port 5001 (recommended for local network testing). Set explicitly only if your backend runs on a different host/port or against a remote environment
+VITE_API_URL=
 
 # Do not change this
 VITE_DO_BUCKET_NAME=litefarm

--- a/packages/webapp/.env.default
+++ b/packages/webapp/.env.default
@@ -14,7 +14,7 @@ VITE_GOOGLE_OAUTH_CLIENT_ID=?
 VITE_ENV=development
 NODE_ENV=development
 
-# To view LiteFarm on your mobile device over the local network, replace "localhost" below with the network address returned by pnpm run dev or with your computer's network name, e.g. http://192.168.1.142:5001 or http://my-laptop:5001
+# To view LiteFarm on your mobile device over the local network, replace "localhost" below with the network address returned by pnpm run dev or with your computer's network name, e.g. http://192.168.1.142:5001 or http://my-laptop.local:5001
 VITE_API_URL=http://localhost:5001
 
 # Do not change this

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -25,7 +25,7 @@ if (VITE_NGROK_API && hostNameSplit && hostNameSplit.length > 1 && hostNameSplit
   URI = import.meta.env.VITE_API_URL;
 } else {
   if (VITE_ENV === 'development') {
-    URI = window.location.href.replace(/3000.*/, '5000');
+    URI = window.location.href.replace(/3000.*/, '5001');
   } else if (VITE_ENV === 'production') {
     URI = 'https://api.app.litefarm.org';
   } else if (VITE_ENV === 'integration') {

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
 
   server: {
     port: 3000,
+    allowedHosts: ['.local'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
**Description**

Two small DX (Developer Experience) improvements for testing LiteFarm over the local network.

1. Add `.local` (hostname reserved for the local network) to `allowedHosts` in the server block of vite.config.ts (applies only to `vite --host` and `vite preview --host`). Functions like `allowedHosts: true` without being quite so permissive.
2. Fix the dev environment fallback in `apiConfig` so that `VITE_API_URL` can be unset. This works for hostname as well, but the main target is devs (or non-dev contributors) who use the variable network IP address returned by `vite --host` (`pnpm dev`) so they don't have to keep those two in sync. Also allows for slightly easier onboarding

Jira link: https://lite-farm.atlassian.net/browse/LF-5477

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [ ] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [x] Other (please explain)

Checked both changes with my phone over my local network

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
