### PR TITLE
LF-5483 Update the filename of FAO TAPE Step 1

### DIFF
--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -57,7 +57,7 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     image: tape_survey,
     ResultsComponent: TapeResults,
     cdnDirectory: 'tape_surveys',
-    versionsByCountry: { default: 'step0_step1', AU: 'au' },
+    versionsByCountry: { default: 'step01-survey', AU: 'au' },
     resolveVersion: (defaultVersion: string, language: string) => {
       return language === 'en'
         ? { version: `fao/${defaultVersion}` }

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -48,7 +48,7 @@ interface SurveyInfo {
  *  2. Add the title in useSurveyTitle.ts by calling t() with the key INSIGHTS.<KEY>.TITLE.
  *  3. Add that title string to public/locales/en/translation.json (English only; Crowdin propagates).
  *  4. Upload the survey's <version>.json to its CDN directory. A translatable default version goes
- *     in a per-language subfolder (e.g. fao/step0_step1.json for English, fao_fr/step0_step1_fr.json
+ *     in a per-language subfolder (e.g. fao/step01-survey.json for English, fao_fr/step01-survey_fr.json
  *     for French); a non-translatable, country-specific version (e.g. au) stays flat at the CDN
  *     directory root, no subfolder.
  */


### PR DESCRIPTION
**Description**

Updates the Step 1 JSON filename to the format the data team's script now produces.

Jira link: https://lite-farm.atlassian.net/browse/LF-5483

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Requires updating Digital Ocean, which I have done

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

Updated the files on the local / dev DO Bucket and tested in the 4 currently available languages (en/es/pt/fr)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [ ] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [ ] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
