### PR TITLE
LF-5471: Persist survey drafts to the server

### DIFF
--- a/packages/api/db/migration/20260820000000_create_survey_draft_table.js
+++ b/packages/api/db/migration/20260820000000_create_survey_draft_table.js
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  await knex.schema.createTable('survey_draft', (table) => {
+    table.increments('id').primary();
+    table.uuid('submission_id').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.uuid('farm_id').notNullable().references('farm_id').inTable('farm');
+    table.string('survey_key').notNullable();
+    // defaults to '' rather than being nullable so the partial unique index below
+    // behaves correctly — Postgres treats every NULL as distinct, which would let
+    // multiple "live" drafts exist for the same farm+survey_key when no step applies.
+    table.string('survey_step').notNullable().defaultTo('');
+    table.string('survey_version').notNullable();
+    table.jsonb('survey_data').notNullable();
+    table.integer('current_page_no').notNullable().defaultTo(0);
+    table.string('created_by_user_id').references('user_id').inTable('users');
+    table.string('updated_by_user_id').references('user_id').inTable('users');
+    table.dateTime('created_at').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updated_at').notNullable().defaultTo(knex.fn.now());
+    table.boolean('deleted').notNullable().defaultTo(false);
+
+    // One live (non-deleted) draft per farm+survey_key+survey_step.
+    table.unique(['farm_id', 'survey_key', 'survey_step'], {
+      indexName: 'survey_draft_farm_survey_step_live_unique',
+      predicate: knex.whereRaw('deleted = false'),
+    });
+  });
+
+  // No add:survey_draft — a single route handles create-or-update, gated on edit:survey_draft alone.
+  await knex('permissions').insert([
+    { permission_id: 193, name: 'get:survey_draft', description: 'get survey_draft' },
+    { permission_id: 194, name: 'edit:survey_draft', description: 'edit survey_draft' },
+  ]);
+
+  await knex('rolePermissions').insert([
+    { role_id: 1, permission_id: 193 },
+    { role_id: 2, permission_id: 193 },
+    { role_id: 5, permission_id: 193 },
+    { role_id: 1, permission_id: 194 },
+    { role_id: 2, permission_id: 194 },
+    { role_id: 5, permission_id: 194 },
+  ]);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  await knex.schema.dropTable('survey_draft');
+
+  const permissions = [193, 194];
+  await knex('rolePermissions').whereIn('permission_id', permissions).del();
+  await knex('permissions').whereIn('permission_id', permissions).del();
+};

