### PR TITLE
LF-5477 Streamline developer mobile testing over the local area network (2)

### DIFF
--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -25,7 +25,7 @@ if (VITE_NGROK_API && hostNameSplit && hostNameSplit.length > 1 && hostNameSplit
   URI = import.meta.env.VITE_API_URL;
 } else {
   if (VITE_ENV === 'development') {
-    URI = window.location.href.replace(/3000.*/, '5001');
+    URI = `${window.location.protocol}//${window.location.hostname}:5001`;
   } else if (VITE_ENV === 'production') {
     URI = 'https://api.app.litefarm.org';
   } else if (VITE_ENV === 'integration') {


### PR DESCRIPTION
**Description**

In #4321 I fixed the port of the unset `VITE_API_URL` fallback for the development environment, but I should have have also adjusted the method of replacement -- the exact match on :3000 works for the `pnpm dev` default, but fails immediately on `pnpm preview`.

This PR just replaces that line with a more robust strategy that is port agnostic.

Again this is a development environment-only change, allowing `VITE_API_URL` to be unset.

Jira link: https://lite-farm.atlassian.net/browse/LF-5477

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Immediately spotted this issue when testing the service worker cache on another PR!

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
