### PR TITLE
LF-5482 Custom task type page uses inconsistent terminology

### DIFF
--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -108,9 +108,9 @@
     "WHAT_YOU_WILL_BE_APPLYING": "What will you be applying?"
   },
   "ADD_TASK": {
-    "ADD_A_CUSTOM_TASK": "Add a custom task",
+    "ADD_A_CUSTOM_TASK": "Add a custom task type",
     "ADD_A_TASK": "Add a task",
-    "ADD_CUSTOM_TASK": "Add custom task",
+    "ADD_CUSTOM_TASK": "Add custom task type",
     "AFFECT_PLANS": "Will this task affect any plans?",
     "ASSIGN_ALL_TO_PERSON": "Assign all tasks on this date to {{name}}",
     "ASSIGN_DATE": "Change task date",
@@ -125,7 +125,7 @@
     },
     "CLEAR_ALL": "Clear all",
     "CLEAR_ALL_PLANS": "Clear all plans",
-    "CUSTOM_TASK": "Custom Task",
+    "CUSTOM_TASK": "Custom Task Type",
     "CUSTOM_TASK_CHAR_LIMIT": "Custom task type name cannot exceed 25 characters",
     "CUSTOM_TASK_NAME": "Custom task name",
     "CUSTOM_TASK_TYPE": "Custom Task Type",
@@ -203,7 +203,7 @@
       },
       "WHAT_TYPE_OF_IRRIGATION": "What type of irrigation?"
     },
-    "MANAGE_CUSTOM_TASKS": "Manage your custom tasks",
+    "MANAGE_CUSTOM_TASKS": "Manage your custom task types",
     "MOVEMENT_VIEW": {
       "MOVEMENT_PURPOSE_LABEL": "What's the purpose of this movement?",
       "MOVEMENT_PURPOSE_PLACEHOLDER": "Select the purpose for this movement",


### PR DESCRIPTION
**Description**

The previous wording was misleading, the page is actually referred to custom task types, but from the wording you may think that it was referring to custom tasks. Users should know that this page is not about managing individual custom tasks.

Jira link: https://lite-farm.atlassian.net/browse/LF-5482

Screenshots: 
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="240" alt="Screenshot_20260901_193241_Chrome" src="https://github.com/user-attachments/assets/bdc4c5a1-229b-4add-b9d8-0beb54fb9e64" />
</td>
    <td>
<img width="240"  alt="Screenshot_20260901_193104_Chrome" src="https://github.com/user-attachments/assets/b4118aa7-6408-40ba-ba34-8ed8db870eb9" />
</td>
  </tr>
  <tr>
    <td>
<img width="240"  alt="Custom Tasks New" src="https://github.com/user-attachments/assets/bb91e6ff-146e-4c54-bf1c-f71647f0ed59" />
 />
</td>
    <td>
<img width="240"  alt="Screenshot_20260901_193059_Chrome" src="https://github.com/user-attachments/assets/cf666d69-6da4-47dc-ae1d-586cada2821f" />
</td>
  </tr>
</table>

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Passes test case
- [x] UI components visually reviewed on desktop view
- [x] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