--- a/packages/api/db/migration/20260820000000_create_survey_draft_table.js
+++ b/packages/api/db/migration/20260820000000_create_survey_draft_table.js
@@ -23,10 +23,6 @@ export const up = async function (knex) {
     table.uuid('submission_id').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('farm_id').notNullable().references('farm_id').inTable('farm');
     table.string('survey_key').notNullable();
-    // defaults to '' rather than being nullable so the partial unique index below
-    // behaves correctly — Postgres treats every NULL as distinct, which would let
-    // multiple "live" drafts exist for the same farm+survey_key when no step applies.
-    table.string('survey_step').notNullable().defaultTo('');
     table.string('survey_version').notNullable();
     table.jsonb('survey_data').notNullable();
     table.integer('current_page_no').notNullable().defaultTo(0);
@@ -36,9 +32,9 @@ export const up = async function (knex) {
     table.dateTime('updated_at').notNullable().defaultTo(knex.fn.now());
     table.boolean('deleted').notNullable().defaultTo(false);
 
-    // One live (non-deleted) draft per farm+survey_key+survey_step.
-    table.unique(['farm_id', 'survey_key', 'survey_step'], {
-      indexName: 'survey_draft_farm_survey_step_live_unique',
+    // One live (non-deleted) draft per farm+survey_key.
+    table.unique(['farm_id', 'survey_key'], {
+      indexName: 'survey_draft_farm_survey_live_unique',
       predicate: knex.whereRaw('deleted = false'),
     });
   });

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -80,7 +80,8 @@ const surveyDraftController = {
           })
           .returning('*');
 
-        const wasCreated = upserted.created_at === upserted.updated_at;
+        const wasCreated =
+          new Date(upserted.created_at).getTime() === new Date(upserted.updated_at).getTime();
         return res.status(wasCreated ? 201 : 200).send(upserted);
       } catch (error) {
         console.error(error);

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -30,11 +30,11 @@ const surveyDraftController = {
     return async (req: LiteFarmRequest<unknown, SurveyDraftParams>, res: Response) => {
       try {
         const { farm_id } = req.headers;
-        const { survey_key, survey_step = '' } = req.params;
+        const { survey_key } = req.params;
         /* @ts-expect-error known issue with models */
         const result = await SurveyDraftModel.query()
           .whereNotDeleted()
-          .findOne({ farm_id, survey_key, survey_step });
+          .findOne({ farm_id, survey_key });
         return res.status(200).json(result ?? null);
       } catch (error) {
         console.error(error);
@@ -52,7 +52,7 @@ const surveyDraftController = {
       try {
         const { farm_id } = req.headers;
         const user_id = req.auth?.user_id;
-        const { survey_key, survey_step = '' } = req.params;
+        const { survey_key } = req.params;
         const { survey_version, survey_data, current_page_no = 0 } = req.body;
 
         /* @ts-expect-error known issue with models */
@@ -61,12 +61,11 @@ const surveyDraftController = {
           .insert({
             farm_id,
             survey_key,
-            survey_step,
             survey_version,
             survey_data,
             current_page_no,
           })
-          .onConflict(knex.raw('(farm_id, survey_key, survey_step) where deleted = false'))
+          .onConflict(knex.raw('(farm_id, survey_key) where deleted = false'))
           .merge({
             survey_version,
             survey_data,

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Response } from 'express';
+import knex from '../util/knex.js';
+import SurveyDraftModel from '../models/surveyDraftModel.js';
+import { SurveyDraftParams } from '../middleware/validation/checkSurveyDraft.js';
+import { LiteFarmRequest } from '../types.js';
+
+interface UpsertDraftReqBody {
+  survey_version: string;
+  survey_data: Record<string, unknown>;
+  current_page_no?: number;
+}
+
+const surveyDraftController = {
+  getDraft() {
+    return async (req: LiteFarmRequest<unknown, SurveyDraftParams>, res: Response) => {
+      try {
+        const { farm_id } = req.headers;
+        const { survey_key } = req.params;
+        const survey_step = req.params.survey_step ?? '';
+        /* @ts-expect-error known issue with models */
+        const result = await SurveyDraftModel.query()
+          .whereNotDeleted()
+          .findOne({ farm_id, survey_key, survey_step });
+        return res.status(200).send(result ?? null);
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({ error });
+      }
+    };
+  },
+
+  // Idempotent; full overwrite of the draft at this key, or create it if it doesn't exist yet.
+  upsertDraft() {
+    return async (
+      req: LiteFarmRequest<unknown, SurveyDraftParams, unknown, UpsertDraftReqBody>,
+      res: Response,
+    ) => {
+      try {
+        const { farm_id } = req.headers;
+        const user_id = req.auth?.user_id;
+        const { survey_key, survey_step = '' } = req.params;
+        const { survey_version, survey_data, current_page_no = 0 } = req.body;
+
+        /* @ts-expect-error known issue with models */
+        const upserted = await SurveyDraftModel.query()
+          .context({ user_id })
+          .insert({
+            farm_id,
+            survey_key,
+            survey_step,
+            survey_version,
+            survey_data,
+            current_page_no,
+          })
+          .onConflict(knex.raw('(farm_id, survey_key, survey_step) where deleted = false'))
+          .merge({
+            survey_version,
+            survey_data,
+            current_page_no,
+            // $beforeUpdate does NOT fire on this path — Objection only sees an .insert() call,
+            // it has no visibility into Postgres resolving it as an UPDATE — so updated_at and
+            // updated_by_user_id are set explicitly.
+            updated_at: new Date().toISOString(),
+            updated_by_user_id: user_id,
+          })
+          .returning('*');
+
+        const wasCreated = upserted.created_at === upserted.updated_at;
+        return res.status(wasCreated ? 201 : 200).send(upserted);
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({ error });
+      }
+    };
+  },
+};
+
+export default surveyDraftController;

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -30,8 +30,7 @@ const surveyDraftController = {
     return async (req: LiteFarmRequest<unknown, SurveyDraftParams>, res: Response) => {
       try {
         const { farm_id } = req.headers;
-        const { survey_key } = req.params;
-        const survey_step = req.params.survey_step ?? '';
+        const { survey_key, survey_step = '' } = req.params;
         /* @ts-expect-error known issue with models */
         const result = await SurveyDraftModel.query()
           .whereNotDeleted()

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -16,10 +16,10 @@
 import { Response } from 'express';
 import knex from '../util/knex.js';
 import SurveyDraftModel from '../models/surveyDraftModel.js';
-import { SurveyDraftParams } from '../middleware/validation/checkSurveyDraft.js';
+import { SurveyDraftParams, UpsertDraftBody } from '../middleware/validation/checkSurveyDraft.js';
 import { LiteFarmRequest } from '../types.js';
 
-interface UpsertDraftReqBody {
+interface UpsertDraftReqBody extends UpsertDraftBody {
   survey_version: string;
   survey_data: Record<string, unknown>;
   current_page_no?: number;

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -35,7 +35,7 @@ const surveyDraftController = {
         const result = await SurveyDraftModel.query()
           .whereNotDeleted()
           .findOne({ farm_id, survey_key, survey_step });
-        return res.status(200).send(result ?? null);
+        return res.status(200).json(result ?? null);
       } catch (error) {
         console.error(error);
         return res.status(500).json({ error });

--- a/packages/api/src/controllers/surveyResponseController.ts
+++ b/packages/api/src/controllers/surveyResponseController.ts
@@ -23,6 +23,7 @@ import SurveyDraftModel from '../models/surveyDraftModel.js';
 interface SurveyResponseData {
   survey_version: string;
   project_id: string;
+  survey_step?: string;
   [key: string]: unknown;
 }
 
@@ -60,7 +61,7 @@ const surveyResponseController = {
           await trx.rollback();
           return res.status(400).json({ error: 'survey_key is required' });
         }
-        const { survey_version, project_id } = survey_response;
+        const { survey_version, project_id, survey_step } = survey_response;
 
         // A live draft, if one exists, hands its submission_id over to the response so a draft
         // write that arrives after this point can recognize its own lineage is now complete.
@@ -79,6 +80,7 @@ const surveyResponseController = {
           survey_response,
           survey_version,
           project_id,
+          survey_step,
         });
 
         if (liveDraft) {

--- a/packages/api/src/controllers/surveyResponseController.ts
+++ b/packages/api/src/controllers/surveyResponseController.ts
@@ -109,7 +109,7 @@ const surveyResponseController = {
           .where({ farm_id, survey_key })
           .orderBy('created_at', 'desc')
           .first();
-        return res.status(200).send(result ?? null);
+        return res.status(200).json(result ?? null);
       } catch (error) {
         console.error(error);
         return res.status(500).json({ error });

--- a/packages/api/src/controllers/surveyResponseController.ts
+++ b/packages/api/src/controllers/surveyResponseController.ts
@@ -23,7 +23,6 @@ import SurveyDraftModel from '../models/surveyDraftModel.js';
 interface SurveyResponseData {
   survey_version: string;
   project_id: string;
-  survey_step?: string;
   [key: string]: unknown;
 }
 
@@ -61,14 +60,14 @@ const surveyResponseController = {
           await trx.rollback();
           return res.status(400).json({ error: 'survey_key is required' });
         }
-        const { survey_version, project_id, survey_step } = survey_response;
+        const { survey_version, project_id } = survey_response;
 
         // A live draft, if one exists, hands its submission_id over to the response so a draft
         // write that arrives after this point can recognize its own lineage is now complete.
         /* @ts-expect-error known issue with models */
         const liveDraft = await SurveyDraftModel.query(trx)
           .whereNotDeleted()
-          .findOne({ farm_id, survey_key, survey_step: survey_step ?? '' });
+          .findOne({ farm_id, survey_key });
 
         const insertQuery = SurveyResponseModel.query(trx).context({
           user_id,
@@ -80,7 +79,6 @@ const surveyResponseController = {
           survey_response,
           survey_version,
           project_id,
-          survey_step,
         });
 
         if (liveDraft) {

--- a/packages/api/src/controllers/surveyResponseController.ts
+++ b/packages/api/src/controllers/surveyResponseController.ts
@@ -14,8 +14,11 @@
  */
 
 import { Response } from 'express';
+import { transaction, Model } from 'objection';
 import { LiteFarmRequest } from '../types.js';
+import { handleObjectionError } from '../util/errorCodes.js';
 import SurveyResponseModel from '../models/surveyResponseModel.js';
+import SurveyDraftModel from '../models/surveyDraftModel.js';
 
 interface SurveyResponseData {
   survey_version: string;
@@ -49,19 +52,29 @@ const surveyResponseController = {
       req: LiteFarmRequest<unknown, unknown, unknown, CreateSurveyResponseReqBody>,
       res: Response,
     ) => {
+      const trx = await transaction.start(Model.knex());
       try {
         const { farm_id } = req.headers;
         const user_id = req.auth?.user_id;
         const { survey_key, survey_response } = req.body;
         if (!survey_key) {
+          await trx.rollback();
           return res.status(400).json({ error: 'survey_key is required' });
         }
         const { survey_version, project_id, survey_step } = survey_response;
 
-        const insertQuery = SurveyResponseModel.query().context({
+        // A live draft, if one exists, hands its submission_id over to the response so a draft
+        // write that arrives after this point can recognize its own lineage is now complete.
+        /* @ts-expect-error known issue with models */
+        const liveDraft = await SurveyDraftModel.query(trx)
+          .whereNotDeleted()
+          .findOne({ farm_id, survey_key, survey_step: survey_step ?? '' });
+
+        const insertQuery = SurveyResponseModel.query(trx).context({
           user_id,
         }) as unknown as InsertableQuery;
         await insertQuery.insert({
+          ...(liveDraft ? { submission_id: liveDraft.submission_id } : {}),
           farm_id,
           survey_key,
           survey_response,
@@ -70,10 +83,15 @@ const surveyResponseController = {
           survey_step,
         });
 
+        if (liveDraft) {
+          /* @ts-expect-error known issue with models */
+          await SurveyDraftModel.query(trx).context({ user_id }).deleteById(liveDraft.id);
+        }
+
+        await trx.commit();
         return res.status(201).send();
       } catch (error) {
-        console.error(error);
-        return res.status(500).json({ error });
+        return await handleObjectionError(error as Error, res, trx);
       }
     };
   },

--- a/packages/api/src/middleware/validation/checkSurveyDraft.ts
+++ b/packages/api/src/middleware/validation/checkSurveyDraft.ts
@@ -14,6 +14,7 @@
  */
 
 import { NextFunction, Response } from 'express';
+import SurveyResponseModel from '../../models/surveyResponseModel.js';
 import { LiteFarmRequest } from '../../types.js';
 
 export interface SurveyDraftParams {
@@ -21,11 +22,33 @@ export interface SurveyDraftParams {
   survey_step?: string;
 }
 
+export interface UpsertDraftBody {
+  submission_id?: string;
+}
+
 export function checkSurveyDraftKey() {
   return (req: LiteFarmRequest<unknown, SurveyDraftParams>, res: Response, next: NextFunction) => {
     const { survey_key } = req.params;
     if (!survey_key) {
       return res.status(400).json({ error: 'survey_key is required' });
+    }
+    next();
+  };
+}
+
+export function checkDraftNotCompleted() {
+  return async (
+    req: LiteFarmRequest<unknown, unknown, unknown, UpsertDraftBody>,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const { submission_id } = req.body;
+    if (!submission_id) {
+      return next();
+    }
+    const existing = await SurveyResponseModel.query().findOne({ submission_id });
+    if (existing) {
+      return res.status(409).json({ error: 'Survey has already been completed' });
     }
     next();
   };

--- a/packages/api/src/middleware/validation/checkSurveyDraft.ts
+++ b/packages/api/src/middleware/validation/checkSurveyDraft.ts
@@ -38,7 +38,7 @@ export function checkSurveyDraftKey() {
 
 export function checkDraftNotCompleted() {
   return async (
-    req: LiteFarmRequest<unknown, unknown, unknown, UpsertDraftBody>,
+    req: LiteFarmRequest<unknown, SurveyDraftParams, unknown, UpsertDraftBody>,
     res: Response,
     next: NextFunction,
   ) => {

--- a/packages/api/src/middleware/validation/checkSurveyDraft.ts
+++ b/packages/api/src/middleware/validation/checkSurveyDraft.ts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { NextFunction, Response } from 'express';
+import { LiteFarmRequest } from '../../types.js';
+
+export interface SurveyDraftParams {
+  survey_key: string;
+  survey_step?: string;
+}
+
+export function checkSurveyDraftKey() {
+  return (req: LiteFarmRequest<unknown, SurveyDraftParams>, res: Response, next: NextFunction) => {
+    const { survey_key } = req.params;
+    if (!survey_key) {
+      return res.status(400).json({ error: 'survey_key is required' });
+    }
+    next();
+  };
+}

--- a/packages/api/src/middleware/validation/checkSurveyDraft.ts
+++ b/packages/api/src/middleware/validation/checkSurveyDraft.ts
@@ -36,17 +36,23 @@ export function checkSurveyDraftKey() {
   };
 }
 
+// TODO: LF-5192 Adjust logic
+// Only correct while retake isn't supported: "a response exists" is treated as permanently done.
+// Once retakes exist, this will incorrectly block starting a new attempt after a prior one completes.
 export function checkDraftNotCompleted() {
   return async (
     req: LiteFarmRequest<unknown, SurveyDraftParams, unknown, UpsertDraftBody>,
     res: Response,
     next: NextFunction,
   ) => {
-    const { submission_id } = req.body;
-    if (!submission_id) {
-      return next();
-    }
-    const existing = await SurveyResponseModel.query().findOne({ submission_id });
+    const { farm_id } = req.headers;
+    const { survey_key, survey_step = '' } = req.params;
+
+    const existing = await SurveyResponseModel.query().findOne({
+      farm_id,
+      survey_key,
+      survey_step,
+    });
     if (existing) {
       return res.status(409).json({ error: 'Survey has already been completed' });
     }

--- a/packages/api/src/middleware/validation/checkSurveyDraft.ts
+++ b/packages/api/src/middleware/validation/checkSurveyDraft.ts
@@ -19,7 +19,6 @@ import { LiteFarmRequest } from '../../types.js';
 
 export interface SurveyDraftParams {
   survey_key: string;
-  survey_step?: string;
 }
 
 export interface UpsertDraftBody {
@@ -46,12 +45,11 @@ export function checkDraftNotCompleted() {
     next: NextFunction,
   ) => {
     const { farm_id } = req.headers;
-    const { survey_key, survey_step = '' } = req.params;
+    const { survey_key } = req.params;
 
     const existing = await SurveyResponseModel.query().findOne({
       farm_id,
       survey_key,
-      survey_step,
     });
     if (existing) {
       return res.status(409).json({ error: 'Survey has already been completed' });

--- a/packages/api/src/models/surveyDraftModel.js
+++ b/packages/api/src/models/surveyDraftModel.js
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import BaseModel from './baseModel.js';
+
+class SurveyDraftModel extends BaseModel {
+  static get tableName() {
+    return 'survey_draft';
+  }
+
+  static get idColumn() {
+    return 'id';
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['farm_id', 'survey_key', 'survey_version', 'survey_data'],
+      properties: {
+        id: { type: 'string' },
+        submission_id: { type: 'string' },
+        farm_id: { type: 'string' },
+        survey_key: { type: 'string' },
+        survey_step: { type: 'string' },
+        survey_version: { type: 'string' },
+        survey_data: { type: 'object' },
+        current_page_no: { type: 'integer' },
+        ...this.baseProperties,
+      },
+      additionalProperties: false,
+    };
+  }
+}
+
+export default SurveyDraftModel;

--- a/packages/api/src/models/surveyDraftModel.js
+++ b/packages/api/src/models/surveyDraftModel.js
@@ -37,7 +37,6 @@ class SurveyDraftModel extends BaseModel {
         submission_id: { type: 'string' },
         farm_id: { type: 'string' },
         survey_key: { type: 'string' },
-        survey_step: { type: 'string' },
         survey_version: { type: 'string' },
         survey_data: { type: 'object' },
         current_page_no: { type: 'integer' },

--- a/packages/api/src/models/surveyDraftModel.js
+++ b/packages/api/src/models/surveyDraftModel.js
@@ -24,6 +24,10 @@ class SurveyDraftModel extends BaseModel {
     return 'id';
   }
 
+  static get hidden() {
+    return ['created_at', 'created_by_user_id', 'updated_by_user_id', 'deleted'];
+  }
+
   static get jsonSchema() {
     return {
       type: 'object',

--- a/packages/api/src/routes/surveyDraftRoute.ts
+++ b/packages/api/src/routes/surveyDraftRoute.ts
@@ -23,11 +23,9 @@ import surveyDraftController from '../controllers/surveyDraftController.js';
 
 const router = express.Router();
 
-// One live draft per farm_id + survey_key + survey_step (survey_step is optional,
-// and it defaults to '' on the survey_draft row).
+// One live draft per farm_id + survey_key
 router.get(
-  // TODO: LF-5475 Update the Express 4-specific `?` optional-param syntax to `{/:survey_step}`
-  '/:survey_key/:survey_step?',
+  '/:survey_key',
   checkScope(['get:survey_draft']),
   checkSurveyDraftKey(),
   surveyDraftController.getDraft(),
@@ -36,8 +34,7 @@ router.get(
 // Idempotent create-or-replace at this exact key — PUT, not POST, since the resource's
 // address is fully known up front rather than server-assigned.
 router.put(
-  // TODO: LF-5475 Update the Express 4-specific `?` optional-param syntax to `{/:survey_step}`
-  '/:survey_key/:survey_step?',
+  '/:survey_key',
   checkScope(['edit:survey_draft']),
   checkSurveyDraftKey(),
   checkDraftNotCompleted(),

--- a/packages/api/src/routes/surveyDraftRoute.ts
+++ b/packages/api/src/routes/surveyDraftRoute.ts
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import express from 'express';
+import checkScope from '../middleware/acl/checkScope.js';
+import { checkSurveyDraftKey } from '../middleware/validation/checkSurveyDraft.js';
+import surveyDraftController from '../controllers/surveyDraftController.js';
+
+const router = express.Router();
+
+// One live draft per farm_id + survey_key + survey_step (survey_step is optional,
+// and it defaults to '' on the survey_draft row).
+router.get(
+  // TODO: LF-5475 Update the Express 4-specific `?` optional-param syntax to `{/:survey_step}`
+  '/:survey_key/:survey_step?',
+  checkScope(['get:survey_draft']),
+  checkSurveyDraftKey(),
+  surveyDraftController.getDraft(),
+);
+
+// Idempotent create-or-replace at this exact key — PUT, not POST, since the resource's
+// address is fully known up front rather than server-assigned.
+router.put(
+  // TODO: LF-5475 Update the Express 4-specific `?` optional-param syntax to `{/:survey_step}`
+  '/:survey_key/:survey_step?',
+  checkScope(['edit:survey_draft']),
+  checkSurveyDraftKey(),
+  surveyDraftController.upsertDraft(),
+);
+
+export default router;

--- a/packages/api/src/routes/surveyDraftRoute.ts
+++ b/packages/api/src/routes/surveyDraftRoute.ts
@@ -15,7 +15,10 @@
 
 import express from 'express';
 import checkScope from '../middleware/acl/checkScope.js';
-import { checkSurveyDraftKey } from '../middleware/validation/checkSurveyDraft.js';
+import {
+  checkSurveyDraftKey,
+  checkDraftNotCompleted,
+} from '../middleware/validation/checkSurveyDraft.js';
 import surveyDraftController from '../controllers/surveyDraftController.js';
 
 const router = express.Router();
@@ -37,6 +40,7 @@ router.put(
   '/:survey_key/:survey_step?',
   checkScope(['edit:survey_draft']),
   checkSurveyDraftKey(),
+  checkDraftNotCompleted(),
   surveyDraftController.upsertDraft(),
 );
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -182,6 +182,7 @@ import marketProductCategoryRoute from './routes/marketProductCategoryRoute.js';
 import marketDirectoryPartnerRoute from './routes/marketDirectoryPartnerRoute.js';
 import offlineEventLogRoute from './routes/offlineEventLogRoute.js';
 import surveyResponseRoute from './routes/surveyResponseRoute.js';
+import surveyDraftRoute from './routes/surveyDraftRoute.js';
 import farmNoteRoute from './routes/farmNoteRoute.js';
 import farmNotesReadRoute from './routes/farmNotesReadRoute.js';
 
@@ -372,6 +373,7 @@ app
   .use('/market_directory_partners', marketDirectoryPartnerRoute)
   .use('/offline_event_log', offlineEventLogRoute)
   .use('/survey_response', surveyResponseRoute)
+  .use('/survey_drafts', surveyDraftRoute)
   .use('/farm_notes', farmNoteRoute)
   .use('/farm_notes_read', farmNotesReadRoute);
 

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -2999,6 +2999,28 @@ const farm_noteFactory = async (
     .returning('*');
 };
 
+const fakeSurveyDraft = (defaultData = {}) => {
+  return {
+    survey_key: 'tape',
+    survey_step: '',
+    survey_version: 'v1',
+    survey_data: { [faker.lorem.word()]: faker.lorem.word() },
+    current_page_no: 0,
+    ...defaultData,
+  };
+};
+
+const survey_draftFactory = async (
+  { promisedUserFarm = userFarmFactory({ roleId: 1 }) } = {},
+  surveyDraft = fakeSurveyDraft(),
+) => {
+  const [[{ user_id, farm_id }]] = await Promise.all([promisedUserFarm]);
+
+  return await knex('survey_draft')
+    .insert({ farm_id, ...baseProperties(user_id), ...surveyDraft })
+    .returning('*');
+};
+
 export default {
   weather_stationFactory,
   fakeStation,
@@ -3178,6 +3200,8 @@ export default {
   market_directory_partner_permissionsFactory,
   fakeFarmNote,
   farm_noteFactory,
+  fakeSurveyDraft,
+  survey_draftFactory,
   fakeAnimalSale,
   animal_saleFactory,
   fakeFarmExpenseCropVariety,

--- a/packages/api/tests/mock.factories.js
+++ b/packages/api/tests/mock.factories.js
@@ -3002,7 +3002,6 @@ const farm_noteFactory = async (
 const fakeSurveyDraft = (defaultData = {}) => {
   return {
     survey_key: 'tape',
-    survey_step: '',
     survey_version: 'v1',
     survey_data: { [faker.lorem.word()]: faker.lorem.word() },
     current_page_no: 0,

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -63,7 +63,7 @@ describe('Survey draft endpoint tests', () => {
   async function putRequest(
     survey_data,
     { user_id = owner.user_id, farm_id = farm.farm_id, survey_key = 'tape', survey_step } = {},
-    { survey_version = 'v1', current_page_no = 0 } = {},
+    { survey_version = 'v1', current_page_no = 0, submission_id } = {},
   ) {
     return chai
       .request(server)
@@ -71,7 +71,7 @@ describe('Survey draft endpoint tests', () => {
       .set('Content-Type', 'application/json')
       .set('user_id', user_id)
       .set('farm_id', farm_id)
-      .send({ farm_id, survey_version, survey_data, current_page_no });
+      .send({ farm_id, survey_version, survey_data, current_page_no, submission_id });
   }
 
   beforeEach(async () => {
@@ -189,6 +189,31 @@ describe('Survey draft endpoint tests', () => {
         .where({ farm_id: farm.farm_id, survey_key: 'tape' })
         .first();
       expect(responseRow.submission_id).toBeTruthy();
+    });
+
+    test('A draft write is rejected once its submission_id has already been completed', async () => {
+      await postSurveyResponse();
+      const { submission_id } = await knex('survey_response')
+        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+        .first();
+
+      const res = await putRequest({ q1: 'too late' }, {}, { submission_id });
+      expect(res.status).toBe(409);
+
+      const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
+      expect(rows.length).toBe(0);
+    });
+
+    test('A draft write is unaffected by a completed survey under a different submission_id', async () => {
+      await postSurveyResponse();
+      const { submission_id: completedId } = await knex('survey_response')
+        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+        .first();
+      const unrelatedId = '11111111-1111-1111-1111-111111111111';
+      expect(unrelatedId).not.toBe(completedId);
+
+      const res = await putRequest({ q1: 'answer' }, {}, { submission_id: unrelatedId });
+      expect(res.status).toBe(201);
     });
   });
 

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -1,0 +1,246 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+import server from './../src/server.js';
+import knex from '../src/util/knex.js';
+import { tableCleanup } from './testEnvironment.js';
+
+jest.mock('jsdom');
+jest.mock('../src/middleware/acl/checkJwt.js', () =>
+  jest.fn((req, _res, next) => {
+    req.auth = {};
+    req.auth.user_id = req.get('user_id');
+    next();
+  }),
+);
+
+import mocks from './mock.factories.js';
+import { createUserFarmIds } from './utils/testDataSetup.js';
+
+describe('Survey draft endpoint tests', () => {
+  let owner;
+  let farm;
+  let _ownerFarm;
+
+  function fakeUserFarm(role = 1) {
+    return { ...mocks.fakeUserFarm(), role_id: role };
+  }
+
+  function draftPath(survey_key = 'tape', survey_step) {
+    return survey_step
+      ? `/survey_drafts/${survey_key}/${survey_step}`
+      : `/survey_drafts/${survey_key}`;
+  }
+
+  async function getDraftRequest({
+    user_id = owner.user_id,
+    farm_id = farm.farm_id,
+    survey_key = 'tape',
+    survey_step,
+  } = {}) {
+    return chai
+      .request(server)
+      .get(draftPath(survey_key, survey_step))
+      .set('user_id', user_id)
+      .set('farm_id', farm_id);
+  }
+
+  async function putRequest(
+    survey_data,
+    { user_id = owner.user_id, farm_id = farm.farm_id, survey_key = 'tape', survey_step } = {},
+    { survey_version = 'v1', current_page_no = 0 } = {},
+  ) {
+    return chai
+      .request(server)
+      .put(draftPath(survey_key, survey_step))
+      .set('Content-Type', 'application/json')
+      .set('user_id', user_id)
+      .set('farm_id', farm_id)
+      .send({ farm_id, survey_version, survey_data, current_page_no });
+  }
+
+  beforeEach(async () => {
+    [owner] = await mocks.usersFactory();
+    [farm] = await mocks.farmFactory();
+    [_ownerFarm] = await mocks.userFarmFactory(
+      { promisedUser: [owner], promisedFarm: [farm] },
+      fakeUserFarm(1),
+    );
+  });
+
+  afterEach(async () => {
+    await tableCleanup(knex);
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+  });
+
+  describe('GET /survey_drafts/:survey_key/:survey_step?', () => {
+    test('Should return no content when no draft exists', async () => {
+      const res = await getDraftRequest();
+      expect(res.status).toBe(200);
+      expect(res.body?.survey_data).toBeUndefined();
+    });
+
+    test('Should return the live draft for the farm when no survey_step is given', async () => {
+      await mocks.survey_draftFactory(
+        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
+        mocks.fakeSurveyDraft({ survey_data: { q1: 'answer' } }),
+      );
+      const res = await getDraftRequest();
+      expect(res.status).toBe(200);
+      expect(res.body.survey_data).toEqual({ q1: 'answer' });
+      expect(res.body.survey_step).toBe('');
+    });
+
+    test('Should return the live draft for the farm for a given survey_step', async () => {
+      await mocks.survey_draftFactory(
+        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
+        mocks.fakeSurveyDraft({ survey_data: { q1: 'answer' }, survey_step: 'step-1' }),
+      );
+      const res = await getDraftRequest({ survey_step: 'step-1' });
+      expect(res.status).toBe(200);
+      expect(res.body.survey_data).toEqual({ q1: 'answer' });
+      expect(res.body.survey_step).toBe('step-1');
+    });
+
+    test('Should not return another farm draft', async () => {
+      const otherFarm = await createUserFarmIds(1);
+      await mocks.survey_draftFactory(
+        { promisedUserFarm: [otherFarm] },
+        mocks.fakeSurveyDraft({ survey_data: { q1: 'answer' } }),
+      );
+
+      const res = await getDraftRequest();
+      expect(res.status).toBe(200);
+      expect(res.body?.survey_data).toBeUndefined();
+    });
+
+    test('Worker should not be able to get a draft', async () => {
+      const userFarmIds = await createUserFarmIds(3);
+      const res = await getDraftRequest(userFarmIds);
+      expect(res.status).toBe(403);
+    });
+
+    test('Should return 403 if user is not part of the farm', async () => {
+      const idsA = await createUserFarmIds(1);
+      const idsB = await createUserFarmIds(1);
+      const res = await getDraftRequest({ farm_id: idsA.farm_id, user_id: idsB.user_id });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Draft cleanup on survey submission', () => {
+    async function postSurveyResponse(survey_key = 'tape') {
+      return chai
+        .request(server)
+        .post('/survey_response')
+        .set('Content-Type', 'application/json')
+        .set('user_id', owner.user_id)
+        .set('farm_id', farm.farm_id)
+        .send({
+          farm_id: farm.farm_id,
+          survey_key,
+          survey_response: { survey_version: 'v1', project_id: 'project-1', survey_step: 'step-1' },
+        });
+    }
+
+    test('Submitting the survey soft-deletes the live draft and reuses its submission_id', async () => {
+      const [draft] = await mocks.survey_draftFactory(
+        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
+        mocks.fakeSurveyDraft({ survey_step: 'step-1' }),
+      );
+
+      await postSurveyResponse();
+
+      const getRes = await getDraftRequest({ survey_step: 'step-1' });
+      expect(getRes.body?.survey_data).toBeUndefined();
+
+      const draftRow = await knex('survey_draft').where({ id: draft.id }).first();
+      expect(draftRow.deleted).toBe(true);
+
+      const responseRow = await knex('survey_response')
+        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+        .first();
+      expect(responseRow.submission_id).toBe(draft.submission_id);
+    });
+
+    test('Submitting without a prior draft still succeeds with a fresh submission_id', async () => {
+      const res = await postSurveyResponse();
+      expect(res.status).toBe(201);
+
+      const responseRow = await knex('survey_response')
+        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+        .first();
+      expect(responseRow.submission_id).toBeTruthy();
+    });
+  });
+
+  describe('PUT /survey_drafts/:survey_key/:survey_step?', () => {
+    test('Admin roles should be able to create a draft', async () => {
+      const adminRoles = [1, 2, 5];
+      for (const role of adminRoles) {
+        const userFarmIds = await createUserFarmIds(role);
+        const res = await putRequest({ q1: 'answer' }, userFarmIds);
+
+        expect(res.status).toBe(201);
+        expect(res.body.survey_data).toEqual({ q1: 'answer' });
+        expect(res.body.submission_id).toBeTruthy();
+      }
+    });
+
+    test('Worker should not be able to save a draft', async () => {
+      const userFarmIds = await createUserFarmIds(3);
+      const res = await putRequest({ q1: 'answer' }, userFarmIds);
+      expect(res.status).toBe(403);
+    });
+
+    test('Should return 403 if user is not part of the farm', async () => {
+      const idsA = await createUserFarmIds(1);
+      const idsB = await createUserFarmIds(1);
+      const res = await putRequest(
+        { q1: 'answer' },
+        { farm_id: idsA.farm_id, user_id: idsB.user_id },
+      );
+      expect(res.status).toBe(403);
+    });
+
+    test('Saving again for the same key updates the existing draft rather than creating a new one', async () => {
+      const first = await putRequest({ q1: 'first' }, {}, { current_page_no: 0 });
+      expect(first.status).toBe(201);
+
+      const second = await putRequest({ q1: 'second' }, {}, { current_page_no: 1 });
+      expect(second.status).toBe(200);
+      expect(second.body.id).toBe(first.body.id);
+      expect(second.body.submission_id).toBe(first.body.submission_id);
+      expect(second.body.survey_data).toEqual({ q1: 'second' });
+
+      const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
+      expect(rows.length).toBe(1);
+    });
+
+    test('A different survey_step for the same survey_key is a separate draft', async () => {
+      await putRequest({ q1: 'step-1-answer' }, { survey_step: 'step-1' });
+      await putRequest({ q1: 'step-2-answer' }, { survey_step: 'step-2' });
+
+      const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
+      expect(rows.length).toBe(2);
+    });
+  });
+});

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -72,6 +72,20 @@ describe('Survey draft endpoint tests', () => {
       .send({ farm_id, survey_version, survey_data, current_page_no, submission_id });
   }
 
+  async function postSurveyResponse(survey_key = 'tape') {
+    return chai
+      .request(server)
+      .post('/survey_response')
+      .set('Content-Type', 'application/json')
+      .set('user_id', owner.user_id)
+      .set('farm_id', farm.farm_id)
+      .send({
+        farm_id: farm.farm_id,
+        survey_key,
+        survey_response: { survey_version: 'v1', project_id: 'project-1', survey_step: 'step-1' },
+      });
+  }
+
   beforeEach(async () => {
     [owner] = await mocks.usersFactory();
     [farm] = await mocks.farmFactory();
@@ -90,6 +104,21 @@ describe('Survey draft endpoint tests', () => {
   });
 
   describe('GET /survey_drafts/:survey_key', () => {
+    test('Admin roles should be able to get a draft', async () => {
+      const adminRoles = [1, 2, 5];
+      for (const role of adminRoles) {
+        const userFarmIds = await createUserFarmIds(role);
+        await mocks.survey_draftFactory(
+          { promisedUserFarm: [userFarmIds] },
+          mocks.fakeSurveyDraft({ survey_data: { q1: 'answer' } }),
+        );
+
+        const res = await getDraftRequest(userFarmIds);
+        expect(res.status).toBe(200);
+        expect(res.body.survey_data).toEqual({ q1: 'answer' });
+      }
+    });
+
     test('Should return no content when no draft exists', async () => {
       const res = await getDraftRequest();
       expect(res.status).toBe(200);
@@ -130,83 +159,6 @@ describe('Survey draft endpoint tests', () => {
       const idsB = await createUserFarmIds(1);
       const res = await getDraftRequest({ farm_id: idsA.farm_id, user_id: idsB.user_id });
       expect(res.status).toBe(403);
-    });
-  });
-
-  describe('Draft cleanup on survey submission', () => {
-    async function postSurveyResponse(survey_key = 'tape') {
-      return chai
-        .request(server)
-        .post('/survey_response')
-        .set('Content-Type', 'application/json')
-        .set('user_id', owner.user_id)
-        .set('farm_id', farm.farm_id)
-        .send({
-          farm_id: farm.farm_id,
-          survey_key,
-          survey_response: { survey_version: 'v1', project_id: 'project-1', survey_step: 'step-1' },
-        });
-    }
-
-    test('Submitting the survey soft-deletes the live draft and reuses its submission_id', async () => {
-      const [draft] = await mocks.survey_draftFactory(
-        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
-        mocks.fakeSurveyDraft(),
-      );
-
-      await postSurveyResponse();
-
-      const getRes = await getDraftRequest();
-      expect(getRes.body?.survey_data).toBeUndefined();
-
-      const draftRow = await knex('survey_draft').where({ id: draft.id }).first();
-      expect(draftRow.deleted).toBe(true);
-
-      const responseRow = await knex('survey_response')
-        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
-        .first();
-      expect(responseRow.submission_id).toBe(draft.submission_id);
-    });
-
-    test('Submitting without a prior draft still succeeds with a fresh submission_id', async () => {
-      const res = await postSurveyResponse();
-      expect(res.status).toBe(201);
-
-      const responseRow = await knex('survey_response')
-        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
-        .first();
-      expect(responseRow.submission_id).toBeTruthy();
-    });
-
-    test('A draft write is rejected once its submission_id has already been completed', async () => {
-      await postSurveyResponse();
-      const { submission_id } = await knex('survey_response')
-        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
-        .first();
-
-      const res = await putRequest({ q1: 'too late' }, {}, { submission_id });
-      expect(res.status).toBe(409);
-
-      const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
-      expect(rows.length).toBe(0);
-    });
-
-    // TODO: LF-5192 Delete once we support retake/update
-    test('A draft write is rejected regardless of which submission_id is sent, once the survey is completed', async () => {
-      await postSurveyResponse();
-      const unrelatedId = '11111111-1111-1111-1111-111111111111';
-
-      const res = await putRequest({ q1: 'too late' }, {}, { submission_id: unrelatedId });
-      expect(res.status).toBe(409);
-    });
-
-    // TODO: LF-5192 Enable
-    xtest('A draft write is unaffected by a completed survey under a different submission_id', async () => {
-      await postSurveyResponse();
-      const unrelatedId = '11111111-1111-1111-1111-111111111111';
-
-      const res = await putRequest({ q1: 'answer' }, {}, { submission_id: unrelatedId });
-      expect(res.status).toBe(201);
     });
   });
 
@@ -252,6 +204,71 @@ describe('Survey draft endpoint tests', () => {
 
       const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
       expect(rows.length).toBe(1);
+    });
+
+    describe('Draft writes after survey completion', () => {
+      test('A draft write is rejected once its submission_id has already been completed', async () => {
+        await postSurveyResponse();
+        const { submission_id } = await knex('survey_response')
+          .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+          .first();
+
+        const res = await putRequest({ q1: 'too late' }, {}, { submission_id });
+        expect(res.status).toBe(409);
+
+        const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
+        expect(rows.length).toBe(0);
+      });
+
+      // TODO: LF-5192 Delete once we support retake/update
+      test('A draft write is rejected regardless of which submission_id is sent, once the survey is completed', async () => {
+        await postSurveyResponse();
+        const unrelatedId = '11111111-1111-1111-1111-111111111111';
+
+        const res = await putRequest({ q1: 'too late' }, {}, { submission_id: unrelatedId });
+        expect(res.status).toBe(409);
+      });
+
+      // TODO: LF-5192 Enable
+      xtest('A draft write is unaffected by a completed survey under a different submission_id', async () => {
+        await postSurveyResponse();
+        const unrelatedId = '11111111-1111-1111-1111-111111111111';
+
+        const res = await putRequest({ q1: 'answer' }, {}, { submission_id: unrelatedId });
+        expect(res.status).toBe(201);
+      });
+    });
+  });
+
+  describe('Draft cleanup on survey submission', () => {
+    test('Submitting the survey soft-deletes the live draft and reuses its submission_id', async () => {
+      const [draft] = await mocks.survey_draftFactory(
+        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
+        mocks.fakeSurveyDraft(),
+      );
+
+      await postSurveyResponse();
+
+      const getRes = await getDraftRequest();
+      expect(getRes.body?.survey_data).toBeUndefined();
+
+      const draftRow = await knex('survey_draft').where({ id: draft.id }).first();
+      expect(draftRow.deleted).toBe(true);
+
+      const responseRow = await knex('survey_response')
+        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+        .first();
+      expect(responseRow.submission_id).toBe(draft.submission_id);
+    });
+
+    test('Submitting without a prior draft still succeeds with a fresh submission_id', async () => {
+      const res = await postSurveyResponse();
+      expect(res.status).toBe(201);
+
+      const responseRow = await knex('survey_response')
+        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
+        .first();
+      expect(responseRow.submission_id).toBeTruthy();
     });
   });
 });

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -193,27 +193,45 @@ describe('Survey draft endpoint tests', () => {
     });
 
     test('A draft write is rejected once its submission_id has already been completed', async () => {
-      await postSurveyResponse();
+      await postSurveyResponse(); // completes survey_step: 'step-1'
       const { submission_id } = await knex('survey_response')
         .where({ farm_id: farm.farm_id, survey_key: 'tape' })
         .first();
 
-      const res = await putRequest({ q1: 'too late' }, {}, { submission_id });
+      const res = await putRequest(
+        { q1: 'too late' },
+        { survey_step: 'step-1' },
+        { submission_id },
+      );
       expect(res.status).toBe(409);
 
       const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
       expect(rows.length).toBe(0);
     });
 
-    test('A draft write is unaffected by a completed survey under a different submission_id', async () => {
-      await postSurveyResponse();
-      const { submission_id: completedId } = await knex('survey_response')
-        .where({ farm_id: farm.farm_id, survey_key: 'tape' })
-        .first();
+    // TODO: LF-5192 Delete once we support retake/update
+    test('A draft write is rejected regardless of which submission_id is sent, once the survey_step is completed', async () => {
+      await postSurveyResponse(); // completes survey_step: 'step-1'
       const unrelatedId = '11111111-1111-1111-1111-111111111111';
-      expect(unrelatedId).not.toBe(completedId);
 
-      const res = await putRequest({ q1: 'answer' }, {}, { submission_id: unrelatedId });
+      const res = await putRequest(
+        { q1: 'too late' },
+        { survey_step: 'step-1' },
+        { submission_id: unrelatedId },
+      );
+      expect(res.status).toBe(409);
+    });
+
+    // TODO: LF-5192 Enable
+    xtest('A draft write is unaffected by a completed survey under a different submission_id', async () => {
+      await postSurveyResponse(); // completes survey_step: 'step-1'
+      const unrelatedId = '11111111-1111-1111-1111-111111111111';
+
+      const res = await putRequest(
+        { q1: 'answer' },
+        { survey_step: 'step-1' },
+        { submission_id: unrelatedId },
+      );
       expect(res.status).toBe(201);
     });
   });

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -107,6 +107,7 @@ describe('Survey draft endpoint tests', () => {
       expect(res.status).toBe(200);
       expect(res.body.survey_data).toEqual({ q1: 'answer' });
       expect(res.body.survey_step).toBe('');
+      expect(res.body.updated_at).toBeTruthy();
     });
 
     test('Should return the live draft for the farm for a given survey_step', async () => {
@@ -227,6 +228,7 @@ describe('Survey draft endpoint tests', () => {
         expect(res.status).toBe(201);
         expect(res.body.survey_data).toEqual({ q1: 'answer' });
         expect(res.body.submission_id).toBeTruthy();
+        expect(res.body.updated_at).toBeTruthy();
       }
     });
 

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -16,6 +16,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 chai.use(chaiHttp);
+import { faker } from '@faker-js/faker';
 import server from './../src/server.js';
 import knex from '../src/util/knex.js';
 import { tableCleanup } from './testEnvironment.js';
@@ -41,33 +42,30 @@ describe('Survey draft endpoint tests', () => {
     return { ...mocks.fakeUserFarm(), role_id: role };
   }
 
-  function draftPath(survey_key = 'tape', survey_step) {
-    return survey_step
-      ? `/survey_drafts/${survey_key}/${survey_step}`
-      : `/survey_drafts/${survey_key}`;
+  function draftPath(survey_key = 'tape') {
+    return `/survey_drafts/${survey_key}`;
   }
 
   async function getDraftRequest({
     user_id = owner.user_id,
     farm_id = farm.farm_id,
     survey_key = 'tape',
-    survey_step,
   } = {}) {
     return chai
       .request(server)
-      .get(draftPath(survey_key, survey_step))
+      .get(draftPath(survey_key))
       .set('user_id', user_id)
       .set('farm_id', farm_id);
   }
 
   async function putRequest(
     survey_data,
-    { user_id = owner.user_id, farm_id = farm.farm_id, survey_key = 'tape', survey_step } = {},
+    { user_id = owner.user_id, farm_id = farm.farm_id, survey_key = 'tape' } = {},
     { survey_version = 'v1', current_page_no = 0, submission_id } = {},
   ) {
     return chai
       .request(server)
-      .put(draftPath(survey_key, survey_step))
+      .put(draftPath(survey_key))
       .set('Content-Type', 'application/json')
       .set('user_id', user_id)
       .set('farm_id', farm_id)
@@ -91,34 +89,22 @@ describe('Survey draft endpoint tests', () => {
     await knex.destroy();
   });
 
-  describe('GET /survey_drafts/:survey_key/:survey_step?', () => {
+  describe('GET /survey_drafts/:survey_key', () => {
     test('Should return no content when no draft exists', async () => {
       const res = await getDraftRequest();
       expect(res.status).toBe(200);
       expect(res.body?.survey_data).toBeUndefined();
     });
 
-    test('Should return the live draft for the farm when no survey_step is given', async () => {
+    test('Should return the live draft for the farm for a given survey_key', async () => {
+      const surveyKey = faker.lorem.word();
       await mocks.survey_draftFactory(
         { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
-        mocks.fakeSurveyDraft({ survey_data: { q1: 'answer' } }),
+        mocks.fakeSurveyDraft({ survey_key: surveyKey, survey_data: { q1: 'answer' } }),
       );
-      const res = await getDraftRequest();
+      const res = await getDraftRequest({ survey_key: surveyKey });
       expect(res.status).toBe(200);
       expect(res.body.survey_data).toEqual({ q1: 'answer' });
-      expect(res.body.survey_step).toBe('');
-      expect(res.body.updated_at).toBeTruthy();
-    });
-
-    test('Should return the live draft for the farm for a given survey_step', async () => {
-      await mocks.survey_draftFactory(
-        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
-        mocks.fakeSurveyDraft({ survey_data: { q1: 'answer' }, survey_step: 'step-1' }),
-      );
-      const res = await getDraftRequest({ survey_step: 'step-1' });
-      expect(res.status).toBe(200);
-      expect(res.body.survey_data).toEqual({ q1: 'answer' });
-      expect(res.body.survey_step).toBe('step-1');
     });
 
     test('Should not return another farm draft', async () => {
@@ -165,12 +151,12 @@ describe('Survey draft endpoint tests', () => {
     test('Submitting the survey soft-deletes the live draft and reuses its submission_id', async () => {
       const [draft] = await mocks.survey_draftFactory(
         { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
-        mocks.fakeSurveyDraft({ survey_step: 'step-1' }),
+        mocks.fakeSurveyDraft(),
       );
 
       await postSurveyResponse();
 
-      const getRes = await getDraftRequest({ survey_step: 'step-1' });
+      const getRes = await getDraftRequest();
       expect(getRes.body?.survey_data).toBeUndefined();
 
       const draftRow = await knex('survey_draft').where({ id: draft.id }).first();
@@ -193,16 +179,12 @@ describe('Survey draft endpoint tests', () => {
     });
 
     test('A draft write is rejected once its submission_id has already been completed', async () => {
-      await postSurveyResponse(); // completes survey_step: 'step-1'
+      await postSurveyResponse();
       const { submission_id } = await knex('survey_response')
         .where({ farm_id: farm.farm_id, survey_key: 'tape' })
         .first();
 
-      const res = await putRequest(
-        { q1: 'too late' },
-        { survey_step: 'step-1' },
-        { submission_id },
-      );
+      const res = await putRequest({ q1: 'too late' }, {}, { submission_id });
       expect(res.status).toBe(409);
 
       const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
@@ -210,33 +192,25 @@ describe('Survey draft endpoint tests', () => {
     });
 
     // TODO: LF-5192 Delete once we support retake/update
-    test('A draft write is rejected regardless of which submission_id is sent, once the survey_step is completed', async () => {
-      await postSurveyResponse(); // completes survey_step: 'step-1'
+    test('A draft write is rejected regardless of which submission_id is sent, once the survey is completed', async () => {
+      await postSurveyResponse();
       const unrelatedId = '11111111-1111-1111-1111-111111111111';
 
-      const res = await putRequest(
-        { q1: 'too late' },
-        { survey_step: 'step-1' },
-        { submission_id: unrelatedId },
-      );
+      const res = await putRequest({ q1: 'too late' }, {}, { submission_id: unrelatedId });
       expect(res.status).toBe(409);
     });
 
     // TODO: LF-5192 Enable
     xtest('A draft write is unaffected by a completed survey under a different submission_id', async () => {
-      await postSurveyResponse(); // completes survey_step: 'step-1'
+      await postSurveyResponse();
       const unrelatedId = '11111111-1111-1111-1111-111111111111';
 
-      const res = await putRequest(
-        { q1: 'answer' },
-        { survey_step: 'step-1' },
-        { submission_id: unrelatedId },
-      );
+      const res = await putRequest({ q1: 'answer' }, {}, { submission_id: unrelatedId });
       expect(res.status).toBe(201);
     });
   });
 
-  describe('PUT /survey_drafts/:survey_key/:survey_step?', () => {
+  describe('PUT /survey_drafts/:survey_key', () => {
     test('Admin roles should be able to create a draft', async () => {
       const adminRoles = [1, 2, 5];
       for (const role of adminRoles) {
@@ -278,14 +252,6 @@ describe('Survey draft endpoint tests', () => {
 
       const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
       expect(rows.length).toBe(1);
-    });
-
-    test('A different survey_step for the same survey_key is a separate draft', async () => {
-      await putRequest({ q1: 'step-1-answer' }, { survey_step: 'step-1' });
-      await putRequest({ q1: 'step-2-answer' }, { survey_step: 'step-2' });
-
-      const rows = await knex('survey_draft').where({ farm_id: farm.farm_id });
-      expect(rows.length).toBe(2);
     });
   });
 });

--- a/packages/api/tests/testEnvironment.js
+++ b/packages/api/tests/testEnvironment.js
@@ -157,6 +157,7 @@ async function tableCleanup(knex) {
     DELETE FROM "market_directory_partner_auth";
     DELETE FROM "market_directory_partner";
     DELETE FROM "survey_response";
+    DELETE FROM "survey_draft";
     DELETE FROM "farm_notes_read";
     DELETE FROM "farm_note";
     DELETE FROM "location";

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -103,10 +103,7 @@ export const supportTicketUrl = `${URI}/support_ticket`;
 export const logUserInfoUrl = `${URI}/userLog`;
 export const offlineEventLogUrl = `${URI}/offline_event_log`;
 export const surveyResponseUrl = `${URI}/survey_response`;
-export const getSurveyDraftUrl = (surveyKey, surveyStep) =>
-  surveyStep
-    ? `${URI}/survey_drafts/${surveyKey}/${surveyStep}`
-    : `${URI}/survey_drafts/${surveyKey}`;
+export const getSurveyDraftUrl = (surveyKey) => `${URI}/survey_drafts/${surveyKey}`;
 export const farmNoteUrl = `${URI}/farm_notes`;
 export const farmNotesReadUrl = `${URI}/farm_notes_read`;
 export const certificationsUrl = `${URI}/certifications`;

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -103,6 +103,10 @@ export const supportTicketUrl = `${URI}/support_ticket`;
 export const logUserInfoUrl = `${URI}/userLog`;
 export const offlineEventLogUrl = `${URI}/offline_event_log`;
 export const surveyResponseUrl = `${URI}/survey_response`;
+export const getSurveyDraftUrl = (surveyKey, surveyStep) =>
+  surveyStep
+    ? `${URI}/survey_drafts/${surveyKey}/${surveyStep}`
+    : `${URI}/survey_drafts/${surveyKey}`;
 export const farmNoteUrl = `${URI}/farm_notes`;
 export const farmNotesReadUrl = `${URI}/farm_notes_read`;
 export const certificationsUrl = `${URI}/certifications`;

--- a/packages/webapp/src/containers/Insights/Survey/SurveyInsightTile.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/SurveyInsightTile.tsx
@@ -21,7 +21,7 @@ import { Semibold, Text } from '../../../components/Typography';
 import { useGetLatestSurveyResponseQuery } from '../../../store/api/surveyApi';
 import { useSurveyTitle } from './useSurveyTitle';
 import useInitialDraft from './useInitialDraft';
-import { getSurveyStep, surveyHasResultsPage } from './surveyConfig';
+import { surveyHasResultsPage } from './surveyConfig';
 
 interface SurveyInsightTileProps {
   surveyId: string;
@@ -45,8 +45,7 @@ function SurveyInsightTile({ surveyId, image, index }: SurveyInsightTileProps) {
     isFetching,
   } = useGetLatestSurveyResponseQuery({ surveyKey: surveyId });
 
-  const surveyStep = getSurveyStep(surveyId);
-  const { isDraftLoading, initialDraft } = useInitialDraft(surveyId, surveyStep);
+  const { isDraftLoading, initialDraft } = useInitialDraft(surveyId);
   const inProgress = Object.keys(initialDraft.surveyData || {}).length > 0;
 
   const isCompleted = !isError && !!surveyResponse?.id;

--- a/packages/webapp/src/containers/Insights/Survey/SurveyInsightTile.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/SurveyInsightTile.tsx
@@ -13,16 +13,15 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { BsChevronRight } from 'react-icons/bs';
 import insightStyles from '../styles.module.scss';
 import { Semibold, Text } from '../../../components/Typography';
 import { useGetLatestSurveyResponseQuery } from '../../../store/api/surveyApi';
-import { surveyInProgressSelector } from './surveyDraftSlice';
 import { useSurveyTitle } from './useSurveyTitle';
-import { surveyHasResultsPage } from './surveyConfig';
+import useInitialDraft from './useInitialDraft';
+import { getSurveyStep, surveyHasResultsPage } from './surveyConfig';
 
 interface SurveyInsightTileProps {
   surveyId: string;
@@ -45,12 +44,15 @@ function SurveyInsightTile({ surveyId, image, index }: SurveyInsightTileProps) {
     isError,
     isFetching,
   } = useGetLatestSurveyResponseQuery({ surveyKey: surveyId });
-  const inProgress = useSelector(surveyInProgressSelector(surveyId));
+
+  const surveyStep = getSurveyStep(surveyId);
+  const { isDraftLoading, initialDraft } = useInitialDraft(surveyId, surveyStep);
+  const inProgress = Object.keys(initialDraft.surveyData || {}).length > 0;
 
   const isCompleted = !isError && !!surveyResponse?.id;
 
   let currentData = t('INSIGHTS.TAPE.NOT_FILLED');
-  if (isFetching) {
+  if (isFetching || isDraftLoading) {
     currentData = t('common:LOADING');
   } else if (inProgress) {
     currentData = t('INSIGHTS.TAPE.IN_PROGRESS');

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { CompleteEvent } from 'survey-core';
@@ -145,6 +145,17 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
     [surveyId, surveyStep, surveyVersion, dispatch, upsertSurveyDraft],
   );
 
+  const latestDraftRef = useRef({ surveyData: surveyDataInProgress, currentPageNo: savedPageNo });
+
+  useEffect(() => {
+    return () => {
+      persistDraft({
+        survey_data: latestDraftRef.current.surveyData,
+        current_page_no: latestDraftRef.current.currentPageNo,
+      });
+    };
+  }, []);
+
   const initialData = { ...prepopulatedData, ...surveyDataInProgress };
 
   const handleDataChange = useCallback(
@@ -152,6 +163,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       dispatch(
         saveSurveyProgress({ surveyId, currentPageNo, surveyData, surveyVersion, surveyStep }),
       );
+      latestDraftRef.current = { surveyData, currentPageNo };
     },
     [surveyId, surveyVersion, surveyStep],
   );
@@ -234,6 +246,14 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
 
   const isLoading = isPrepopulatedDataLoading || isSurveyJsonLoading;
 
+  const onCurrentPageChanged = useCallback(
+    (currentPageNo: number, surveyData: Record<string, unknown>) => {
+      persistDraft({ current_page_no: currentPageNo, survey_data: surveyData });
+      latestDraftRef.current = { surveyData, currentPageNo };
+    },
+    [persistDraft],
+  );
+
   return (
     <div className={insightStyles.insightContainer}>
       <PageTitle title={surveyTitle} backUrl="/Insights" />
@@ -251,6 +271,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
             onValueChanged={handleDataChange}
             initialData={initialData}
             initialPageNo={savedPageNo}
+            onCurrentPageChanged={onCurrentPageChanged}
           />
         )}
       </div>

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useSurveyPrepopulatedData } from './useSurveyPrepopulatedData';
 import { useSurveyTitle } from './useSurveyTitle';
 import { saveSurveyProgress, clearSurvey } from './surveyDraftSlice';
-import { SURVEY_INFO, getSurveyCdnPath, getSurveyStep, getSurveyVersion } from './surveyConfig';
+import { SURVEY_INFO, getSurveyCdnPath, getSurveyVersion } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
 import PageTitle from '../../../components/PageTitle';
@@ -53,9 +53,8 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const { farm_id, country_code } = useSelector(userFarmSelector);
 
   const cdnDirectory = SURVEY_INFO[surveyId]?.cdnDirectory;
-  const surveyStep = getSurveyStep(surveyId);
 
-  const draftState = useInitialDraft(surveyId, surveyStep);
+  const draftState = useInitialDraft(surveyId);
   const hasDraft = Object.keys(draftState.initialDraft.surveyData || {}).length > 0;
 
   const { version: cdnPath, fallbackVersion: cdnFallbackPath } =
@@ -97,7 +96,6 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const { onCurrentPageChanged, recordLatestDraft } = useSurveyDraftSync({
     surveyId,
     surveyVersion,
-    surveyStep,
     ...draftState,
   });
 
@@ -108,12 +106,10 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
 
   const handleDataChange = useCallback(
     (currentPageNo: number, surveyData: Record<string, any>) => {
-      dispatch(
-        saveSurveyProgress({ surveyId, currentPageNo, surveyData, surveyVersion, surveyStep }),
-      );
+      dispatch(saveSurveyProgress({ surveyId, currentPageNo, surveyData, surveyVersion }));
       recordLatestDraft(surveyData, currentPageNo);
     },
-    [surveyId, surveyVersion, surveyStep],
+    [surveyId, surveyVersion],
   );
 
   const handleComplete = useCallback(
@@ -125,7 +121,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
           farm_id,
         }).unwrap();
         prefetchLatestResponse({ surveyKey: surveyId });
-        dispatch(clearSurvey({ surveyId, surveyStep }));
+        dispatch(clearSurvey({ surveyId }));
         // Replace instead of push so the submitted survey is not left in the history stack
         history.replace(`/insights/survey/${surveyId}/results`);
       } catch {

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useSurveyPrepopulatedData } from './useSurveyPrepopulatedData';
 import { useSurveyTitle } from './useSurveyTitle';
 import { saveSurveyProgress, clearSurvey } from './surveyDraftSlice';
-import { SURVEY_INFO, getSurveyCdnPath, getSurveyVersion } from './surveyConfig';
+import { SURVEY_INFO, getSurveyCdnPath, getSurveyStep, getSurveyVersion } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
 import PageTitle from '../../../components/PageTitle';
@@ -42,14 +42,6 @@ import useInitialDraft from './useInitialDraft';
 interface SurveyProps {
   isCompactSideMenu: boolean;
 }
-
-// TODO: LF-5127 Implement properly
-const getSurveyStep = (surveyId: string) => {
-  if (surveyId === 'cathi_gao') {
-    return '';
-  }
-  return 'STEP1';
-};
 
 function Survey({ isCompactSideMenu }: SurveyProps) {
   const { t } = useTranslation();

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -215,6 +215,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
             surveyData: serverDraft.survey_data,
             surveyVersion: serverDraft.survey_version,
             surveyStep,
+            updatedAt: new Date(serverDraft.updated_at).getTime(),
           }),
         );
       }

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { CompleteEvent } from 'survey-core';
@@ -21,12 +21,7 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { useSurveyPrepopulatedData } from './useSurveyPrepopulatedData';
 import { useSurveyTitle } from './useSurveyTitle';
-import {
-  saveSurveyProgress,
-  setDraftSubmissionId,
-  clearSurvey,
-  surveyDraftSelector,
-} from './surveyDraftSlice';
+import { saveSurveyProgress, clearSurvey } from './surveyDraftSlice';
 import { SURVEY_INFO, getSurveyCdnPath, getSurveyVersion } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
@@ -36,14 +31,13 @@ import {
   usePrefetch,
   useGetSurveyJsonQuery,
   useAddSurveyResponseMutation,
-  useGetSurveyDraftQuery,
-  useUpsertSurveyDraftMutation,
 } from '../../../store/api/surveyApi';
-import { isFetchBaseQueryError } from '../../../store/api/typeGuards';
 import { enqueueErrorSnackbar, snackbarSelector } from '../../Snackbar/snackbarSlice';
 import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 import styles from './styles.module.scss';
 import insightStyles from '../styles.module.scss';
+import useSurveyDraftSync from './useSurveyDraftSync';
+import useInitialDraft from './useInitialDraft';
 
 interface SurveyProps {
   isCompactSideMenu: boolean;
@@ -69,23 +63,19 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const cdnDirectory = SURVEY_INFO[surveyId]?.cdnDirectory;
   const surveyStep = getSurveyStep(surveyId);
 
-  const {
-    surveyData: surveyDataInProgress,
-    currentPageNo: savedPageNo,
-    surveyVersion: draftSurveyVersion,
-    submissionId,
-  } = useSelector(surveyDraftSelector(surveyId, surveyStep));
-
-  const hasDraft = Object.keys(surveyDataInProgress).length > 0;
+  const draftState = useInitialDraft(surveyId, surveyStep);
+  const hasDraft = Object.keys(draftState.initialDraft.surveyData || {}).length > 0;
 
   const { version: cdnPath, fallbackVersion: cdnFallbackPath } =
-    getSurveyCdnPath(
-      surveyId,
-      country_code,
-      getLanguageFromLocalStorage() || 'en',
-      draftSurveyVersion,
-      hasDraft,
-    ) || {};
+    (!draftState.isDraftLoading &&
+      getSurveyCdnPath(
+        surveyId,
+        country_code,
+        getLanguageFromLocalStorage() || 'en',
+        draftState.initialDraft.surveyVersion,
+        hasDraft,
+      )) ||
+    {};
 
   const {
     data: surveyJson,
@@ -108,62 +98,28 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const [addSurveyResponse] = useAddSurveyResponseMutation();
   const prefetchLatestResponse = usePrefetch('getLatestSurveyResponse');
 
-  const { data: serverDraft, isLoading: isServerDraftLoading } = useGetSurveyDraftQuery(
-    { surveyKey: surveyId, surveyStep },
-    { skip: !surveyId },
-  );
-  const [upsertSurveyDraft] = useUpsertSurveyDraftMutation();
-
   const notifications: { message: string }[] = useSelector(snackbarSelector);
 
   const surveyVersion = surveyJson ? getSurveyVersion(surveyJson) : undefined;
 
-  // Upserts the draft to the server, then syncs the returned submission_id into Redux.
-  const persistDraft = useCallback(
-    async (payload: { survey_data: Record<string, any>; current_page_no?: number }) => {
-      if (!surveyVersion) {
-        return;
-      }
-      try {
-        const created = await upsertSurveyDraft({
-          surveyKey: surveyId,
-          surveyStep,
-          survey_version: surveyVersion,
-          ...payload,
-        }).unwrap();
-        dispatch(
-          setDraftSubmissionId({ surveyId, surveyStep, submissionId: created.submission_id }),
-        );
-      } catch (error) {
-        if (isFetchBaseQueryError(error) && error.status === 409) {
-          // TODO: Handle 409 (survey already completed)
-          return;
-        }
-        // Best effort — a later save trigger will retry.
-      }
-    },
-    [surveyId, surveyStep, surveyVersion, dispatch, upsertSurveyDraft],
-  );
+  const { onCurrentPageChanged, recordLatestDraft } = useSurveyDraftSync({
+    surveyId,
+    surveyVersion,
+    surveyStep,
+    ...draftState,
+  });
 
-  const latestDraftRef = useRef({ surveyData: surveyDataInProgress, currentPageNo: savedPageNo });
-
-  useEffect(() => {
-    return () => {
-      persistDraft({
-        survey_data: latestDraftRef.current.surveyData,
-        current_page_no: latestDraftRef.current.currentPageNo,
-      });
-    };
-  }, []);
-
-  const initialData = { ...prepopulatedData, ...surveyDataInProgress };
+  const initialData = {
+    ...prepopulatedData,
+    ...(!draftState.isDraftLoading ? draftState.initialDraft.surveyData : {}),
+  };
 
   const handleDataChange = useCallback(
     (currentPageNo: number, surveyData: Record<string, any>) => {
       dispatch(
         saveSurveyProgress({ surveyId, currentPageNo, surveyData, surveyVersion, surveyStep }),
       );
-      latestDraftRef.current = { surveyData, currentPageNo };
+      recordLatestDraft(surveyData, currentPageNo);
     },
     [surveyId, surveyVersion, surveyStep],
   );
@@ -195,45 +151,6 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
     }
   }, [cdnPath, history]);
 
-  // Ensure a submission_id exists on mount — adopted from the server draft, or created fresh —
-  // so a stale write can later be recognized as already completed. Only adopt the server draft's
-  // content when there's no local draft yet; otherwise defer reconciliation.
-  useEffect(() => {
-    if (!surveyVersion || isServerDraftLoading || submissionId) {
-      return;
-    }
-    if (serverDraft) {
-      dispatch(
-        setDraftSubmissionId({ surveyId, surveyStep, submissionId: serverDraft.submission_id }),
-      );
-
-      if (!hasDraft) {
-        dispatch(
-          saveSurveyProgress({
-            surveyId,
-            currentPageNo: serverDraft.current_page_no,
-            surveyData: serverDraft.survey_data,
-            surveyVersion: serverDraft.survey_version,
-            surveyStep,
-            updatedAt: new Date(serverDraft.updated_at).getTime(),
-          }),
-        );
-      }
-      return;
-    }
-    persistDraft({ survey_data: {} });
-  }, [
-    surveyVersion,
-    isServerDraftLoading,
-    serverDraft,
-    submissionId,
-    hasDraft,
-    surveyId,
-    surveyStep,
-    dispatch,
-    persistDraft,
-  ]);
-
   useEffect(() => {
     if (isSurveyJsonError) {
       const activeError = notifications.find(
@@ -246,14 +163,6 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   }, [isSurveyJsonError]);
 
   const isLoading = isPrepopulatedDataLoading || isSurveyJsonLoading;
-
-  const onCurrentPageChanged = useCallback(
-    (currentPageNo: number, surveyData: Record<string, unknown>) => {
-      persistDraft({ current_page_no: currentPageNo, survey_data: surveyData });
-      latestDraftRef.current = { surveyData, currentPageNo };
-    },
-    [persistDraft],
-  );
 
   return (
     <div className={insightStyles.insightContainer}>
@@ -271,7 +180,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
             onComplete={handleComplete}
             onValueChanged={handleDataChange}
             initialData={initialData}
-            initialPageNo={savedPageNo}
+            initialPageNo={!draftState.isDraftLoading ? draftState.initialDraft.currentPageNo : 0}
             onCurrentPageChanged={onCurrentPageChanged}
           />
         )}

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -134,10 +134,10 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
 
   // Redirect to Insights if this survey is unknown or not available to the farm's country
   useEffect(() => {
-    if (!cdnPath) {
+    if (!draftState.isDraftLoading && !cdnPath) {
       history.replace('/Insights');
     }
-  }, [cdnPath, history]);
+  }, [draftState.isDraftLoading, cdnPath, history]);
 
   useEffect(() => {
     if (isSurveyJsonError) {

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -21,7 +21,12 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { useSurveyPrepopulatedData } from './useSurveyPrepopulatedData';
 import { useSurveyTitle } from './useSurveyTitle';
-import { saveSurveyProgress, clearSurvey, surveyDraftSelector } from './surveyDraftSlice';
+import {
+  saveSurveyProgress,
+  setDraftSubmissionId,
+  clearSurvey,
+  surveyDraftSelector,
+} from './surveyDraftSlice';
 import { SURVEY_INFO, getSurveyCdnPath, getSurveyVersion } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
@@ -31,7 +36,10 @@ import {
   usePrefetch,
   useGetSurveyJsonQuery,
   useAddSurveyResponseMutation,
+  useGetSurveyDraftQuery,
+  useUpsertSurveyDraftMutation,
 } from '../../../store/api/surveyApi';
+import { isFetchBaseQueryError } from '../../../store/api/typeGuards';
 import { enqueueErrorSnackbar, snackbarSelector } from '../../Snackbar/snackbarSlice';
 import { getLanguageFromLocalStorage } from '../../../util/getLanguageFromLocalStorage';
 import styles from './styles.module.scss';
@@ -40,6 +48,14 @@ import insightStyles from '../styles.module.scss';
 interface SurveyProps {
   isCompactSideMenu: boolean;
 }
+
+// TODO: LF-5127 Implement properly
+const getSurveyStep = (surveyId: string) => {
+  if (surveyId === 'cathi_gao') {
+    return '';
+  }
+  return 'STEP1';
+};
 
 function Survey({ isCompactSideMenu }: SurveyProps) {
   const { t } = useTranslation();
@@ -51,12 +67,14 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const { farm_id, country_code } = useSelector(userFarmSelector);
 
   const cdnDirectory = SURVEY_INFO[surveyId]?.cdnDirectory;
+  const surveyStep = getSurveyStep(surveyId);
 
   const {
     surveyData: surveyDataInProgress,
     currentPageNo: savedPageNo,
     surveyVersion: draftSurveyVersion,
-  } = useSelector(surveyDraftSelector(surveyId));
+    submissionId,
+  } = useSelector(surveyDraftSelector(surveyId, surveyStep));
 
   const hasDraft = Object.keys(surveyDataInProgress).length > 0;
 
@@ -90,17 +108,52 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const [addSurveyResponse] = useAddSurveyResponseMutation();
   const prefetchLatestResponse = usePrefetch('getLatestSurveyResponse');
 
+  const { data: serverDraft, isLoading: isServerDraftLoading } = useGetSurveyDraftQuery(
+    { surveyKey: surveyId, surveyStep },
+    { skip: !surveyId },
+  );
+  const [upsertSurveyDraft] = useUpsertSurveyDraftMutation();
+
   const notifications: { message: string }[] = useSelector(snackbarSelector);
 
   const surveyVersion = surveyJson ? getSurveyVersion(surveyJson) : undefined;
+
+  // Upserts the draft to the server, then syncs the returned submission_id into Redux.
+  const persistDraft = useCallback(
+    async (payload: { survey_data: Record<string, any>; current_page_no?: number }) => {
+      if (!surveyVersion) {
+        return;
+      }
+      try {
+        const created = await upsertSurveyDraft({
+          surveyKey: surveyId,
+          surveyStep,
+          survey_version: surveyVersion,
+          ...payload,
+        }).unwrap();
+        dispatch(
+          setDraftSubmissionId({ surveyId, surveyStep, submissionId: created.submission_id }),
+        );
+      } catch (error) {
+        if (isFetchBaseQueryError(error) && error.status === 409) {
+          // TODO: Handle 409 (survey already completed)
+          return;
+        }
+        // Best effort — a later save trigger will retry.
+      }
+    },
+    [surveyId, surveyStep, surveyVersion, dispatch, upsertSurveyDraft],
+  );
 
   const initialData = { ...prepopulatedData, ...surveyDataInProgress };
 
   const handleDataChange = useCallback(
     (currentPageNo: number, surveyData: Record<string, any>) => {
-      dispatch(saveSurveyProgress({ surveyId, currentPageNo, surveyData, surveyVersion }));
+      dispatch(
+        saveSurveyProgress({ surveyId, currentPageNo, surveyData, surveyVersion, surveyStep }),
+      );
     },
-    [surveyId, surveyVersion],
+    [surveyId, surveyVersion, surveyStep],
   );
 
   const handleComplete = useCallback(
@@ -112,7 +165,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
           farm_id,
         }).unwrap();
         prefetchLatestResponse({ surveyKey: surveyId });
-        dispatch(clearSurvey({ surveyId }));
+        dispatch(clearSurvey({ surveyId, surveyStep }));
         // Replace instead of push so the submitted survey is not left in the history stack
         history.replace(`/insights/survey/${surveyId}/results`);
       } catch {
@@ -129,6 +182,44 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       history.replace('/Insights');
     }
   }, [cdnPath, history]);
+
+  // Ensure a submission_id exists on mount — adopted from the server draft, or created fresh —
+  // so a stale write can later be recognized as already completed. Only adopt the server draft's
+  // content when there's no local draft yet; otherwise defer reconciliation.
+  useEffect(() => {
+    if (!surveyVersion || isServerDraftLoading || submissionId) {
+      return;
+    }
+    if (serverDraft) {
+      dispatch(
+        setDraftSubmissionId({ surveyId, surveyStep, submissionId: serverDraft.submission_id }),
+      );
+
+      if (!hasDraft) {
+        dispatch(
+          saveSurveyProgress({
+            surveyId,
+            currentPageNo: serverDraft.current_page_no,
+            surveyData: serverDraft.survey_data,
+            surveyVersion: serverDraft.survey_version,
+            surveyStep,
+          }),
+        );
+      }
+      return;
+    }
+    persistDraft({ survey_data: {} });
+  }, [
+    surveyVersion,
+    isServerDraftLoading,
+    serverDraft,
+    submissionId,
+    hasDraft,
+    surveyId,
+    surveyStep,
+    dispatch,
+    persistDraft,
+  ]);
 
   useEffect(() => {
     if (isSurveyJsonError) {

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -139,6 +139,19 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
     }
   }, [draftState.isDraftLoading, cdnPath, history]);
 
+  // TODO: LF-5192 Remove useEffect once retake is supported.
+  useEffect(() => {
+    // The draft has already been completed on the server. Send the user to the results page
+    // instead of showing an empty form they can't actually save progress on.
+    if (
+      !draftState.isDraftLoading &&
+      draftState.initialDraft.needsLocalSync &&
+      !draftState.initialDraft.submissionId
+    ) {
+      history.replace(`/insights/survey/${surveyId}/results`);
+    }
+  }, [draftState.isDraftLoading, draftState.initialDraft, surveyId, history]);
+
   useEffect(() => {
     if (isSurveyJsonError) {
       const activeError = notifications.find(

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -127,6 +127,14 @@ export const getSurveyCdnPath = (
   return getLatestCdnPath(surveyId, countryCode, language);
 };
 
+// TODO: LF-5127 Implement properly
+export const getSurveyStep = (surveyId: string): string | undefined => {
+  if (surveyId === 'cathi_gao') {
+    return '';
+  }
+  return 'STEP1';
+};
+
 /**
  * The survey ids available to a farm in the given country: those with a country-specific or global
  * version. Drives the Insights tile list.

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -127,14 +127,6 @@ export const getSurveyCdnPath = (
   return getLatestCdnPath(surveyId, countryCode, language);
 };
 
-// TODO: LF-5127 Implement properly
-export const getSurveyStep = (surveyId: string): string | undefined => {
-  if (surveyId === 'cathi_gao') {
-    return '';
-  }
-  return 'STEP1';
-};
-
 /**
  * The survey ids available to a farm in the given country: those with a country-specific or global
  * version. Drives the Insights tile list.

--- a/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
@@ -25,8 +25,7 @@ interface SurveyDraft {
 }
 
 interface SurveyDraftState {
-  // e.g., { tape: { STEP1: {...}, STEP2: {...} }, cathi_gao: { '': {...} } }
-  bySurveyId: Record<string, Record<string, SurveyDraft>>;
+  bySurveyId: Record<string, SurveyDraft>;
 }
 
 const initialState: SurveyDraftState = {
@@ -34,8 +33,6 @@ const initialState: SurveyDraftState = {
 };
 
 const emptyDraft: SurveyDraft = { currentPageNo: 0, surveyData: {} };
-
-const normalizeStep = (surveyStep?: string) => surveyStep ?? '';
 
 const surveyDraftSlice = createSlice({
   name: 'surveyDraftReducer',
@@ -48,7 +45,6 @@ const surveyDraftSlice = createSlice({
         currentPageNo: number;
         surveyData: Record<string, any>;
         surveyVersion?: string;
-        surveyStep?: string;
         // Defaults to now; callers adopting server content should pass the server's own
         // updated_at, not when it was merely copied into this store.
         updatedAt?: number;
@@ -59,46 +55,28 @@ const surveyDraftSlice = createSlice({
         currentPageNo,
         surveyData,
         surveyVersion,
-        surveyStep,
         updatedAt = Date.now(),
       } = action.payload;
-      const step = normalizeStep(surveyStep);
-      const previous = state.bySurveyId[surveyId]?.[step] ?? emptyDraft;
       state.bySurveyId[surveyId] = {
         ...state.bySurveyId[surveyId],
-        [step]: {
-          ...previous,
-          currentPageNo,
-          surveyData,
-          surveyVersion,
-          updatedAt,
-        },
+        currentPageNo,
+        surveyData,
+        surveyVersion,
+        updatedAt,
       };
     },
     setDraftSubmissionId: (
       state,
-      action: PayloadAction<{ surveyId: string; surveyStep?: string; submissionId: string }>,
+      action: PayloadAction<{ surveyId: string; submissionId: string }>,
     ) => {
-      const { surveyId, surveyStep, submissionId } = action.payload;
-      const step = normalizeStep(surveyStep);
+      const { surveyId, submissionId } = action.payload;
       state.bySurveyId[surveyId] = {
         ...state.bySurveyId[surveyId],
-        [step]: {
-          ...(state.bySurveyId[surveyId]?.[step] ?? emptyDraft),
-          submissionId,
-        },
+        submissionId,
       };
     },
-    clearSurvey: (state, action: PayloadAction<{ surveyId: string; surveyStep?: string }>) => {
-      const { surveyId, surveyStep } = action.payload;
-      const surveyDrafts = state.bySurveyId[surveyId];
-      if (!surveyDrafts) {
-        return;
-      }
-      delete surveyDrafts[normalizeStep(surveyStep)];
-      if (Object.keys(surveyDrafts).length === 0) {
-        delete state.bySurveyId[surveyId];
-      }
+    clearSurvey: (state, action: PayloadAction<{ surveyId: string }>) => {
+      delete state.bySurveyId[action.payload.surveyId];
     },
   },
 });
@@ -110,8 +88,8 @@ export default surveyDraftSlice.reducer;
 const surveyDraftStateSelector = (state: any): SurveyDraftState =>
   state.farmStateReducer[surveyDraftSlice.name] || initialState;
 
-export const surveyDraftSelector = (surveyId: string, surveyStep?: string) =>
+export const surveyDraftSelector = (surveyId: string) =>
   createSelector(
     [surveyDraftStateSelector],
-    (draftState) => draftState.bySurveyId[surveyId]?.[normalizeStep(surveyStep)] || emptyDraft,
+    (draftState) => draftState.bySurveyId[surveyId] || emptyDraft,
   );

--- a/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
@@ -20,10 +20,12 @@ interface SurveyDraft {
   currentPageNo: number;
   surveyData: Record<string, any>;
   surveyVersion?: string;
+  submissionId?: string;
 }
 
 interface SurveyDraftState {
-  bySurveyId: Record<string, SurveyDraft>;
+  // e.g., { tape: { STEP1: {...}, STEP2: {...} }, cathi_gao: { '': {...} } }
+  bySurveyId: Record<string, Record<string, SurveyDraft>>;
 }
 
 const initialState: SurveyDraftState = {
@@ -31,6 +33,8 @@ const initialState: SurveyDraftState = {
 };
 
 const emptyDraft: SurveyDraft = { currentPageNo: 0, surveyData: {} };
+
+const normalizeStep = (surveyStep?: string) => surveyStep ?? '';
 
 const surveyDraftSlice = createSlice({
   name: 'surveyDraftReducer',
@@ -43,37 +47,72 @@ const surveyDraftSlice = createSlice({
         currentPageNo: number;
         surveyData: Record<string, any>;
         surveyVersion?: string;
+        surveyStep?: string;
       }>,
     ) => {
-      const { surveyId, currentPageNo, surveyData, surveyVersion } = action.payload;
-      const previous = state.bySurveyId[surveyId]?.surveyData ?? {};
+      const { surveyId, currentPageNo, surveyData, surveyVersion, surveyStep } = action.payload;
+      const step = normalizeStep(surveyStep);
+      const previous = state.bySurveyId[surveyId]?.[step] ?? emptyDraft;
       state.bySurveyId[surveyId] = {
-        currentPageNo,
-        surveyData: { ...previous, ...surveyData },
-        surveyVersion,
+        ...state.bySurveyId[surveyId],
+        [step]: {
+          ...previous,
+          currentPageNo,
+          surveyData,
+          surveyVersion,
+        },
       };
     },
-    clearSurvey: (state, action: PayloadAction<{ surveyId: string }>) => {
-      delete state.bySurveyId[action.payload.surveyId];
+    setDraftSubmissionId: (
+      state,
+      action: PayloadAction<{ surveyId: string; surveyStep?: string; submissionId: string }>,
+    ) => {
+      const { surveyId, surveyStep, submissionId } = action.payload;
+      const step = normalizeStep(surveyStep);
+      state.bySurveyId[surveyId] = {
+        ...state.bySurveyId[surveyId],
+        [step]: {
+          ...(state.bySurveyId[surveyId]?.[step] ?? emptyDraft),
+          submissionId,
+        },
+      };
+    },
+    clearSurvey: (state, action: PayloadAction<{ surveyId: string; surveyStep?: string }>) => {
+      const { surveyId, surveyStep } = action.payload;
+      const surveyDrafts = state.bySurveyId[surveyId];
+      if (!surveyDrafts) {
+        return;
+      }
+      delete surveyDrafts[normalizeStep(surveyStep)];
+      if (Object.keys(surveyDrafts).length === 0) {
+        delete state.bySurveyId[surveyId];
+      }
     },
   },
 });
 
-export const { saveSurveyProgress, clearSurvey } = surveyDraftSlice.actions;
+export const { saveSurveyProgress, setDraftSubmissionId, clearSurvey } = surveyDraftSlice.actions;
 export default surveyDraftSlice.reducer;
 
 // Selectors
 const surveyDraftStateSelector = (state: any): SurveyDraftState =>
   state.farmStateReducer[surveyDraftSlice.name] || initialState;
 
-export const surveyDraftSelector = (surveyId: string) =>
+export const surveyDraftSelector = (surveyId: string, surveyStep?: string) =>
   createSelector(
     [surveyDraftStateSelector],
-    (draftState) => draftState.bySurveyId[surveyId] || emptyDraft,
+    (draftState) => draftState.bySurveyId[surveyId]?.[normalizeStep(surveyStep)] || emptyDraft,
   );
 
-export const surveyInProgressSelector = (surveyId: string) =>
-  createSelector(
-    [surveyDraftStateSelector],
-    (draftState) => Object.keys(draftState.bySurveyId[surveyId]?.surveyData ?? {}).length > 0,
-  );
+// With no surveyStep, reports whether any step of this survey has unsaved progress.
+export const surveyInProgressSelector = (surveyId: string, surveyStep?: string) =>
+  createSelector([surveyDraftStateSelector], (draftState) => {
+    const surveyDrafts = draftState.bySurveyId[surveyId];
+    if (!surveyDrafts) {
+      return false;
+    }
+    if (surveyStep !== undefined) {
+      return Object.keys(surveyDrafts[normalizeStep(surveyStep)]?.surveyData ?? {}).length > 0;
+    }
+    return Object.values(surveyDrafts).some((draft) => Object.keys(draft.surveyData).length > 0);
+  });

--- a/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
@@ -21,6 +21,7 @@ interface SurveyDraft {
   surveyData: Record<string, any>;
   surveyVersion?: string;
   submissionId?: string;
+  updatedAt?: number;
 }
 
 interface SurveyDraftState {
@@ -48,9 +49,19 @@ const surveyDraftSlice = createSlice({
         surveyData: Record<string, any>;
         surveyVersion?: string;
         surveyStep?: string;
+        // Defaults to now; callers adopting server content should pass the server's own
+        // updated_at, not when it was merely copied into this store.
+        updatedAt?: number;
       }>,
     ) => {
-      const { surveyId, currentPageNo, surveyData, surveyVersion, surveyStep } = action.payload;
+      const {
+        surveyId,
+        currentPageNo,
+        surveyData,
+        surveyVersion,
+        surveyStep,
+        updatedAt = Date.now(),
+      } = action.payload;
       const step = normalizeStep(surveyStep);
       const previous = state.bySurveyId[surveyId]?.[step] ?? emptyDraft;
       state.bySurveyId[surveyId] = {
@@ -60,6 +71,7 @@ const surveyDraftSlice = createSlice({
           currentPageNo,
           surveyData,
           surveyVersion,
+          updatedAt,
         },
       };
     },

--- a/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
@@ -71,7 +71,7 @@ const surveyDraftSlice = createSlice({
     ) => {
       const { surveyId, submissionId } = action.payload;
       state.bySurveyId[surveyId] = {
-        ...state.bySurveyId[surveyId],
+        ...(state.bySurveyId[surveyId] || emptyDraft),
         submissionId,
       };
     },

--- a/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
@@ -115,16 +115,3 @@ export const surveyDraftSelector = (surveyId: string, surveyStep?: string) =>
     [surveyDraftStateSelector],
     (draftState) => draftState.bySurveyId[surveyId]?.[normalizeStep(surveyStep)] || emptyDraft,
   );
-
-// With no surveyStep, reports whether any step of this survey has unsaved progress.
-export const surveyInProgressSelector = (surveyId: string, surveyStep?: string) =>
-  createSelector([surveyDraftStateSelector], (draftState) => {
-    const surveyDrafts = draftState.bySurveyId[surveyId];
-    if (!surveyDrafts) {
-      return false;
-    }
-    if (surveyStep !== undefined) {
-      return Object.keys(surveyDrafts[normalizeStep(surveyStep)]?.surveyData ?? {}).length > 0;
-    }
-    return Object.values(surveyDrafts).some((draft) => Object.keys(draft.surveyData).length > 0);
-  });

--- a/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
@@ -32,10 +32,10 @@ export type InitialDraftResult =
       };
     };
 
-function useInitialDraft(surveyId: string, surveyStep?: string) {
-  const localDraft = useSelector(surveyDraftSelector(surveyId, surveyStep));
+function useInitialDraft(surveyId: string) {
+  const localDraft = useSelector(surveyDraftSelector(surveyId));
   const { data: serverDraft, isFetching } = useGetSurveyDraftQuery(
-    { surveyKey: surveyId, surveyStep },
+    { surveyKey: surveyId },
     { skip: !surveyId, refetchOnMountOrArgChange: true },
   );
 

--- a/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { surveyDraftSelector } from './surveyDraftSlice';
 import { useGetSurveyDraftQuery } from '../../../store/api/surveyApi';
@@ -34,13 +34,19 @@ export type InitialDraftResult =
 
 function useInitialDraft(surveyId: string, surveyStep?: string) {
   const localDraft = useSelector(surveyDraftSelector(surveyId, surveyStep));
-  const { data: serverDraft, isLoading } = useGetSurveyDraftQuery(
+  const { data: serverDraft, isFetching } = useGetSurveyDraftQuery(
     { surveyKey: surveyId, surveyStep },
-    { skip: !surveyId },
+    { skip: !surveyId, refetchOnMountOrArgChange: true },
   );
 
+  const resolvedRef = useRef<InitialDraftResult | null>(null);
+
   return useMemo<InitialDraftResult>(() => {
-    if (isLoading) {
+    if (resolvedRef.current) {
+      return resolvedRef.current;
+    }
+
+    if (isFetching) {
       return { isDraftLoading: true, initialDraft: {} };
     }
 
@@ -50,7 +56,7 @@ function useInitialDraft(surveyId: string, surveyStep?: string) {
 
     // The draft has been completed on the server, and there is no new server draft
     if (isLocalDraftStale && !serverDraft) {
-      return {
+      resolvedRef.current = {
         isDraftLoading: false,
         initialDraft: {
           submissionId: undefined,
@@ -61,6 +67,7 @@ function useInitialDraft(surveyId: string, surveyStep?: string) {
           updatedAt: undefined,
         },
       };
+      return resolvedRef.current;
     }
 
     const shouldAdoptServer =
@@ -86,12 +93,13 @@ function useInitialDraft(surveyId: string, surveyStep?: string) {
           needsLocalSync: false,
         };
 
-    return { isDraftLoading: false, initialDraft };
+    resolvedRef.current = { isDraftLoading: false, initialDraft };
+    return resolvedRef.current;
 
-    // Deliberately omits serverDraft/localDraft — resolves once when loading finishes and never
-    // again, so later edits/refetches don't retroactively change the survey's starting point.
-    // Do not add them to this array.
-  }, [isLoading]);
+    // Omit serverDraft/localDraft, so a local edit alone never re-runs this.
+    // isFetching also fires on unrelated refetches, but resolvedRef locks in
+    // the first result so those don't produce a new one.
+  }, [isFetching]);
 }
 
 export default useInitialDraft;

--- a/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { surveyDraftSelector } from './surveyDraftSlice';
+import { useGetSurveyDraftQuery } from '../../../store/api/surveyApi';
+
+export type InitialDraftResult =
+  | { isDraftLoading: true; initialDraft: Record<string, never> }
+  | {
+      isDraftLoading: false;
+      initialDraft: {
+        submissionId: string | undefined;
+        surveyVersion: string | undefined;
+        surveyData: Record<string, any>;
+        currentPageNo: number;
+        updatedAt: number | undefined;
+        needsLocalSync: boolean;
+      };
+    };
+
+function useInitialDraft(surveyId: string, surveyStep?: string) {
+  const localDraft = useSelector(surveyDraftSelector(surveyId, surveyStep));
+  const { data: serverDraft, isLoading } = useGetSurveyDraftQuery(
+    { surveyKey: surveyId, surveyStep },
+    { skip: !surveyId },
+  );
+
+  return useMemo<InitialDraftResult>(() => {
+    if (isLoading) {
+      return { isDraftLoading: true, initialDraft: {} };
+    }
+
+    const isLocalDraftStale =
+      (Object.keys(localDraft.surveyData).length === 0 && serverDraft?.submission_id) ||
+      (localDraft.submissionId && localDraft.submissionId !== serverDraft?.submission_id);
+
+    // The draft has been completed on the server, and there is no new server draft
+    if (isLocalDraftStale && !serverDraft) {
+      return {
+        isDraftLoading: false,
+        initialDraft: {
+          submissionId: undefined,
+          surveyVersion: undefined,
+          surveyData: {},
+          currentPageNo: 0,
+          needsLocalSync: true,
+          updatedAt: undefined,
+        },
+      };
+    }
+
+    const shouldAdoptServer =
+      !!serverDraft &&
+      (isLocalDraftStale ||
+        new Date(serverDraft.updated_at).getTime() >= (localDraft.updatedAt ?? 0));
+
+    const initialDraft = shouldAdoptServer
+      ? {
+          submissionId: serverDraft.submission_id,
+          surveyVersion: serverDraft.survey_version,
+          surveyData: serverDraft.survey_data,
+          currentPageNo: serverDraft.current_page_no,
+          updatedAt: new Date(serverDraft.updated_at).getTime(),
+          needsLocalSync: true,
+        }
+      : {
+          submissionId: localDraft.submissionId,
+          surveyVersion: localDraft.surveyVersion,
+          surveyData: localDraft.surveyData,
+          currentPageNo: localDraft.currentPageNo,
+          updatedAt: localDraft.updatedAt,
+          needsLocalSync: false,
+        };
+
+    return { isDraftLoading: false, initialDraft };
+
+    // Deliberately omits serverDraft/localDraft — resolves once when loading finishes and never
+    // again, so later edits/refetches don't retroactively change the survey's starting point.
+    // Do not add them to this array.
+  }, [isLoading]);
+}
+
+export default useInitialDraft;

--- a/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
@@ -16,7 +16,7 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { surveyDraftSelector } from './surveyDraftSlice';
-import { useGetSurveyDraftQuery, useLazyGetSurveyDraftQuery } from '../../../store/api/surveyApi';
+import { useLazyGetSurveyDraftQuery } from '../../../store/api/surveyApi';
 
 export type InitialDraftResult =
   | { isDraftLoading: true; initialDraft: Record<string, never> }
@@ -37,12 +37,6 @@ const loadingResult: InitialDraftResult = { isDraftLoading: true, initialDraft: 
 function useInitialDraft(surveyId: string) {
   const localDraft = useSelector(surveyDraftSelector(surveyId));
   const [fetchDraft] = useLazyGetSurveyDraftQuery();
-  // Read-only: gives us whatever getSurveyDraft last had cached, so a failed fetchDraft can fall
-  // back to it instead of reading as "no draft".
-  const { data: cachedServerDraft } = useGetSurveyDraftQuery(
-    { surveyKey: surveyId },
-    { skip: !surveyId },
-  );
 
   const [resolved, setResolved] = useState<InitialDraftResult>(loadingResult);
 
@@ -54,19 +48,19 @@ function useInitialDraft(surveyId: string) {
     }
     let cancelled = false;
     (async () => {
-      const serverDraft = await fetchDraft({ surveyKey: surveyId })
-        .unwrap()
-        .catch(() => cachedServerDraft);
+      const { data, isSuccess } = await fetchDraft({ surveyKey: surveyId });
       if (cancelled) {
         return;
       }
+
+      const serverDraft = isSuccess ? data : undefined;
 
       const isLocalDraftStale =
         (Object.keys(localDraft.surveyData).length === 0 && serverDraft?.submission_id) ||
         (localDraft.submissionId && localDraft.submissionId !== serverDraft?.submission_id);
 
       // The draft has been completed on the server, and there is no new server draft
-      if (isLocalDraftStale && !serverDraft) {
+      if (isLocalDraftStale && !serverDraft && isSuccess) {
         setResolved({
           isDraftLoading: false,
           initialDraft: {

--- a/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useInitialDraft.tsx
@@ -13,10 +13,10 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useMemo, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { surveyDraftSelector } from './surveyDraftSlice';
-import { useGetSurveyDraftQuery } from '../../../store/api/surveyApi';
+import { useGetSurveyDraftQuery, useLazyGetSurveyDraftQuery } from '../../../store/api/surveyApi';
 
 export type InitialDraftResult =
   | { isDraftLoading: true; initialDraft: Record<string, never> }
@@ -32,74 +32,89 @@ export type InitialDraftResult =
       };
     };
 
+const loadingResult: InitialDraftResult = { isDraftLoading: true, initialDraft: {} };
+
 function useInitialDraft(surveyId: string) {
   const localDraft = useSelector(surveyDraftSelector(surveyId));
-  const { data: serverDraft, isFetching } = useGetSurveyDraftQuery(
+  const [fetchDraft] = useLazyGetSurveyDraftQuery();
+  // Read-only: gives us whatever getSurveyDraft last had cached, so a failed fetchDraft can fall
+  // back to it instead of reading as "no draft".
+  const { data: cachedServerDraft } = useGetSurveyDraftQuery(
     { surveyKey: surveyId },
-    { skip: !surveyId, refetchOnMountOrArgChange: true },
+    { skip: !surveyId },
   );
 
-  const resolvedRef = useRef<InitialDraftResult | null>(null);
+  const [resolved, setResolved] = useState<InitialDraftResult>(loadingResult);
 
-  return useMemo<InitialDraftResult>(() => {
-    if (resolvedRef.current) {
-      return resolvedRef.current;
+  // Resolves once on mount. Uses the lazy trigger, not the normal query hook, since a normal
+  // subscription can briefly show a stale cached value (e.g., isFetching: false).
+  useEffect(() => {
+    if (!surveyId) {
+      return;
     }
+    let cancelled = false;
+    (async () => {
+      const serverDraft = await fetchDraft({ surveyKey: surveyId })
+        .unwrap()
+        .catch(() => cachedServerDraft);
+      if (cancelled) {
+        return;
+      }
 
-    if (isFetching) {
-      return { isDraftLoading: true, initialDraft: {} };
-    }
+      const isLocalDraftStale =
+        (Object.keys(localDraft.surveyData).length === 0 && serverDraft?.submission_id) ||
+        (localDraft.submissionId && localDraft.submissionId !== serverDraft?.submission_id);
 
-    const isLocalDraftStale =
-      (Object.keys(localDraft.surveyData).length === 0 && serverDraft?.submission_id) ||
-      (localDraft.submissionId && localDraft.submissionId !== serverDraft?.submission_id);
+      // The draft has been completed on the server, and there is no new server draft
+      if (isLocalDraftStale && !serverDraft) {
+        setResolved({
+          isDraftLoading: false,
+          initialDraft: {
+            submissionId: undefined,
+            surveyVersion: undefined,
+            surveyData: {},
+            currentPageNo: 0,
+            needsLocalSync: true,
+            updatedAt: undefined,
+          },
+        });
+        return;
+      }
 
-    // The draft has been completed on the server, and there is no new server draft
-    if (isLocalDraftStale && !serverDraft) {
-      resolvedRef.current = {
-        isDraftLoading: false,
-        initialDraft: {
-          submissionId: undefined,
-          surveyVersion: undefined,
-          surveyData: {},
-          currentPageNo: 0,
-          needsLocalSync: true,
-          updatedAt: undefined,
-        },
-      };
-      return resolvedRef.current;
-    }
+      const shouldAdoptServer =
+        !!serverDraft &&
+        (isLocalDraftStale ||
+          new Date(serverDraft.updated_at).getTime() >= (localDraft.updatedAt ?? 0));
 
-    const shouldAdoptServer =
-      !!serverDraft &&
-      (isLocalDraftStale ||
-        new Date(serverDraft.updated_at).getTime() >= (localDraft.updatedAt ?? 0));
+      const initialDraft = shouldAdoptServer
+        ? {
+            submissionId: serverDraft.submission_id,
+            surveyVersion: serverDraft.survey_version,
+            surveyData: serverDraft.survey_data,
+            currentPageNo: serverDraft.current_page_no,
+            updatedAt: new Date(serverDraft.updated_at).getTime(),
+            needsLocalSync: true,
+          }
+        : {
+            submissionId: localDraft.submissionId,
+            surveyVersion: localDraft.surveyVersion,
+            surveyData: localDraft.surveyData,
+            currentPageNo: localDraft.currentPageNo,
+            updatedAt: localDraft.updatedAt,
+            needsLocalSync: false,
+          };
 
-    const initialDraft = shouldAdoptServer
-      ? {
-          submissionId: serverDraft.submission_id,
-          surveyVersion: serverDraft.survey_version,
-          surveyData: serverDraft.survey_data,
-          currentPageNo: serverDraft.current_page_no,
-          updatedAt: new Date(serverDraft.updated_at).getTime(),
-          needsLocalSync: true,
-        }
-      : {
-          submissionId: localDraft.submissionId,
-          surveyVersion: localDraft.surveyVersion,
-          surveyData: localDraft.surveyData,
-          currentPageNo: localDraft.currentPageNo,
-          updatedAt: localDraft.updatedAt,
-          needsLocalSync: false,
-        };
+      setResolved({ isDraftLoading: false, initialDraft });
+    })();
 
-    resolvedRef.current = { isDraftLoading: false, initialDraft };
-    return resolvedRef.current;
+    return () => {
+      cancelled = true;
+    };
 
-    // Omit serverDraft/localDraft, so a local edit alone never re-runs this.
-    // isFetching also fires on unrelated refetches, but resolvedRef locks in
-    // the first result so those don't produce a new one.
-  }, [isFetching]);
+    // Omit localDraft, so a local edit alone never re-runs this.
+  }, [surveyId, fetchDraft]);
+
+  return resolved;
 }
 
 export default useInitialDraft;

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
@@ -44,7 +44,7 @@ function useSurveyDraftSync({
       payload: { survey_data: Record<string, any>; current_page_no?: number },
       { shouldReportErrors = false }: { shouldReportErrors?: boolean } = {},
     ) => {
-      if (!surveyVersion) {
+      if (!surveyVersion || !payload.survey_data) {
         return;
       }
       try {

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
@@ -81,7 +81,9 @@ function useSurveyDraftSync({
         current_page_no: latestDraftRef.current.currentPageNo,
       });
     };
-  }, []);
+    // persistDraft must be a dependency, or the cleanup stays frozen on the mount-time closure
+    // where surveyVersion is still undefined, and no-ops forever.
+  }, [persistDraft]);
 
   // Resolve this survey's draft state with the server on mount: adopt the server's draft when it
   // should win, discard local content when its submission_id no longer matches anything live on

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
@@ -123,7 +123,8 @@ function useSurveyDraftSync({
       // Local's submission_id points to a draft that's already been completed, and no new server
       // draft replaced it — discard the stale local content rather than keep building on it.
       dispatch(clearSurvey({ surveyId }));
-      persistDraft({ survey_data: {}, current_page_no: 0 });
+      // TODO: LF-5192 Remove this comment and uncomment the following line once retake is supported.
+      // persistDraft({ survey_data: {}, current_page_no: 0 });
       return;
     }
 

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
+import * as Sentry from '@sentry/react';
 import { clearSurvey, saveSurveyProgress, setDraftSubmissionId } from './surveyDraftSlice';
 import { useUpsertSurveyDraftMutation } from '../../../store/api/surveyApi';
 import { isFetchBaseQueryError } from '../../../store/api/typeGuards';
@@ -39,7 +40,10 @@ function useSurveyDraftSync({
 
   // Upserts the draft to the server, then syncs the returned submission_id into Redux.
   const persistDraft = useCallback(
-    async (payload: { survey_data: Record<string, any>; current_page_no?: number }) => {
+    async (
+      payload: { survey_data: Record<string, any>; current_page_no?: number },
+      { shouldReportErrors = false }: { shouldReportErrors?: boolean } = {},
+    ) => {
       if (!surveyVersion) {
         return;
       }
@@ -56,7 +60,12 @@ function useSurveyDraftSync({
         dispatch(setDraftSubmissionId({ surveyId, submissionId: created.submission_id }));
       } catch (error) {
         if (isFetchBaseQueryError(error) && error.status === 409) {
-          // TODO: Handle 409 (survey already completed)
+          if (shouldReportErrors) {
+            Sentry.captureException('Draft save rejected: survey already completed', {
+              tags: { surveyId },
+              extra: { submissionId: submissionIdRef.current },
+            });
+          }
           return;
         }
         // Best effort — a later save trigger will retry.
@@ -127,7 +136,13 @@ function useSurveyDraftSync({
 
   const onCurrentPageChanged = useCallback(
     (currentPageNo: number, surveyData: Record<string, unknown>) => {
-      persistDraft({ current_page_no: currentPageNo, survey_data: surveyData });
+      persistDraft(
+        {
+          current_page_no: currentPageNo,
+          survey_data: surveyData,
+        },
+        { shouldReportErrors: true },
+      );
       recordLatestDraft(surveyData, currentPageNo);
     },
     [persistDraft],

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
@@ -23,13 +23,11 @@ import { InitialDraftResult } from './useInitialDraft';
 type UseSurveyDraftSyncProps = InitialDraftResult & {
   surveyId: string;
   surveyVersion?: string;
-  surveyStep?: string;
 };
 
 function useSurveyDraftSync({
   surveyId,
   surveyVersion = '',
-  surveyStep,
   isDraftLoading,
   initialDraft,
 }: UseSurveyDraftSyncProps) {
@@ -48,7 +46,6 @@ function useSurveyDraftSync({
       try {
         const created = await upsertSurveyDraft({
           surveyKey: surveyId,
-          surveyStep,
           survey_version: surveyVersion,
           submission_id: submissionIdRef.current,
           ...payload,
@@ -56,9 +53,7 @@ function useSurveyDraftSync({
 
         submissionIdRef.current = created.submission_id;
 
-        dispatch(
-          setDraftSubmissionId({ surveyId, surveyStep, submissionId: created.submission_id }),
-        );
+        dispatch(setDraftSubmissionId({ surveyId, submissionId: created.submission_id }));
       } catch (error) {
         if (isFetchBaseQueryError(error) && error.status === 409) {
           // TODO: Handle 409 (survey already completed)
@@ -67,7 +62,7 @@ function useSurveyDraftSync({
         // Best effort — a later save trigger will retry.
       }
     },
-    [surveyId, surveyStep, surveyVersion, dispatch, upsertSurveyDraft],
+    [surveyId, surveyVersion, dispatch, upsertSurveyDraft],
   );
 
   const latestDraftRef = useRef({
@@ -108,7 +103,6 @@ function useSurveyDraftSync({
             currentPageNo: initialDraft.currentPageNo,
             surveyData: initialDraft.surveyData,
             surveyVersion: initialDraft.surveyVersion,
-            surveyStep,
             updatedAt: initialDraft.updatedAt,
           }),
         );
@@ -117,7 +111,7 @@ function useSurveyDraftSync({
 
       // Local's submission_id points to a draft that's already been completed, and no new server
       // draft replaced it — discard the stale local content rather than keep building on it.
-      dispatch(clearSurvey({ surveyId, surveyStep }));
+      dispatch(clearSurvey({ surveyId }));
       persistDraft({ survey_data: {}, current_page_no: 0 });
       return;
     }
@@ -127,7 +121,7 @@ function useSurveyDraftSync({
       survey_data: initialDraft.surveyData,
       current_page_no: initialDraft.currentPageNo,
     });
-  }, [surveyVersion, isDraftLoading, initialDraft, surveyId, surveyStep, dispatch, persistDraft]);
+  }, [surveyVersion, isDraftLoading, initialDraft, surveyId, dispatch, persistDraft]);
 
   const onCurrentPageChanged = useCallback(
     (currentPageNo: number, surveyData: Record<string, unknown>) => {

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyDraftSync.tsx
@@ -1,0 +1,143 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { clearSurvey, saveSurveyProgress, setDraftSubmissionId } from './surveyDraftSlice';
+import { useUpsertSurveyDraftMutation } from '../../../store/api/surveyApi';
+import { isFetchBaseQueryError } from '../../../store/api/typeGuards';
+import { InitialDraftResult } from './useInitialDraft';
+
+type UseSurveyDraftSyncProps = InitialDraftResult & {
+  surveyId: string;
+  surveyVersion?: string;
+  surveyStep?: string;
+};
+
+function useSurveyDraftSync({
+  surveyId,
+  surveyVersion = '',
+  surveyStep,
+  isDraftLoading,
+  initialDraft,
+}: UseSurveyDraftSyncProps) {
+  const dispatch = useDispatch();
+
+  const [upsertSurveyDraft] = useUpsertSurveyDraftMutation();
+
+  const submissionIdRef = useRef(initialDraft.submissionId);
+
+  // Upserts the draft to the server, then syncs the returned submission_id into Redux.
+  const persistDraft = useCallback(
+    async (payload: { survey_data: Record<string, any>; current_page_no?: number }) => {
+      if (!surveyVersion) {
+        return;
+      }
+      try {
+        const created = await upsertSurveyDraft({
+          surveyKey: surveyId,
+          surveyStep,
+          survey_version: surveyVersion,
+          submission_id: submissionIdRef.current,
+          ...payload,
+        }).unwrap();
+
+        submissionIdRef.current = created.submission_id;
+
+        dispatch(
+          setDraftSubmissionId({ surveyId, surveyStep, submissionId: created.submission_id }),
+        );
+      } catch (error) {
+        if (isFetchBaseQueryError(error) && error.status === 409) {
+          // TODO: Handle 409 (survey already completed)
+          return;
+        }
+        // Best effort — a later save trigger will retry.
+      }
+    },
+    [surveyId, surveyStep, surveyVersion, dispatch, upsertSurveyDraft],
+  );
+
+  const latestDraftRef = useRef({
+    surveyData: initialDraft.surveyData,
+    currentPageNo: initialDraft.currentPageNo,
+  });
+
+  const recordLatestDraft = (surveyData: Record<string, any>, currentPageNo: number) => {
+    latestDraftRef.current = { surveyData, currentPageNo };
+  };
+
+  useEffect(() => {
+    return () => {
+      persistDraft({
+        survey_data: latestDraftRef.current.surveyData,
+        current_page_no: latestDraftRef.current.currentPageNo,
+      });
+    };
+  }, []);
+
+  // Resolve this survey's draft state with the server on mount: adopt the server's draft when it
+  // should win, discard local content when its submission_id no longer matches anything live on
+  // the server, or register the local draft with the server for the first time.
+  useEffect(() => {
+    if (
+      !surveyVersion ||
+      isDraftLoading ||
+      (!initialDraft.needsLocalSync && initialDraft.submissionId)
+    ) {
+      return;
+    }
+
+    if (initialDraft.needsLocalSync) {
+      if (initialDraft.submissionId) {
+        dispatch(
+          saveSurveyProgress({
+            surveyId,
+            currentPageNo: initialDraft.currentPageNo,
+            surveyData: initialDraft.surveyData,
+            surveyVersion: initialDraft.surveyVersion,
+            surveyStep,
+            updatedAt: initialDraft.updatedAt,
+          }),
+        );
+        return;
+      }
+
+      // Local's submission_id points to a draft that's already been completed, and no new server
+      // draft replaced it — discard the stale local content rather than keep building on it.
+      dispatch(clearSurvey({ surveyId, surveyStep }));
+      persistDraft({ survey_data: {}, current_page_no: 0 });
+      return;
+    }
+
+    // Local wins by default but has never been sent to the server before — register it now.
+    persistDraft({
+      survey_data: initialDraft.surveyData,
+      current_page_no: initialDraft.currentPageNo,
+    });
+  }, [surveyVersion, isDraftLoading, initialDraft, surveyId, surveyStep, dispatch, persistDraft]);
+
+  const onCurrentPageChanged = useCallback(
+    (currentPageNo: number, surveyData: Record<string, unknown>) => {
+      persistDraft({ current_page_no: currentPageNo, survey_data: surveyData });
+      recordLatestDraft(surveyData, currentPageNo);
+    },
+    [persistDraft],
+  );
+
+  return { onCurrentPageChanged, recordLatestDraft };
+}
+
+export default useSurveyDraftSync;

--- a/packages/webapp/src/store/api/apiTags.ts
+++ b/packages/webapp/src/store/api/apiTags.ts
@@ -57,6 +57,7 @@ export const FarmTags = [
   'Weather',
   'MarketDirectoryInfo',
   'SurveyResponse',
+  'SurveyDraft',
   'FarmNote',
   'FarmNotesRead',
   'Certifications',

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -119,7 +119,6 @@ export const {
   useGetSurveyJsonQuery,
   useGetLatestSurveyResponseQuery,
   useAddSurveyResponseMutation,
-  useGetSurveyDraftQuery,
   useLazyGetSurveyDraftQuery,
   useUpsertSurveyDraftMutation,
   usePrefetch,

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -38,7 +38,6 @@ export interface SurveyDraftRecord {
   submission_id: string;
   farm_id: string;
   survey_key: string;
-  survey_step: string;
   survey_version: string;
   survey_data: Record<string, any>;
   current_page_no: number;
@@ -48,15 +47,10 @@ export interface SurveyDraftRecord {
 export interface UpsertSurveyDraftReqBody {
   submission_id?: string;
   surveyKey: string;
-  surveyStep?: string;
   survey_version: string;
   survey_data: Record<string, any>;
   current_page_no?: number;
 }
-
-const formatSurveyKeyStep = (surveyKey: string, surveyStep?: string) => {
-  return surveyStep ? `${surveyKey}-${surveyStep}` : surveyKey;
-};
 
 export const surveyApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -105,20 +99,15 @@ export const surveyApi = api.injectEndpoints({
         { type: 'SurveyResponse', id: survey_key },
       ],
     }),
-    getSurveyDraft: build.query<
-      SurveyDraftRecord | null,
-      { surveyKey: string; surveyStep?: string }
-    >({
-      query: ({ surveyKey, surveyStep }) => ({
-        url: getSurveyDraftUrl(surveyKey, surveyStep),
+    getSurveyDraft: build.query<SurveyDraftRecord | null, { surveyKey: string }>({
+      query: ({ surveyKey }) => ({
+        url: getSurveyDraftUrl(surveyKey),
       }),
-      providesTags: (_result, _error, { surveyKey, surveyStep }) => [
-        { type: 'SurveyDraft', id: formatSurveyKeyStep(surveyKey, surveyStep) },
-      ],
+      providesTags: (_result, _error, { surveyKey }) => [{ type: 'SurveyDraft', id: surveyKey }],
     }),
     upsertSurveyDraft: build.mutation<SurveyDraftRecord, UpsertSurveyDraftReqBody>({
-      query: ({ surveyKey, surveyStep, ...body }) => ({
-        url: getSurveyDraftUrl(surveyKey, surveyStep),
+      query: ({ surveyKey, ...body }) => ({
+        url: getSurveyDraftUrl(surveyKey),
         method: 'PUT',
         body,
       }),

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -120,6 +120,7 @@ export const {
   useGetLatestSurveyResponseQuery,
   useAddSurveyResponseMutation,
   useGetSurveyDraftQuery,
+  useLazyGetSurveyDraftQuery,
   useUpsertSurveyDraftMutation,
   usePrefetch,
 } = surveyApi;

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -14,7 +14,7 @@
  */
 
 import { api } from './apiSlice';
-import { surveyResponseUrl } from '../../apiConfig';
+import { surveyResponseUrl, getSurveyDraftUrl } from '../../apiConfig';
 import { DO_CDN_URL } from '../../util/constants';
 
 export interface SurveyResponseRecord {
@@ -32,6 +32,31 @@ export interface AddSurveyResponseReqBody {
   survey_key: string;
   survey_response: Record<string, any>;
 }
+
+export interface SurveyDraftRecord {
+  id: string;
+  submission_id: string;
+  farm_id: string;
+  survey_key: string;
+  survey_step: string;
+  survey_version: string;
+  survey_data: Record<string, any>;
+  current_page_no: number;
+  updated_at: string;
+}
+
+export interface UpsertSurveyDraftReqBody {
+  submission_id?: string;
+  surveyKey: string;
+  surveyStep?: string;
+  survey_version: string;
+  survey_data: Record<string, any>;
+  current_page_no?: number;
+}
+
+const formatSurveyKeyStep = (surveyKey: string, surveyStep?: string) => {
+  return surveyStep ? `${surveyKey}-${surveyStep}` : surveyKey;
+};
 
 export const surveyApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -80,6 +105,27 @@ export const surveyApi = api.injectEndpoints({
         { type: 'SurveyResponse', id: survey_key },
       ],
     }),
+    getSurveyDraft: build.query<
+      SurveyDraftRecord | null,
+      { surveyKey: string; surveyStep?: string }
+    >({
+      query: ({ surveyKey, surveyStep }) => ({
+        url: getSurveyDraftUrl(surveyKey, surveyStep),
+      }),
+      providesTags: (_result, _error, { surveyKey, surveyStep }) => [
+        { type: 'SurveyDraft', id: formatSurveyKeyStep(surveyKey, surveyStep) },
+      ],
+    }),
+    upsertSurveyDraft: build.mutation<SurveyDraftRecord, UpsertSurveyDraftReqBody>({
+      query: ({ surveyKey, surveyStep, ...body }) => ({
+        url: getSurveyDraftUrl(surveyKey, surveyStep),
+        method: 'PUT',
+        body,
+      }),
+      invalidatesTags: (_result, _error, { surveyKey, surveyStep }) => [
+        { type: 'SurveyDraft', id: formatSurveyKeyStep(surveyKey, surveyStep) },
+      ],
+    }),
   }),
 });
 
@@ -87,5 +133,7 @@ export const {
   useGetSurveyJsonQuery,
   useGetLatestSurveyResponseQuery,
   useAddSurveyResponseMutation,
+  useGetSurveyDraftQuery,
+  useUpsertSurveyDraftMutation,
   usePrefetch,
 } = surveyApi;

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -122,9 +122,6 @@ export const surveyApi = api.injectEndpoints({
         method: 'PUT',
         body,
       }),
-      invalidatesTags: (_result, _error, { surveyKey, surveyStep }) => [
-        { type: 'SurveyDraft', id: formatSurveyKeyStep(surveyKey, surveyStep) },
-      ],
     }),
   }),
 });


### PR DESCRIPTION
**Description**

Persists survey progress to the server as the farmer fills out the survey, and resumes from the server instead of trusting whatever's sitting in local Redux.

**What changed initially (see the comments for subsequent changes)**

**Backend:**

* `GET /survey_drafts/:survey_key/:survey_step?` — fetch the farm's current draft (or `null` if there isn't one).
* `PUT /survey_drafts/:survey_key/:survey_step?` — create-or-replace the draft at that key (idempotent upsert).
* Submitting a survey (`POST /survey_responses`) now soft-deletes the live draft in the same transaction and reuses its `submission_id`, so the finished response and the draft that produced it are traceably linked.
* A draft write is rejected (`409`) once a response already exists for that `survey_key`/`survey_step`.

**Frontend:**

* Redux store shape: drafts are now keyed by `survey_step` in addition to `survey_id` `(bySurveyId[surveyId][step]` instead of `bySurveyId[surveyId]`), so a multi-step survey can have an independent in-progress draft per step.
* `useInitialDraft` — on mount, fetches the server's draft and reconciles it against whatever's in local Redux (comparing `updated_at` timestamps), resolving *once* which one wins. It always forces a fresh server check on mount rather than trusting a stale cache, since this decision only gets made once per mount.
* `useSurveyDraftSync` — on mount, reconciles local vs. server draft (adopts the server's, discards a stale local one, or registers a never-before-saved local one), and thereafter saves progress to the server as the farmer works (on page change and on unmount).
* The Insights page tile for a survey (`SurveyInsightTile`) now shows "in progress" based on this same server-reconciled state instead of local-only Redux.

Jira link: https://lite-farm.atlassian.net/browse/LF-5471

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
