### PR TITLE
LF-5127 Take TAPE Step 2 surveys and see scores within LiteFarm

### DIFF
--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -18,7 +18,7 @@ import knex from '../util/knex.js';
 import SurveyDraftModel from '../models/surveyDraftModel.js';
 import { SurveyDraftParams, UpsertDraftBody } from '../middleware/validation/checkSurveyDraft.js';
 import { LiteFarmRequest } from '../types.js';
-import { SurveyDraft } from '../models/types.js';
+import { SurveyDraftSummary } from '../models/types.js';
 
 interface UpsertDraftReqBody extends UpsertDraftBody {
   survey_version: string;
@@ -48,10 +48,14 @@ const surveyDraftController = {
     return async (req: LiteFarmRequest, res: Response) => {
       try {
         const { farm_id } = req.headers;
-        /* @ts-expect-error known issue with models */
-        const rows = (await SurveyDraftModel.query()
-          .whereNotDeleted()
-          .where({ farm_id })) as unknown as SurveyDraft[];
+
+        const rows =
+          /* @ts-expect-error known issue with models */
+          (await SurveyDraftModel.query()
+            .context({ showHidden: true })
+            .select('survey_key', 'current_page_no', 'created_at')
+            .whereNotDeleted()
+            .where({ farm_id })) as unknown as SurveyDraftSummary[];
 
         const draftsBySurveyKey = Object.fromEntries(rows.map((row) => [row.survey_key, row]));
 

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -18,6 +18,7 @@ import knex from '../util/knex.js';
 import SurveyDraftModel from '../models/surveyDraftModel.js';
 import { SurveyDraftParams, UpsertDraftBody } from '../middleware/validation/checkSurveyDraft.js';
 import { LiteFarmRequest } from '../types.js';
+import { SurveyDraft } from '../models/types.js';
 
 interface UpsertDraftReqBody extends UpsertDraftBody {
   survey_version: string;
@@ -36,6 +37,25 @@ const surveyDraftController = {
           .whereNotDeleted()
           .findOne({ farm_id, survey_key });
         return res.status(200).json(result ?? null);
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({ error });
+      }
+    };
+  },
+
+  getDrafts() {
+    return async (req: LiteFarmRequest, res: Response) => {
+      try {
+        const { farm_id } = req.headers;
+        /* @ts-expect-error known issue with models */
+        const rows = (await SurveyDraftModel.query()
+          .whereNotDeleted()
+          .where({ farm_id })) as unknown as SurveyDraft[];
+
+        const draftsBySurveyKey = Object.fromEntries(rows.map((row) => [row.survey_key, row]));
+
+        return res.status(200).json(draftsBySurveyKey);
       } catch (error) {
         console.error(error);
         return res.status(500).json({ error });

--- a/packages/api/src/controllers/surveyDraftController.ts
+++ b/packages/api/src/controllers/surveyDraftController.ts
@@ -53,11 +53,18 @@ const surveyDraftController = {
           /* @ts-expect-error known issue with models */
           (await SurveyDraftModel.query()
             .context({ showHidden: true })
-            .select('survey_key', 'current_page_no', 'created_at')
+            .select(
+              'survey_key',
+              'current_page_no',
+              'created_at',
+              knex.raw("survey_data <> '{}'::jsonb as has_data"),
+            )
             .whereNotDeleted()
             .where({ farm_id })) as unknown as SurveyDraftSummary[];
 
-        const draftsBySurveyKey = Object.fromEntries(rows.map((row) => [row.survey_key, row]));
+        const draftsBySurveyKey = Object.fromEntries(
+          rows.map(({ survey_key, ...draft }) => [survey_key, draft]),
+        );
 
         return res.status(200).json(draftsBySurveyKey);
       } catch (error) {

--- a/packages/api/src/controllers/surveyResponseController.ts
+++ b/packages/api/src/controllers/surveyResponseController.ts
@@ -19,13 +19,7 @@ import { LiteFarmRequest } from '../types.js';
 import { handleObjectionError } from '../util/errorCodes.js';
 import SurveyResponseModel from '../models/surveyResponseModel.js';
 import SurveyDraftModel from '../models/surveyDraftModel.js';
-
-interface SurveyResponseData {
-  survey_version: string;
-  project_id: string;
-  survey_step?: string;
-  [key: string]: unknown;
-}
+import { SurveyResponse, SurveyResponseData } from '../models/types.js';
 
 interface CreateSurveyResponseReqBody {
   survey_key: string;
@@ -117,6 +111,28 @@ const surveyResponseController = {
     };
   },
 
+  getLatestSurveyResponses() {
+    return async (req: LiteFarmRequest, res: Response) => {
+      try {
+        const { farm_id } = req.headers;
+        const rows = (await SurveyResponseModel.query()
+          .distinctOn('survey_key')
+          .where({ farm_id })
+          .orderBy([
+            { column: 'survey_key' },
+            { column: 'created_at', order: 'desc' },
+          ])) as unknown as SurveyResponse[];
+
+        const responsesBySurveyKey = Object.fromEntries(rows.map((row) => [row.survey_key, row]));
+
+        return res.status(200).json(responsesBySurveyKey);
+      } catch (error) {
+        console.error(error);
+        return res.status(500).json({ error });
+      }
+    };
+  },
+
   // Note: Not currently called from frontend
   updateSurveyResponse() {
     return async (
@@ -136,7 +152,7 @@ const surveyResponseController = {
         const { survey_version, project_id, survey_step } = survey_response;
 
         const existing = (await SurveyResponseModel.query().findOne({ submission_id })) as
-          | { survey_key: string }
+          | SurveyResponse
           | undefined;
         if (!existing) {
           return res.status(404).json({ error: 'Survey response not found' });

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -767,5 +767,8 @@ export interface SurveyDraft {
   survey_version: string;
   survey_data: Record<string, unknown>;
   current_page_no: number;
+  created_at: string;
   updated_at: string;
 }
+
+export type SurveyDraftSummary = Pick<SurveyDraft, 'survey_key' | 'current_page_no' | 'created_at'>;

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -738,3 +738,34 @@ export interface UserFarm {
   step_five_end?: string;
   wage_do_not_ask_again?: boolean;
 }
+
+export interface SurveyResponseData {
+  survey_version: string;
+  project_id: string;
+  survey_step?: string;
+  [key: string]: unknown;
+}
+
+export interface SurveyResponse {
+  id: number;
+  submission_id: string;
+  farm_id: Farm['farm_id'];
+  survey_key: string;
+  survey_version: string;
+  project_id: string;
+  survey_step: string | null;
+  survey_response: SurveyResponseData;
+  created_by_user_id: User['user_id'];
+  created_at: string;
+}
+
+export interface SurveyDraft {
+  id: string;
+  submission_id: string;
+  farm_id: Farm['farm_id'];
+  survey_key: string;
+  survey_version: string;
+  survey_data: Record<string, unknown>;
+  current_page_no: number;
+  updated_at: string;
+}

--- a/packages/api/src/models/types.ts
+++ b/packages/api/src/models/types.ts
@@ -771,4 +771,7 @@ export interface SurveyDraft {
   updated_at: string;
 }
 
-export type SurveyDraftSummary = Pick<SurveyDraft, 'survey_key' | 'current_page_no' | 'created_at'>;
+export type SurveyDraftSummary = Pick<
+  SurveyDraft,
+  'survey_key' | 'current_page_no' | 'created_at'
+> & { has_data: boolean };

--- a/packages/api/src/routes/surveyDraftRoute.ts
+++ b/packages/api/src/routes/surveyDraftRoute.ts
@@ -23,6 +23,8 @@ import surveyDraftController from '../controllers/surveyDraftController.js';
 
 const router = express.Router();
 
+router.get('/', checkScope(['get:survey_draft']), surveyDraftController.getDrafts());
+
 // One live draft per farm_id + survey_key
 router.get(
   '/:survey_key',

--- a/packages/api/src/routes/surveyResponseRoute.ts
+++ b/packages/api/src/routes/surveyResponseRoute.ts
@@ -27,6 +27,12 @@ router.post(
   surveyResponseController.createSurveyResponse(),
 );
 
+router.get(
+  '/latest',
+  checkScope(['get:survey_response']),
+  surveyResponseController.getLatestSurveyResponses(),
+);
+
 // Latest survey response of the kind given by the survey_key query param
 router.get(
   '/',

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -195,7 +195,7 @@ describe('Survey draft endpoint tests', () => {
       expect(res.body.tape_economic.current_page_no).toBe(2);
     });
 
-    test('Should return created_at and leave out survey_data', async () => {
+    test('Should return created_at and leave out survey_data and survey_key', async () => {
       await mocks.survey_draftFactory(
         { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
         mocks.fakeSurveyDraft({ survey_key: 'tape' }),
@@ -205,6 +205,24 @@ describe('Survey draft endpoint tests', () => {
       expect(res.status).toBe(200);
       expect(res.body.tape.created_at).toBeDefined();
       expect(res.body.tape.survey_data).toBeUndefined();
+      expect(res.body.tape.survey_key).toBeUndefined();
+    });
+
+    test('Should report has_data false for a draft holding no answers', async () => {
+      const promisedUserFarm = [{ farm_id: farm.farm_id, user_id: owner.user_id }];
+      await mocks.survey_draftFactory(
+        { promisedUserFarm },
+        mocks.fakeSurveyDraft({ survey_key: 'tape', survey_data: {} }),
+      );
+      await mocks.survey_draftFactory(
+        { promisedUserFarm },
+        mocks.fakeSurveyDraft({ survey_key: 'tape_economic' }),
+      );
+
+      const res = await getDraftsRequest();
+      expect(res.status).toBe(200);
+      expect(res.body.tape.has_data).toBe(false);
+      expect(res.body.tape_economic.has_data).toBe(true);
     });
 
     test('Should not return a soft-deleted draft', async () => {

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -72,6 +72,14 @@ describe('Survey draft endpoint tests', () => {
       .send({ farm_id, survey_version, survey_data, current_page_no, submission_id });
   }
 
+  async function getDraftsRequest({ user_id = owner.user_id, farm_id = farm.farm_id } = {}) {
+    return chai
+      .request(server)
+      .get('/survey_drafts')
+      .set('user_id', user_id)
+      .set('farm_id', farm_id);
+  }
+
   async function postSurveyResponse(survey_key = 'tape') {
     return chai
       .request(server)
@@ -158,6 +166,62 @@ describe('Survey draft endpoint tests', () => {
       const idsA = await createUserFarmIds(1);
       const idsB = await createUserFarmIds(1);
       const res = await getDraftRequest({ farm_id: idsA.farm_id, user_id: idsB.user_id });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('GET /survey_drafts', () => {
+    test('Should return an empty result when the farm has no drafts', async () => {
+      const res = await getDraftsRequest();
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+    });
+
+    test('Should return one entry per survey_key the farm has a live draft for', async () => {
+      const promisedUserFarm = [{ farm_id: farm.farm_id, user_id: owner.user_id }];
+      await mocks.survey_draftFactory(
+        { promisedUserFarm },
+        mocks.fakeSurveyDraft({ survey_key: 'tape', survey_data: { q1: 'parent' } }),
+      );
+      await mocks.survey_draftFactory(
+        { promisedUserFarm },
+        mocks.fakeSurveyDraft({ survey_key: 'tape_economic', survey_data: { q1: 'module' } }),
+      );
+
+      const res = await getDraftsRequest();
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body).sort()).toEqual(['tape', 'tape_economic']);
+      expect(res.body.tape.survey_data).toEqual({ q1: 'parent' });
+      expect(res.body.tape_economic.survey_data).toEqual({ q1: 'module' });
+    });
+
+    test('Should not return a soft-deleted draft', async () => {
+      await mocks.survey_draftFactory(
+        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
+        mocks.fakeSurveyDraft({ survey_key: 'tape' }),
+      );
+      await postSurveyResponse('tape');
+
+      const res = await getDraftsRequest();
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+    });
+
+    test("Should not return another farm's drafts", async () => {
+      const otherFarm = await createUserFarmIds(1);
+      await mocks.survey_draftFactory(
+        { promisedUserFarm: [otherFarm] },
+        mocks.fakeSurveyDraft({ survey_key: 'tape' }),
+      );
+
+      const res = await getDraftsRequest();
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+    });
+
+    test('Worker should not be able to get the drafts', async () => {
+      const userFarmIds = await createUserFarmIds(3);
+      const res = await getDraftsRequest(userFarmIds);
       expect(res.status).toBe(403);
     });
   });

--- a/packages/api/tests/surveyDraft.test.js
+++ b/packages/api/tests/surveyDraft.test.js
@@ -181,18 +181,30 @@ describe('Survey draft endpoint tests', () => {
       const promisedUserFarm = [{ farm_id: farm.farm_id, user_id: owner.user_id }];
       await mocks.survey_draftFactory(
         { promisedUserFarm },
-        mocks.fakeSurveyDraft({ survey_key: 'tape', survey_data: { q1: 'parent' } }),
+        mocks.fakeSurveyDraft({ survey_key: 'tape', current_page_no: 7 }),
       );
       await mocks.survey_draftFactory(
         { promisedUserFarm },
-        mocks.fakeSurveyDraft({ survey_key: 'tape_economic', survey_data: { q1: 'module' } }),
+        mocks.fakeSurveyDraft({ survey_key: 'tape_economic', current_page_no: 2 }),
       );
 
       const res = await getDraftsRequest();
       expect(res.status).toBe(200);
       expect(Object.keys(res.body).sort()).toEqual(['tape', 'tape_economic']);
-      expect(res.body.tape.survey_data).toEqual({ q1: 'parent' });
-      expect(res.body.tape_economic.survey_data).toEqual({ q1: 'module' });
+      expect(res.body.tape.current_page_no).toBe(7);
+      expect(res.body.tape_economic.current_page_no).toBe(2);
+    });
+
+    test('Should return created_at and leave out survey_data', async () => {
+      await mocks.survey_draftFactory(
+        { promisedUserFarm: [{ farm_id: farm.farm_id, user_id: owner.user_id }] },
+        mocks.fakeSurveyDraft({ survey_key: 'tape' }),
+      );
+
+      const res = await getDraftsRequest();
+      expect(res.status).toBe(200);
+      expect(res.body.tape.created_at).toBeDefined();
+      expect(res.body.tape.survey_data).toBeUndefined();
     });
 
     test('Should not return a soft-deleted draft', async () => {

--- a/packages/api/tests/surveyResponse.test.js
+++ b/packages/api/tests/surveyResponse.test.js
@@ -64,6 +64,14 @@ describe('Survey response endpoint tests', () => {
       .set('farm_id', farm_id);
   }
 
+  async function getLatestRequest({ user_id = owner.user_id, farm_id = farm.farm_id } = {}) {
+    return chai
+      .request(server)
+      .get('/survey_response/latest')
+      .set('user_id', user_id)
+      .set('farm_id', farm_id);
+  }
+
   async function patchRequest(
     submission_id,
     survey_response,
@@ -193,6 +201,54 @@ describe('Survey response endpoint tests', () => {
       const idsA = await createUserFarmIds(1);
       const idsB = await createUserFarmIds(1);
       const res = await getRequest({ farm_id: idsA.farm_id, user_id: idsB.user_id });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('GET /survey_response/latest', () => {
+    test('Should return an empty result when the farm has no survey responses', async () => {
+      const res = await getLatestRequest();
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+    });
+
+    test('Should return the latest response for each survey_key the farm has answered', async () => {
+      await postRequest(fakeSurveyPayload(farm.farm_id, 'tape'));
+      await postRequest(fakeSurveyPayload(farm.farm_id, 'tape_economic'));
+      await postRequest({
+        ...fakeSurveyPayload(farm.farm_id, 'tape_soil'),
+        survey_response: {
+          survey_version: 'v1',
+          project_id: 'project-1',
+          survey_step: 'step-1',
+        },
+      });
+      await postRequest({
+        ...fakeSurveyPayload(farm.farm_id, 'tape_soil'),
+        survey_response: {
+          survey_version: 'v2',
+          project_id: 'project-2',
+          survey_step: 'step-2',
+        },
+      });
+
+      const res = await getLatestRequest();
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body).sort()).toEqual(['tape', 'tape_economic', 'tape_soil']);
+      expect(res.body.tape_soil.survey_response.survey_step).toBe('step-2');
+    });
+
+    test("Should not return another farm's survey responses", async () => {
+      await postRequest(fakeSurveyPayload(farm.farm_id, 'tape'));
+      const otherOwner = await createUserFarmIds(1);
+      const res = await getLatestRequest(otherOwner);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+    });
+
+    test('Worker should not be able to get the latest survey responses', async () => {
+      const userFarmIds = await createUserFarmIds(3);
+      const res = await getLatestRequest(userFarmIds);
       expect(res.status).toBe(403);
     });
   });

--- a/packages/webapp/public/locales/en/translation.json
+++ b/packages/webapp/public/locales/en/translation.json
@@ -1303,6 +1303,30 @@
       "TITLE": "TAPE Survey (Tool for Agroecology Performance Evaluation)",
       "UPDATE_ANSWERS": "Update your answers"
     },
+    "TAPE_DIETARY_DIVERSITY": {
+      "TITLE": "Dietary diversity"
+    },
+    "TAPE_ECONOMIC": {
+      "TITLE": "Qualitative economic indicator"
+    },
+    "TAPE_FOOD_SECURITY": {
+      "TITLE": "Food security"
+    },
+    "TAPE_LAND_AWEAI": {
+      "TITLE": "Land tenure"
+    },
+    "TAPE_PESTICIDES": {
+      "TITLE": "Exposure to pesticides"
+    },
+    "TAPE_PRODUCTIVITY_BIODIVERSITY": {
+      "TITLE": "Productivity, income and value added"
+    },
+    "TAPE_SOIL": {
+      "TITLE": "Soil health"
+    },
+    "TAPE_YOUTH": {
+      "TITLE": "Youth employment opportunity and emigration"
+    },
     "TITLE": "Insights",
     "UNAVAILABLE": "Unavailable"
   },

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -103,6 +103,7 @@ export const supportTicketUrl = `${URI}/support_ticket`;
 export const logUserInfoUrl = `${URI}/userLog`;
 export const offlineEventLogUrl = `${URI}/offline_event_log`;
 export const surveyResponseUrl = `${URI}/survey_response`;
+export const latestSurveyResponsesUrl = `${URI}/survey_response/latest`;
 export const getSurveyDraftUrl = (surveyKey) => `${URI}/survey_drafts/${surveyKey}`;
 export const farmNoteUrl = `${URI}/farm_notes`;
 export const farmNotesReadUrl = `${URI}/farm_notes_read`;

--- a/packages/webapp/src/apiConfig.js
+++ b/packages/webapp/src/apiConfig.js
@@ -104,6 +104,7 @@ export const logUserInfoUrl = `${URI}/userLog`;
 export const offlineEventLogUrl = `${URI}/offline_event_log`;
 export const surveyResponseUrl = `${URI}/survey_response`;
 export const latestSurveyResponsesUrl = `${URI}/survey_response/latest`;
+export const surveyDraftsUrl = `${URI}/survey_drafts`;
 export const getSurveyDraftUrl = (surveyKey) => `${URI}/survey_drafts/${surveyKey}`;
 export const farmNoteUrl = `${URI}/farm_notes`;
 export const farmNotesReadUrl = `${URI}/farm_notes_read`;

--- a/packages/webapp/src/components/SurveyComponent/customFunctions.ts
+++ b/packages/webapp/src/components/SurveyComponent/customFunctions.ts
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { FunctionFactory } from 'survey-core';
+
+const TLU_RATES: Record<string, number> = {
+  cow_bull: 0.7,
+  bison: 0.7,
+  water_buffalo: 0.7,
+  horse: 0.8,
+  reindeer: 0.4,
+  donkey: 0.5,
+  mule: 0.6,
+  sheep: 0.1,
+  goat: 0.1,
+  pig: 0.2,
+  camel: 0.7,
+  llama: 0.4,
+  rabbit: 0.02,
+  chicken: 0.01,
+  duck: 0.01,
+  goose: 0.02,
+  turkey: 0.02,
+  pigeon: 0.005,
+  ostrich: 0.05,
+  fish: 0.001,
+  crustaceans: 0.001,
+  molluscs: 0.001,
+  peacock: 0.02,
+  crocodiles: 0.05,
+};
+
+const DEFAULT_TLU_RATE = 0.1;
+
+// Gets the display label of the Nth selected item from a tagbox.
+// Used for crop names, animal names, and product names in panel titles.
+FunctionFactory.Instance.register('getItemAtIndex', ([arr, idx]) =>
+  Array.isArray(arr) ? arr[idx] ?? null : null,
+);
+
+// Gets a field value from another paneldynamic at the same panel index.
+// Used in biodiversity to pull crop area and variety count from productivity.
+FunctionFactory.Instance.register('getPanelValue', ([panelArray, idx, fieldName]) => {
+  if (!Array.isArray(panelArray) || idx >= panelArray.length) {
+    return null;
+  }
+  return panelArray[idx]?.[fieldName] ?? null;
+});
+
+// Gets the Nth selected value (stored code) from a tagbox.
+// Used in biodiversity to identify which animal species each panel refers to.
+FunctionFactory.Instance.register('selectedAt', ([arr, idx]) =>
+  Array.isArray(arr) ? arr[idx] ?? null : null,
+);
+
+FunctionFactory.Instance.register(
+  'getTLUFactor',
+  ([animalCode]) => TLU_RATES[animalCode] ?? DEFAULT_TLU_RATE,
+);

--- a/packages/webapp/src/components/SurveyComponent/index.tsx
+++ b/packages/webapp/src/components/SurveyComponent/index.tsx
@@ -22,6 +22,7 @@ import 'survey-core/i18n/french';
 import 'survey-core/i18n/spanish';
 import 'survey-core/i18n/portuguese';
 import 'survey-core/i18n/italian';
+import './customFunctions';
 
 interface SurveyComponentProps {
   surveyJson: any; // Survey JSON schema object

--- a/packages/webapp/src/containers/Insights/Survey/TapeRadarChart.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/TapeRadarChart.tsx
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Radar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+} from 'chart.js';
+import styles from './styles.module.scss';
+import { roundToOne } from '../../../util/rounding';
+import { MAX_SCORE, TAPEDimension, TAPEDimensionId } from './caetScores';
+
+const CHART_COLOR = 'rgba(85, 143, 112, 1)'; // --Colors-Secondary-Secondary-green-700
+const CHART_FILL_COLOR = 'rgba(85, 143, 112, 0.2)'; // reduced opacity
+
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip);
+
+const CHART_OPTIONS = {
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: {
+    r: {
+      angleLines: {
+        display: true,
+      },
+      suggestedMin: 0,
+      suggestedMax: MAX_SCORE,
+      ticks: {
+        stepSize: 20,
+      },
+      pointLabels: {
+        font: {
+          size: 14,
+        },
+        // Splits labels into a maximum of 2 lines at a word boundary
+        callback: (label: string) => {
+          const words = label.split(' ');
+          const splitIndex = words.length === 1 ? 1 : Math.floor(words.length / 2);
+
+          return [words.slice(0, splitIndex).join(' '), words.slice(splitIndex).join(' ')];
+        },
+      },
+    },
+  },
+  plugins: {
+    tooltip: {
+      callbacks: {
+        label: (context: { label: string; parsed: { r: number } }) =>
+          ` ${context.label}: ${context.parsed.r}%`,
+      },
+    },
+  },
+};
+
+interface TapeRadarChartProps {
+  dimensions: Pick<TAPEDimension, 'dimension' | 'score'>[];
+}
+
+const TapeRadarChart = ({ dimensions }: TapeRadarChartProps) => {
+  const { t } = useTranslation();
+
+  const dimensionLabels: Record<TAPEDimensionId, string> = {
+    diversity: t('INSIGHTS.TAPE.DIMENSIONS.DIVERSITY'),
+    synergy: t('INSIGHTS.TAPE.DIMENSIONS.SYNERGY'),
+    recycling: t('INSIGHTS.TAPE.DIMENSIONS.RECYCLING'),
+    efficiency: t('INSIGHTS.TAPE.DIMENSIONS.EFFICIENCY'),
+    resilience: t('INSIGHTS.TAPE.DIMENSIONS.RESILIENCE'),
+    cultureAndFood: t('INSIGHTS.TAPE.DIMENSIONS.CULTURE_AND_FOOD'),
+    cocreationAndKnowledge: t('INSIGHTS.TAPE.DIMENSIONS.COCREATION_AND_KNOWLEDGE'),
+    humanAndSocial: t('INSIGHTS.TAPE.DIMENSIONS.HUMAN_AND_SOCIAL'),
+    circularEconomy: t('INSIGHTS.TAPE.DIMENSIONS.CIRCULAR_ECONOMY'),
+    responsibleGovernance: t('INSIGHTS.TAPE.DIMENSIONS.RESPONSIBLE_GOVERNANCE'),
+  };
+
+  const chartData = {
+    labels: dimensions.map((d) => dimensionLabels[d.dimension]),
+    datasets: [
+      {
+        data: dimensions.map((d) => roundToOne(d.score)),
+        backgroundColor: CHART_FILL_COLOR,
+        borderColor: CHART_COLOR,
+        borderWidth: 2,
+        pointBackgroundColor: CHART_COLOR,
+        pointHoverBorderColor: CHART_COLOR,
+      },
+    ],
+  };
+
+  return (
+    <div className={styles.chartContainerWrapper}>
+      <div className={styles.chartContainer}>
+        <Radar data={chartData} options={CHART_OPTIONS} />
+      </div>
+    </div>
+  );
+};
+
+export default TapeRadarChart;

--- a/packages/webapp/src/containers/Insights/Survey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/TapeResults.tsx
@@ -17,50 +17,14 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
-import { Radar } from 'react-chartjs-2';
-import {
-  Chart as ChartJS,
-  RadialLinearScale,
-  PointElement,
-  LineElement,
-  Filler,
-  Tooltip,
-} from 'chart.js';
 import styles from './styles.module.scss';
 import insightStyles from '../styles.module.scss';
 import { Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
-import { roundToOne } from '../../../util/rounding';
+import TapeRadarChart from './TapeRadarChart';
+import { getTAPEDimensionScores } from './caetScores';
 import { useGetLatestSurveyResponseQuery } from '../../../store/api/surveyApi';
 import { enqueueErrorSnackbar, snackbarSelector } from '../../Snackbar/snackbarSlice';
-
-const CHART_COLOR = 'rgba(85, 143, 112, 1)'; // --Colors-Secondary-Secondary-green-700
-const CHART_FILL_COLOR = 'rgba(85, 143, 112, 0.2)'; // reduced opacity
-const MAX_SCORE = 100;
-const RAW_MAX_SCORE = 4;
-
-ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip);
-
-const DIMENSIONS = [
-  { id: 'diversity', prefix: 'diversity_1', scoreField: 'div_score' },
-  { id: 'synergy', prefix: 'synergy_2', scoreField: 'synergy_score' },
-  { id: 'recycling', prefix: 'recycling_3', scoreField: 'recycling_score' },
-  { id: 'efficiency', prefix: 'efficiency_4', scoreField: 'efficiency_score' },
-  { id: 'resilience', prefix: 'resilience_5', scoreField: 'resilience_score' },
-  { id: 'cultureAndFood', prefix: 'culture_6', scoreField: 'cultfood_score' },
-  { id: 'cocreationAndKnowledge', prefix: 'knowledge_7', scoreField: 'cocrea_score' },
-  { id: 'humanAndSocial', prefix: 'human_8', scoreField: 'human_score' },
-  { id: 'circularEconomy', prefix: 'circular_9', scoreField: 'circular_score' },
-  { id: 'responsibleGovernance', prefix: 'governance_10', scoreField: 'respgov_score' },
-] as const;
-
-type TAPEDimensionId = (typeof DIMENSIONS)[number]['id'];
-
-interface TAPEDimension {
-  dimension: TAPEDimensionId;
-  score: number;
-  maxScore: number;
-}
 
 function TAPEResults({ surveyId = 'tape' }: { surveyId?: string }) {
   const { t } = useTranslation();
@@ -92,70 +56,7 @@ function TAPEResults({ surveyId = 'tape' }: { surveyId?: string }) {
     }
   }, [surveyDataError, isSuccess, surveyData]);
 
-  const tapeData = survey_response ? getTAPEDimensionScores(survey_response) : [];
-
-  const dimensionLabels: Record<TAPEDimensionId, string> = {
-    diversity: t('INSIGHTS.TAPE.DIMENSIONS.DIVERSITY'),
-    synergy: t('INSIGHTS.TAPE.DIMENSIONS.SYNERGY'),
-    recycling: t('INSIGHTS.TAPE.DIMENSIONS.RECYCLING'),
-    efficiency: t('INSIGHTS.TAPE.DIMENSIONS.EFFICIENCY'),
-    resilience: t('INSIGHTS.TAPE.DIMENSIONS.RESILIENCE'),
-    cultureAndFood: t('INSIGHTS.TAPE.DIMENSIONS.CULTURE_AND_FOOD'),
-    cocreationAndKnowledge: t('INSIGHTS.TAPE.DIMENSIONS.COCREATION_AND_KNOWLEDGE'),
-    humanAndSocial: t('INSIGHTS.TAPE.DIMENSIONS.HUMAN_AND_SOCIAL'),
-    circularEconomy: t('INSIGHTS.TAPE.DIMENSIONS.CIRCULAR_ECONOMY'),
-    responsibleGovernance: t('INSIGHTS.TAPE.DIMENSIONS.RESPONSIBLE_GOVERNANCE'),
-  };
-
-  const chartData = {
-    labels: tapeData.map((d) => dimensionLabels[d.dimension]),
-    datasets: [
-      {
-        data: tapeData.map((d) => roundToOne(d.score)),
-        backgroundColor: CHART_FILL_COLOR,
-        borderColor: CHART_COLOR,
-        borderWidth: 2,
-        pointBackgroundColor: CHART_COLOR,
-        pointHoverBorderColor: CHART_COLOR,
-      },
-    ],
-  };
-
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    scales: {
-      r: {
-        angleLines: {
-          display: true,
-        },
-        suggestedMin: 0,
-        suggestedMax: MAX_SCORE,
-        ticks: {
-          stepSize: 20,
-        },
-        pointLabels: {
-          font: {
-            size: 14,
-          },
-          // Splits labels into a maximum of 2 lines at a word boundary
-          callback: (label: any) => {
-            const words = label.split(' ');
-            const splitIndex = words.length === 1 ? 1 : Math.floor(words.length / 2);
-
-            return [words.slice(0, splitIndex).join(' '), words.slice(splitIndex).join(' ')];
-          },
-        },
-      },
-    },
-    plugins: {
-      tooltip: {
-        callbacks: {
-          label: (context: any) => ` ${context.label}: ${context.parsed.r}%`,
-        },
-      },
-    },
-  };
+  const caetScores = survey_response ? getTAPEDimensionScores(survey_response) : [];
 
   return (
     <div className={insightStyles.insightContainer}>
@@ -163,54 +64,11 @@ function TAPEResults({ surveyId = 'tape' }: { surveyId?: string }) {
       <div className={styles.resultsContainer}>
         <div className={styles.sectionContainer}>
           <Semibold className={styles.titleText}>{t('INSIGHTS.TAPE.RESULTS_TITLE')}</Semibold>
-          <div className={styles.chartContainerWrapper}>
-            {tapeData && tapeData.length > 0 && (
-              <div className={styles.chartContainer}>
-                <Radar data={chartData} options={options} />
-              </div>
-            )}
-          </div>
+          {caetScores.length > 0 && <TapeRadarChart dimensions={caetScores} />}
         </div>
       </div>
     </div>
   );
 }
-
-const OVERALL_SCORE_FIELD = 'caet_score';
-
-const getTAPEDimensionScores = (data: any): TAPEDimension[] => {
-  if (!data) {
-    return [];
-  }
-
-  return OVERALL_SCORE_FIELD in data ? readTAPEScores(data) : analyzeTAPEData(data);
-};
-
-const readTAPEScores = (data: any): TAPEDimension[] =>
-  DIMENSIONS.map(({ id, scoreField }) => ({
-    dimension: id,
-    score: Number(data[scoreField]) || 0,
-    maxScore: MAX_SCORE,
-  }));
-
-const analyzeTAPEData = (data: any): TAPEDimension[] => {
-  return DIMENSIONS.map(({ id, prefix }) => {
-    const scores = Object.keys(data)
-      .filter((key) => key.startsWith(prefix))
-      .map((key) => Number(data[key]) || 0);
-
-    if (!scores.length) {
-      return { dimension: id, score: 0, maxScore: MAX_SCORE };
-    }
-
-    const averageRawScore = scores.reduce((sum, value) => sum + value, 0) / scores.length;
-
-    return {
-      dimension: id,
-      score: (averageRawScore / RAW_MAX_SCORE) * MAX_SCORE,
-      maxScore: MAX_SCORE,
-    };
-  });
-};
 
 export default TAPEResults;

--- a/packages/webapp/src/containers/Insights/Survey/TapeResults.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/TapeResults.tsx
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
@@ -23,6 +23,8 @@ import { Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
 import TapeRadarChart from './TapeRadarChart';
 import { getTAPEDimensionScores } from './caetScores';
+import SurveyModuleSection from '../../../components/Insights/Survey/SurveyModuleSection';
+import { useSurveyModules } from './useSurveyModules';
 import { useGetLatestSurveyResponseQuery } from '../../../store/api/surveyApi';
 import { enqueueErrorSnackbar, snackbarSelector } from '../../Snackbar/snackbarSlice';
 
@@ -57,6 +59,12 @@ function TAPEResults({ surveyId = 'tape' }: { surveyId?: string }) {
   }, [surveyDataError, isSuccess, surveyData]);
 
   const caetScores = survey_response ? getTAPEDimensionScores(survey_response) : [];
+  const modules = useSurveyModules(surveyId, survey_response);
+
+  const openModule = useCallback(
+    (moduleSurveyId: string) => history.push(`/insights/survey/${moduleSurveyId}`),
+    [history],
+  );
 
   return (
     <div className={insightStyles.insightContainer}>
@@ -66,6 +74,9 @@ function TAPEResults({ surveyId = 'tape' }: { surveyId?: string }) {
           <Semibold className={styles.titleText}>{t('INSIGHTS.TAPE.RESULTS_TITLE')}</Semibold>
           {caetScores.length > 0 && <TapeRadarChart dimensions={caetScores} />}
         </div>
+        {modules.length > 0 && (
+          <SurveyModuleSection modules={modules} onModuleAction={openModule} />
+        )}
       </div>
     </div>
   );

--- a/packages/webapp/src/containers/Insights/Survey/ThankYouResults.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/ThankYouResults.tsx
@@ -19,6 +19,7 @@ import insightStyles from '../styles.module.scss';
 import { Semibold } from '../../../components/Typography';
 import PageTitle from '../../../components/PageTitle';
 import { useSurveyTitle } from './useSurveyTitle';
+import { getSurveyBackUrl } from './surveyConfig';
 
 /**
  * Default results component for surveys that do not need a custom visualization. Rendered by the
@@ -30,7 +31,7 @@ function ThankYouResults({ surveyId }: { surveyId: string }) {
 
   return (
     <div className={insightStyles.insightContainer}>
-      <PageTitle title={surveyTitle} backUrl="/Insights" />
+      <PageTitle title={surveyTitle} backUrl={getSurveyBackUrl(surveyId)} />
       <div className={styles.resultsContainer}>
         <div className={styles.sectionContainer}>
           <Semibold className={styles.titleText}>{t('INSIGHTS.SURVEY.THANK_YOU')}</Semibold>

--- a/packages/webapp/src/containers/Insights/Survey/caetScores.ts
+++ b/packages/webapp/src/containers/Insights/Survey/caetScores.ts
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { CAET_SCORE_FIELD } from './surveyConfig';
+
+export const MAX_SCORE = 100;
+export const RAW_MAX_SCORE = 4;
+
+export const DIMENSIONS = [
+  { id: 'diversity', prefix: 'diversity_1', scoreField: 'div_score' },
+  { id: 'synergy', prefix: 'synergy_2', scoreField: 'synergy_score' },
+  { id: 'recycling', prefix: 'recycling_3', scoreField: 'recycling_score' },
+  { id: 'efficiency', prefix: 'efficiency_4', scoreField: 'efficiency_score' },
+  { id: 'resilience', prefix: 'resilience_5', scoreField: 'resilience_score' },
+  { id: 'cultureAndFood', prefix: 'culture_6', scoreField: 'cultfood_score' },
+  { id: 'cocreationAndKnowledge', prefix: 'knowledge_7', scoreField: 'cocrea_score' },
+  { id: 'humanAndSocial', prefix: 'human_8', scoreField: 'human_score' },
+  { id: 'circularEconomy', prefix: 'circular_9', scoreField: 'circular_score' },
+  { id: 'responsibleGovernance', prefix: 'governance_10', scoreField: 'respgov_score' },
+] as const;
+
+export type TAPEDimensionId = (typeof DIMENSIONS)[number]['id'];
+
+export interface TAPEDimension {
+  dimension: TAPEDimensionId;
+  score: number;
+  maxScore: number;
+}
+
+export const getTAPEDimensionScores = (
+  data: Record<string, unknown> | null | undefined,
+): TAPEDimension[] => {
+  if (!data) {
+    return [];
+  }
+
+  return CAET_SCORE_FIELD in data ? readTAPEScores(data) : analyzeTAPEData(data);
+};
+
+const readTAPEScores = (data: Record<string, unknown>): TAPEDimension[] =>
+  DIMENSIONS.map(({ id, scoreField }) => ({
+    dimension: id,
+    score: Number(data[scoreField]) || 0,
+    maxScore: MAX_SCORE,
+  }));
+
+const analyzeTAPEData = (data: Record<string, unknown>): TAPEDimension[] => {
+  return DIMENSIONS.map(({ id, prefix }) => {
+    const scores = Object.keys(data)
+      .filter((key) => key.startsWith(prefix))
+      .map((key) => Number(data[key]) || 0);
+
+    if (!scores.length) {
+      return { dimension: id, score: 0, maxScore: MAX_SCORE };
+    }
+
+    const averageRawScore = scores.reduce((sum, value) => sum + value, 0) / scores.length;
+
+    return {
+      dimension: id,
+      score: (averageRawScore / RAW_MAX_SCORE) * MAX_SCORE,
+      maxScore: MAX_SCORE,
+    };
+  });
+};

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -27,6 +27,7 @@ import {
   getSurveyCdnPath,
   getSurveyVersion,
   getPostSubmitRoute,
+  getSurveyBackUrl,
 } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
@@ -172,7 +173,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
 
   return (
     <div className={insightStyles.insightContainer}>
-      <PageTitle title={surveyTitle} backUrl="/Insights" />
+      <PageTitle title={surveyTitle} backUrl={getSurveyBackUrl(surveyId)} />
       <div className={clsx(styles.surveyContainer, isCompactSideMenu && styles.compactSideMenu)}>
         {/* wait for prepopulated data and survey JSON to load */}
         {isLoading && (

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -22,7 +22,12 @@ import { useTranslation } from 'react-i18next';
 import { useSurveyPrepopulatedData } from './useSurveyPrepopulatedData';
 import { useSurveyTitle } from './useSurveyTitle';
 import { saveSurveyProgress, clearSurvey } from './surveyDraftSlice';
-import { SURVEY_INFO, getSurveyCdnPath, getSurveyVersion } from './surveyConfig';
+import {
+  SURVEY_INFO,
+  getSurveyCdnPath,
+  getSurveyVersion,
+  getPostSubmitRoute,
+} from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
 import PageTitle from '../../../components/PageTitle';
@@ -123,7 +128,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
         prefetchLatestResponse({ surveyKey: surveyId });
         dispatch(clearSurvey({ surveyId }));
         // Replace instead of push so the submitted survey is not left in the history stack
-        history.replace(`/insights/survey/${surveyId}/results`);
+        history.replace(getPostSubmitRoute(surveyId));
       } catch {
         // Display the default "An error occurred and we could not save the results." message.
         options.showSaveError();
@@ -148,7 +153,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       draftState.initialDraft.needsLocalSync &&
       !draftState.initialDraft.submissionId
     ) {
-      history.replace(`/insights/survey/${surveyId}/results`);
+      history.replace(getPostSubmitRoute(surveyId));
     }
   }, [draftState.isDraftLoading, draftState.initialDraft, surveyId, history]);
 

--- a/packages/webapp/src/containers/Insights/Survey/index.tsx
+++ b/packages/webapp/src/containers/Insights/Survey/index.tsx
@@ -28,6 +28,7 @@ import {
   getSurveyVersion,
   getPostSubmitRoute,
   getSurveyBackUrl,
+  getAvailableModuleIds,
 } from './surveyConfig';
 import { userFarmSelector } from '../../../containers/userFarmSlice';
 import SurveyComponent from '../../../components/SurveyComponent';
@@ -36,6 +37,7 @@ import Spinner from '../../../components/Spinner';
 import {
   usePrefetch,
   useGetSurveyJsonQuery,
+  useGetLatestSurveyResponseQuery,
   useAddSurveyResponseMutation,
 } from '../../../store/api/surveyApi';
 import { enqueueErrorSnackbar, snackbarSelector } from '../../Snackbar/snackbarSlice';
@@ -59,6 +61,19 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
   const { farm_id, country_code } = useSelector(userFarmSelector);
 
   const cdnDirectory = SURVEY_INFO[surveyId]?.cdnDirectory;
+  const parentSurveyId = SURVEY_INFO[surveyId]?.parentSurveyId;
+
+  const { data: parentResponse, isLoading: isParentResponseLoading } =
+    useGetLatestSurveyResponseQuery({ surveyKey: parentSurveyId ?? '' }, { skip: !parentSurveyId });
+
+  const isGuardPending = !!parentSurveyId && isParentResponseLoading;
+
+  const isUnauthorizedModule =
+    !!parentSurveyId &&
+    !isParentResponseLoading &&
+    !getAvailableModuleIds(parentSurveyId, parentResponse?.survey_response).includes(surveyId);
+
+  const isBlockedModule = isGuardPending || isUnauthorizedModule;
 
   const draftState = useInitialDraft(surveyId);
   const hasDraft = Object.keys(draftState.initialDraft.surveyData || {}).length > 0;
@@ -84,7 +99,7 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
       version: cdnPath ?? '',
       fallbackVersion: cdnFallbackPath,
     },
-    { skip: !cdnDirectory || !cdnPath },
+    { skip: !cdnDirectory || !cdnPath || isBlockedModule },
   );
 
   const { prepopulatedData, isLoading: isPrepopulatedDataLoading } = useSurveyPrepopulatedData(
@@ -140,10 +155,10 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
 
   // Redirect to Insights if this survey is unknown or not available to the farm's country
   useEffect(() => {
-    if (!draftState.isDraftLoading && !cdnPath) {
+    if ((!draftState.isDraftLoading && !cdnPath) || isUnauthorizedModule) {
       history.replace('/Insights');
     }
-  }, [draftState.isDraftLoading, cdnPath, history]);
+  }, [draftState.isDraftLoading, cdnPath, isUnauthorizedModule, history]);
 
   // TODO: LF-5192 Remove useEffect once retake is supported.
   useEffect(() => {
@@ -169,11 +184,11 @@ function Survey({ isCompactSideMenu }: SurveyProps) {
     }
   }, [isSurveyJsonError]);
 
-  const isLoading = isPrepopulatedDataLoading || isSurveyJsonLoading;
+  const isLoading = isPrepopulatedDataLoading || isSurveyJsonLoading || isBlockedModule;
 
   return (
     <div className={insightStyles.insightContainer}>
-      <PageTitle title={surveyTitle} backUrl={getSurveyBackUrl(surveyId)} />
+      {!isBlockedModule && <PageTitle title={surveyTitle} backUrl={getSurveyBackUrl(surveyId)} />}
       <div className={clsx(styles.surveyContainer, isCompactSideMenu && styles.compactSideMenu)}>
         {/* wait for prepopulated data and survey JSON to load */}
         {isLoading && (

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -36,6 +36,9 @@ interface SurveyInfo {
   ) => { version: string; fallbackVersion?: string };
   parentSurveyId?: string;
   isAvailable?: (parentResponse: Record<string, any>) => boolean;
+  scoreField?: string;
+  pages?: number;
+  estimatedMinutes?: number;
 }
 
 const resolveFaoVersion = (defaultVersion: string, language: string) =>
@@ -88,12 +91,18 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step2-economic' },
     resolveVersion: resolveFaoVersion,
+    scoreField: 'econ_index',
+    pages: 1,
+    estimatedMinutes: 5,
   },
   tape_food_security: {
     parentSurveyId: 'tape',
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step2-food-security' },
     resolveVersion: resolveFaoVersion,
+    scoreField: 'fies_score',
+    pages: 1,
+    estimatedMinutes: 5,
   },
   tape_dietary_diversity: {
     parentSurveyId: 'tape',
@@ -103,6 +112,9 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     isAvailable: (parentResponse) =>
       toHouseholdCount(parentResponse.people?.hh_women) > 0 ||
       toHouseholdCount(parentResponse.people?.hh_fyoung) > 0,
+    scoreField: 'dietary_score',
+    pages: 3,
+    estimatedMinutes: 10,
   },
   tape_youth: {
     parentSurveyId: 'tape',
@@ -112,30 +124,43 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     isAvailable: (parentResponse) =>
       toHouseholdCount(parentResponse.people?.hh_myoung) > 0 ||
       toHouseholdCount(parentResponse.people?.hh_fyoung) > 0,
+    pages: 1,
+    estimatedMinutes: 10,
   },
   tape_soil: {
     parentSurveyId: 'tape',
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step2-soil-health' },
     resolveVersion: resolveFaoVersion,
+    scoreField: 'soilhealth_score',
+    pages: 1,
+    estimatedMinutes: 5,
   },
   tape_pesticides: {
     parentSurveyId: 'tape',
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step2-pesticides' },
     resolveVersion: resolveFaoVersion,
+    pages: 1,
+    estimatedMinutes: 10,
   },
   tape_land_aweai: {
     parentSurveyId: 'tape',
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step2-land-tenure-aweai' },
     resolveVersion: resolveFaoVersion,
+    scoreField: 'aweai',
+    pages: 9,
+    estimatedMinutes: 25,
   },
   tape_productivity_biodiversity: {
     parentSurveyId: 'tape',
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step2-productivity-biodiversity' },
     resolveVersion: resolveFaoVersion,
+    scoreField: 'GSI_overall',
+    pages: 13,
+    estimatedMinutes: 45,
   },
   cathi_gao: {
     image: tape_survey,
@@ -225,6 +250,16 @@ export const getAvailableModuleIds = (
 
     return belongsToParent && isModuleAvailable;
   });
+};
+
+/**
+ * Where the back caret leads: a module returns to its parent's results page, a top-level survey to
+ * the Insights list.
+ */
+export const getSurveyBackUrl = (surveyId: string): string => {
+  const parentSurveyId = SURVEY_INFO[surveyId]?.parentSurveyId;
+
+  return parentSurveyId ? `/insights/survey/${parentSurveyId}/results` : '/Insights';
 };
 
 export const getPostSubmitRoute = (surveyId: string): string =>

--- a/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyConfig.ts
@@ -19,7 +19,7 @@ import TapeResults from './TapeResults';
 import ThankYouResults from './ThankYouResults';
 
 interface SurveyInfo {
-  image: string;
+  image?: string;
   ResultsComponent?: ComponentType<{ surveyId: string }>;
   // CDN directory under DO_CDN_URL holding the survey's file(s), optionally nested under a per-language
   // subfolder (see resolveVersion below).
@@ -34,7 +34,29 @@ interface SurveyInfo {
     defaultVersion: string,
     language: string,
   ) => { version: string; fallbackVersion?: string };
+  parentSurveyId?: string;
+  isAvailable?: (parentResponse: Record<string, any>) => boolean;
 }
+
+const resolveFaoVersion = (defaultVersion: string, language: string) =>
+  language === 'en'
+    ? { version: `fao/${defaultVersion}` }
+    : {
+        version: `fao_${language}/${defaultVersion}_${language}`,
+        fallbackVersion: `fao/${defaultVersion}`,
+      };
+
+const UNKNOWN_COUNT = -99;
+
+const toHouseholdCount = (value: unknown): number => {
+  // Current JSONs lack inputType: number on these questions and return a string
+  const numeric = typeof value === 'string' ? Number(value.trim()) : Number(value);
+
+  if (!Number.isFinite(numeric) || numeric === UNKNOWN_COUNT) {
+    return 0;
+  }
+  return numeric;
+};
 
 /**
  * The catalog of surveys, keyed by survey `key` (the same string stored in survey_response.survey_key).
@@ -45,6 +67,7 @@ interface SurveyInfo {
  * Adding a survey:
  *  1. Add a SURVEY_INFO entry here: image, ResultsComponent (omit for the generic thank-you page),
  *     cdnDirectory, versionsByCountry, and resolveVersion if the default version has localized files.
+ *     For a child module, set parentSurveyId (and optionally isAvailable) and omit image/ResultsComponent.
  *  2. Add the title in useSurveyTitle.ts by calling t() with the key INSIGHTS.<KEY>.TITLE.
  *  3. Add that title string to public/locales/en/translation.json (English only; Crowdin propagates).
  *  4. Upload the survey's <version>.json to its CDN directory. A translatable default version goes
@@ -58,14 +81,61 @@ export const SURVEY_INFO: Record<string, SurveyInfo> = {
     ResultsComponent: TapeResults,
     cdnDirectory: 'tape_surveys',
     versionsByCountry: { default: 'step01-survey', AU: 'au' },
-    resolveVersion: (defaultVersion: string, language: string) => {
-      return language === 'en'
-        ? { version: `fao/${defaultVersion}` }
-        : {
-            version: `fao_${language}/${defaultVersion}_${language}`,
-            fallbackVersion: `fao/${defaultVersion}`,
-          };
-    },
+    resolveVersion: resolveFaoVersion,
+  },
+  tape_economic: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-economic' },
+    resolveVersion: resolveFaoVersion,
+  },
+  tape_food_security: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-food-security' },
+    resolveVersion: resolveFaoVersion,
+  },
+  tape_dietary_diversity: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-dietary-diversity' },
+    resolveVersion: resolveFaoVersion,
+    isAvailable: (parentResponse) =>
+      toHouseholdCount(parentResponse.people?.hh_women) > 0 ||
+      toHouseholdCount(parentResponse.people?.hh_fyoung) > 0,
+  },
+  tape_youth: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-youth' },
+    resolveVersion: resolveFaoVersion,
+    isAvailable: (parentResponse) =>
+      toHouseholdCount(parentResponse.people?.hh_myoung) > 0 ||
+      toHouseholdCount(parentResponse.people?.hh_fyoung) > 0,
+  },
+  tape_soil: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-soil-health' },
+    resolveVersion: resolveFaoVersion,
+  },
+  tape_pesticides: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-pesticides' },
+    resolveVersion: resolveFaoVersion,
+  },
+  tape_land_aweai: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-land-tenure-aweai' },
+    resolveVersion: resolveFaoVersion,
+  },
+  tape_productivity_biodiversity: {
+    parentSurveyId: 'tape',
+    cdnDirectory: 'tape_surveys',
+    versionsByCountry: { default: 'step2-productivity-biodiversity' },
+    resolveVersion: resolveFaoVersion,
   },
   cathi_gao: {
     image: tape_survey,
@@ -133,8 +203,32 @@ export const getSurveyCdnPath = (
  */
 export const getAvailableSurveyIds = (countryCode?: string): string[] =>
   Object.keys(SURVEY_INFO).filter(
-    (surveyId) => getLatestCdnPath(surveyId, countryCode) !== undefined,
+    (surveyId) =>
+      // Hide child modules from the Insight tile list
+      !SURVEY_INFO[surveyId].parentSurveyId &&
+      getLatestCdnPath(surveyId, countryCode) !== undefined,
   );
+
+export const CAET_SCORE_FIELD = 'caet_score';
+
+export const getAvailableModuleIds = (
+  parentSurveyId: string,
+  parentResponse?: Record<string, unknown>,
+): string[] => {
+  if (!parentResponse || !(CAET_SCORE_FIELD in parentResponse)) {
+    return [];
+  }
+  return Object.keys(SURVEY_INFO).filter((surveyId) => {
+    const info = SURVEY_INFO[surveyId];
+    const belongsToParent = info.parentSurveyId === parentSurveyId;
+    const isModuleAvailable = info.isAvailable?.(parentResponse) ?? true;
+
+    return belongsToParent && isModuleAvailable;
+  });
+};
+
+export const getPostSubmitRoute = (surveyId: string): string =>
+  `/insights/survey/${SURVEY_INFO[surveyId]?.parentSurveyId ?? surveyId}/results`;
 
 export const getSurveyVersion = (surveyJson: any): string | undefined => {
   const expression = surveyJson?.calculatedValues?.find(

--- a/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
+++ b/packages/webapp/src/containers/Insights/Survey/surveyDraftSlice.ts
@@ -16,7 +16,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 
-interface SurveyDraft {
+export interface SurveyDraft {
   currentPageNo: number;
   surveyData: Record<string, any>;
   surveyVersion?: string;
@@ -87,6 +87,11 @@ export default surveyDraftSlice.reducer;
 // Selectors
 const surveyDraftStateSelector = (state: any): SurveyDraftState =>
   state.farmStateReducer[surveyDraftSlice.name] || initialState;
+
+export const allSurveyDraftsSelector = createSelector(
+  [surveyDraftStateSelector],
+  (draftState) => draftState.bySurveyId,
+);
 
 export const surveyDraftSelector = (surveyId: string) =>
   createSelector(

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyModules.ts
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyModules.ts
@@ -60,7 +60,7 @@ const getSurveyState = (
 
   const hasLocalDraft = !!localDraft && Object.keys(localDraft.surveyData).length > 0;
 
-  if (serverDraft || hasLocalDraft) {
+  if (serverDraft?.has_data || hasLocalDraft) {
     const currentPageNo = Math.max(
       serverDraft?.current_page_no ?? 0,
       localDraft?.currentPageNo ?? 0,

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyModules.ts
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyModules.ts
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2026 LiteFarm.org
+ *  This file is part of LiteFarm.
+ *
+ *  LiteFarm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  LiteFarm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useSelector } from 'react-redux';
+import {
+  useGetLatestSurveyResponsesQuery,
+  useGetSurveyDraftsQuery,
+  SurveyResponseRecord,
+  SurveyDraftSummary,
+} from '../../../store/api/surveyApi';
+import { SURVEY_INFO, getAvailableModuleIds } from './surveyConfig';
+import { allSurveyDraftsSelector, SurveyDraft } from './surveyDraftSlice';
+import { useSurveyTitles } from './useSurveyTitle';
+import type { SurveyModule } from '../../../components/Insights/Survey/SurveyModuleSection';
+import type { SurveyState } from '../../../components/Insights/Survey/SurveyModuleCard';
+
+const DEFAULT_ESTIMATED_MINUTES = 10;
+const DEFAULT_PAGE_COUNT = 1;
+
+const readScore = (response: SurveyResponseRecord, scoreField?: string): number | undefined => {
+  if (!scoreField) {
+    return undefined;
+  }
+  const score = Number(response.survey_response?.[scoreField]);
+
+  return Number.isFinite(score) ? score : undefined;
+};
+
+const getProgress = (currentPageNo: number, pages: number): number =>
+  // Use + 0.5 offset to place progress halfway through the active page
+  Math.min(Math.round((100 * (currentPageNo + 0.5)) / pages), 100);
+
+const getSurveyState = (
+  surveyId: string,
+  response: SurveyResponseRecord | undefined,
+  serverDraft: SurveyDraftSummary | undefined,
+  localDraft: SurveyDraft | undefined,
+): SurveyState => {
+  const { scoreField, pages = DEFAULT_PAGE_COUNT, estimatedMinutes } = SURVEY_INFO[surveyId];
+
+  if (response) {
+    return {
+      type: 'completed',
+      completedAt: new Date(response.created_at),
+      score: readScore(response, scoreField),
+    };
+  }
+
+  const hasLocalDraft = !!localDraft && Object.keys(localDraft.surveyData).length > 0;
+
+  if (serverDraft || hasLocalDraft) {
+    const currentPageNo = Math.max(
+      serverDraft?.current_page_no ?? 0,
+      localDraft?.currentPageNo ?? 0,
+    );
+    const startedAt = serverDraft
+      ? new Date(serverDraft.created_at)
+      : new Date(localDraft?.updatedAt ?? Date.now());
+
+    return { type: 'in-progress', progress: getProgress(currentPageNo, pages), startedAt };
+  }
+
+  return {
+    type: 'not-started',
+    estimatedMinutes: estimatedMinutes ?? DEFAULT_ESTIMATED_MINUTES,
+  };
+};
+
+export const useSurveyModules = (
+  parentSurveyId: string,
+  parentResponse?: Record<string, any>,
+): SurveyModule[] => {
+  const titleBySurveyId = useSurveyTitles();
+  const localDrafts: Record<string, SurveyDraft> = useSelector(allSurveyDraftsSelector);
+  const moduleIds = getAvailableModuleIds(parentSurveyId, parentResponse);
+
+  const { data: responses } = useGetLatestSurveyResponsesQuery(undefined, {
+    skip: !moduleIds.length,
+  });
+  const { data: serverDrafts } = useGetSurveyDraftsQuery(undefined, { skip: !moduleIds.length });
+
+  return moduleIds.map((surveyId) => ({
+    surveyId,
+    title: titleBySurveyId[surveyId],
+    survey: getSurveyState(
+      surveyId,
+      responses?.[surveyId],
+      serverDrafts?.[surveyId],
+      localDrafts[surveyId],
+    ),
+  }));
+};

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyTitle.ts
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyTitle.ts
@@ -26,6 +26,14 @@ export const useSurveyTitle = (surveyId: string): string => {
 
   const titleBySurveyId: Record<string, string> = {
     tape: t('INSIGHTS.TAPE.TITLE'),
+    tape_economic: t('INSIGHTS.TAPE_ECONOMIC.TITLE'),
+    tape_food_security: t('INSIGHTS.TAPE_FOOD_SECURITY.TITLE'),
+    tape_dietary_diversity: t('INSIGHTS.TAPE_DIETARY_DIVERSITY.TITLE'),
+    tape_youth: t('INSIGHTS.TAPE_YOUTH.TITLE'),
+    tape_soil: t('INSIGHTS.TAPE_SOIL.TITLE'),
+    tape_pesticides: t('INSIGHTS.TAPE_PESTICIDES.TITLE'),
+    tape_land_aweai: t('INSIGHTS.TAPE_LAND_AWEAI.TITLE'),
+    tape_productivity_biodiversity: t('INSIGHTS.TAPE_PRODUCTIVITY_BIODIVERSITY.TITLE'),
     cathi_gao: t('INSIGHTS.CATHI_GAO.TITLE'),
   };
 

--- a/packages/webapp/src/containers/Insights/Survey/useSurveyTitle.ts
+++ b/packages/webapp/src/containers/Insights/Survey/useSurveyTitle.ts
@@ -21,10 +21,10 @@ import { useTranslation } from 'react-i18next';
  * Kept free of component imports so it can be used by both the tile list and the survey/results
  * pages without an import cycle.
  */
-export const useSurveyTitle = (surveyId: string): string => {
+export const useSurveyTitles = (): Record<string, string> => {
   const { t } = useTranslation();
 
-  const titleBySurveyId: Record<string, string> = {
+  return {
     tape: t('INSIGHTS.TAPE.TITLE'),
     tape_economic: t('INSIGHTS.TAPE_ECONOMIC.TITLE'),
     tape_food_security: t('INSIGHTS.TAPE_FOOD_SECURITY.TITLE'),
@@ -36,6 +36,11 @@ export const useSurveyTitle = (surveyId: string): string => {
     tape_productivity_biodiversity: t('INSIGHTS.TAPE_PRODUCTIVITY_BIODIVERSITY.TITLE'),
     cathi_gao: t('INSIGHTS.CATHI_GAO.TITLE'),
   };
+};
+
+export const useSurveyTitle = (surveyId: string): string => {
+  const { t } = useTranslation();
+  const titleBySurveyId = useSurveyTitles();
 
   return titleBySurveyId[surveyId] ?? t('INSIGHTS.SURVEY.TITLE');
 };

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -14,7 +14,7 @@
  */
 
 import { api } from './apiSlice';
-import { surveyResponseUrl, getSurveyDraftUrl } from '../../apiConfig';
+import { surveyResponseUrl, latestSurveyResponsesUrl, getSurveyDraftUrl } from '../../apiConfig';
 import { DO_CDN_URL } from '../../util/constants';
 
 export interface SurveyResponseRecord {
@@ -89,6 +89,12 @@ export const surveyApi = api.injectEndpoints({
       }),
       providesTags: (_result, _error, { surveyKey }) => [{ type: 'SurveyResponse', id: surveyKey }],
     }),
+    getLatestSurveyResponses: build.query<Record<string, SurveyResponseRecord>, void>({
+      query: () => ({
+        url: latestSurveyResponsesUrl,
+      }),
+      providesTags: [{ type: 'SurveyResponse', id: 'LIST' }],
+    }),
     addSurveyResponse: build.mutation<void, AddSurveyResponseReqBody>({
       query: (body) => ({
         url: surveyResponseUrl,
@@ -97,6 +103,7 @@ export const surveyApi = api.injectEndpoints({
       }),
       invalidatesTags: (_result, _error, { survey_key }) => [
         { type: 'SurveyResponse', id: survey_key },
+        { type: 'SurveyResponse', id: 'LIST' },
       ],
     }),
     getSurveyDraft: build.query<SurveyDraftRecord | null, { surveyKey: string }>({
@@ -118,6 +125,7 @@ export const surveyApi = api.injectEndpoints({
 export const {
   useGetSurveyJsonQuery,
   useGetLatestSurveyResponseQuery,
+  useGetLatestSurveyResponsesQuery,
   useAddSurveyResponseMutation,
   useLazyGetSurveyDraftQuery,
   useUpsertSurveyDraftMutation,

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -30,6 +30,7 @@ export interface SurveyResponseRecord {
   survey_version: string;
   project_id: string;
   survey_step: string;
+  created_at: string;
 }
 
 export interface AddSurveyResponseReqBody {
@@ -46,8 +47,11 @@ export interface SurveyDraftRecord {
   survey_version: string;
   survey_data: Record<string, any>;
   current_page_no: number;
+  created_at: string;
   updated_at: string;
 }
+
+export type SurveyDraftSummary = Pick<SurveyDraftRecord, 'current_page_no' | 'created_at'>;
 
 export interface UpsertSurveyDraftReqBody {
   submission_id?: string;
@@ -118,7 +122,7 @@ export const surveyApi = api.injectEndpoints({
       }),
       providesTags: (_result, _error, { surveyKey }) => [{ type: 'SurveyDraft', id: surveyKey }],
     }),
-    getSurveyDrafts: build.query<Record<string, SurveyDraftRecord>, void>({
+    getSurveyDrafts: build.query<Record<string, SurveyDraftSummary>, void>({
       query: () => ({
         url: surveyDraftsUrl,
       }),

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -14,7 +14,12 @@
  */
 
 import { api } from './apiSlice';
-import { surveyResponseUrl, latestSurveyResponsesUrl, getSurveyDraftUrl } from '../../apiConfig';
+import {
+  surveyResponseUrl,
+  latestSurveyResponsesUrl,
+  surveyDraftsUrl,
+  getSurveyDraftUrl,
+} from '../../apiConfig';
 import { DO_CDN_URL } from '../../util/constants';
 
 export interface SurveyResponseRecord {
@@ -104,6 +109,7 @@ export const surveyApi = api.injectEndpoints({
       invalidatesTags: (_result, _error, { survey_key }) => [
         { type: 'SurveyResponse', id: survey_key },
         { type: 'SurveyResponse', id: 'LIST' },
+        { type: 'SurveyDraft', id: 'LIST' },
       ],
     }),
     getSurveyDraft: build.query<SurveyDraftRecord | null, { surveyKey: string }>({
@@ -111,6 +117,12 @@ export const surveyApi = api.injectEndpoints({
         url: getSurveyDraftUrl(surveyKey),
       }),
       providesTags: (_result, _error, { surveyKey }) => [{ type: 'SurveyDraft', id: surveyKey }],
+    }),
+    getSurveyDrafts: build.query<Record<string, SurveyDraftRecord>, void>({
+      query: () => ({
+        url: surveyDraftsUrl,
+      }),
+      providesTags: [{ type: 'SurveyDraft', id: 'LIST' }],
     }),
     upsertSurveyDraft: build.mutation<SurveyDraftRecord, UpsertSurveyDraftReqBody>({
       query: ({ surveyKey, ...body }) => ({
@@ -128,6 +140,7 @@ export const {
   useGetLatestSurveyResponsesQuery,
   useAddSurveyResponseMutation,
   useLazyGetSurveyDraftQuery,
+  useGetSurveyDraftsQuery,
   useUpsertSurveyDraftMutation,
   usePrefetch,
 } = surveyApi;

--- a/packages/webapp/src/store/api/surveyApi.ts
+++ b/packages/webapp/src/store/api/surveyApi.ts
@@ -51,7 +51,9 @@ export interface SurveyDraftRecord {
   updated_at: string;
 }
 
-export type SurveyDraftSummary = Pick<SurveyDraftRecord, 'current_page_no' | 'created_at'>;
+export type SurveyDraftSummary = Pick<SurveyDraftRecord, 'current_page_no' | 'created_at'> & {
+  has_data: boolean;
+};
 
 export interface UpsertSurveyDraftReqBody {
   submission_id?: string;
@@ -134,6 +136,7 @@ export const surveyApi = api.injectEndpoints({
         method: 'PUT',
         body,
       }),
+      invalidatesTags: [{ type: 'SurveyDraft', id: 'LIST' }],
     }),
   }),
 });


### PR DESCRIPTION
**Description**

This PR adds the TAPE Step 2 Modules to the Tape Results Page. I confirmed with Riddhi on Friday that she is blocked on building the data dashboard's visualizations until she can take these surveys and see what the results look like.

It would therefore be good to coordinate with Riddhi and merge to beta a little early, and then let adjustments happen alongside her own testing (even after I get back next week), as long as the data in `survey_response` is likely not to change -- and it shouldn't, as it's not touched by any of the logic in this PR. I've put all the files on Digital Ocean so beta should work as soon as the code is merged.

### In this PR:

- (Only backend change) Adds two batching endpoints, used by the module/results view, for the survey responses and the survey drafts. This allows populating the modules with data from a single query instead of up to 18 (9 x 2).
  - The batched survey response endpoint returns the full survey data, as keys within that object are needed to show the scores
  - The batched draft endpoint only returns the properties needed to show the status of an in-progress survey, and omits `survey_data`
- Adds the functions given to us by the data team for use in the step 2 biodiversity survey
- Extracts the original TAPE Results Radar Chart calculations and display into their own component + utility file
- Gates the display of (and direct URL navigation to) the modules on having completed the FAO TAPE Step 1. Two modules are additionally gated on specific responses within FAO TAPE Step 1
  - To see all the modules, answer "What types of holding is this --> Household" and then put 1 or more in "Young female household members" as this will unlock both Dietary Diversity -- whose instructions read "The dietary diversity module should be answered by any woman (young or adult) in the household." -- and Youth
- Adds the Step 2 modules to surveyConfig, including the JSON-derived `pages` and `estimatedMinutes` as needed by the modules
  - Minutes are based on the question count, but are almost certainly poor estimates; those will need updating
- (Unconfigured but happens to work) The update button *kind of* works as a retake right now. The button will let you re-take a module (all the persisted drafts will error / 409 though) and create a fresh `survey_response` in the DB with a new `submission_id`. That might be useful to Riddhi as a way to generate a number of responses quickly, or she might not need to use it at all. If you could kindly let her know that is how it works, though, until real update is implemented 🙏


### What I did not get to / what is not included:
- the new version tag behaviour and display goes with the version-pinning ticket and not this one, as specified in the entrypoint in `claude-docs/`. All docs should all be up-to-date.
- I don't love the names and URLs for the two batched endpoints (drafts and responses), particularly the `/latest` but I couldn't think of a pleasing alternative in time
- need to check with Loïc if the page-based progress indicator is sufficient. It means one page surveys will show either not started, 50%, or complete. I considered a question-based progress indicator but this seemed simpler
- I'm not stoked that we'll have to keep the numbers of pages on the config object up-to-date with the surveys, but I think it's preferable to actually pulling the full survey JSONs into the results view only to grab the page count. Another alternative would be to store the number of pages with the draft (like a new column on `survey_drafts`) which I did not implement only because I didn't want to migrate at this time. But maybe that method would have been better?
- the last feature to be added and which I did not particularly well-review is the URL gating / redirect in `Insights/Survey/index.tsx` based on which modules are available; I have tested it and it works, but I was surprised at the amount of code logic considering that we already have a functional redirect on, e.g., cathi-gao survey for a non-Niger farm
- not sure if the reconciliation logic for `serverDraft` + `hasLocalDraft` ("in-progress" state) in `getSurveyState` is ideal

I hope that's about everything! Have a great week!

Jira link: https://lite-farm.atlassian.net/browse/LF-5127

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] Passes test case
- [x] UI components visually reviewed on desktop view
- [ ] UI components visually reviewed on mobile view
- [ ] Other (please explain)

**Checklist:**

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The precommit and linting ran successfully
- [ ] I have added or updated language tags for text that's part of the UI
- [x] I have ordered translation keys alphabetically (optional: run `pnpm i18n` to help with this)
- [x] I have added [the GNU General Public License](https://lite-farm.atlassian.net/l/cp/BT0Dd7WW) to all new files
